### PR TITLE
[dev] TornadoVM collection types return backing array

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Byte3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Byte3.java
@@ -41,21 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.ByteBuffer.wrap;
-
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 3x bytes e.g. <byte,byte,byte>
- *
- * @author James Clarkson
- *
- */
 @Vector
 public final class Byte3 implements PrimitiveStorage<ByteBuffer> {
 
@@ -87,6 +78,10 @@ public final class Byte3 implements PrimitiveStorage<ByteBuffer> {
         setX(x);
         setY(y);
         setZ(z);
+    }
+
+    public byte[] getArray() {
+        return storage;
     }
 
     public void set(Byte3 value) {
@@ -139,7 +134,7 @@ public final class Byte3 implements PrimitiveStorage<ByteBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY(), getZ());
+        return String.format(fmt, getX(), getY(), getZ());
     }
 
     public String toString() {
@@ -167,7 +162,7 @@ public final class Byte3 implements PrimitiveStorage<ByteBuffer> {
 
     @Override
     public ByteBuffer asBuffer() {
-        return wrap(storage);
+        return ByteBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Byte4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Byte4.java
@@ -41,20 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.ByteBuffer.wrap;
-
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 3x bytes e.g. <byte,byte,byte>
- *
- * @author jamesclarkson
- */
 @Vector
 public final class Byte4 implements PrimitiveStorage<ByteBuffer> {
 
@@ -87,6 +79,10 @@ public final class Byte4 implements PrimitiveStorage<ByteBuffer> {
         setY(y);
         setZ(z);
         setW(w);
+    }
+
+    public byte[] getArray() {
+        return storage;
     }
 
     public void set(Byte4 value) {
@@ -148,7 +144,7 @@ public final class Byte4 implements PrimitiveStorage<ByteBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY(), getZ(), getW());
+        return String.format(fmt, getX(), getY(), getZ(), getW());
     }
 
     @Override
@@ -179,7 +175,7 @@ public final class Byte4 implements PrimitiveStorage<ByteBuffer> {
 
     @Override
     public ByteBuffer asBuffer() {
-        return wrap(storage);
+        return ByteBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ByteOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ByteOps.java
@@ -48,7 +48,4 @@ public class ByteOps {
     public static final String fmt3 = "{%3d,%3d,%3d}";
     public static final String fmt4 = "{%3d,%3d,%3d,%3d}";
 
-    public static boolean compare(byte a, byte b) {
-        return a == b;
-    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double2.java
@@ -41,22 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.DoubleBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.DoubleOps.fmt2;
-
 import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 2x doubles e.g. <double,double>
- *
- * @author jamesclarkson
- *
- */
 @Vector
 public final class Double2 implements PrimitiveStorage<DoubleBuffer> {
 
@@ -85,6 +75,10 @@ public final class Double2 implements PrimitiveStorage<DoubleBuffer> {
         this();
         setX(x);
         setY(y);
+    }
+
+    public double[] getArray() {
+        return storage;
     }
 
     public double get(int index) {
@@ -128,12 +122,12 @@ public final class Double2 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY());
+        return String.format(fmt, getX(), getY());
     }
 
     @Override
     public String toString() {
-        return toString(fmt2);
+        return toString(DoubleOps.fmt2);
     }
 
     protected static Double2 loadFromArray(final double[] array, int index) {
@@ -155,7 +149,7 @@ public final class Double2 implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public DoubleBuffer asBuffer() {
-        return wrap(storage);
+        return DoubleBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double3.java
@@ -41,21 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.DoubleBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.DoubleOps.fmt3;
-
 import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 3x doubles e.g. <double,double,double>
- *
- * @author jamesclarkson
- */
 @Vector
 public final class Double3 implements PrimitiveStorage<DoubleBuffer> {
 
@@ -85,6 +76,10 @@ public final class Double3 implements PrimitiveStorage<DoubleBuffer> {
         setX(x);
         setY(y);
         setZ(z);
+    }
+
+    public double[] getArray() {
+        return storage;
     }
 
     public double get(int index) {
@@ -161,12 +156,12 @@ public final class Double3 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY(), getZ());
+        return String.format(fmt, getX(), getY(), getZ());
     }
 
     @Override
     public String toString() {
-        return toString(fmt3);
+        return toString(DoubleOps.fmt3);
     }
 
     /**
@@ -199,7 +194,7 @@ public final class Double3 implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public DoubleBuffer asBuffer() {
-        return wrap(storage);
+        return DoubleBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double4.java
@@ -41,21 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.DoubleBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.DoubleOps.fmt4;
-
 import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 4x doubles e.g. <double,double,double>
- *
- * @author jamesclarkson
- */
 @Vector
 public final class Double4 implements PrimitiveStorage<DoubleBuffer> {
 
@@ -94,6 +85,10 @@ public final class Double4 implements PrimitiveStorage<DoubleBuffer> {
         setY(y);
         setZ(z);
         setW(w);
+    }
+
+    public double[] getArray() {
+        return storage;
     }
 
     public void set(Double4 value) {
@@ -147,12 +142,12 @@ public final class Double4 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY(), getZ(), getW());
+        return String.format(fmt, getX(), getY(), getZ(), getW());
     }
 
     @Override
     public String toString() {
-        return toString(fmt4);
+        return toString(DoubleOps.fmt4);
     }
 
     /**
@@ -199,7 +194,7 @@ public final class Double4 implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public DoubleBuffer asBuffer() {
-        return wrap(storage);
+        return DoubleBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double6.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double6.java
@@ -41,23 +41,11 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Double.MAX_VALUE;
-import static java.lang.Double.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.DoubleBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.DoubleOps.fmt6;
-
 import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 
-/**
- * Class that represents a vector of 3x doubles e.g. <double,double,double>
- *
- * @author jamesclarkson
- *
- */
 public final class Double6 implements PrimitiveStorage<DoubleBuffer> {
 
     public static final Class<Double6> TYPE = Double6.class;
@@ -65,7 +53,8 @@ public final class Double6 implements PrimitiveStorage<DoubleBuffer> {
     /**
      * backing array
      */
-    @Payload final protected double[] storage;
+    @Payload
+    final protected double[] storage;
 
     /**
      * number of elements in the storage
@@ -88,6 +77,10 @@ public final class Double6 implements PrimitiveStorage<DoubleBuffer> {
         setS3(s3);
         setS4(s4);
         setS5(s5);
+    }
+
+    public double[] getArray() {
+        return storage;
     }
 
     public void set(Double6 value) {
@@ -166,7 +159,7 @@ public final class Double6 implements PrimitiveStorage<DoubleBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Double6}
      */
     public Double6 duplicate() {
         final Double6 vector = new Double6();
@@ -175,15 +168,15 @@ public final class Double6 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getS0(), getS1(), getS2(), getS3(), getS4(), getS5());
+        return String.format(fmt, getS0(), getS1(), getS2(), getS3(), getS4(), getS5());
     }
 
     @Override
     public String toString() {
-        return toString(fmt6);
+        return toString(DoubleOps.fmt6);
     }
 
-    public static final Double6 loadFromArray(final double[] array, int index) {
+    public static Double6 loadFromArray(final double[] array, int index) {
         final Double6 result = new Double6();
         for (int i = 0; i < numElements; i++) {
             result.set(i, array[index + i]);
@@ -204,7 +197,7 @@ public final class Double6 implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public DoubleBuffer asBuffer() {
-        return wrap(storage);
+        return DoubleBuffer.wrap(storage);
     }
 
     @Override
@@ -348,7 +341,7 @@ public final class Double6 implements PrimitiveStorage<DoubleBuffer> {
      * vector wide operations
      */
     public static double min(Double6 value) {
-        double result = MAX_VALUE;
+        double result = Double.MAX_VALUE;
         for (int i = 0; i < numElements; i++) {
             result = Math.min(result, value.get(i));
         }
@@ -356,7 +349,7 @@ public final class Double6 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public static double max(Double6 value) {
-        double result = MIN_VALUE;
+        double result = Double.MIN_VALUE;
         for (int i = 0; i < numElements; i++) {
             result = Math.max(result, value.get(i));
         }
@@ -375,7 +368,7 @@ public final class Double6 implements PrimitiveStorage<DoubleBuffer> {
     /**
      * Returns the vector length e.g. the sqrt of all elements squared
      *
-     * @return
+     * @return double
      */
     public static double length(Double6 value) {
         return TornadoMath.sqrt(dot(value, value));

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double8.java
@@ -41,24 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Double.MAX_VALUE;
-import static java.lang.Double.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.DoubleBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.DoubleOps.fmt8;
-
 import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 3x doubles e.g. <double,double,double>
- *
- * @author jamesclarkson
- *
- */
 @Vector
 public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
 
@@ -67,7 +55,8 @@ public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
     /**
      * backing array
      */
-    @Payload final protected double[] storage;
+    @Payload
+    final protected double[] storage;
 
     /**
      * number of elements in the storage
@@ -88,11 +77,14 @@ public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
         setS1(s1);
         setS2(s2);
         setS3(s3);
-
         setS4(s4);
         setS5(s5);
         setS6(s6);
         setS7(s7);
+    }
+
+    public double[] getArray() {
+        return storage;
     }
 
     public double get(int index) {
@@ -184,7 +176,7 @@ public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Double8}
      */
     public Double8 duplicate() {
         Double8 vector = new Double8();
@@ -193,15 +185,15 @@ public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getS0(), getS1(), getS2(), getS3(), getS4(), getS5(), getS6(), getS7());
+        return String.format(fmt, getS0(), getS1(), getS2(), getS3(), getS4(), getS5(), getS6(), getS7());
     }
 
     @Override
     public String toString() {
-        return toString(fmt8);
+        return toString(DoubleOps.fmt8);
     }
 
-    protected static final Double8 loadFromArray(final double[] array, int index) {
+    protected static Double8 loadFromArray(final double[] array, int index) {
         final Double8 result = new Double8();
         for (int i = 0; i < numElements; i++) {
             result.set(i, array[index + i]);
@@ -222,7 +214,7 @@ public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public DoubleBuffer asBuffer() {
-        return wrap(storage);
+        return DoubleBuffer.wrap(storage);
     }
 
     @Override
@@ -306,7 +298,7 @@ public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public static double min(Double8 value) {
-        double result = MAX_VALUE;
+        double result = Double.MAX_VALUE;
         for (int i = 0; i < numElements; i++) {
             result = Math.min(result, value.get(i));
         }
@@ -322,7 +314,7 @@ public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public static double max(Double8 value) {
-        double result = MIN_VALUE;
+        double result = Double.MIN_VALUE;
         for (int i = 0; i < numElements; i++) {
             result = Math.max(result, value.get(i));
         }
@@ -344,5 +336,4 @@ public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
     public static double findULPDistance(Double8 value, Double8 expected) {
         return TornadoMath.findULPDistance(value.asBuffer().array(), expected.asBuffer().array());
     }
-
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/DoubleOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/DoubleOps.java
@@ -41,10 +41,7 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Double.doubleToRawLongBits;
-import static java.lang.Math.abs;
-import static java.lang.Math.ulp;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.findULPDistance;
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 
 public class DoubleOps {
 
@@ -60,67 +57,67 @@ public class DoubleOps {
     public static final String fmt8 = "{%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f}";
     public static final String fmt6e = "{%e,%e,%e,%e,%e,%e}";
 
-    public static final boolean compareBits(double a, double b) {
-        long ai = doubleToRawLongBits(a);
-        long bi = doubleToRawLongBits(b);
+    public static boolean compareBits(double a, double b) {
+        long ai = Double.doubleToRawLongBits(a);
+        long bi = Double.doubleToRawLongBits(b);
 
         long diff = ai ^ bi;
         return (diff == 0);
     }
 
-    public static final boolean compareULP(double value, double expected, double ulps) {
-        final double tol = ulps * ulp(expected);
+    public static boolean compareULP(double value, double expected, double ulps) {
+        final double tol = ulps * Math.ulp(expected);
         if (value == expected) {
             return true;
         }
 
-        return abs(value - expected) < tol;
+        return Math.abs(value - expected) < tol;
     }
 
-    public static final double findMaxULP(Double2 value, Double2 expected) {
-        return findULPDistance(value.storage, expected.storage);
+    public static double findMaxULP(Double2 value, Double2 expected) {
+        return TornadoMath.findULPDistance(value.storage, expected.storage);
     }
 
-    public static final double findMaxULP(Double3 value, Double3 expected) {
-        return findULPDistance(value.storage, expected.storage);
+    public static double findMaxULP(Double3 value, Double3 expected) {
+        return TornadoMath.findULPDistance(value.storage, expected.storage);
     }
 
-    public static final double findMaxULP(Double4 value, Double4 expected) {
-        return findULPDistance(value.storage, expected.storage);
+    public static double findMaxULP(Double4 value, Double4 expected) {
+        return TornadoMath.findULPDistance(value.storage, expected.storage);
     }
 
-    public static final double findMaxULP(Double6 value, Double6 expected) {
-        return findULPDistance(value.storage, expected.storage);
+    public static double findMaxULP(Double6 value, Double6 expected) {
+        return TornadoMath.findULPDistance(value.storage, expected.storage);
     }
 
-    public static final double findMaxULP(Double8 value, Double8 expected) {
-        return findULPDistance(value.storage, expected.storage);
+    public static double findMaxULP(Double8 value, Double8 expected) {
+        return TornadoMath.findULPDistance(value.storage, expected.storage);
     }
 
-    public static final double findMaxULP(double value, double expected) {
-        final double ULP = ulp(expected);
+    public static double findMaxULP(double value, double expected) {
+        final double ULP = Math.ulp(expected);
 
         if (value == expected) {
             return 0f;
         }
 
-        final double absValue = abs(value - expected);
+        final double absValue = Math.abs(value - expected);
         return absValue / ULP;
     }
 
-    public static final boolean compare(double a, double b) {
-        return (abs(a - b) <= EPSILON);
+    public static boolean compare(double a, double b) {
+        return (Math.abs(a - b) <= EPSILON);
     }
 
-    public static final boolean compare(double a, double b, double tol) {
-        return (abs(a - b) <= tol);
+    public static boolean compare(double a, double b, double tol) {
+        return (Math.abs(a - b) <= tol);
     }
 
-    public static final double sq(double value) {
+    public static double sq(double value) {
         return value * value;
     }
 
-    public static final void atomicAdd(double[] array, int index, double value) {
+    public static void atomicAdd(double[] array, int index, double value) {
         array[index] += value;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float2.java
@@ -41,22 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt2;
-
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 2x floats e.g. <float,float>
- *
- * @author jamesclarkson
- *
- */
 @Vector
 public final class Float2 implements PrimitiveStorage<FloatBuffer> {
 
@@ -65,7 +55,8 @@ public final class Float2 implements PrimitiveStorage<FloatBuffer> {
     /**
      * backing array
      */
-    @Payload final protected float[] storage;
+    @Payload
+    final protected float[] storage;
 
     /**
      * number of elements in the storage
@@ -84,6 +75,10 @@ public final class Float2 implements PrimitiveStorage<FloatBuffer> {
         this();
         setX(x);
         setY(y);
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     public float get(int index) {
@@ -118,7 +113,7 @@ public final class Float2 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Float2}
      */
     public Float2 duplicate() {
         Float2 vector = new Float2();
@@ -127,15 +122,15 @@ public final class Float2 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY());
+        return String.format(fmt, getX(), getY());
     }
 
     @Override
     public String toString() {
-        return toString(fmt2);
+        return toString(FloatOps.fmt2);
     }
 
-    protected static final Float2 loadFromArray(final float[] array, int index) {
+    protected static Float2 loadFromArray(final float[] array, int index) {
         final Float2 result = new Float2();
         result.setX(array[index]);
         result.setY(array[index + 1]);
@@ -154,7 +149,7 @@ public final class Float2 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override
@@ -283,9 +278,8 @@ public final class Float2 implements PrimitiveStorage<FloatBuffer> {
         x.setY(TornadoMath.clamp(x.getY(), min, max));
     }
 
-    public static void normalise(Float2 value) {
-        final float len = length(value);
-        scaleByInverse(value, len);
+    public static Float2 normalise(Float2 value) {
+        return scaleByInverse(value, length(value));
     }
 
     /*
@@ -307,7 +301,7 @@ public final class Float2 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Returns the vector length e.g. the sqrt of all elements squared
      *
-     * @return
+     * @return float
      */
     public static float length(Float2 value) {
         return TornadoMath.sqrt(dot(value, value));

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float3.java
@@ -41,21 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
-
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 3x floats e.g. <float,float,float>
- *
- * @author jamesclarkson
- */
 @Vector
 public final class Float3 implements PrimitiveStorage<FloatBuffer> {
 
@@ -85,6 +76,10 @@ public final class Float3 implements PrimitiveStorage<FloatBuffer> {
         setX(x);
         setY(y);
         setZ(z);
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     public float get(int index) {
@@ -152,7 +147,7 @@ public final class Float3 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Float3}
      */
     public Float3 duplicate() {
         final Float3 vector = new Float3();
@@ -161,24 +156,24 @@ public final class Float3 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY(), getZ());
+        return String.format(fmt, getX(), getY(), getZ());
     }
 
     @Override
     public String toString() {
-        return toString(fmt3);
+        return toString(FloatOps.fmt3);
     }
 
     /**
-     * Cast vector into a Float2
+     * Cast vector From Float3 into a Float2
      *
-     * @return
+     * @return {@link Float2}
      */
     public Float2 asFloat2() {
         return new Float2(getX(), getY());
     }
 
-    protected static final Float3 loadFromArray(final float[] array, int index) {
+    protected static Float3 loadFromArray(final float[] array, int index) {
         final Float3 result = new Float3();
         result.setX(array[index]);
         result.setY(array[index + 1]);
@@ -199,7 +194,7 @@ public final class Float3 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override
@@ -322,7 +317,7 @@ public final class Float3 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Returns the vector length e.g. the sqrt of all elements squared
      *
-     * @return
+     * @return float
      */
     public static float length(Float3 value) {
         return TornadoMath.sqrt(dot(value, value));

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float4.java
@@ -41,21 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt4;
-
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 4x floats e.g. <float,float,float>
- *
- * @author jamesclarkson
- */
 @Vector
 public final class Float4 implements PrimitiveStorage<FloatBuffer> {
 
@@ -64,7 +55,8 @@ public final class Float4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * backing array
      */
-    @Payload final protected float[] storage;
+    @Payload
+    final protected float[] storage;
 
     /**
      * number of elements in the storage
@@ -93,6 +85,10 @@ public final class Float4 implements PrimitiveStorage<FloatBuffer> {
         setY(y);
         setZ(z);
         setW(w);
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     public void set(Float4 value) {
@@ -137,7 +133,7 @@ public final class Float4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Float4}
      */
     public Float4 duplicate() {
         final Float4 vector = new Float4();
@@ -146,18 +142,18 @@ public final class Float4 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY(), getZ(), getW());
+        return String.format(fmt, getX(), getY(), getZ(), getW());
     }
 
     @Override
     public String toString() {
-        return toString(fmt4);
+        return toString(FloatOps.fmt4);
     }
 
     /**
      * Cast vector into a Float2
      *
-     * @return
+     * @return {@link Float2}
      */
     public Float2 asFloat2() {
         return new Float2(getX(), getY());
@@ -175,7 +171,7 @@ public final class Float4 implements PrimitiveStorage<FloatBuffer> {
         return new Float2(getZ(), getW());
     }
 
-    protected static final Float4 loadFromArray(final float[] array, int index) {
+    protected static Float4 loadFromArray(final float[] array, int index) {
         final Float4 result = new Float4();
         result.setX(array[index]);
         result.setY(array[index + 1]);
@@ -198,7 +194,7 @@ public final class Float4 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override
@@ -303,9 +299,8 @@ public final class Float4 implements PrimitiveStorage<FloatBuffer> {
         return new Float4(TornadoMath.clamp(x.getX(), min, max), TornadoMath.clamp(x.getY(), min, max), TornadoMath.clamp(x.getZ(), min, max), TornadoMath.clamp(x.getW(), min, max));
     }
 
-    public static void normalise(Float4 value) {
-        final float len = length(value);
-        scaleByInverse(value, len);
+    public static Float4 normalise(Float4 value) {
+        return scaleByInverse(value, length(value));
     }
 
     /*
@@ -327,7 +322,7 @@ public final class Float4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Returns the vector length e.g. the sqrt of all elements squared
      *
-     * @return
+     * @return float
      */
     public static float length(Float4 value) {
         return TornadoMath.sqrt(dot(value, value));

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float6.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float6.java
@@ -41,23 +41,11 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Float.MAX_VALUE;
-import static java.lang.Float.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt6;
-
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 
-/**
- * Class that represents a vector of 3x floats e.g. <float,float,float>
- *
- * @author jamesclarkson
- *
- */
 public final class Float6 implements PrimitiveStorage<FloatBuffer> {
 
     public static final Class<Float6> TYPE = Float6.class;
@@ -65,7 +53,8 @@ public final class Float6 implements PrimitiveStorage<FloatBuffer> {
     /**
      * backing array
      */
-    @Payload final protected float[] storage;
+    @Payload
+    final protected float[] storage;
 
     /**
      * number of elements in the storage
@@ -88,6 +77,10 @@ public final class Float6 implements PrimitiveStorage<FloatBuffer> {
         setS3(s3);
         setS4(s4);
         setS5(s5);
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     public void set(Float6 value) {
@@ -166,7 +159,7 @@ public final class Float6 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Float6}
      */
     public Float6 duplicate() {
         final Float6 vector = new Float6();
@@ -175,15 +168,15 @@ public final class Float6 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getS0(), getS1(), getS2(), getS3(), getS4(), getS5());
+        return String.format(fmt, getS0(), getS1(), getS2(), getS3(), getS4(), getS5());
     }
 
     @Override
     public String toString() {
-        return toString(fmt6);
+        return toString(FloatOps.fmt6);
     }
 
-    public static final Float6 loadFromArray(final float[] array, int index) {
+    public static Float6 loadFromArray(final float[] array, int index) {
         final Float6 result = new Float6();
         for (int i = 0; i < numElements; i++) {
             result.set(i, array[index + i]);
@@ -204,7 +197,7 @@ public final class Float6 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override
@@ -348,7 +341,7 @@ public final class Float6 implements PrimitiveStorage<FloatBuffer> {
      * vector wide operations
      */
     public static float min(Float6 value) {
-        float result = MAX_VALUE;
+        float result = Float.MAX_VALUE;
         for (int i = 0; i < numElements; i++) {
             result = Math.min(result, value.get(i));
         }
@@ -356,7 +349,7 @@ public final class Float6 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public static float max(Float6 value) {
-        float result = MIN_VALUE;
+        float result = Float.MIN_VALUE;
         for (int i = 0; i < numElements; i++) {
             result = Math.max(result, value.get(i));
         }
@@ -375,7 +368,7 @@ public final class Float6 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Returns the vector length e.g. the sqrt of all elements squared
      *
-     * @return
+     * @return float
      */
     public static float length(Float6 value) {
         return TornadoMath.sqrt(dot(value, value));

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float8.java
@@ -87,10 +87,6 @@ public final class Float8 implements PrimitiveStorage<FloatBuffer> {
         return storage;
     }
 
-    public float[] getStorage() {
-        return storage;
-    }
-
     public float get(int index) {
         return storage[index];
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float8.java
@@ -41,25 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Float.MAX_VALUE;
-import static java.lang.Float.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt8;
-
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 8x floats e.g.
- * <float,float,float,float,float,float,float,float>
- *
- * @author jamesclarkson
- *
- */
 @Vector
 public final class Float8 implements PrimitiveStorage<FloatBuffer> {
 
@@ -68,7 +55,8 @@ public final class Float8 implements PrimitiveStorage<FloatBuffer> {
     /**
      * backing array
      */
-    @Payload final protected float[] storage;
+    @Payload
+    final protected float[] storage;
 
     /**
      * number of elements in the storage
@@ -89,11 +77,14 @@ public final class Float8 implements PrimitiveStorage<FloatBuffer> {
         setS1(s1);
         setS2(s2);
         setS3(s3);
-
         setS4(s4);
         setS5(s5);
         setS6(s6);
         setS7(s7);
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     public float[] getStorage() {
@@ -189,7 +180,7 @@ public final class Float8 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Float8}
      */
     public Float8 duplicate() {
         Float8 vector = new Float8();
@@ -198,15 +189,15 @@ public final class Float8 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getS0(), getS1(), getS2(), getS3(), getS4(), getS5(), getS6(), getS7());
+        return String.format(fmt, getS0(), getS1(), getS2(), getS3(), getS4(), getS5(), getS6(), getS7());
     }
 
     @Override
     public String toString() {
-        return toString(fmt8);
+        return toString(FloatOps.fmt8);
     }
 
-    protected static final Float8 loadFromArray(final float[] array, int index) {
+    protected static Float8 loadFromArray(final float[] array, int index) {
         final Float8 result = new Float8();
         for (int i = 0; i < numElements; i++) {
             result.set(i, array[index + i]);
@@ -227,7 +218,7 @@ public final class Float8 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override
@@ -311,7 +302,7 @@ public final class Float8 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public static float min(Float8 value) {
-        float result = MAX_VALUE;
+        float result = Float.MAX_VALUE;
         for (int i = 0; i < numElements; i++) {
             result = Math.min(result, value.get(i));
         }
@@ -327,7 +318,7 @@ public final class Float8 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public static float max(Float8 value) {
-        float result = MIN_VALUE;
+        float result = Float.MIN_VALUE;
         for (int i = 0; i < numElements; i++) {
             result = Math.max(result, value.get(i));
         }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/FloatOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/FloatOps.java
@@ -41,10 +41,7 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Float.floatToRawIntBits;
-import static java.lang.Math.abs;
-import static java.lang.Math.ulp;
-import static uk.ac.manchester.tornado.api.collections.math.TornadoMath.findULPDistance;
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 
 public class FloatOps {
 
@@ -60,67 +57,67 @@ public class FloatOps {
     public static final String fmt8 = "{%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f}";
     public static final String fmt6e = "{%e,%e,%e,%e,%e,%e}";
 
-    public static final boolean compareBits(float a, float b) {
-        long ai = floatToRawIntBits(a);
-        long bi = floatToRawIntBits(b);
+    public static boolean compareBits(float a, float b) {
+        long ai = Float.floatToRawIntBits(a);
+        long bi = Float.floatToRawIntBits(b);
 
         long diff = ai ^ bi;
         return (diff == 0);
     }
 
-    public static final boolean compareULP(float value, float expected, float ulps) {
-        final float tol = ulps * ulp(expected);
+    public static boolean compareULP(float value, float expected, float ulps) {
+        final float tol = ulps * Math.ulp(expected);
         if (value == expected) {
             return true;
         }
 
-        return abs(value - expected) < tol;
+        return Math.abs(value - expected) < tol;
     }
 
-    public static final float findMaxULP(Float2 value, Float2 expected) {
-        return findULPDistance(value.storage, expected.storage);
+    public static float findMaxULP(Float2 value, Float2 expected) {
+        return TornadoMath.findULPDistance(value.storage, expected.storage);
     }
 
-    public static final float findMaxULP(Float3 value, Float3 expected) {
-        return findULPDistance(value.storage, expected.storage);
+    public static float findMaxULP(Float3 value, Float3 expected) {
+        return TornadoMath.findULPDistance(value.storage, expected.storage);
     }
 
-    public static final float findMaxULP(Float4 value, Float4 expected) {
-        return findULPDistance(value.storage, expected.storage);
+    public static float findMaxULP(Float4 value, Float4 expected) {
+        return TornadoMath.findULPDistance(value.storage, expected.storage);
     }
 
-    public static final float findMaxULP(Float6 value, Float6 expected) {
-        return findULPDistance(value.storage, expected.storage);
+    public static float findMaxULP(Float6 value, Float6 expected) {
+        return TornadoMath.findULPDistance(value.storage, expected.storage);
     }
 
-    public static final float findMaxULP(Float8 value, Float8 expected) {
-        return findULPDistance(value.storage, expected.storage);
+    public static float findMaxULP(Float8 value, Float8 expected) {
+        return TornadoMath.findULPDistance(value.storage, expected.storage);
     }
 
-    public static final float findMaxULP(float value, float expected) {
-        final float ULP = ulp(expected);
+    public static float findMaxULP(float value, float expected) {
+        final float ULP = Math.ulp(expected);
 
         if (value == expected) {
             return 0f;
         }
 
-        final float absValue = abs(value - expected);
+        final float absValue = Math.abs(value - expected);
         return absValue / ULP;
     }
 
-    public static final boolean compare(float a, float b) {
-        return (abs(a - b) <= EPSILON);
+    public static boolean compare(float a, float b) {
+        return (Math.abs(a - b) <= EPSILON);
     }
 
-    public static final boolean compare(float a, float b, float tol) {
-        return (abs(a - b) <= tol);
+    public static boolean compare(float a, float b, float tol) {
+        return (Math.abs(a - b) <= tol);
     }
 
-    public static final float sq(float value) {
+    public static float sq(float value) {
         return value * value;
     }
 
-    public static final void atomicAdd(float[] array, int index, float value) {
+    public static void atomicAdd(float[] array, int index, float value) {
         array[index] += value;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/FloatSE3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/FloatSE3.java
@@ -108,19 +108,6 @@ public class FloatSE3 {
         matrix.set(0, 3, value.getX());
         matrix.set(1, 3, value.getY());
         matrix.set(2, 3, value.getZ());
-
-        /*
-         * Matrix.set(matrix,1,0, -v[2]); Matrix.set(matrix,2,0, v[1]);
-         * Matrix.set(matrix,2,1, -v[0]);
-         *
-         * Matrix.set(matrix,0,1, v[2]); Matrix.set(matrix,0,2, -v[1]);
-         * Matrix.set(matrix,1,2, v[0]);
-         *
-         * Matrix.set(matrix,3,0, v[3]); Matrix.set(matrix,3,1, v[4]);
-         * Matrix.set(matrix,3,2, v[5]);
-         */
-        // Matrix.set(matrix, 3, 3, 1f);
-        // System.out.printf("matrix=\n%s\n",matrix.toString());
     }
 
     public void exp(Float6 mu) {
@@ -164,7 +151,6 @@ public class FloatSE3 {
     }
 
     private void rodrigues_so3_exp(Float3 w, float A, float B) {
-
         {
             final float wx2 = sq(w.getX());
             final float wy2 = sq(w.getY());

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageByte3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageByte3.java
@@ -41,12 +41,6 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.ByteBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.Byte3.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.ByteOps.fmt3;
-import static uk.ac.manchester.tornado.api.collections.types.StorageFormats.toRowMajor;
-
 import java.nio.ByteBuffer;
 
 public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
@@ -75,11 +69,11 @@ public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
     /**
      * Storage format for matrix
      *
-     * @param height
-     *            number of columns
      * @param width
      *            number of rows
-     * @param data
+     * @param height
+     *            number of columns
+     * @param array
      *            array reference which contains data
      */
     public ImageByte3(int width, int height, byte[] array) {
@@ -92,17 +86,21 @@ public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
     /**
      * Storage format for matrix
      *
-     * @param height
-     *            number of columns
      * @param width
      *            number of rows
+     * @param height
+     *            number of columns
      */
     public ImageByte3(int width, int height) {
         this(width, height, new byte[width * height * elementSize]);
     }
 
     public ImageByte3(byte[][] matrix) {
-        this(matrix.length / elementSize, matrix[0].length / elementSize, toRowMajor(matrix));
+        this(matrix.length / elementSize, matrix[0].length / elementSize, StorageFormats.toRowMajor(matrix));
+    }
+
+    public byte[] getArray() {
+        return storage;
     }
 
     private int toIndex(int x, int y) {
@@ -119,7 +117,7 @@ public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
 
     public Byte3 get(int x, int y) {
         final int offset = toIndex(x, y);
-        return loadFromArray(storage, offset);
+        return Byte3.loadFromArray(storage, offset);
     }
 
     public void set(int x, int y, Byte3 value) {
@@ -155,20 +153,18 @@ public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
 
     public String toString(String fmt) {
         String str = "";
-
         for (int i = 0; i < Y; i++) {
             for (int j = 0; j < X; j++) {
                 str += get(j, i).toString(fmt) + "\n";
             }
         }
-
         return str;
     }
 
     public String toString() {
-        String result = format("ImageByte3 <%d x %d>", X, Y);
+        String result = String.format("ImageByte3 <%d x %d>", X, Y);
         if (X <= 8 && Y <= 8) {
-            result += "\n" + toString(fmt3);
+            result += "\n" + toString(ByteOps.fmt3);
         }
         return result;
     }
@@ -180,7 +176,7 @@ public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
 
     @Override
     public ByteBuffer asBuffer() {
-        return wrap(storage);
+        return ByteBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageByte4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageByte4.java
@@ -41,15 +41,6 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Float.MAX_VALUE;
-import static java.lang.Float.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.ByteBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.Byte4.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.ByteOps.fmt4;
-import static uk.ac.manchester.tornado.api.collections.types.Float4.sqrt;
-import static uk.ac.manchester.tornado.api.collections.types.StorageFormats.toRowMajor;
-
 import java.nio.ByteBuffer;
 
 public class ImageByte4 implements PrimitiveStorage<ByteBuffer> {
@@ -78,10 +69,10 @@ public class ImageByte4 implements PrimitiveStorage<ByteBuffer> {
     /**
      * Storage format for matrix
      *
-     * @param height
-     *            number of columns
      * @param width
      *            number of rows
+     * @param height
+     *            number of columns
      * @param array
      *            array reference which contains data
      */
@@ -95,17 +86,21 @@ public class ImageByte4 implements PrimitiveStorage<ByteBuffer> {
     /**
      * Storage format for matrix
      *
-     * @param height
-     *            number of columns
      * @param width
      *            number of rows
+     * @param height
+     *            number of columns
      */
     public ImageByte4(int width, int height) {
         this(width, height, new byte[width * height * elementSize]);
     }
 
     public ImageByte4(byte[][] matrix) {
-        this(matrix.length / elementSize, matrix[0].length / elementSize, toRowMajor(matrix));
+        this(matrix.length / elementSize, matrix[0].length / elementSize, StorageFormats.toRowMajor(matrix));
+    }
+
+    public byte[] getArray() {
+        return storage;
     }
 
     private int toIndex(int x, int y) {
@@ -122,7 +117,7 @@ public class ImageByte4 implements PrimitiveStorage<ByteBuffer> {
 
     public Byte4 get(int x, int y) {
         final int offset = toIndex(x, y);
-        return loadFromArray(storage, offset);
+        return Byte4.loadFromArray(storage, offset);
     }
 
     public void set(int x, int y, Byte4 value) {
@@ -170,7 +165,7 @@ public class ImageByte4 implements PrimitiveStorage<ByteBuffer> {
     }
 
     public Float4 min() {
-        Float4 result = new Float4(MAX_VALUE, MAX_VALUE, MAX_VALUE, MAX_VALUE);
+        Float4 result = new Float4(Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE);
 
         for (int row = 0; row < Y; row++) {
             for (int col = 0; col < X; col++) {
@@ -184,7 +179,7 @@ public class ImageByte4 implements PrimitiveStorage<ByteBuffer> {
     }
 
     public Float4 max() {
-        Float4 result = new Float4(MIN_VALUE, MIN_VALUE, MIN_VALUE, MIN_VALUE);
+        Float4 result = new Float4(Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE);
 
         for (int row = 0; row < Y; row++) {
             for (int col = 0; col < X; col++) {
@@ -212,11 +207,11 @@ public class ImageByte4 implements PrimitiveStorage<ByteBuffer> {
 
             }
         }
-        return sqrt(varience);
+        return Float4.sqrt(varience);
     }
 
     public String summerise() {
-        return format("ImageByte4<%dx%d>: min=%s, max=%s, mean=%s, sd=%s", X, Y, min(), max(), mean(), stdDev());
+        return String.format("ImageByte4<%dx%d>: min=%s, max=%s, mean=%s, sd=%s", X, Y, min(), max(), mean(), stdDev());
     }
 
     public String toString(String fmt) {
@@ -234,22 +229,20 @@ public class ImageByte4 implements PrimitiveStorage<ByteBuffer> {
 
     public String toString(String fmt, int width, int height) {
         String str = "";
-
         for (int i = 0; i < width; i++) {
             for (int j = 0; j < height; j++) {
                 str += get(j, i).toString(fmt) + " ";
             }
             str += "\n";
         }
-
         return str;
     }
 
     @Override
     public String toString() {
-        String result = format("ImageByte4 <%d x %d>", X, Y);
+        String result = String.format("ImageByte4 <%d x %d>", X, Y);
         if (X <= 8 && Y <= 8) {
-            result += "\n" + toString(fmt4);
+            result += "\n" + toString(ByteOps.fmt4);
         }
         return result;
     }
@@ -261,7 +254,7 @@ public class ImageByte4 implements PrimitiveStorage<ByteBuffer> {
 
     @Override
     public ByteBuffer asBuffer() {
-        return wrap(storage);
+        return ByteBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat.java
@@ -71,11 +71,11 @@ public class ImageFloat implements PrimitiveStorage<FloatBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
      *            number of rows
-     * @param data
+     * @param height
+     *            number of columns
+     * @param array
      *            array reference which contains data
      */
     public ImageFloat(int width, int height, float[] array) {
@@ -88,10 +88,10 @@ public class ImageFloat implements PrimitiveStorage<FloatBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
      *            number of rows
+     * @param height
+     *            number of columns
      */
     public ImageFloat(int width, int height) {
         this(width, height, new float[width * height]);
@@ -99,6 +99,10 @@ public class ImageFloat implements PrimitiveStorage<FloatBuffer> {
 
     public ImageFloat(float[][] matrix) {
         this(matrix.length, matrix[0].length, StorageFormats.toRowMajor(matrix));
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     public float get(int i) {
@@ -116,7 +120,7 @@ public class ImageFloat implements PrimitiveStorage<FloatBuffer> {
      *            row index
      * @param j
      *            column index
-     * @return
+     * @return float
      */
     public float get(int i, int j) {
         return storage[StorageFormats.toRowMajor(j, i, X)];

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat3.java
@@ -41,15 +41,6 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Float.MAX_VALUE;
-import static java.lang.Float.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.Float3.findULPDistance;
-import static uk.ac.manchester.tornado.api.collections.types.Float3.sqrt;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
-import static uk.ac.manchester.tornado.api.collections.types.StorageFormats.toRowMajor;
-
 import java.nio.FloatBuffer;
 
 public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
@@ -77,12 +68,12 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
 
     /**
      * Storage format for matrix
-     *
-     * @param height
-     *            number of columns
+     * 
      * @param width
      *            number of rows
-     * @param data
+     * @param height
+     *            number of columns
+     * @param array
      *            array reference which contains data
      */
     public ImageFloat3(int width, int height, float[] array) {
@@ -94,18 +85,22 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
 
     /**
      * Storage format for matrix
-     *
-     * @param height
-     *            number of columns
+     * 
      * @param width
      *            number of rows
+     * @param height
+     *            number of columns
      */
     public ImageFloat3(int width, int height) {
         this(width, height, new float[width * height * elementSize]);
     }
 
     public ImageFloat3(float[][] matrix) {
-        this(matrix.length / elementSize, matrix[0].length / elementSize, toRowMajor(matrix));
+        this(matrix.length / elementSize, matrix[0].length / elementSize, StorageFormats.toRowMajor(matrix));
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     private int toIndex(int x, int y) {
@@ -170,9 +165,9 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public String toString() {
-        String result = format("ImageFloat3 <%d x %d>", X, Y);
+        String result = String.format("ImageFloat3 <%d x %d>", X, Y);
         if (X <= 8 && Y <= 8) {
-            result += "\n" + toString(fmt3);
+            result += "\n" + toString(FloatOps.fmt3);
         }
         return result;
     }
@@ -189,7 +184,7 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public Float3 min() {
-        Float3 result = new Float3(MAX_VALUE, MAX_VALUE, MAX_VALUE);
+        Float3 result = new Float3(Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE);
 
         for (int row = 0; row < Y; row++) {
             for (int col = 0; col < X; col++) {
@@ -201,7 +196,7 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public Float3 max() {
-        Float3 result = new Float3(MIN_VALUE, MIN_VALUE, MIN_VALUE);
+        Float3 result = new Float3(Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE);
 
         for (int row = 0; row < Y; row++) {
             for (int col = 0; col < X; col++) {
@@ -224,11 +219,11 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
             }
         }
 
-        return sqrt(varience);
+        return Float3.sqrt(varience);
     }
 
     public String summerise() {
-        return format("ImageFloat3<%dx%d>: min=%s, max=%s, mean=%s, sd=%s", X, Y, min(), max(), mean(), stdDev());
+        return String.format("ImageFloat3<%dx%d>: min=%s, max=%s, mean=%s, sd=%s", X, Y, min(), max(), mean(), stdDev());
     }
 
     @Override
@@ -238,7 +233,7 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override
@@ -247,8 +242,8 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public FloatingPointError calculateULP(ImageFloat3 ref) {
-        float maxULP = MIN_VALUE;
-        float minULP = MAX_VALUE;
+        float maxULP = Float.MIN_VALUE;
+        float minULP = Float.MAX_VALUE;
         float averageULP = 0f;
 
         /*
@@ -264,7 +259,7 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
                 final Float3 v = get(i, j);
                 final Float3 r = ref.get(i, j);
 
-                final float ulpFactor = findULPDistance(v, r);
+                final float ulpFactor = Float3.findULPDistance(v, r);
                 averageULP += ulpFactor;
                 minULP = Math.min(ulpFactor, minULP);
                 maxULP = Math.max(ulpFactor, maxULP);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat4.java
@@ -41,15 +41,6 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Float.MAX_VALUE;
-import static java.lang.Float.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.Float4.findULPDistance;
-import static uk.ac.manchester.tornado.api.collections.types.Float4.sqrt;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
-import static uk.ac.manchester.tornado.api.collections.types.StorageFormats.toRowMajor;
-
 import java.nio.FloatBuffer;
 
 public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
@@ -77,12 +68,12 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
 
     /**
      * Storage format for matrix
-     *
-     * @param height
-     *            number of columns
+     * 
      * @param width
      *            number of rows
-     * @param data
+     * @param height
+     *            number of columns
+     * @param array
      *            array reference which contains data
      */
     public ImageFloat4(int width, int height, float[] array) {
@@ -94,18 +85,22 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
 
     /**
      * Storage format for matrix
-     *
-     * @param height
-     *            number of columns
+     * 
      * @param width
      *            number of rows
+     * @param height
+     *            number of column
      */
     public ImageFloat4(int width, int height) {
         this(width, height, new float[width * height * elementSize]);
     }
 
     public ImageFloat4(float[][] matrix) {
-        this(matrix.length / elementSize, matrix[0].length / elementSize, toRowMajor(matrix));
+        this(matrix.length / elementSize, matrix[0].length / elementSize, StorageFormats.toRowMajor(matrix));
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     private int toIndex(int x, int y) {
@@ -170,9 +165,9 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public String toString() {
-        String result = format("ImageFloat4 <%d x %d>", X, Y);
+        String result = String.format("ImageFloat4 <%d x %d>", X, Y);
         if (X <= 8 && Y <= 8) {
-            result += "\n" + toString(fmt3);
+            result += "\n" + toString(FloatOps.fmt3);
         }
         return result;
     }
@@ -189,7 +184,7 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public Float4 min() {
-        Float4 result = new Float4(MAX_VALUE, MAX_VALUE, MAX_VALUE, MAX_VALUE);
+        Float4 result = new Float4(Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE);
 
         for (int row = 0; row < Y; row++) {
             for (int col = 0; col < X; col++) {
@@ -201,7 +196,7 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public Float4 max() {
-        Float4 result = new Float4(MIN_VALUE, MIN_VALUE, MIN_VALUE, MIN_VALUE);
+        Float4 result = new Float4(Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE);
 
         for (int row = 0; row < Y; row++) {
             for (int col = 0; col < X; col++) {
@@ -224,11 +219,11 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
             }
         }
 
-        return sqrt(varience);
+        return Float4.sqrt(varience);
     }
 
     public String summerise() {
-        return format("ImageFloat4<%dx%d>: min=%s, max=%s, mean=%s, sd=%s", X, Y, min(), max(), mean(), stdDev());
+        return String.format("ImageFloat4<%dx%d>: min=%s, max=%s, mean=%s, sd=%s", X, Y, min(), max(), mean(), stdDev());
     }
 
     @Override
@@ -238,7 +233,7 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override
@@ -247,8 +242,8 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public FloatingPointError calculateULP(ImageFloat4 ref) {
-        float maxULP = MIN_VALUE;
-        float minULP = MAX_VALUE;
+        float maxULP = Float.MIN_VALUE;
+        float minULP = Float.MAX_VALUE;
         float averageULP = 0f;
 
         /*
@@ -264,7 +259,7 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
                 final Float4 v = get(i, j);
                 final Float4 r = ref.get(i, j);
 
-                final float ulpFactor = findULPDistance(v, r);
+                final float ulpFactor = Float4.findULPDistance(v, r);
                 averageULP += ulpFactor;
                 minULP = Math.min(ulpFactor, minULP);
                 maxULP = Math.max(ulpFactor, maxULP);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat8.java
@@ -41,15 +41,6 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Float.MAX_VALUE;
-import static java.lang.Float.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.Float8.findULPDistance;
-import static uk.ac.manchester.tornado.api.collections.types.Float8.sqrt;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt8;
-import static uk.ac.manchester.tornado.api.collections.types.StorageFormats.toRowMajor;
-
 import java.nio.FloatBuffer;
 
 public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Float8> {
@@ -77,12 +68,12 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
 
     /**
      * Storage format for matrix
-     *
-     * @param height
-     *            number of columns
+     * 
      * @param width
      *            number of rows
-     * @param data
+     * @param height
+     *            number of columns
+     * @param array
      *            array reference which contains data
      */
     public ImageFloat8(int width, int height, float[] array) {
@@ -94,18 +85,22 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
 
     /**
      * Storage format for matrix
-     *
-     * @param height
-     *            number of columns
+     * 
      * @param width
      *            number of rows
+     * @param height
+     *            number of columns
      */
     public ImageFloat8(int width, int height) {
         this(width, height, new float[width * height * elementSize]);
     }
 
     public ImageFloat8(float[][] matrix) {
-        this(matrix.length / elementSize, matrix[0].length / elementSize, toRowMajor(matrix));
+        this(matrix.length / elementSize, matrix[0].length / elementSize, StorageFormats.toRowMajor(matrix));
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     private int toIndex(int x, int y) {
@@ -175,9 +170,9 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
 
     @Override
     public String toString() {
-        String result = format("ImageFloat8 <%d x %d>", X, Y);
+        String result = String.format("ImageFloat8 <%d x %d>", X, Y);
         if (X <= 4 && Y <= 4) {
-            result += "\n" + toString(fmt8);
+            result += "\n" + toString(FloatOps.fmt8);
         }
         return result;
     }
@@ -194,7 +189,7 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
     }
 
     public Float8 min() {
-        Float8 result = new Float8(MAX_VALUE, MAX_VALUE, MAX_VALUE, MAX_VALUE, MAX_VALUE, MAX_VALUE, MAX_VALUE, MAX_VALUE);
+        Float8 result = new Float8(Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE);
 
         for (int row = 0; row < Y; row++) {
             for (int col = 0; col < X; col++) {
@@ -206,7 +201,7 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
     }
 
     public Float8 max() {
-        Float8 result = new Float8(MIN_VALUE, MIN_VALUE, MIN_VALUE, MIN_VALUE, MIN_VALUE, MIN_VALUE, MIN_VALUE, MIN_VALUE);
+        Float8 result = new Float8(Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE);
 
         for (int row = 0; row < Y; row++) {
             for (int col = 0; col < X; col++) {
@@ -228,11 +223,11 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
                 varience = Float8.add(v, varience);
             }
         }
-        return sqrt(varience);
+        return Float8.sqrt(varience);
     }
 
     public String summerise() {
-        return format("ImageFloat8<%dx%d>: min=%s, max=%s, mean=%s, sd=%s", X, Y, min(), max(), mean(), stdDev());
+        return String.format("ImageFloat8<%dx%d>: min=%s, max=%s, mean=%s, sd=%s", X, Y, min(), max(), mean(), stdDev());
     }
 
     @Override
@@ -242,7 +237,7 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override
@@ -251,8 +246,8 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
     }
 
     public FloatingPointError calculateULP(ImageFloat8 ref) {
-        float maxULP = MIN_VALUE;
-        float minULP = MAX_VALUE;
+        float maxULP = Float.MIN_VALUE;
+        float minULP = Float.MAX_VALUE;
         float averageULP = 0f;
 
         /*
@@ -267,7 +262,7 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
                 final Float8 v = get(i, j);
                 final Float8 r = ref.get(i, j);
 
-                final float ulpFactor = findULPDistance(v, r);
+                final float ulpFactor = Float8.findULPDistance(v, r);
                 averageULP += ulpFactor;
                 minULP = Math.min(ulpFactor, minULP);
                 maxULP = Math.max(ulpFactor, maxULP);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Int2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Int2.java
@@ -41,21 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.IntBuffer.wrap;
-
 import java.nio.IntBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 2x ints e.g. <int,int>
- *
- * @author jamesclarkson
- *
- */
 @Vector
 public final class Int2 implements PrimitiveStorage<IntBuffer> {
 
@@ -66,7 +57,8 @@ public final class Int2 implements PrimitiveStorage<IntBuffer> {
     /**
      * backing array
      */
-    @Payload final protected int[] storage;
+    @Payload
+    final protected int[] storage;
 
     /**
      * number of elements in the storage
@@ -85,6 +77,10 @@ public final class Int2 implements PrimitiveStorage<IntBuffer> {
         this();
         setX(x);
         setY(y);
+    }
+
+    public int[] getArray() {
+        return storage;
     }
 
     public int get(int index) {
@@ -127,7 +123,7 @@ public final class Int2 implements PrimitiveStorage<IntBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Int2}
      */
     public Int2 duplicate() {
         Int2 vector = new Int2();
@@ -136,7 +132,7 @@ public final class Int2 implements PrimitiveStorage<IntBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY());
+        return String.format(fmt, getX(), getY());
     }
 
     @Override
@@ -144,7 +140,7 @@ public final class Int2 implements PrimitiveStorage<IntBuffer> {
         return toString(numberFormat);
     }
 
-    protected static final Int2 loadFromArray(final int[] array, int index) {
+    protected static Int2 loadFromArray(final int[] array, int index) {
         final Int2 result = new Int2();
         result.setX(array[index]);
         result.setY(array[index + 1]);
@@ -163,7 +159,7 @@ public final class Int2 implements PrimitiveStorage<IntBuffer> {
 
     @Override
     public IntBuffer asBuffer() {
-        return wrap(storage);
+        return IntBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Int3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Int3.java
@@ -41,21 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.IntBuffer.wrap;
-
 import java.nio.IntBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 3x ints e.g. <int,int,int>
- *
- * @author jamesclarkson
- *
- */
 @Vector
 public final class Int3 implements PrimitiveStorage<IntBuffer> {
 
@@ -66,7 +57,8 @@ public final class Int3 implements PrimitiveStorage<IntBuffer> {
     /**
      * backing array
      */
-    @Payload final protected int[] storage;
+    @Payload
+    final protected int[] storage;
 
     /**
      * number of elements in the storage
@@ -86,6 +78,10 @@ public final class Int3 implements PrimitiveStorage<IntBuffer> {
         setX(x);
         setY(y);
         setZ(z);
+    }
+
+    public int[] getArray() {
+        return storage;
     }
 
     public int get(int index) {
@@ -129,7 +125,7 @@ public final class Int3 implements PrimitiveStorage<IntBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Int3}
      */
     public Int3 duplicate() {
         Int3 vector = new Int3();
@@ -142,7 +138,7 @@ public final class Int3 implements PrimitiveStorage<IntBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY(), getZ());
+        return String.format(fmt, getX(), getY(), getZ());
     }
 
     @Override
@@ -150,7 +146,7 @@ public final class Int3 implements PrimitiveStorage<IntBuffer> {
         return toString(numberFormat);
     }
 
-    protected static final Int3 loadFromArray(final int[] array, int index) {
+    protected static Int3 loadFromArray(final int[] array, int index) {
         final Int3 result = new Int3();
         result.setX(array[index]);
         result.setY(array[index + 1]);
@@ -171,7 +167,7 @@ public final class Int3 implements PrimitiveStorage<IntBuffer> {
 
     @Override
     public IntBuffer asBuffer() {
-        return wrap(storage);
+        return IntBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Int4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Int4.java
@@ -41,21 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.IntBuffer.wrap;
-
 import java.nio.IntBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 4x ints e.g. <int,int,int,int>
- *
- * @author jamesclarkson
- *
- */
 @Vector
 public final class Int4 implements PrimitiveStorage<IntBuffer> {
 
@@ -66,7 +57,8 @@ public final class Int4 implements PrimitiveStorage<IntBuffer> {
     /**
      * backing array
      */
-    @Payload final protected int[] storage;
+    @Payload
+    final protected int[] storage;
 
     /**
      * number of elements in the storage
@@ -87,6 +79,10 @@ public final class Int4 implements PrimitiveStorage<IntBuffer> {
         setY(y);
         setZ(z);
         setW(w);
+    }
+
+    public int[] getArray() {
+        return storage;
     }
 
     public int get(int index) {
@@ -139,7 +135,7 @@ public final class Int4 implements PrimitiveStorage<IntBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Int4}
      */
     public Int4 duplicate() {
         Int4 vector = new Int4();
@@ -156,7 +152,7 @@ public final class Int4 implements PrimitiveStorage<IntBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY(), getZ(), getW());
+        return String.format(fmt, getX(), getY(), getZ(), getW());
     }
 
     @Override
@@ -164,7 +160,7 @@ public final class Int4 implements PrimitiveStorage<IntBuffer> {
         return toString(numberFormat);
     }
 
-    protected static final Int4 loadFromArray(final int[] array, int index) {
+    protected static Int4 loadFromArray(final int[] array, int index) {
         final Int4 result = new Int4();
         result.setX(array[index]);
         result.setY(array[index + 1]);
@@ -187,7 +183,7 @@ public final class Int4 implements PrimitiveStorage<IntBuffer> {
 
     @Override
     public IntBuffer asBuffer() {
-        return wrap(storage);
+        return IntBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/IntOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/IntOps.java
@@ -49,7 +49,7 @@ public class IntOps {
     public static final String fmt3 = "{%d,%d,%d}";
     public static String fmt6 = "{%d,%d,%d,%d,%d,%d}";
 
-    public static final boolean compare(float a, float b) {
+    public static boolean compare(float a, float b) {
         return (a == b);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DDouble.java
@@ -99,7 +99,7 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
         this(matrix.length, matrix[0].length, StorageFormats.toRowMajor(matrix));
     }
 
-    public double[] getFlattenedMatrix() {
+    public double[] getFlattenedArray() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DDouble.java
@@ -41,14 +41,8 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Math.min;
-import static java.lang.String.format;
-import static java.nio.DoubleBuffer.wrap;
-import static java.util.Arrays.copyOfRange;
-import static uk.ac.manchester.tornado.api.collections.types.DoubleOps.fmt;
-import static uk.ac.manchester.tornado.api.collections.types.StorageFormats.toRowMajor;
-
 import java.nio.DoubleBuffer;
+import java.util.Arrays;
 
 public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
     /**
@@ -74,11 +68,11 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
      *            number of rows
-     * @param data
+     * @param height
+     *            number of columns
+     * @param array
      *            array reference which contains data
      */
     public Matrix2DDouble(int width, int height, double[] array) {
@@ -91,25 +85,30 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
      *            number of rows
+     * @param height
+     *            number of columns
+     * 
      */
     public Matrix2DDouble(int width, int height) {
         this(width, height, new double[width * height]);
     }
 
     public Matrix2DDouble(double[][] matrix) {
-        this(matrix.length, matrix[0].length, toRowMajor(matrix));
+        this(matrix.length, matrix[0].length, StorageFormats.toRowMajor(matrix));
+    }
+
+    public double[] getFlattenMatrix() {
+        return storage;
     }
 
     public double get(int i, int j) {
-        return storage[toRowMajor(i, j, M)];
+        return storage[StorageFormats.toRowMajor(i, j, M)];
     }
 
     public void set(int i, int j, double value) {
-        storage[toRowMajor(i, j, M)] = value;
+        storage[StorageFormats.toRowMajor(i, j, M)] = value;
     }
 
     public int M() {
@@ -121,12 +120,12 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public VectorDouble row(int row) {
-        int index = toRowMajor(row, 0, N);
-        return new VectorDouble(N, copyOfRange(storage, index, N));
+        int index = StorageFormats.toRowMajor(row, 0, N);
+        return new VectorDouble(N, Arrays.copyOfRange(storage, index, N));
     }
 
     public VectorDouble column(int col) {
-        int index = toRowMajor(0, col, N);
+        int index = StorageFormats.toRowMajor(0, col, N);
         final VectorDouble v = new VectorDouble(M);
         for (int i = 0; i < M; i++) {
             v.set(i, storage[index + (i * N)]);
@@ -135,7 +134,7 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public VectorDouble diag() {
-        final VectorDouble v = new VectorDouble(min(M, N));
+        final VectorDouble v = new VectorDouble(Math.min(M, N));
         for (int i = 0; i < M; i++) {
             v.set(i, storage[i * (N + 1)]);
         }
@@ -163,7 +162,7 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
     /**
      * Transposes the matrix in-place
      * 
-     * @param m
+     * @param matrix
      *            matrix to transpose
      */
     public static void transpose(Matrix2DDouble matrix) {
@@ -195,7 +194,7 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
         String str = "";
         for (int i = 0; i < M; i++) {
             for (int j = 0; j < N; j++) {
-                str += format(fmt, get(i, j)) + " ";
+                str += String.format(fmt, get(i, j)) + " ";
             }
             str += "\n";
         }
@@ -204,9 +203,9 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public String toString() {
-        String result = format("MatrixDouble <%d x %d>", M, N);
+        String result = String.format("MatrixDouble <%d x %d>", M, N);
         if (M < 16 && N < 16) {
-            result += "\n" + toString(fmt);
+            result += "\n" + toString(DoubleOps.fmt);
         }
         return result;
     }
@@ -224,7 +223,7 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public DoubleBuffer asBuffer() {
-        return wrap(storage);
+        return DoubleBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DDouble.java
@@ -99,7 +99,7 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
         this(matrix.length, matrix[0].length, StorageFormats.toRowMajor(matrix));
     }
 
-    public double[] getFlattenMatrix() {
+    public double[] getFlattenedMatrix() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat.java
@@ -104,7 +104,7 @@ public class Matrix2DFloat implements PrimitiveStorage<FloatBuffer> {
         this(matrix.length, matrix[0].length, toRowMajor(matrix));
     }
 
-    public float[] getFlattenedMatrix() {
+    public float[] getFlattenedArray() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat.java
@@ -41,14 +41,14 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import java.nio.FloatBuffer;
-
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.nio.FloatBuffer.wrap;
 import static java.util.Arrays.copyOfRange;
 import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt;
 import static uk.ac.manchester.tornado.api.collections.types.StorageFormats.toRowMajor;
+
+import java.nio.FloatBuffer;
 
 public class Matrix2DFloat implements PrimitiveStorage<FloatBuffer> {
     /**
@@ -74,11 +74,11 @@ public class Matrix2DFloat implements PrimitiveStorage<FloatBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param height
      *            number of rows
-     * @param data
+     * @param array
      *            array reference which contains data
      */
     public Matrix2DFloat(int width, int height, float[] array) {
@@ -91,9 +91,9 @@ public class Matrix2DFloat implements PrimitiveStorage<FloatBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param height
      *            number of rows
      */
     public Matrix2DFloat(int width, int height) {
@@ -102,6 +102,10 @@ public class Matrix2DFloat implements PrimitiveStorage<FloatBuffer> {
 
     public Matrix2DFloat(float[][] matrix) {
         this(matrix.length, matrix[0].length, toRowMajor(matrix));
+    }
+
+    public float[] getFlattenMatrix() {
+        return storage;
     }
 
     public float get(int i, int j) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat.java
@@ -104,7 +104,7 @@ public class Matrix2DFloat implements PrimitiveStorage<FloatBuffer> {
         this(matrix.length, matrix[0].length, toRowMajor(matrix));
     }
 
-    public float[] getFlattenMatrix() {
+    public float[] getFlattenedMatrix() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat4.java
@@ -73,11 +73,11 @@ public class Matrix2DFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param height
      *            number of rows
-     * @param data
+     * @param array
      *            array reference which contains data
      */
     public Matrix2DFloat4(int width, int height, float[] array) {
@@ -90,13 +90,17 @@ public class Matrix2DFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param height
      *            number of rows
      */
     public Matrix2DFloat4(int width, int height) {
         this(width, height, new float[width * height * VECTOR_ELEMENTS]);
+    }
+
+    public float[] getFlattenMatrix() {
+        return storage;
     }
 
     public Float4 get(int i, int j) {
@@ -163,7 +167,7 @@ public class Matrix2DFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Transposes the matrix in-place
      * 
-     * @param m
+     * @param matrix
      *            matrix to transpose
      */
     public static void transpose(Matrix2DFloat4 matrix) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat4.java
@@ -99,7 +99,7 @@ public class Matrix2DFloat4 implements PrimitiveStorage<FloatBuffer> {
         this(width, height, new float[width * height * VECTOR_ELEMENTS]);
     }
 
-    public float[] getFlattenedMatrix() {
+    public float[] getFlattenedArray() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat4.java
@@ -99,7 +99,7 @@ public class Matrix2DFloat4 implements PrimitiveStorage<FloatBuffer> {
         this(width, height, new float[width * height * VECTOR_ELEMENTS]);
     }
 
-    public float[] getFlattenMatrix() {
+    public float[] getFlattenedMatrix() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DInt.java
@@ -98,7 +98,7 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
         this(matrix.length, matrix[0].length, StorageFormats.toRowMajor(matrix));
     }
 
-    public int[] getFlattenMatrix() {
+    public int[] getFlattenedMatrix() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DInt.java
@@ -98,7 +98,7 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
         this(matrix.length, matrix[0].length, StorageFormats.toRowMajor(matrix));
     }
 
-    public int[] getFlattenedMatrix() {
+    public int[] getFlattenedArray() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DInt.java
@@ -41,15 +41,8 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Math.min;
-import static java.lang.String.format;
-import static java.lang.System.out;
-import static java.nio.IntBuffer.wrap;
-import static java.util.Arrays.copyOfRange;
-import static uk.ac.manchester.tornado.api.collections.types.IntOps.fmt;
-import static uk.ac.manchester.tornado.api.collections.types.StorageFormats.toRowMajor;
-
 import java.nio.IntBuffer;
+import java.util.Arrays;
 
 public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
     /**
@@ -75,11 +68,11 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param height
      *            number of rows
-     * @param data
+     * @param array
      *            array reference which contains data
      */
     public Matrix2DInt(int width, int height, int[] array) {
@@ -92,9 +85,9 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param height
      *            number of rows
      */
     public Matrix2DInt(int width, int height) {
@@ -102,15 +95,19 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
     }
 
     public Matrix2DInt(int[][] matrix) {
-        this(matrix.length, matrix[0].length, toRowMajor(matrix));
+        this(matrix.length, matrix[0].length, StorageFormats.toRowMajor(matrix));
+    }
+
+    public int[] getFlattenMatrix() {
+        return storage;
     }
 
     public int get(int i, int j) {
-        return storage[toRowMajor(i, j, M)];
+        return storage[StorageFormats.toRowMajor(i, j, M)];
     }
 
     public void set(int i, int j, int value) {
-        storage[toRowMajor(i, j, M)] = value;
+        storage[StorageFormats.toRowMajor(i, j, M)] = value;
     }
 
     public int M() {
@@ -122,12 +119,12 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
     }
 
     public VectorInt row(int row) {
-        int index = toRowMajor(row, 0, N);
-        return new VectorInt(N, copyOfRange(storage, index, N));
+        int index = StorageFormats.toRowMajor(row, 0, N);
+        return new VectorInt(N, Arrays.copyOfRange(storage, index, N));
     }
 
     public VectorInt column(int col) {
-        int index = toRowMajor(0, col, N);
+        int index = StorageFormats.toRowMajor(0, col, N);
         final VectorInt v = new VectorInt(M);
         for (int i = 0; i < M; i++) {
             v.set(i, storage[index + (i * N)]);
@@ -136,7 +133,7 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
     }
 
     public VectorInt diag() {
-        final VectorInt v = new VectorInt(min(M, N));
+        final VectorInt v = new VectorInt(Math.min(M, N));
         for (int i = 0; i < M; i++) {
             v.set(i, storage[i * (N + 1)]);
         }
@@ -162,8 +159,8 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
     }
 
     public void tmultiply(Matrix2DInt a, Matrix2DInt b) {
-        out.printf("tmult: M=%d (expect %d)\n", M(), a.M());
-        out.printf("tmult: N=%d (expect %d)\n", N(), b.M());
+        System.out.printf("tmult: M=%d (expect %d)\n", M(), a.M());
+        System.out.printf("tmult: N=%d (expect %d)\n", N(), b.M());
         for (int row = 0; row < M(); row++) {
             for (int col = 0; col < b.M(); col++) {
                 int sum = 0;
@@ -178,7 +175,7 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
     /**
      * Transposes the matrix in-place
      * 
-     * @param m
+     * @param matrix
      *            matrix to transpose
      */
     public static void transpose(Matrix2DInt matrix) {
@@ -212,7 +209,7 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
 
         for (int i = 0; i < M; i++) {
             for (int j = 0; j < N; j++) {
-                str += format(fmt, get(i, j)) + " ";
+                str += String.format(fmt, get(i, j)) + " ";
             }
             str += "\n";
         }
@@ -221,9 +218,9 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
 
     @Override
     public String toString() {
-        String result = format("MatrixInt <%d x %d>", M, N);
+        String result = String.format("MatrixInt <%d x %d>", M, N);
         if (M < 16 && N < 16) {
-            result += "\n" + toString(fmt);
+            result += "\n" + toString(IntOps.fmt);
         }
         return result;
     }
@@ -241,7 +238,7 @@ public class Matrix2DInt implements PrimitiveStorage<IntBuffer> {
 
     @Override
     public IntBuffer asBuffer() {
-        return wrap(storage);
+        return IntBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat.java
@@ -103,7 +103,7 @@ public class Matrix3DFloat implements PrimitiveStorage<FloatBuffer> {
         this(matrix.length, matrix[0].length, matrix[0][0].length, StorageFormats.toRowMajor3D(matrix));
     }
 
-    public float[] getFlattenMatrix() {
+    public float[] getFlattenedMatrix() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat.java
@@ -103,7 +103,7 @@ public class Matrix3DFloat implements PrimitiveStorage<FloatBuffer> {
         this(matrix.length, matrix[0].length, matrix[0][0].length, StorageFormats.toRowMajor3D(matrix));
     }
 
-    public float[] getFlattenedMatrix() {
+    public float[] getFlattenedArray() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat.java
@@ -72,11 +72,11 @@ public class Matrix3DFloat implements PrimitiveStorage<FloatBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param height
      *            number of rows
-     * @param data
+     * @param array
      *            array reference which contains data
      */
     public Matrix3DFloat(int width, int height, int depth, float[] array) {
@@ -90,9 +90,9 @@ public class Matrix3DFloat implements PrimitiveStorage<FloatBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param height
      *            number of rows
      */
     public Matrix3DFloat(int width, int height, int depth) {
@@ -101,6 +101,10 @@ public class Matrix3DFloat implements PrimitiveStorage<FloatBuffer> {
 
     public Matrix3DFloat(float[][][] matrix) {
         this(matrix.length, matrix[0].length, matrix[0][0].length, StorageFormats.toRowMajor3D(matrix));
+    }
+
+    public float[] getFlattenMatrix() {
+        return storage;
     }
 
     public float get(int i, int j, int k) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat4.java
@@ -106,7 +106,7 @@ public class Matrix3DFloat4 implements PrimitiveStorage<FloatBuffer> {
         this(width, height, depth, new float[width * height * depth * VECTOR_ELEMENTS]);
     }
 
-    public float[] getFlattenedMatrix() {
+    public float[] getFlattenedArray() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat4.java
@@ -106,7 +106,7 @@ public class Matrix3DFloat4 implements PrimitiveStorage<FloatBuffer> {
         this(width, height, depth, new float[width * height * depth * VECTOR_ELEMENTS]);
     }
 
-    public float[] getFlattenMatrix() {
+    public float[] getFlattenedMatrix() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat4.java
@@ -77,11 +77,11 @@ public class Matrix3DFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param height
      *            number of rows
-     * @param data
+     * @param array
      *            array reference which contains data
      */
     public Matrix3DFloat4(int width, int height, int depth, float[] array) {
@@ -95,13 +95,19 @@ public class Matrix3DFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param height
      *            number of rows
+     * @param depth
+     *            depth-rows
      */
     public Matrix3DFloat4(int width, int height, int depth) {
         this(width, height, depth, new float[width * height * depth * VECTOR_ELEMENTS]);
+    }
+
+    public float[] getFlattenMatrix() {
+        return storage;
     }
 
     public Float4 get(int i, int j, int k) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix4x4Float.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix4x4Float.java
@@ -41,16 +41,6 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Float.MAX_VALUE;
-import static java.lang.Float.MIN_VALUE;
-import static java.lang.Math.max;
-import static java.lang.Math.min;
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.Float4.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.findMaxULP;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt4m;
-
 import java.nio.FloatBuffer;
 
 public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
@@ -83,6 +73,10 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
         storage = array;
     }
 
+    public float[] getFlattenMatrix() {
+        return storage;
+    }
+
     private int toIndex(int i, int j) {
         return j + (i * N);
     }
@@ -102,7 +96,7 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
      *            row index
      * @param j
      *            col index
-     * @return
+     * @return float
      */
     public float get(int i, int j) {
         return storage[toIndex(i, j)];
@@ -115,7 +109,7 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
      *            row index
      * @param j
      *            col index
-     * @return
+     * @return float
      */
     public void set(int i, int j, float value) {
         storage[toIndex(i, j)] = value;
@@ -124,7 +118,7 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
     /**
      * Returns the number of rows in this matrix
      * 
-     * @return
+     * @return int
      */
     public int M() {
         return M;
@@ -133,7 +127,7 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
     /**
      * Returns the number of columns in the matrix
      * 
-     * @return
+     * @return int
      */
     public int N() {
         return N;
@@ -141,7 +135,7 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
 
     public Float4 row(int row) {
         int offset = M * row;
-        return loadFromArray(storage, offset);
+        return Float4.loadFromArray(storage, offset);
     }
 
     public Float4 column(int col) {
@@ -183,8 +177,8 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
     }
 
     public String toString() {
-        String result = format("MatrixFloat <%d x %d>", M, N);
-        result += "\n" + toString(fmt4m);
+        String result = String.format("MatrixFloat <%d x %d>", M, N);
+        result += "\n" + toString(FloatOps.fmt4m);
         return result;
     }
 
@@ -206,7 +200,7 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override
@@ -215,8 +209,8 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
     }
 
     public FloatingPointError calculateULP(Matrix4x4Float ref) {
-        float maxULP = MIN_VALUE;
-        float minULP = MAX_VALUE;
+        float maxULP = Float.MIN_VALUE;
+        float minULP = Float.MAX_VALUE;
         float averageULP = 0f;
 
         /*
@@ -231,10 +225,10 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
                 final float v = get(i, j);
                 final float r = ref.get(i, j);
 
-                final float ulpFactor = findMaxULP(v, r);
+                final float ulpFactor = FloatOps.findMaxULP(v, r);
                 averageULP += ulpFactor;
-                minULP = min(ulpFactor, minULP);
-                maxULP = max(ulpFactor, maxULP);
+                minULP = Math.min(ulpFactor, minULP);
+                maxULP = Math.max(ulpFactor, maxULP);
 
             }
         }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix4x4Float.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix4x4Float.java
@@ -73,7 +73,7 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
         storage = array;
     }
 
-    public float[] getFlattenedMatrix() {
+    public float[] getFlattenedArray() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix4x4Float.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix4x4Float.java
@@ -73,7 +73,7 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
         storage = array;
     }
 
-    public float[] getFlattenMatrix() {
+    public float[] getFlattenedMatrix() {
         return storage;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Short2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Short2.java
@@ -41,22 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.ShortBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.ShortOps.fmt2;
-
 import java.nio.ShortBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 2x shorts e.g. <short,short>
- *
- * @author jamesclarkson
- *
- */
 @Vector
 public final class Short2 implements PrimitiveStorage<ShortBuffer> {
 
@@ -65,7 +55,8 @@ public final class Short2 implements PrimitiveStorage<ShortBuffer> {
     /**
      * backing array
      */
-    @Payload final protected short[] storage;
+    @Payload
+    final protected short[] storage;
 
     /**
      * number of elements in the storage
@@ -84,6 +75,10 @@ public final class Short2 implements PrimitiveStorage<ShortBuffer> {
         this();
         setX(x);
         setY(y);
+    }
+
+    public short[] getArray() {
+        return storage;
     }
 
     public short get(int index) {
@@ -118,7 +113,7 @@ public final class Short2 implements PrimitiveStorage<ShortBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link Short2}
      */
     public Short2 duplicate() {
         Short2 vector = new Short2();
@@ -127,15 +122,15 @@ public final class Short2 implements PrimitiveStorage<ShortBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY());
+        return String.format(fmt, getX(), getY());
     }
 
     @Override
     public String toString() {
-        return toString(fmt2);
+        return toString(ShortOps.fmt2);
     }
 
-    protected static final Short2 loadFromArray(final short[] array, int index) {
+    protected static Short2 loadFromArray(final short[] array, int index) {
         final Short2 result = new Short2();
         result.setX(array[index]);
         result.setY(array[index + 1]);
@@ -154,7 +149,7 @@ public final class Short2 implements PrimitiveStorage<ShortBuffer> {
 
     @Override
     public ShortBuffer asBuffer() {
-        return wrap(storage);
+        return ShortBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Short3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Short3.java
@@ -41,21 +41,12 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.ShortBuffer.wrap;
-
 import java.nio.ShortBuffer;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.api.type.annotations.Payload;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 
-/**
- * Class that represents a vector of 3x shorts e.g. <short,short,short>
- *
- * @author jamesclarkson
- *
- */
 @Vector
 public final class Short3 implements PrimitiveStorage<ShortBuffer> {
 
@@ -66,7 +57,8 @@ public final class Short3 implements PrimitiveStorage<ShortBuffer> {
     /**
      * backing array
      */
-    @Payload final protected short[] storage;
+    @Payload
+    final protected short[] storage;
 
     /**
      * number of elements in the storage
@@ -92,6 +84,10 @@ public final class Short3 implements PrimitiveStorage<ShortBuffer> {
         setX(value.getX());
         setY(value.getY());
         setZ(value.getZ());
+    }
+
+    public short[] getArray() {
+        return storage;
     }
 
     public short get(int index) {
@@ -126,11 +122,6 @@ public final class Short3 implements PrimitiveStorage<ShortBuffer> {
         set(2, value);
     }
 
-    /**
-     * Duplicates this vector
-     *
-     * @return
-     */
     public Short3 duplicate() {
         Short3 vector = new Short3();
         vector.set(this);
@@ -138,7 +129,7 @@ public final class Short3 implements PrimitiveStorage<ShortBuffer> {
     }
 
     public String toString(String fmt) {
-        return format(fmt, getX(), getY(), getZ());
+        return String.format(fmt, getX(), getY(), getZ());
     }
 
     @Override
@@ -146,7 +137,7 @@ public final class Short3 implements PrimitiveStorage<ShortBuffer> {
         return toString(numberFormat);
     }
 
-    protected static final Short3 loadFromArray(final short[] array, int index) {
+    protected static Short3 loadFromArray(final short[] array, int index) {
         final Short3 result = new Short3();
         result.setX(array[index]);
         result.setY(array[index + 1]);
@@ -167,7 +158,7 @@ public final class Short3 implements PrimitiveStorage<ShortBuffer> {
 
     @Override
     public ShortBuffer asBuffer() {
-        return wrap(storage);
+        return ShortBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ShortOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ShortOps.java
@@ -47,7 +47,7 @@ public class ShortOps {
     public static final String fmt2 = "{%3d,%3d}";
     public static final String fmt3 = "{%3d,%3d,%.3d}";
 
-    public static final boolean compare(short a, short b) {
+    public static boolean compare(short a, short b) {
         return Short.compare(a, b) == 0;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/StorageFormats.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/StorageFormats.java
@@ -55,9 +55,9 @@ public final class StorageFormats {
      *            column index
      * @param ld
      *            length of a column
-     * @return
+     * @return int
      */
-    public final static int toColumnMajor(int i, int j, int ld) {
+    public static int toColumnMajor(int i, int j, int ld) {
         return (j * ld) + i;
     }
 
@@ -70,21 +70,21 @@ public final class StorageFormats {
      *            column index
      * @param yMax
      *            length of a row
-     * @return
+     * @return int
      */
-    public final static int toRowMajor(int i, int j, int yMax) {
+    public static int toRowMajor(int i, int j, int yMax) {
         return (i * yMax) + j;
     }
 
-    public final static int toRowMajorVector(int i, int j, int xMax, int width) {
+    public static int toRowMajorVector(int i, int j, int xMax, int width) {
         return (i * xMax * width) + j;
     }
 
-    public final static int toRowMajor3D(int i, int j, int k, int zMax, int yMax) {
+    public static int toRowMajor3D(int i, int j, int k, int zMax, int yMax) {
         return (i * zMax * yMax) + (j * zMax) + k;
     }
 
-    public final static int toRowMajor3DVector(int i, int j, int k, int zSize, int ySize, int vectorWidth) {
+    public static int toRowMajor3DVector(int i, int j, int k, int zSize, int ySize, int vectorWidth) {
         return (i * zSize * ySize * vectorWidth) + (j * zSize) + k;
     }
 
@@ -99,9 +99,9 @@ public final class StorageFormats {
      *            length of a row
      * @param el
      *            length of each element in a row
-     * @return
+     * @return int
      */
-    public final static int toRowMajor(int i, int j, int ld, int el) {
+    public static int toRowMajor(int i, int j, int ld, int el) {
         return (i * ld) + (j * el);
     }
 
@@ -120,9 +120,9 @@ public final class StorageFormats {
      *            leading edge length 2dn dimension
      * @param el
      *            basic element length
-     * @return
+     * @return int
      */
-    public final static int toRowMajor(int i, int j, int k, int ld1, int ld2, int el) {
+    public static int toRowMajor(int i, int j, int k, int ld1, int ld2, int el) {
         return toRowMajor(i, j, ld1, el) + (k * ld2);
     }
 
@@ -139,9 +139,9 @@ public final class StorageFormats {
      *            col step
      * @param ld
      *            length of a row
-     * @return
+     * @return int
      */
-    public final static int toRowMajor(int i, int j, int incm, int incn, int ld) {
+    public static int toRowMajor(int i, int j, int incm, int incn, int ld) {
         return (i * ld * incn) + (j * incm);
     }
 
@@ -154,18 +154,18 @@ public final class StorageFormats {
      *            column index
      * @param ld
      *            length of a column
-     * @return
+     * @return int
      */
-    public final static int toFortran(int i, int j, int ld) {
+    public static int toFortran(int i, int j, int ld) {
         return ((j - 1) * ld) + (i - 1);
     }
 
     /**
-     * Converts a matrix stored in multi-dimensional arrays into Row-Major
-     * format
+     * Converts a matrix stored in multi-dimensional arrays into Row-Major format
      * 
      * @param matrix
-     * @return
+     *            input matrix
+     * @return double[]
      */
     public static double[] toRowMajor(double[][] matrix) {
         final int N = matrix[0].length;
@@ -180,11 +180,11 @@ public final class StorageFormats {
     }
 
     /**
-     * Converts a matrix stored in multi-dimensional arrays into Row-Major
-     * format
+     * Converts a matrix stored in multi-dimensional arrays into Row-Major format
      * 
      * @param matrix
-     * @return
+     *            input matrix
+     * @return float[]
      */
     public static float[] toRowMajor(float[][] matrix) {
         final int M = matrix.length;
@@ -219,11 +219,11 @@ public final class StorageFormats {
     }
 
     /**
-     * Converts a matrix stored in multi-dimensional arrays into Row-Major
-     * format
+     * Converts a matrix stored in multi-dimensional arrays into Row-Major format
      * 
      * @param matrix
-     * @return
+     *            input matrix
+     * @return int[]
      */
     public static int[] toRowMajor(int[][] matrix) {
         final int M = matrix.length;
@@ -239,11 +239,11 @@ public final class StorageFormats {
     }
 
     /**
-     * Converts a matrix stored in multi-dimensional arrays into Row-Major
-     * format
+     * Converts a matrix stored in multi-dimensional arrays into Row-Major format
      * 
      * @param matrix
-     * @return
+     *            input matrix
+     * @return byte[]
      */
     public static byte[] toRowMajor(byte[][] matrix) {
         final int m = matrix[0].length;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble.java
@@ -41,14 +41,8 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Double.MAX_VALUE;
-import static java.lang.Double.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.DoubleBuffer.wrap;
-import static java.util.Arrays.copyOf;
-import static uk.ac.manchester.tornado.api.collections.types.DoubleOps.fmt;
-
 import java.nio.DoubleBuffer;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 
@@ -58,15 +52,6 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
     private final double[] storage;
     private static final int elementSize = 1;
 
-    /**
-     * Creates a vector using the provided backing array
-     *
-     * @param numElements
-     * @param offset
-     * @param step
-     * @param elementSize
-     * @param array
-     */
     protected VectorDouble(int numElements, double[] array) {
         this.numElements = numElements;
         this.storage = array;
@@ -76,6 +61,7 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
      * Creates an empty vector with
      *
      * @param numElements
+     *            Number of elements
      */
     public VectorDouble(int numElements) {
         this(numElements, new double[numElements]);
@@ -85,16 +71,21 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
      * Creates an new vector from the provided storage
      *
      * @param storage
+     *            vector to be stored
      */
     public VectorDouble(double[] storage) {
         this(storage.length / elementSize, storage);
+    }
+
+    public double[] getArray() {
+        return storage;
     }
 
     /**
      * Returns the double at the given index of this vector
      *
      * @param index
-     *
+     *            Position
      * @return value
      */
     public double get(int index) {
@@ -105,7 +96,9 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
      * Sets the double at the given index of this vector
      *
      * @param index
+     *            Position
      * @param value
+     *            value to be stored
      */
     public void set(int index, double value) {
         storage[index] = value;
@@ -126,6 +119,7 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
      * Sets the elements of this vector to that of the provided array
      *
      * @param values
+     *            input vector to be stored
      */
     public void set(double[] values) {
         for (int i = 0; i < values.length; i++) {
@@ -137,6 +131,7 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
      * Sets all elements to value
      *
      * @param value
+     *            input vector to be stored
      */
     public void fill(double value) {
         for (int i = 0; i < storage.length; i++) {
@@ -149,10 +144,10 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
      *
      * @param start
      *            starting index
-     * @param numElements
+     * @param length
      *            number of elements
      *
-     * @return
+     * @return vector with elements updated
      */
     public VectorDouble subVector(int start, int length) {
         final VectorDouble v = new VectorDouble(length);
@@ -166,14 +161,14 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return a new Vector of Doubles
      */
     public VectorDouble duplicate() {
-        return new VectorDouble(copyOf(storage, storage.length));
+        return new VectorDouble(Arrays.copyOf(storage, storage.length));
     }
 
     public static double min(VectorDouble v) {
-        double result = MAX_VALUE;
+        double result = Double.MAX_VALUE;
         for (int i = 0; i < v.storage.length; i++) {
             result = Math.min(v.storage[i], result);
         }
@@ -182,7 +177,7 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public static double max(VectorDouble v) {
-        double result = MIN_VALUE;
+        double result = Double.MIN_VALUE;
         for (int i = 0; i < v.storage.length; i++) {
             result = Math.max(v.storage[i], result);
         }
@@ -194,6 +189,7 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
      * Vector equality test
      *
      * @param vector
+     *            input Vector
      *
      * @return true if vectors match
      */
@@ -202,11 +198,11 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
     }
 
     /**
-     * dot product (this . this)
+     * Perform dot product
      *
-     * @return
+     * @return dot-product value
      */
-    public static final double dot(VectorDouble a, VectorDouble b) {
+    public static double dot(VectorDouble a, VectorDouble b) {
         double sum = 0;
         for (int i = 0; i < a.size(); i++) {
             sum += a.get(i) * b.get(i);
@@ -218,25 +214,23 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
      * Prints the vector using the specified format string
      *
      * @param fmt
-     *
-     * @return
+     *            String Format
+     * @return String
      */
     public String toString(String fmt) {
-        String str = "[ ";
-
+        StringBuffer sb = new StringBuffer("[");
+        sb.append("[ ");
         for (int i = 0; i < numElements; i++) {
-            str += format(fmt, get(i)) + " ";
+            sb.append(String.format(fmt, get(i)) + " ");
         }
-
-        str += "]";
-
-        return str;
+        sb.append("]");
+        return sb.toString();
     }
 
     public String toString() {
-        String str = format("VectorDouble <%d>", numElements);
+        String str = String.format("VectorDouble <%d>", numElements);
         if (numElements < 32) {
-            str += toString(fmt);
+            str += toString(DoubleOps.fmt);
         }
         return str;
     }
@@ -249,7 +243,7 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public DoubleBuffer asBuffer() {
-        return wrap(storage);
+        return DoubleBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat.java
@@ -41,14 +41,8 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Float.MAX_VALUE;
-import static java.lang.Float.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static java.util.Arrays.copyOf;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt;
-
 import java.nio.FloatBuffer;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 
@@ -58,12 +52,6 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
     private final float[] storage;
     private static final int elementSize = 1;
 
-    /**
-     * Creates a vector using the provided backing array
-     * 
-     * @param numElements
-     * @param array
-     */
     protected VectorFloat(int numElements, float[] array) {
         this.numElements = numElements;
         this.storage = array;
@@ -73,6 +61,7 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
      * Creates an empty vector with
      * 
      * @param numElements
+     *            Number of elements
      */
     public VectorFloat(int numElements) {
         this(numElements, new float[numElements]);
@@ -82,15 +71,21 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
      * Creates an new vector from the provided storage
      * 
      * @param storage
+     *            Array to be stored
      */
     public VectorFloat(float[] storage) {
         this(storage.length / elementSize, storage);
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     /**
      * Returns the float at the given index of this vector
      * 
      * @param index
+     *            Position
      * @return value
      */
     public float get(int index) {
@@ -101,7 +96,9 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
      * Sets the float at the given index of this vector
      * 
      * @param index
+     *            Position
      * @param value
+     *            Float value to be stored
      */
     public void set(int index, float value) {
         storage[index] = value;
@@ -111,6 +108,7 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
      * Sets the elements of this vector to that of the provided vector
      * 
      * @param values
+     *            VectorFloat4
      */
     public void set(VectorFloat values) {
         for (int i = 0; i < values.storage.length; i++) {
@@ -122,6 +120,7 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
      * Sets the elements of this vector to that of the provided array
      * 
      * @param values
+     *            Set input array as internal stored
      */
     public void set(float[] values) {
         for (int i = 0; i < values.length; i++) {
@@ -133,6 +132,7 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
      * Sets all elements to value
      * 
      * @param value
+     *            Fill input array with value
      */
     public void fill(float value) {
         for (int i = 0; i < storage.length; i++) {
@@ -145,9 +145,9 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
      * 
      * @param start
      *            starting index
-     * @param numElements
+     * @param length
      *            number of elements
-     * @return
+     * @return a new Vector Float
      */
     public VectorFloat subVector(int start, int length) {
         final VectorFloat v = new VectorFloat(length);
@@ -160,14 +160,14 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
     /**
      * Duplicates this vector
      * 
-     * @return
+     * @return a new Vector Float
      */
     public VectorFloat duplicate() {
-        return new VectorFloat(copyOf(storage, storage.length));
+        return new VectorFloat(Arrays.copyOf(storage, storage.length));
     }
 
     public static float min(VectorFloat v) {
-        float result = MAX_VALUE;
+        float result = Float.MAX_VALUE;
         for (int i = 0; i < v.storage.length; i++) {
             result = Math.min(v.storage[i], result);
         }
@@ -175,7 +175,7 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
     }
 
     public static float max(VectorFloat v) {
-        float result = MIN_VALUE;
+        float result = Float.MIN_VALUE;
         for (int i = 0; i < v.storage.length; i++) {
             result = Math.max(v.storage[i], result);
         }
@@ -186,6 +186,7 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
      * Vector equality test
      * 
      * @param vector
+     *            input vector
      * @return true if vectors match
      */
     public boolean isEqual(VectorFloat vector) {
@@ -193,11 +194,11 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
     }
 
     /**
-     * dot product (this . this)
+     * Performs Dot-product
      * 
-     * @return
+     * @return dot-product value
      */
-    public static final float dot(VectorFloat a, VectorFloat b) {
+    public static float dot(VectorFloat a, VectorFloat b) {
         float sum = 0;
         for (int i = 0; i < a.size(); i++) {
             sum += a.get(i) * b.get(i);
@@ -207,24 +208,25 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
 
     /**
      * Prints the vector using the specified format string
-     * 
+     *
      * @param fmt
-     * @return
+     *            String Format
+     * @return String
      */
     public String toString(String fmt) {
-        String str = "[ ";
-
+        StringBuffer sb = new StringBuffer("[");
+        sb.append("[ ");
         for (int i = 0; i < numElements; i++) {
-            str += format(fmt, get(i)) + " ";
+            sb.append(String.format(fmt, get(i)) + " ");
         }
-        str += "]";
-        return str;
+        sb.append("]");
+        return sb.toString();
     }
 
     public String toString() {
-        String str = format("VectorFloat <%d>", numElements);
+        String str = String.format("VectorFloat <%d>", numElements);
         if (numElements < 32) {
-            str += toString(fmt);
+            str += toString(FloatOps.fmt);
         }
         return str;
     }
@@ -236,7 +238,7 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat3.java
@@ -41,12 +41,6 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.Float3.add;
-import static uk.ac.manchester.tornado.api.collections.types.Float3.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
-
 import java.nio.FloatBuffer;
 
 public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
@@ -66,7 +60,9 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
      * Creates a vector using the provided backing array
      *
      * @param numElements
+     *            Number of elements
      * @param array
+     *            array to be copied
      */
     protected VectorFloat3(int numElements, float[] array) {
         this.numElements = numElements;
@@ -80,10 +76,15 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
         this(array.length / elementSize, array);
     }
 
+    public float[] getArray() {
+        return storage;
+    }
+
     /**
      * Creates an empty vector with
      *
      * @param numElements
+     *            Number of elements
      */
     public VectorFloat3(int numElements) {
         this(numElements, new float[numElements * elementSize]);
@@ -97,18 +98,20 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
      * Returns the float at the given index of this vector
      *
      * @param index
-     *
-     * @return value
+     *            Position
+     * @return {@link Float3}
      */
     public Float3 get(int index) {
-        return loadFromArray(storage, toIndex(index));
+        return Float3.loadFromArray(storage, toIndex(index));
     }
 
     /**
      * Sets the float at the given index of this vector
      *
      * @param index
+     *            Position
      * @param value
+     *            Value to be set
      */
     public void set(int index, Float3 value) {
         value.storeToArray(storage, toIndex(index));
@@ -118,6 +121,7 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
      * Sets the elements of this vector to that of the provided vector
      *
      * @param values
+     *            set an input array into the internal array
      */
     public void set(VectorFloat3 values) {
         for (int i = 0; i < numElements; i++) {
@@ -129,6 +133,7 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
      * Sets the elements of this vector to that of the provided array
      *
      * @param values
+     *            set an input array into the internal array
      */
     public void set(float[] values) {
         VectorFloat3 vector = new VectorFloat3(values);
@@ -146,7 +151,7 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return A new vector
      */
     public VectorFloat3 duplicate() {
         VectorFloat3 vector = new VectorFloat3(numElements);
@@ -158,34 +163,31 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
      * Prints the vector using the specified format string
      *
      * @param fmt
-     *
-     * @return
+     *            String Format
+     * @return String
      */
     public String toString(String fmt) {
-        String str = "";
-
+        StringBuffer sb = new StringBuffer("[");
+        sb.append("[ ");
         for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
+            sb.append(String.format(fmt, get(i)) + " ");
         }
-
-        return str;
+        sb.append("]");
+        return sb.toString();
     }
 
-    /**
-     *
-     */
     public String toString() {
         if (numElements > 4) {
-            return format("VectorFloat3 <%d>", numElements);
+            return String.format("VectorFloat3 <%d>", numElements);
         } else {
-            return toString(fmt3);
+            return toString(FloatOps.fmt3);
         }
     }
 
     public Float3 sum() {
         Float3 result = new Float3();
         for (int i = 0; i < numElements; i++) {
-            result = add(result, get(i));
+            result = Float3.add(result, get(i));
         }
         return result;
     }
@@ -213,7 +215,7 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat4.java
@@ -41,13 +41,6 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.lang.System.out;
-import static java.nio.FloatBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.Float4.add;
-import static uk.ac.manchester.tornado.api.collections.types.Float4.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt4;
-
 import java.nio.FloatBuffer;
 
 public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
@@ -67,7 +60,9 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
      * Creates a vector using the provided backing array
      *
      * @param numElements
+     *            Number of elements
      * @param array
+     *            Array to be stored
      */
     protected VectorFloat4(int numElements, float[] array) {
         this.numElements = numElements;
@@ -85,9 +80,14 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
      * Creates an empty vector with
      *
      * @param numElements
+     *            Number of elements
      */
     public VectorFloat4(int numElements) {
         this(numElements, new float[numElements * elementSize]);
+    }
+
+    public float[] getArray() {
+        return storage;
     }
 
     private int toIndex(int index) {
@@ -98,18 +98,20 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
      * Returns the float at the given index of this vector
      *
      * @param index
-     *
+     *            Position
      * @return value
      */
     public Float4 get(int index) {
-        return loadFromArray(storage, toIndex(index));
+        return Float4.loadFromArray(storage, toIndex(index));
     }
 
     /**
      * Sets the float at the given index of this vector
      *
      * @param index
+     *            position
      * @param value
+     *            value to be stored
      */
     public void set(int index, Float4 value) {
         value.storeToArray(storage, toIndex(index));
@@ -119,6 +121,7 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
      * Sets the elements of this vector to that of the provided vector
      *
      * @param values
+     *            set a {@link VectorFloat4} into the internal array
      */
     public void set(VectorFloat4 values) {
         for (int i = 0; i < numElements; i++) {
@@ -130,6 +133,7 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
      * Sets the elements of this vector to that of the provided array
      *
      * @param values
+     *            set an input array into the internal array
      */
     public void set(float[] values) {
         VectorFloat4 vector = new VectorFloat4(values);
@@ -147,7 +151,7 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Duplicates this vector
      *
-     * @return
+     * @return {@link VectorFloat4}
      */
     public VectorFloat4 duplicate() {
         VectorFloat4 vector = new VectorFloat4(numElements);
@@ -159,34 +163,31 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
      * Prints the vector using the specified format string
      *
      * @param fmt
-     *
-     * @return
+     *            String Format
+     * @return String
      */
     public String toString(String fmt) {
-        String str = "";
-        out.printf("has %d elements\n", numElements);
+        StringBuffer sb = new StringBuffer("[");
+        sb.append("[ ");
         for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
+            sb.append(String.format(fmt, get(i)) + " ");
         }
-
-        return str;
+        sb.append("]");
+        return sb.toString();
     }
 
-    /**
-     *
-     */
     public String toString() {
         if (numElements > 4) {
-            return format("VectorFloat4 <%d>", numElements);
+            return String.format("VectorFloat4 <%d>", numElements);
         } else {
-            return toString(fmt4);
+            return toString(FloatOps.fmt4);
         }
     }
 
     public Float4 sum() {
         Float4 result = new Float4();
         for (int i = 0; i < numElements; i++) {
-            result = add(result, get(i));
+            result = Float4.add(result, get(i));
         }
         return result;
     }
@@ -214,7 +215,7 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public FloatBuffer asBuffer() {
-        return wrap(storage);
+        return FloatBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt.java
@@ -41,14 +41,8 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.Integer.MAX_VALUE;
-import static java.lang.Integer.MIN_VALUE;
-import static java.lang.String.format;
-import static java.nio.IntBuffer.wrap;
-import static java.util.Arrays.copyOf;
-import static uk.ac.manchester.tornado.api.collections.types.IntOps.fmt;
-
 import java.nio.IntBuffer;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 
@@ -62,7 +56,9 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
      * Creates a vector using the provided backing array
      * 
      * @param numElements
+     *            number of elements
      * @param array
+     *            reference to the input array
      */
     protected VectorInt(int numElements, int[] array) {
         this.numElements = numElements;
@@ -73,6 +69,7 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
      * Creates an empty vector with
      * 
      * @param numElements
+     *            number of elements
      */
     public VectorInt(int numElements) {
         this(numElements, new int[numElements]);
@@ -82,16 +79,22 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
      * Creates an new vector from the provided storage
      * 
      * @param storage
+     *            vector int array
      */
     public VectorInt(int[] storage) {
         this(storage.length / elementSize, storage);
+    }
+
+    public int[] getArray() {
+        return storage;
     }
 
     /**
      * Returns the int at the given index of this vector
      * 
      * @param index
-     * @return value
+     *            index value
+     * @return int
      */
     public int get(int index) {
         return storage[index];
@@ -101,7 +104,9 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
      * Sets the int at the given index of this vector
      * 
      * @param index
+     *            index value
      * @param value
+     *            value to be set in position index
      */
     public void set(int index, int value) {
         storage[index] = value;
@@ -111,6 +116,7 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
      * Sets the elements of this vector to that of the provided vector
      * 
      * @param values
+     *            assign an input vector int to the internal array
      */
     public void set(VectorInt values) {
         for (int i = 0; i < values.storage.length; i++) {
@@ -122,6 +128,7 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
      * Sets the elements of this vector to that of the provided array
      * 
      * @param values
+     *            assign an input vector int to the internal array
      */
     public void set(int[] values) {
         for (int i = 0; i < values.length; i++) {
@@ -133,6 +140,7 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
      * Sets all elements to value
      * 
      * @param value
+     *            Fill input vector with value
      */
     public void fill(int value) {
         for (int i = 0; i < storage.length; i++) {
@@ -145,9 +153,9 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
      * 
      * @param start
      *            starting index
-     * @param numElements
+     * @param length
      *            number of elements
-     * @return
+     * @return {@link VectorInt}
      */
     public VectorInt subVector(int start, int length) {
         final VectorInt v = new VectorInt(length);
@@ -161,14 +169,14 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
     /**
      * Duplicates this vector
      * 
-     * @return
+     * @return {@link VectorInt}
      */
     public VectorInt duplicate() {
-        return new VectorInt(copyOf(storage, storage.length));
+        return new VectorInt(Arrays.copyOf(storage, storage.length));
     }
 
     public static int min(VectorInt v) {
-        int result = MAX_VALUE;
+        int result = Integer.MAX_VALUE;
         for (int i = 0; i < v.storage.length; i++) {
             result = Math.min(v.storage[i], result);
         }
@@ -176,7 +184,7 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
     }
 
     public static int max(VectorInt v) {
-        int result = MIN_VALUE;
+        int result = Integer.MIN_VALUE;
         for (int i = 0; i < v.storage.length; i++) {
             result = Math.max(v.storage[i], result);
         }
@@ -187,6 +195,7 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
      * Vector equality test
      * 
      * @param vector
+     *            Input vector to compare
      * @return true if vectors match
      */
     public boolean isEqual(VectorInt vector) {
@@ -194,11 +203,11 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
     }
 
     /**
-     * dot product (this . this)
+     * Perform dot-product
      * 
-     * @return
+     * @return int value
      */
-    public static final int dot(VectorInt a, VectorInt b) {
+    public static int dot(VectorInt a, VectorInt b) {
         int sum = 0;
         for (int i = 0; i < a.size(); i++) {
             sum += a.get(i) * b.get(i);
@@ -210,24 +219,23 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
      * Prints the vector using the specified format string
      * 
      * @param fmt
-     * @return
+     *            String Format
+     * @return String
      */
     public String toString(String fmt) {
-        String str = "[ ";
-
+        StringBuffer sb = new StringBuffer("[");
+        sb.append("[ ");
         for (int i = 0; i < numElements; i++) {
-            str += format(fmt, get(i)) + " ";
+            sb.append(String.format(fmt, get(i)) + " ");
         }
-
-        str += "]";
-
-        return str;
+        sb.append("]");
+        return sb.toString();
     }
 
     public String toString() {
-        String str = format("VectorInt <%d>", numElements);
+        String str = String.format("VectorInt <%d>", numElements);
         if (numElements < 32) {
-            str += toString(fmt);
+            str += toString(IntOps.fmt);
         }
         return str;
     }
@@ -239,7 +247,7 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
 
     @Override
     public IntBuffer asBuffer() {
-        return wrap(storage);
+        return IntBuffer.wrap(storage);
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VolumeOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VolumeOps.java
@@ -41,34 +41,26 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static uk.ac.manchester.tornado.api.collections.types.Float3.floor;
-import static uk.ac.manchester.tornado.api.collections.types.Float3.fract;
-import static uk.ac.manchester.tornado.api.collections.types.Float3.mult;
-import static uk.ac.manchester.tornado.api.collections.types.Int3.add;
-import static uk.ac.manchester.tornado.api.collections.types.Int3.max;
-import static uk.ac.manchester.tornado.api.collections.types.Int3.min;
-import static uk.ac.manchester.tornado.api.collections.types.Int3.sub;
-
 public class VolumeOps {
 
-    public static final Float3 grad(final VolumeShort2 volume, final Float3 dim, final Float3 point) {
+    public static Float3 grad(final VolumeShort2 volume, final Float3 dim, final Float3 point) {
 
         final Float3 scaledPos = new Float3(((point.getX() * volume.X()) / dim.getX()) - 0.5f, ((point.getY() * volume.Y()) / dim.getY()) - 0.5f, ((point.getZ() * volume.Z()) / dim.getZ()) - 0.5f);
 
-        final Float3 tmp = floor(scaledPos);
+        final Float3 tmp = Float3.floor(scaledPos);
 
-        final Float3 factor = fract(scaledPos);
+        final Float3 factor = Float3.fract(scaledPos);
 
         final Int3 base = new Int3((int) tmp.getX(), (int) tmp.getY(), (int) tmp.getZ());
 
         // factor.frac();
         final Int3 zeros = new Int3();
-        final Int3 limits = sub(new Int3(volume.X(), volume.Y(), volume.Z()), 1);
+        final Int3 limits = Int3.sub(new Int3(volume.X(), volume.Y(), volume.Z()), 1);
 
-        final Int3 lowerLower = max(zeros, sub(base, 1));
-        final Int3 lowerUpper = max(zeros, base);
-        final Int3 upperLower = min(limits, add(base, 1));
-        final Int3 upperUpper = min(limits, add(base, 2));
+        final Int3 lowerLower = Int3.max(zeros, Int3.sub(base, 1));
+        final Int3 lowerUpper = Int3.max(zeros, base);
+        final Int3 upperLower = Int3.min(limits, Int3.add(base, 1));
+        final Int3 upperUpper = Int3.min(limits, Int3.add(base, 2));
 
         final Int3 lower = lowerUpper;
         final Int3 upper = upperLower;
@@ -154,26 +146,26 @@ public class VolumeOps {
                 * factor.getX()))
                 * factor.getY())) * factor.getZ());
         // @formatter:on
-        final Float3 tmp1 = mult(new Float3(dim.getX() / volume.X(), dim.getY() / volume.Y(), dim.getZ() / volume.Z()), (0.5f * 0.00003051944088f));
+        final Float3 tmp1 = Float3.mult(new Float3(dim.getX() / volume.X(), dim.getY() / volume.Y(), dim.getZ() / volume.Z()), (0.5f * 0.00003051944088f));
 
-        return mult(new Float3(gx, gy, gz), tmp1);
+        return Float3.mult(new Float3(gx, gy, gz), tmp1);
 
     }
 
-    public static final float interp(final VolumeShort2 volume, final Float3 dim, final Float3 point) {
+    public static float interp(final VolumeShort2 volume, final Float3 dim, final Float3 point) {
 
         final Float3 scaledPos = new Float3((point.getX() * volume.X() / dim.getX()) - 0.5f, (point.getY() * volume.Y() / dim.getY()) - 0.5f, (point.getZ() * volume.Z() / dim.getZ()) - 0.5f);
 
-        final Float3 tmp = floor(scaledPos);
-        final Float3 factor = fract(scaledPos);
+        final Float3 tmp = Float3.floor(scaledPos);
+        final Float3 factor = Float3.fract(scaledPos);
 
         final Int3 base = new Int3((int) tmp.getX(), (int) tmp.getY(), (int) tmp.getZ());
 
         final Int3 zeros = new Int3(0, 0, 0);
-        final Int3 limits = sub(new Int3(volume.X(), volume.Y(), volume.Z()), 1);
+        final Int3 limits = Int3.sub(new Int3(volume.X(), volume.Y(), volume.Z()), 1);
 
-        final Int3 lower = max(base, zeros);
-        final Int3 upper = min(limits, add(base, 1));
+        final Int3 lower = Int3.max(base, zeros);
+        final Int3 upper = Int3.min(limits, Int3.add(base, 1));
 
         final float factorX = (1 - factor.getX());
         final float factorY = (1 - factor.getY());
@@ -194,11 +186,11 @@ public class VolumeOps {
         return c * 0.00003051944088f;
     }
 
-    public static final float vs1(int x, int y, int z, VolumeShort2 v) {
+    public static float vs1(int x, int y, int z, VolumeShort2 v) {
         return vs(v, x, y, z);
     }
 
-    public final static float vs(final VolumeShort2 cube, int x, int y, int z) {
+    public static float vs(final VolumeShort2 cube, int x, int y, int z) {
         return cube.get(x, y, z).getX();
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VolumeShort2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VolumeShort2.java
@@ -41,10 +41,6 @@
  */
 package uk.ac.manchester.tornado.api.collections.types;
 
-import static java.lang.String.format;
-import static java.nio.ShortBuffer.wrap;
-import static uk.ac.manchester.tornado.api.collections.types.Short2.loadFromArray;
-
 import java.nio.ShortBuffer;
 
 public class VolumeShort2 implements PrimitiveStorage<ShortBuffer> {
@@ -86,13 +82,17 @@ public class VolumeShort2 implements PrimitiveStorage<ShortBuffer> {
     /**
      * Storage format for matrix
      * 
-     * @param height
-     *            number of columns
      * @param width
+     *            number of columns
+     * @param depth
      *            number of rows
      */
     public VolumeShort2(int width, int height, int depth) {
         this(width, height, depth, new short[width * height * depth * elementSize]);
+    }
+
+    public short[] getArray() {
+        return storage;
     }
 
     private int toIndex(int x, int y, int z) {
@@ -101,7 +101,7 @@ public class VolumeShort2 implements PrimitiveStorage<ShortBuffer> {
 
     public Short2 get(int x, int y, int z) {
         final int index = toIndex(x, y, z);
-        return loadFromArray(storage, index);
+        return Short2.loadFromArray(storage, index);
     }
 
     public void set(int x, int y, int z, Short2 value) {
@@ -143,11 +143,11 @@ public class VolumeShort2 implements PrimitiveStorage<ShortBuffer> {
         String str = "";
 
         for (int z = 0; z < Z(); z++) {
-            str += format("z = %d\n", z);
+            str += String.format("z = %d\n", z);
             for (int y = 0; y < Y(); y++) {
                 for (int x = 0; x < X(); x++) {
                     final Short2 point = get(x, y, z);
-                    str += format(fmt, point.getX(), point.getY()) + " ";
+                    str += String.format(fmt, point.getX(), point.getY()) + " ";
                 }
                 str += "\n";
             }
@@ -157,7 +157,7 @@ public class VolumeShort2 implements PrimitiveStorage<ShortBuffer> {
     }
 
     public String toString() {
-        return format("VolumeShort2 <%d x %d x %d>", Y, X, Z);
+        return String.format("VolumeShort2 <%d x %d x %d>", Y, X, Z);
     }
 
     @Override
@@ -167,7 +167,7 @@ public class VolumeShort2 implements PrimitiveStorage<ShortBuffer> {
 
     @Override
     public ShortBuffer asBuffer() {
-        return wrap(storage);
+        return ShortBuffer.wrap(storage);
     }
 
     @Override


### PR DESCRIPTION
This PR addresses  Github issue #25 

This patch includes:
* Get backing array for wrap-types (e.g., `ImageByte3#getArray()`) 
* Clean-up TornadoVM Wrapper-APIs 

All unittests are passing as well as `kfusion-tornadovm`. 