### PR TITLE
#11 Fix TornadoVM crashes when no OpenCL devices are available - fixed

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDriver.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDriver.java
@@ -36,6 +36,7 @@ import org.graalvm.compiler.phases.util.Providers;
 import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoNoOpenCLPlatformException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
@@ -58,7 +59,7 @@ public final class OCLDriver extends TornadoLogger implements TornadoAccelerator
         final int numPlatforms = OpenCL.getNumPlatforms();
 
         if (numPlatforms < 1) {
-            throw new TornadoNoOpenCLPlatformException("[ERROR] No OpenCL platforms found. Please install OpenCL drivers on your machine");
+            throw new TornadoBailoutRuntimeException("[WARNING] No OpenCL platforms found. Deoptimizing to sequential execution.");
         }
 
         backends = new OCLBackend[numPlatforms][];


### PR DESCRIPTION
With the introduction of TornadoBailoutRuntimeException this exception should be used. The handling of this exception is in `TornadoTaskSchedule#addTask` and then via `bailout` flag in `schedule` method