### PR TITLE
Remove redundant final modifier and redundant variables

### DIFF
--- a/benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/ComputeKernels.java
+++ b/benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/ComputeKernels.java
@@ -53,10 +53,9 @@ public class ComputeKernels {
      */
     public static void monteCarlo(float[] result, int size) {
 
-        int total = size;
         final int iter = 25000;
 
-        for (@Parallel int idx = 0; idx < total; idx++) {
+        for (@Parallel int idx = 0; idx < size; idx++) {
 
             long seed = idx;
             float sum = 0.0f;

--- a/benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/ComputeKernels.java
+++ b/benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/ComputeKernels.java
@@ -163,9 +163,7 @@ public class ComputeKernels {
 
         final float y = (one - (oneBySqrt2pi * TornadoMath.exp((-X * X) / two) * t * (c1 + (t * (c2 + (t * (c3 + (t * (c4 + (t * c5))))))))));
 
-        final float result = (X < zero) ? (one - y) : y;
-
-        return result;
+        return (X < zero) ? (one - y) : y;
     }
 
     /*

--- a/benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/BlackScholes.java
+++ b/benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/BlackScholes.java
@@ -109,9 +109,7 @@ public class BlackScholes {
 
         final float y = (one - (oneBySqrt2pi * TornadoMath.exp((-X * X) / two) * t * (c1 + (t * (c2 + (t * (c3 + (t * (c4 + (t * c5))))))))));
 
-        final float result = (X < zero) ? (one - y) : y;
-
-        return result;
+        return (X < zero) ? (one - y) : y;
     }
 
     static final float S_LOWER_LIMIT = 10.0f;

--- a/benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/corrmatrix/CorrMatrixKernel.java
+++ b/benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/corrmatrix/CorrMatrixKernel.java
@@ -74,12 +74,11 @@ public class CorrMatrixKernel {
          */
         // generated from pop_array via sed 's/A\[\([^]]*\)\]/\(A[\1] \&
         // B[\1]\)/g'
-        final int n = numWords;
         int tot = 0,tot8 = 0;
         long ones = 0,twos = 0,fours = 0;
 
         int i;
-        for (i = 0; i <= (n - 8); i += 8) {
+        for (i = 0; i <= (numWords - 8); i += 8) {
             long twosA = 0;
             long twosB = 0;
             long foursA = 0;
@@ -145,7 +144,7 @@ public class CorrMatrixKernel {
             tot8 += Long.bitCount(eights);
         }
 
-        if (i <= (n - 4)) {
+        if (i <= (numWords - 4)) {
             final int ai = aStart + i;
             final int bi = bStart + i;
 
@@ -181,7 +180,7 @@ public class CorrMatrixKernel {
             i += 4;
         }
 
-        if (i <= (n - 2)) {
+        if (i <= (numWords - 2)) {
             final int ai = aStart + i;
             final int bi = bStart + i;
 
@@ -200,7 +199,7 @@ public class CorrMatrixKernel {
             i += 2;
         }
 
-        if (i < n) {
+        if (i < numWords) {
             final int ai = aStart + i;
             final int bi = bStart + i;
 

--- a/benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rodinia/kmean/Kmean.java
+++ b/benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rodinia/kmean/Kmean.java
@@ -126,7 +126,7 @@ public class Kmean {
         return (float) Math.sqrt(sum / numPoints);
     }
 
-    private final static float euclidDist(final int numFeatures, final float[] a, int aIndex, final float[] b, int bIndex) {
+    private static float euclidDist(final int numFeatures, final float[] a, int aIndex, final float[] b, int bIndex) {
         float value = 0f;
         for (int i = 0; i < numFeatures; i++) {
             final float dist = a[aIndex + i] - b[bIndex + i];

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLTargetDescription.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLTargetDescription.java
@@ -79,7 +79,7 @@ public class OCLTargetDescription extends TargetDescription {
     }
 
     // should use OCLKind.lookupLengthIndex instead
-    private final static int lookupLengthIndex(int vectorLength) {
+    private static int lookupLengthIndex(int vectorLength) {
         switch (vectorLength) {
             case 2:
                 return 0;

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLHotSpotBackendFactory.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLHotSpotBackendFactory.java
@@ -108,8 +108,7 @@ public class OCLHotSpotBackendFactory {
             lowerer.initialize(options, new DummySnippetFactory(), providers, snippetReflection);
         }
         try (InitTimer rt = timer("instantiate backend")) {
-            OCLBackend backend = new OCLBackend(options, providers, target, codeCache, openclContext, deviceContext);
-            return backend;
+            return new OCLBackend(options, providers, target, codeCache, openclContext, deviceContext);
         }
     }
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLMoveFactory.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLMoveFactory.java
@@ -48,8 +48,7 @@ public class OCLMoveFactory implements MoveFactory {
 
     @Override
     public LIRInstruction createMove(AllocatableValue av, Value value) {
-        AssignStmt assign = new AssignStmt(av, value);
-        return assign;
+        return new AssignStmt(av, value);
     }
 
     @Override

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/VectorPlugins.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/VectorPlugins.java
@@ -259,7 +259,7 @@ public final class VectorPlugins {
         });
     }
 
-    private static final void registerGeometricBIFS(final InvocationPlugins plugins, final OCLKind vectorKind, final Class<?> storageType, final Class<?> elementType) {
+    private static void registerGeometricBIFS(final InvocationPlugins plugins, final OCLKind vectorKind, final Class<?> storageType, final Class<?> elementType) {
         final Class<?> declaringClass = vectorKind.getJavaClass();
 
         final Registration r = new Registration(plugins, declaringClass);

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLAddressLowering.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLAddressLowering.java
@@ -55,7 +55,6 @@ public class OCLAddressLowering extends AddressLowering {
         }
 
         OCLAddressNode result = new OCLAddressNode(base, offset, memoryRegister);
-        OCLAddressNode unique = base.graph().unique(result);
-        return unique;
+        return base.graph().unique(result);
     }
 }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/vector/VectorLoadElementProxyNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/vector/VectorLoadElementProxyNode.java
@@ -103,7 +103,7 @@ public final class VectorLoadElementProxyNode extends FixedWithNextNode {
         return (isOriginResolvable() && laneOrigin != null && laneOrigin instanceof ConstantNode);
     }
 
-    private final boolean isOriginResolvable() {
+    private boolean isOriginResolvable() {
         return (origin != null && (origin instanceof VectorValueNode));
     }
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
@@ -104,8 +104,7 @@ public class FieldBuffer {
             debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: reading with offset != 0
-        int event = objectBuffer.read(getFieldValue(ref), 0, events, useDeps);
-        return event;
+        return objectBuffer.read(getFieldValue(ref), 0, events, useDeps);
     }
 
     public long toAbsoluteAddress() {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemoryManager.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemoryManager.java
@@ -99,8 +99,7 @@ public class OCLMemoryManager extends TornadoLogger implements TornadoMemoryProv
     }
 
     private static long align(final long address, final long alignment) {
-        long newAddress = (address % alignment == 0) ? address : address + (alignment - address % alignment);
-        return newAddress;
+        return (address % alignment == 0) ? address : address + (alignment - address % alignment);
     }
 
     public long tryAllocate(final Class<?> type, final long bytes, final int headerSize, int alignment) throws TornadoOutOfMemoryException {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/PrimitiveSerialiser.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/PrimitiveSerialiser.java
@@ -31,7 +31,7 @@ import uk.ac.manchester.tornado.runtime.common.Tornado;
 
 public class PrimitiveSerialiser {
 
-    private static final void align(ByteBuffer buffer, int align) {
+    private static void align(ByteBuffer buffer, int align) {
         while (buffer.position() % align != 0)
             buffer.put((byte) 0);
     }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -473,8 +473,7 @@ public class OCLTornadoDevice implements TornadoAcceleratorDevice {
 
         if (BENCHMARKING_MODE || !state.hasContents()) {
             state.setContents(true);
-            List<Integer> writeEvents = state.getBuffer().enqueueWrite(object, batchSize, offset, events, events == null);
-            return writeEvents;
+            return state.getBuffer().enqueueWrite(object, batchSize, offset, events, events == null);
         }
         return null;
     }

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/compression/HuffmanTornadoDecoder.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/compression/HuffmanTornadoDecoder.java
@@ -162,8 +162,7 @@ public class HuffmanTornadoDecoder {
 
         int size = 5000000;
         int[] result = new int[size];
-        KernelPackage kernelPackage = new KernelPackage(bits, frequencies, left, right, data, result);
-        return kernelPackage;
+        return new KernelPackage(bits, frequencies, left, right, data, result);
     }
 
     public static void main(String[] args) throws ClassNotFoundException, IOException {

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/BFS.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/BFS.java
@@ -82,8 +82,7 @@ public class BFS {
         Random r = new Random();
         int bound = r.nextInt(numNodes);
         IntStream streamArray = r.ints(bound, 0, numNodes);
-        int[] array = streamArray.toArray();
-        return array;
+        return streamArray.toArray();
     }
 
     public static void generateRandomGraph(int[] adjacencyMatrix, int numNodes, int root) {

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/BlackScholes.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/BlackScholes.java
@@ -72,8 +72,7 @@ public class BlackScholes {
         float absX = TornadoMath.abs(X);
         float t = one / (one + temp4 * absX);
         float y = (float) (one - oneBySqrt2pi * TornadoMath.exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5)))));
-        float result = (X < zero) ? (one - y) : y;
-        return result;
+        return (X < zero) ? (one - y) : y;
     }
 
     private static boolean checkResult(float[] call, float[] put, float[] callPrice, float[] putPrice) {

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/dynamic/BlackScholesDynamic.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/dynamic/BlackScholesDynamic.java
@@ -76,8 +76,7 @@ public class BlackScholesDynamic {
         float absX = TornadoMath.abs(X);
         float t = one / (one + temp4 * absX);
         float y = (float) (one - oneBySqrt2pi * TornadoMath.exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5)))));
-        float result = (X < zero) ? (one - y) : y;
-        return result;
+        return (X < zero) ? (one - y) : y;
     }
 
     private static boolean checkResult(float[] call, float[] put, float[] callPrice, float[] putPrice) {

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/dynamic/BlackScholesMT.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/dynamic/BlackScholesMT.java
@@ -110,8 +110,7 @@ public class BlackScholesMT {
         float absX = TornadoMath.abs(X);
         float t = one / (one + temp4 * absX);
         float y = (float) (one - oneBySqrt2pi * TornadoMath.exp(-X * X / two) * t * (c1 + t * (c2 + t * (c3 + t * (c4 + t * c5)))));
-        float result = (X < zero) ? (one - y) : y;
-        return result;
+        return (X < zero) ? (one - y) : y;
     }
 
     private static boolean checkResult(float[] call, float[] put, float[] callPrice, float[] putPrice) {

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
@@ -303,8 +303,7 @@ public class RuntimeUtilities {
 
     public static double elapsedTimeInSeconds(long start, long end) {
         final long duration = end - start;
-        double elapsed = duration * 1e-9;
-        return elapsed;
+        return duration * 1e-9;
     }
 
     public static double elapsedTimeInMilliSeconds(long start, long end) {

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoShapeAnalysis.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoShapeAnalysis.java
@@ -48,7 +48,7 @@ import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
  */
 public class TornadoShapeAnalysis extends BasePhase<TornadoHighTierContext> {
 
-    private static final int resolveInt(ValueNode value) {
+    private static int resolveInt(ValueNode value) {
         if (value instanceof ConstantNode) {
             return ((ConstantNode) value).asJavaConstant().asInt();
         } else {

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
@@ -90,8 +90,7 @@ public class TaskMetaData extends AbstractMetaData {
     }
 
     public static TaskMetaData create(ScheduleMetaData scheduleMeta, String id, Method method, boolean readMetaData) {
-        final TaskMetaData meta = new TaskMetaData(scheduleMeta, id, Modifier.isStatic(method.getModifiers()) ? method.getParameterCount() : method.getParameterCount() + 1);
-        return meta;
+        return new TaskMetaData(scheduleMeta, id, Modifier.isStatic(method.getModifiers()) ? method.getParameterCount() : method.getParameterCount() + 1);
     }
 
     private boolean inspectLocalWork() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageByte3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageByte3.java
@@ -105,7 +105,7 @@ public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
         this(matrix.length / elementSize, matrix[0].length / elementSize, toRowMajor(matrix));
     }
 
-    private final int toIndex(int x, int y) {
+    private int toIndex(int x, int y) {
         return (x * elementSize) + (y * elementSize * X);
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat8.java
@@ -108,7 +108,7 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
         this(matrix.length / elementSize, matrix[0].length / elementSize, toRowMajor(matrix));
     }
 
-    private final int toIndex(int x, int y) {
+    private int toIndex(int x, int y) {
         return (x * elementSize) + (y * elementSize * X);
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat3.java
@@ -89,7 +89,7 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
         this(numElements, new float[numElements * elementSize]);
     }
 
-    private final int toIndex(int index) {
+    private int toIndex(int index) {
         return (index * elementSize);
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat4.java
@@ -90,7 +90,7 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
         this(numElements, new float[numElements * elementSize]);
     }
 
-    private final int toIndex(int index) {
+    private int toIndex(int index) {
         return (index * elementSize);
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VolumeOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VolumeOps.java
@@ -156,9 +156,7 @@ public class VolumeOps {
         // @formatter:on
         final Float3 tmp1 = mult(new Float3(dim.getX() / volume.X(), dim.getY() / volume.Y(), dim.getZ() / volume.Z()), (0.5f * 0.00003051944088f));
 
-        final Float3 gradient = mult(new Float3(gx, gy, gz), tmp1);
-
-        return gradient;
+        return mult(new Float3(gx, gy, gz), tmp1);
 
     }
 
@@ -193,9 +191,7 @@ public class VolumeOps {
 
         final float c = (c0 * factorZ) + (c1 * factor.getZ());
 
-        final float result = c * 0.00003051944088f;
-
-        return result;
+        return c * 0.00003051944088f;
     }
 
     public static final float vs1(int x, int y, int z, VolumeShort2 v) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VolumeShort2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VolumeShort2.java
@@ -95,7 +95,7 @@ public class VolumeShort2 implements PrimitiveStorage<ShortBuffer> {
         this(width, height, depth, new short[width * height * depth * elementSize]);
     }
 
-    private final int toIndex(int x, int y, int z) {
+    private int toIndex(int x, int y, int z) {
         return (z * X * Y * elementSize) + (y * elementSize * X) + (x * elementSize);
     }
 
@@ -155,8 +155,7 @@ public class VolumeShort2 implements PrimitiveStorage<ShortBuffer> {
     }
 
     public String toString() {
-        String result = format("VolumeShort2 <%d x %d x %d>", Y, X, Z);
-        return result;
+        return format("VolumeShort2 <%d x %d x %d>", Y, X, Z);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/utils/TornadoUtilities.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/utils/TornadoUtilities.java
@@ -308,8 +308,7 @@ public class TornadoUtilities {
 
     public static double elapsedTimeInSeconds(long start, long end) {
         final long duration = end - start;
-        double elapsed = duration * 1e-9;
-        return elapsed;
+        return duration * 1e-9;
     }
 
     public static String formatArray(Object object) {

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/instances/LocalVariableInstance.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/instances/LocalVariableInstance.java
@@ -91,8 +91,7 @@ public class LocalVariableInstance {
         }
 
         MyMap mm = new MyMap();
-        MiddleMap md = (MiddleMap) mm;
-        MapSkeleton msk = new MapSkeleton(md);
+        MapSkeleton msk = new MapSkeleton((MiddleMap) mm);
 
         // @formatter:off
         TaskSchedule task = new TaskSchedule("s0")

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/slam/graphics/GraphicsTests.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/slam/graphics/GraphicsTests.java
@@ -81,9 +81,8 @@ public class GraphicsTests extends TornadoTestBase {
         verticies.set(0, 0, vertex);
     }
 
-    private static final Float3 rotate(Matrix4x4Float m, Float3 v) {
-        final Float3 result = new Float3(Float3.dot(m.row(0).asFloat3(), v), Float3.dot(m.row(1).asFloat3(), v), Float3.dot(m.row(2).asFloat3(), v));
-        return result;
+    private static Float3 rotate(Matrix4x4Float m, Float3 v) {
+        return new Float3(Float3.dot(m.row(0).asFloat3(), v), Float3.dot(m.row(1).asFloat3(), v), Float3.dot(m.row(2).asFloat3(), v));
     }
 
     private static void testRotate(Matrix4x4Float m, VectorFloat3 v, VectorFloat3 result) {
@@ -911,14 +910,12 @@ public class GraphicsTests extends TornadoTestBase {
 
     private Float8 createFloat8() {
         Random r = new Random();
-        Float8 f = new Float8(random(r), random(r), random(r), random(r), random(r), random(r), random(r), random(r));
-        return f;
+        return new Float8(random(r), random(r), random(r), random(r), random(r), random(r), random(r), random(r));
     }
 
     private Float4 createFloat4() {
         Random r = new Random();
-        Float4 f = new Float4(random(r), random(r), random(r), random(r));
-        return f;
+        return new Float4(random(r), random(r), random(r), random(r));
     }
 
     @Test


### PR DESCRIPTION
Below is the gist of changes:
- Remove redundant final modifier in front of private methods. In java private already implies that a subclass can not override a method, declaring a private method to be final is redundant
- I found few redundant variables though out the code. I have performed a bit of code clean up. Let me know if you do not agree with any of the change

PS: I did not want to open a new MR but while reverting few files in my previous MR, by mistake I reverted everything :(. And Github closed my previous MR automatically. I re-implemented the required changes and raised this new MR.