### PR TITLE
[TP-21] Parallelization of loops with constant loop-bounds

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
@@ -25,23 +25,21 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.graal.phases;
 
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
-import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
-
-import java.lang.reflect.Array;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.ResolvedJavaField;
 import org.graalvm.compiler.core.common.type.ObjectStamp;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.graph.Graph.Mark;
 import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.graph.iterators.NodeIterable;
 import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.LogicConstantNode;
 import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.ParameterNode;
+import org.graalvm.compiler.nodes.PhiNode;
 import org.graalvm.compiler.nodes.PiNode;
 import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.calc.IntegerLessThanNode;
 import org.graalvm.compiler.nodes.calc.IsNullNode;
 import org.graalvm.compiler.nodes.java.ArrayLengthNode;
 import org.graalvm.compiler.nodes.java.LoadFieldNode;
@@ -49,18 +47,23 @@ import org.graalvm.compiler.nodes.util.GraphUtil;
 import org.graalvm.compiler.phases.BasePhase;
 import org.graalvm.compiler.phases.common.CanonicalizerPhase;
 import org.graalvm.compiler.phases.common.DeadCodeEliminationPhase;
-
-import jdk.vm.ci.meta.JavaKind;
-import jdk.vm.ci.meta.ResolvedJavaField;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoLoopUnroller;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoValueTypeReplacement;
 
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
+import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
+
 public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext> {
 
-    private static final int MAX_ITERATIONS = 10;
+    private static final int MAX_ITERATIONS = 15;
 
     private final CanonicalizerPhase canonicalizer;
     private final TornadoValueTypeReplacement valueTypeReplacement;
@@ -226,7 +229,9 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
             graph.addWithoutUnique(constant);
             parameterNode.replaceAtUsages(constant);
         } else {
-            parameterNode.usages().snapshot().forEach(n -> evaluate(graph, n, args[parameterNode.index()]));
+            parameterNode.usages().snapshot().forEach(n -> {
+                evaluate(graph, n, args[parameterNode.index()]);
+            });
         }
     }
 
@@ -240,15 +245,11 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
         while (hasWork) {
             final Mark mark = graph.getMark();
             if (context.hasArgs()) {
+                getDebugContext().dump(DebugContext.INFO_LEVEL, graph, "Before Phase Propagate Parameters");
                 for (final ParameterNode param : graph.getNodes(ParameterNode.TYPE)) {
                     propagateParameters(graph, param, context.getArgs());
                 }
                 getDebugContext().dump(DebugContext.INFO_LEVEL, graph, "After Phase Propagate Parameters");
-            } else {
-                for (final ParameterNode param : graph.getNodes(ParameterNode.TYPE)) {
-                    assumeNonNull(param);
-                }
-                getDebugContext().dump(DebugContext.INFO_LEVEL, graph, "After Phase assume non null Parameters");
             }
 
             canonicalizer.apply(graph, context);
@@ -271,29 +272,49 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
 
             deadCodeElimination.run(graph);
 
-            getDebugContext().dump(DebugContext.INFO_LEVEL, graph, "After TaskSpecialisation iteration=" + iterations);
+            getDebugContext().dump(DebugContext.INFO_LEVEL, graph, "After TaskSpecialisation iteration = " + iterations);
 
-            hasWork = (lastNodeCount != graph.getNodeCount() || graph.getNewNodes(mark).isNotEmpty()) // ||
-                                                                                                      // hasGuardingPiNodes)
-                    && (iterations < MAX_ITERATIONS);
+            hasWork = (lastNodeCount != graph.getNodeCount() || graph.getNewNodes(mark).isNotEmpty()) && (iterations < MAX_ITERATIONS);
             lastNodeCount = graph.getNodeCount();
             iterations++;
         }
+
+        graph.getNodes().filter(ParallelRangeNode.class).forEach(range -> {
+            if (range.value() instanceof PhiNode) {
+                PhiNode phiNode = (PhiNode) range.value();
+                NodeIterable<Node> usages = range.usages();
+                for (Node usage : usages) {
+                    if (usage instanceof IntegerLessThanNode) {
+                        IntegerLessThanNode less = (IntegerLessThanNode) usage;
+                        ConstantNode constant = null;
+                        if (less.getX() instanceof ConstantNode) {
+                            constant = (ConstantNode) less.getX();
+                        } else if (less.getY() instanceof ConstantNode) {
+                            constant = (ConstantNode) less.getY();
+                        }
+
+                        // we swap the values between the new Constant and the PhiNode
+                        if (constant != null) {
+                            getDebugContext().dump(DebugContext.INFO_LEVEL, graph, "Before Swapping Constant-Phi");
+                            ParallelRangeNode pr = new ParallelRangeNode(range.index(), constant, range.offset(), range.stride());
+                            graph.addOrUnique(pr);
+                            range.safeDelete();
+
+                            IntegerLessThanNode intLess = new IntegerLessThanNode(phiNode, pr);
+                            graph.addOrUnique(intLess);
+                            less.usages().first().replaceAllInputs(less, intLess);
+                            less.safeDelete();
+                            getDebugContext().dump(DebugContext.INFO_LEVEL, graph, "After Swapping Constant-Phi");
+                        }
+                    }
+                }
+            }
+        });
 
         if (iterations == MAX_ITERATIONS) {
             Tornado.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
         }
         Tornado.debug("TaskSpecialisation ran %d iterations", iterations);
         Tornado.debug("valid graph? %s", graph.verify());
-    }
-
-    private void assumeNonNull(ParameterNode param) {
-        if (param.getStackKind().isObject() && param.usages().filter(IsNullNode.class).count() > 0) {
-            final IsNullNode isNullNode = (IsNullNode) param.usages().filter(IsNullNode.class).first();
-            // for (final GuardingPiNode guardingPiNode :
-            // isNullNode.usages().filter(GuardingPiNode.class).distinct()) {
-            // guardingPiNode.replaceAtUsages(param);
-            // }
-        }
     }
 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/nodes/AbstractParallelNode.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/nodes/AbstractParallelNode.java
@@ -27,7 +27,6 @@ import jdk.vm.ci.meta.JavaKind;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.FloatingNode;
 

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/nodes/AbstractParallelNode.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/nodes/AbstractParallelNode.java
@@ -27,6 +27,7 @@ import jdk.vm.ci.meta.JavaKind;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.FloatingNode;
 
@@ -36,7 +37,8 @@ public abstract class AbstractParallelNode extends FloatingNode implements Compa
     public static final NodeClass<AbstractParallelNode> TYPE = NodeClass.create(AbstractParallelNode.class);
 
     protected int index;
-    @Input protected ValueNode value;
+    @Input
+    protected ValueNode value;
 
     protected AbstractParallelNode(NodeClass<? extends AbstractParallelNode> type, int index, ValueNode value) {
         super(type, StampFactory.forKind(JavaKind.Int));
@@ -56,6 +58,10 @@ public abstract class AbstractParallelNode extends FloatingNode implements Compa
     @Override
     public int compareTo(AbstractParallelNode o) {
         return Integer.compare(index, o.index);
+    }
+
+    public void setValue(ValueNode value) {
+        this.value = value;
     }
 
 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/nodes/ParallelRangeNode.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/nodes/ParallelRangeNode.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -28,6 +28,7 @@ package uk.ac.manchester.tornado.runtime.graal.nodes;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.InputType;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.ValueNode;
 
 @NodeInfo(nameTemplate = "Range")
@@ -35,8 +36,10 @@ public class ParallelRangeNode extends AbstractParallelNode {
 
     public static final NodeClass<ParallelRangeNode> TYPE = NodeClass.create(ParallelRangeNode.class);
 
-    @Input(InputType.Association) private ParallelOffsetNode offset;
-    @Input(InputType.Association) private ParallelStrideNode stride;
+    @Input(InputType.Association)
+    private ParallelOffsetNode offset;
+    @Input(InputType.Association)
+    private ParallelStrideNode stride;
 
     public ParallelRangeNode(int index, ValueNode range, ParallelOffsetNode offset, ParallelStrideNode stride) {
         super(TYPE, index, range);

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/nodes/ParallelRangeNode.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/nodes/ParallelRangeNode.java
@@ -28,7 +28,6 @@ package uk.ac.manchester.tornado.runtime.graal.nodes;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.InputType;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.ValueNode;
 
 @NodeInfo(nameTemplate = "Range")

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestLoops.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestLoops.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.collections.types.Matrix2DFloat;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 public class TestLoops extends TornadoTestBase {
@@ -87,6 +88,52 @@ public class TestLoops extends TornadoTestBase {
                 .execute();
         for (int value : a) {
             assertEquals(10, value);
+        }
+    }
+
+    public static void forConstant04(Matrix2DFloat m, int n) {
+        for (@Parallel int i = 0; i <= n; i++) {
+            for (@Parallel int j = 0; j <= n; j++) {
+                m.set(i, j, 10);
+            }
+        }
+    }
+
+    @Test
+    public void testForConstant04() {
+        int size = 255;
+        Matrix2DFloat m = new Matrix2DFloat(size, size);
+        new TaskSchedule("s0") //
+                .task("t0", TestLoops::forConstant04, m, size) //
+                .streamOut(m) //
+                .execute();
+        for (int i = 0; i < m.M(); i++) {
+            for (int j = 0; j < m.N(); j++) {
+                assertEquals(10.0f, m.get(i, j), 0.001f);
+            }
+        }
+    }
+
+    public static void forConstant05(Matrix2DFloat m, int n) {
+        for (@Parallel int i = 0; i < n; i++) {
+            for (@Parallel int j = 0; j < n; j++) {
+                m.set(i, j, 10);
+            }
+        }
+    }
+
+    @Test
+    public void testForConstant05() {
+        int size = 256;
+        Matrix2DFloat m = new Matrix2DFloat(size, size);
+        new TaskSchedule("s0") //
+                .task("t0", TestLoops::forConstant05, m, size) //
+                .streamOut(m) //
+                .execute();
+        for (int i = 0; i < m.M(); i++) {
+            for (int j = 0; j < m.N(); j++) {
+                assertEquals(10.0f, m.get(i, j), 0.001f);
+            }
         }
     }
 

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestLoops.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestLoops.java
@@ -30,6 +30,66 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 public class TestLoops extends TornadoTestBase {
 
+    public static void forConstant01(int[] a, final int n) {
+        for (@Parallel int i = 0; i < n; i++) {
+            a[i] = 10;
+        }
+    }
+
+    @Test
+    public void testForConstant01() {
+        final int size = 256;
+        int[] a = new int[size];
+        Arrays.fill(a, 1);
+        new TaskSchedule("s0") //
+                .task("t0", TestLoops::forConstant01, a, size) //
+                .streamOut(a) //
+                .execute();
+        for (int value : a) {
+            assertEquals(10, value);
+        }
+    }
+
+    public static void forConstant02(int[] a, final int n) {
+        for (@Parallel int i = 0; i <= n; i++) {
+            a[i] = 10;
+        }
+    }
+
+    @Test
+    public void testForConstant02() {
+        final int size = 256;
+        int[] a = new int[size];
+        Arrays.fill(a, 1);
+        new TaskSchedule("s0") //
+                .task("t0", TestLoops::forConstant02, a, size) //
+                .streamOut(a) //
+                .execute();
+        for (int value : a) {
+            assertEquals(10, value);
+        }
+    }
+
+    public static void forConstant03(int[] a, int n) {
+        for (@Parallel int i = 0; i < n; i++) {
+            a[i] = 10;
+        }
+    }
+
+    @Test
+    public void testForConstant03() {
+        int size = 256;
+        int[] a = new int[size];
+        Arrays.fill(a, 1);
+        new TaskSchedule("s0") //
+                .task("t0", TestLoops::forConstant03, a, size) //
+                .streamOut(a) //
+                .execute();
+        for (int value : a) {
+            assertEquals(10, value);
+        }
+    }
+
     public static void forLoopOneD(int[] a) {
         for (@Parallel int i = 0; i < a.length; i++) {
             a[i] = 10;

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestLoops.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestLoops.java
@@ -63,7 +63,7 @@ public class TestLoops extends TornadoTestBase {
         int[] a = new int[size];
         Arrays.fill(a, 1);
         new TaskSchedule("s0") //
-                .task("t0", TestLoops::forConstant02, a, size) //
+                .task("t0", TestLoops::forConstant02, a, (size - 1)) //
                 .streamOut(a) //
                 .execute();
         for (int value : a) {
@@ -104,7 +104,7 @@ public class TestLoops extends TornadoTestBase {
         int size = 255;
         Matrix2DFloat m = new Matrix2DFloat(size, size);
         new TaskSchedule("s0") //
-                .task("t0", TestLoops::forConstant04, m, size) //
+                .task("t0", TestLoops::forConstant04, m, (size - 1)) //
                 .streamOut(m) //
                 .execute();
         for (int i = 0; i < m.M(); i++) {
@@ -133,6 +133,30 @@ public class TestLoops extends TornadoTestBase {
         for (int i = 0; i < m.M(); i++) {
             for (int j = 0; j < m.N(); j++) {
                 assertEquals(10.0f, m.get(i, j), 0.001f);
+            }
+        }
+    }
+
+    public static void forConstant06(Matrix2DFloat m2, int n, int m) {
+        for (@Parallel int i = 0; i <= n; i++) {
+            for (@Parallel int j = 0; j <= m; j++) {
+                m2.set(i, j, 10);
+            }
+        }
+    }
+
+    @Test
+    public void testForConstant06() {
+        int m = 256;
+        int n = 64;
+        Matrix2DFloat m2 = new Matrix2DFloat(m, n);
+        new TaskSchedule("s0") //
+                .task("t0", TestLoops::forConstant06, m2, (m - 1), (n - 1)) //
+                .streamOut(m2) //
+                .execute();
+        for (int i = 0; i < m2.M(); i++) {
+            for (int j = 0; j < m2.N(); j++) {
+                assertEquals(10.0f, m2.get(i, j), 0.001f);
             }
         }
     }


### PR DESCRIPTION
The issue was that for expressions such as "<=", the `TornadoTaskSpecialization` phase was inserting the constant node outside the parallel range node.

```java
public static void forConstant01(int[] a, final int n) {
        for (@Parallel int i = 0; i < n; i++) {
            a[i] = 10;
        }
   }
```

The solution is that, for the cases in which the Parallel Range contains a PhiNode as value, we can inspect the condition of the loop-bound. If a constant node is found, we can perform node swapping between these two.

Github issue #21

#### How to test?

```bash
$ tornado-test.py -V -pk --debug  uk.ac.manchester.tornado.unittests.loops.TestLoops#testForConstant02 

task info: s0.t0
	platform          : NVIDIA CUDA
	device            : GeForce GTX 1050 CL_DEVICE_TYPE_GPU (available)
	dims              : 1
	global work offset: [0]
	global work size  : [257]
	local  work size  : [257, 1, 1]
```

