### PR TITLE
[fix] FMA optimizations can be disabled

### DIFF
--- a/assembly/src/docs/6_TORNADO_FLAGS.md
+++ b/assembly/src/docs/6_TORNADO_FLAGS.md
@@ -63,3 +63,9 @@ It enables profiler information such as `COPY_IN`, `COPY_OUT`, compilation time,
 * `-Dtornado.opencl.compiler.options=LIST_OF_OPTIONS`:  
 It allows to pass the compile options specified by the OpenCL ``CLBuildProgram`` [specification](https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/clBuildProgram.html) to TornadoVM at runtime. By default it doesn't enable any. 
 
+
+##### Optimizations
+
+* `-Dtornado.enable.fma=True`:  
+It enables Fused-Multiply-Add optimizations. This option is enabled bu default. However, for some platforms, such as Xilinx with OpenCL 1.0, this option must be disabled. 
+

--- a/assembly/src/docs/6_TORNADO_FLAGS.md
+++ b/assembly/src/docs/6_TORNADO_FLAGS.md
@@ -67,5 +67,5 @@ It allows to pass the compile options specified by the OpenCL ``CLBuildProgram``
 ##### Optimizations
 
 * `-Dtornado.enable.fma=True`:  
-It enables Fused-Multiply-Add optimizations. This option is enabled bu default. However, for some platforms, such as Xilinx with OpenCL 1.0, this option must be disabled. 
+It enables Fused-Multiply-Add optimizations. This option is enabled by default. However, for some platforms, such as the Xilinx FPGA using SDAccel 2018.2 and OpenCL 1.0, this option must be disabled as it causes runtime errors. See issue on [Github](https://github.com/beehive-lab/TornadoVM/issues/24).
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLowTier.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLowTier.java
@@ -73,7 +73,9 @@ public class OCLLowTier extends TornadoLowTier {
 
         appendPhase(new TornadoLoopCanonicalization());
 
-        appendPhase(new OCLFMAPhase());
+        if (TornadoOptions.ENABLE_FMA) {
+            appendPhase(new OCLFMAPhase());
+        }
 
         appendPhase(new SchedulePhase(SchedulePhase.SchedulingStrategy.LATEST_OUT_OF_LOOPS));
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLMidTier.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLMidTier.java
@@ -41,9 +41,9 @@ import org.graalvm.compiler.phases.common.IterativeConditionalEliminationPhase;
 import org.graalvm.compiler.phases.common.LoweringPhase;
 import org.graalvm.compiler.phases.common.RemoveValueProxyPhase;
 
+import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoFloatingReadReplacement;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoPartialLoopUnroll;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoFloatingReadReplacement;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoMidTier;
 import uk.ac.manchester.tornado.runtime.graal.phases.ExceptionCheckingElimination;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoMemoryPhiElimination;
@@ -94,7 +94,6 @@ public class OCLMidTier extends TornadoMidTier {
             appendPhase(new ReassociateInvariantPhase());
         }
 
-        // appendPhase(new TornadoIfCanonicalization());
         appendPhase(canonicalizer);
     }
 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -74,6 +74,11 @@ public class TornadoOptions {
     public final static boolean FEATURE_EXTRACTION = getBooleanValue("tornado.feature.extraction", "False");
 
     /**
+     * Enable/Disable FMA Optimizations. True by default.
+     */
+    public static final boolean ENABLE_FMA = getBooleanValue("tornado.enable.fma", "True");
+
+    /**
      * Option to enable profiler. It can be disabled at any point during runtime.
      * 
      * @return boolean.


### PR DESCRIPTION
For Xilinx FPGAs running OpenCL 1.0 we need to disable FMA optimizations.
Use the flag `-Dtornado.enable.fma=False`

This flag is enabled by default.

Github issue #24 (Public)