### PR TITLE
#12 regulate amount of allocated device heap depending on the device

### DIFF
--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -1,33 +1,34 @@
 /*
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
  * The University of Manchester.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 
 package uk.ac.manchester.tornado.unittests.batches;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import uk.ac.manchester.tornado.api.TaskSchedule;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+import uk.ac.manchester.tornado.unittests.tools.Exceptions.UnsupportedConfigurationException;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
-
-import uk.ac.manchester.tornado.api.TaskSchedule;
-import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+import static org.junit.Assert.assertEquals;
+import static uk.ac.manchester.tornado.unittests.virtualization.TestsVirtualLayer.getTornadoRuntime;
 
 public class TestBatches extends TornadoTestBase {
 
@@ -76,8 +77,19 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test100MB() {
 
+        long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
+
+        //check if there is enough memory for at least one chunk
+        if (maxAllocMemory < 100 * 1024 * 1024) {
+            throw new UnsupportedConfigurationException("Not enough memory to run the test");
+        }
+
         // Fill 800MB of float array
         int size = 200000000;
+        // or as much as we can
+        if (size * 4 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 4 / 2) * 0.9);
+        }
         float[] arrayA = new float[size];
         float[] arrayB = new float[size];
 
@@ -87,9 +99,9 @@ public class TestBatches extends TornadoTestBase {
 
         // @formatter:off
         ts.batch("100MB")   // Slots of 100 MB
-          .task("t0", TestBatches::compute, arrayA, arrayB)
-          .streamOut((Object) arrayB)
-          .execute();
+                .task("t0", TestBatches::compute, arrayA, arrayB)
+                .streamOut((Object) arrayB)
+                .execute();
         // @formatter:on
 
         for (int i = 0; i < arrayB.length; i++) {
@@ -100,8 +112,19 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test300MB() {
 
+        long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
+
+        //check if there is enough memory for at least one chunk
+        if (maxAllocMemory < 300 * 1024 * 1024) {
+            throw new UnsupportedConfigurationException("Not enough memory to run the test");
+        }
+
         // Fill 1.0GB
-        int size = 250000000;
+        int size = 250_000_000;
+        // Or as much as we can
+        if (size * 4 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 4 / 2) * 0.9);
+        }
         float[] arrayA = new float[size];
         float[] arrayB = new float[size];
 
@@ -112,9 +135,9 @@ public class TestBatches extends TornadoTestBase {
 
         // @formatter:off
         ts.batch("300MB")   // Slots of 300 MB
-          .task("t0", TestBatches::compute, arrayA, arrayB)
-          .streamOut((Object) arrayB)
-          .execute();
+                .task("t0", TestBatches::compute, arrayA, arrayB)
+                .streamOut((Object) arrayB)
+                .execute();
         // @formatter:on
 
         for (int i = 0; i < arrayB.length; i++) {
@@ -125,8 +148,19 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test512MB() {
 
+        long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
+
+        //check if there is enough memory for at least one chunk
+        if (maxAllocMemory < 512 * 1024 * 1024) {
+            throw new UnsupportedConfigurationException("Not enough memory to run the test");
+        }
+
         // Fill 800MB
         int size = 200000000;
+        // or as much as we can
+        if (size * 4 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 4) * 0.9);
+        }
         float[] arrayA = new float[size];
 
         IntStream.range(0, arrayA.length).sequential().forEach(idx -> arrayA[idx] = idx);
@@ -135,9 +169,9 @@ public class TestBatches extends TornadoTestBase {
 
         // @formatter:off
         ts.batch("512MB")   // Slots of 512 MB
-          .task("t0", TestBatches::compute, arrayA)
-          .streamOut((Object) arrayA)
-          .execute();
+                .task("t0", TestBatches::compute, arrayA)
+                .streamOut((Object) arrayA)
+                .execute();
         // @formatter:on
 
         for (int i = 0; i < arrayA.length; i++) {
@@ -148,8 +182,19 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MB() {
 
+        long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
+
+        //check if there is enough memory for at least one chunk
+        if (maxAllocMemory < 50 * 1024 * 1024) {
+            throw new UnsupportedConfigurationException("Not enough memory to run the test");
+        }
+
         // Fill 80MB of input Array
         int size = 20000000;
+        // or as much as we can
+        if (size * 4 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 4 / 3) * 0.9);
+        }
         float[] arrayA = new float[size];
         float[] arrayB = new float[size];
         float[] arrayC = new float[size];
@@ -163,9 +208,9 @@ public class TestBatches extends TornadoTestBase {
 
         // @formatter:off
         ts.batch("50MB")   // Process Slots of 50 MB
-          .task("t0", TestBatches::compute, arrayA, arrayB, arrayC)
-          .streamOut((Object) arrayC)
-          .execute();
+                .task("t0", TestBatches::compute, arrayA, arrayB, arrayC)
+                .streamOut((Object) arrayC)
+                .execute();
         // @formatter:on
 
         for (int i = 0; i < arrayA.length; i++) {
@@ -176,8 +221,19 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBInteger() {
 
+        long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
+
+        //check if there is enough memory for at least one chunk
+        if (maxAllocMemory < 50 * 1024 * 1024) {
+            throw new UnsupportedConfigurationException("Not enough memory to run the test");
+        }
+
         // Fill 80MB of input Array
         int size = 20000000;
+        // or as much as we can
+        if (size * 4 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 4 / 3) * 0.9);
+        }
         int[] arrayA = new int[size];
         int[] arrayB = new int[size];
         int[] arrayC = new int[size];
@@ -191,9 +247,9 @@ public class TestBatches extends TornadoTestBase {
 
         // @formatter:off
         ts.batch("50MB")   // Process Slots of 50 MB
-          .task("t0", TestBatches::compute, arrayA, arrayB, arrayC)
-          .streamOut((Object) arrayC)
-          .execute();
+                .task("t0", TestBatches::compute, arrayA, arrayB, arrayC)
+                .streamOut((Object) arrayC)
+                .execute();
         // @formatter:on
 
         for (int i = 0; i < arrayA.length; i++) {
@@ -204,8 +260,19 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBShort() {
 
+        long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
+
+        //check if there is enough memory for at least one chunk
+        if (maxAllocMemory < 50 * 1024 * 1024) {
+            throw new UnsupportedConfigurationException("Not enough memory to run the test");
+        }
+
         // Fill 160MB of input Array
         int size = 80000000;
+        // or as much as we can
+        if (size * 2 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 2 / 3) * 0.9);
+        }
         short[] arrayA = new short[size];
         short[] arrayB = new short[size];
         short[] arrayC = new short[size];
@@ -233,7 +300,18 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBDouble() {
 
+        long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
+
+        //check if there is enough memory for at least one chunk
+        if (maxAllocMemory < 50 * 1024 * 1024) {
+            throw new UnsupportedConfigurationException("Not enough memory to run the test");
+        }
+
         int size = 20000000;
+        // or as much as we can
+        if (size * 8 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 8 / 3) * 0.9);
+        }
         double[] arrayA = new double[size];
         double[] arrayB = new double[size];
         double[] arrayC = new double[size];
@@ -260,8 +338,19 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBLong() {
 
+        long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
+
+        //check if there is enough memory for at least one chunk
+        if (maxAllocMemory < 50 * 1024 * 1024) {
+            throw new UnsupportedConfigurationException("Not enough memory to run the test");
+        }
+
         // Fill 160MB of input Array
         int size = 20000000;
+        // or as much as we can
+        if (size * 8 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 8 / 3) * 0.9);
+        }
         long[] arrayA = new long[size];
         long[] arrayB = new long[size];
         long[] arrayC = new long[size];


### PR DESCRIPTION
I've examined the tests and it looks like TestBatches is the only candidate for this ticket.

I've added some checks before every test to watch for the allocated heap (-Dtornado.heap.allocation flag).
If there is not enough memory even for one chunk - UnsupportedConfigurationException is thrown , thus test will end up with "Unsupported Configuration" status.

I hope i've got the ticket #12 right :)