### PR TITLE
OBSOLETE: Fix non-JNI types in PTXStream.cpp; fix posix_memalign usage in OCLCo…

### DIFF
--- a/assembly/src/bin/tornado
+++ b/assembly/src/bin/tornado
@@ -120,7 +120,7 @@ if [[ $JAVA_VERSION == "9.0" || $JAVA_VERSION == "10.0" ]]; then
   exit 0
 fi
 
-TORNADO_FLAGS="-Djava.library.path=${TORNADO_SDK}/lib:$EXTERNAL_DIRS "
+TORNADO_FLAGS="-Djava.library.path=${TORNADO_SDK}/lib"
 if [ "$JAVA_VERSION" = "1.8" ]; then
   TORNADO_FLAGS="${TORNADO_FLAGS} -Djava.ext.dirs=${TORNADO_SDK}/share/java/tornado"
 else

--- a/drivers/opencl-jni/src/main/cpp/CMakeLists.txt
+++ b/drivers/opencl-jni/src/main/cpp/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(OpenCL REQUIRED)
 find_package(JNI REQUIRED)
 
 set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fpermissive -rdynamic -fPIC ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fpermissive -export-dynamic -fPIC ")
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include_directories(
@@ -29,3 +29,4 @@ add_library(tornado-opencl SHARED
 		source/opencl_time_utils.cpp)
 
 target_link_libraries(tornado-opencl ${OpenCL_LIBRARIES} ${JNI_LIB_DIRS})
+set_target_properties(tornado-opencl PROPERTIES PREFIX "")

--- a/drivers/opencl-jni/src/main/cpp/source/OCLCommandQueue.cpp
+++ b/drivers/opencl-jni/src/main/cpp/source/OCLCommandQueue.cpp
@@ -221,7 +221,8 @@ jlong transferFromHostToDevice(JNIEnv * env, jclass javaClass,
         std::cout << "[TornadoVM-JNI] H2D time: " << writeTime << " (ns)" << std::endl;
     } else {
         /* we must wait irrespective of jboolean blocking flag or we risk Java GC/OpenCL Runtime race condition */
-        clWaitForEvents(1, &event);
+        // No need, only introduce blocking  
+        // clWaitForEvents(1, &event);
     }
     if (hostArray != NULL) {
         env->ReleasePrimitiveArrayCritical(hostArray, buffer, JNI_ABORT);
@@ -334,7 +335,8 @@ jlong transfersFromDeviceToHost(JNIEnv *env, jclass javaClass,
         std::cout << "[TornadoVM-JNI] D2H time: " << readTime << " (ns)" << std::endl;
     } else {
         /* we must wait irrespective of jboolean blocking flag or we risk Java GC/OpenCL Runtime race condition */
-        clWaitForEvents(1, &readEvent);
+        // No need, only introduce blocking
+        //clWaitForEvents(1, &readEvent);
     }
     if (hostArray != NULL) {
         env->ReleasePrimitiveArrayCritical(hostArray, buffer, JNI_ABORT);

--- a/drivers/opencl-jni/src/main/cpp/source/OCLCommandQueue.h
+++ b/drivers/opencl-jni/src/main/cpp/source/OCLCommandQueue.h
@@ -225,11 +225,27 @@ JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLCommandQ
 
 /*
  * Class:     uk_ac_manchester_tornado_drivers_opencl_OCLCommandQueue
+ * Method:    clEnqueueMarker
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLCommandQueue_clEnqueueMarker
+        (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_opencl_OCLCommandQueue
  * Method:    clEnqueueBarrierWithWaitList
  * Signature: (J[J)J
  */
 JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLCommandQueue_clEnqueueBarrierWithWaitList
         (JNIEnv *, jclass, jlong, jlongArray);
+
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_opencl_OCLCommandQueue
+ * Method:    clEnqueueBarrier
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLCommandQueue_clEnqueueBarrier
+        (JNIEnv *, jclass, jlong);
 
 /*
  * Class:     uk_ac_manchester_tornado_drivers_opencl_OCLCommandQueue

--- a/drivers/opencl-jni/src/main/cpp/source/OCLContext.cpp
+++ b/drivers/opencl-jni/src/main/cpp/source/OCLContext.cpp
@@ -81,11 +81,18 @@ JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLContext_
  */
 JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLContext_allocateOffHeapMemory
 (JNIEnv *env, jclass clazz, jlong size, jlong alignment) {
+    /*
     void *ptr;
     int rc = posix_memalign(&ptr, (size_t) alignment, (size_t) size);
     if (rc != 0) {
         printf("posix_memalign: did not work!\n");
     }
+    */
+    void *ptr = _aligned_malloc((size_t) alignment, (size_t) size);
+    if (ptr == 0) {
+        printf("_aligned_malloc: did not work!\n");
+    }
+
     memset(ptr, 0, (size_t) size);
     size_t i = 0;
     for (; i < (size_t) size / 4; i++) {

--- a/drivers/opencl-jni/src/main/cpp/source/OCLEvent.cpp
+++ b/drivers/opencl-jni/src/main/cpp/source/OCLEvent.cpp
@@ -128,11 +128,11 @@ void CL_CALLBACK onOpenCLEventCompletion(cl_event event, cl_int eventStatus, voi
             //std::cout << "Attached ok" << std::endl;
             attached = true;
         }
-    } else if (jniStatus == JNI_EVERSION) {
-        //std::cout << "GetEnv: version not supported" << std::endl;
     } else if (jniStatus == JNI_OK) {
 	//
     } else {
+        // ERRORS
+        // if (jniStatus == JNI_EVERSION) {}
         //std::cout << "GetEnv: unknown jniStatus " << jniStatus << std::endl;
     }
     if (env != NULL) {
@@ -149,12 +149,7 @@ void CL_CALLBACK onOpenCLEventCompletion(cl_event event, cl_int eventStatus, voi
         } else {
             throwError(env, "Unable to get object class");
         }
-
         env->DeleteGlobalRef(target);
-
-        if (env->ExceptionCheck()) {
-            //env->ExceptionDescribe();
-        }
     }
     if (attached) {
         jvm->DetachCurrentThread();

--- a/drivers/opencl-jni/src/main/cpp/source/OCLEvent.h
+++ b/drivers/opencl-jni/src/main/cpp/source/OCLEvent.h
@@ -61,6 +61,14 @@ JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLEvent_clW
 JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLEvent_clReleaseEvent
         (JNIEnv *, jclass, jlong);
 
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_opencl_OCLEvent
+ * Method:    clAttachCallback
+ * Signature: (JLjava/lang/Object;)V
+ */
+JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLEvent_clAttachCallback
+        (JNIEnv *env, jclass clazz, jlong event, jobject callback);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/opencl-jni/src/main/cpp/source/OpenCL.cpp
+++ b/drivers/opencl-jni/src/main/cpp/source/OpenCL.cpp
@@ -24,6 +24,7 @@
 #include <jni.h>
 
 #define CL_TARGET_OPENCL_VERSION 120
+#define EXTERN
 
 #ifdef __APPLE__
     #include <OpenCL/cl.h>
@@ -35,6 +36,16 @@
 #include <stdio.h>
 #include "OpenCL.h"
 #include "ocl_log.h"
+#include "global_vars.h"
+
+jint JNI_OnLoad(JavaVM *vm, void *reserved) {
+    jvm = vm;
+    return JNI_VERSION_1_2;
+}
+
+void JNI_OnUnload(JavaVM *vm, void *reserved) {
+    jvm = NULL;
+}
 
 /*
  * Class:     uk_ac_manchester_tornado_drivers_opencl_OpenCL

--- a/drivers/opencl-jni/src/main/cpp/source/OpenCL.h
+++ b/drivers/opencl-jni/src/main/cpp/source/OpenCL.h
@@ -57,6 +57,9 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OpenCL_clGet
 JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OpenCL_clGetPlatformIDs
         (JNIEnv *, jclass, jlongArray);
 
+jint JNI_OnLoad(JavaVM *vm, void *reserved);
+
+void JNI_OnUnload(JavaVM *vm, void *reserved);
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/opencl-jni/src/main/cpp/source/global_vars.h
+++ b/drivers/opencl-jni/src/main/cpp/source/global_vars.h
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2020, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -22,36 +22,19 @@
  *
  */
 
-#ifndef utils_h
-#define utils_h
+#ifndef EXTERN
+#define EXTERN extern
+#endif
+
+#include <jni.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define CL_TARGET_OPENCL_VERSION 120
+EXTERN JavaVM *jvm;
 
-#ifdef __APPLE__
-    #include <OpenCL/cl.h>
-#else
-    #include <CL/cl.h>
-#endif
-
-#include <jni.h>
-
-char *getOpenCLError(char *, cl_int);
-
-jint throwError(JNIEnv *env, const char *message);
-
-jint throwNoClassDefFoundError(JNIEnv *env, const char *message);
-
-jint throwNoSuchMethodError(JNIEnv *env, const char *className, const char *methodName, const char *signature );
-/*
-jint throwNoSuchFieldError(JNIEnv *env, const char *message);
-
-jint throwOutOfMemoryError(JNIEnv *env, const char *message);
-*/
 #ifdef __cplusplus
 }
 #endif
-#endif
+

--- a/drivers/opencl-jni/src/main/cpp/source/utils.cpp
+++ b/drivers/opencl-jni/src/main/cpp/source/utils.cpp
@@ -58,4 +58,49 @@ char *getOpenCLError(char *func, cl_int code) {
     return const_cast<char *>(outString.str().c_str());
 }
 
+jint throwError(JNIEnv *env, const char *message) {
+    const char *className = "java/lang/Error";
+    jclass exClass = env->FindClass(className);
+    return env->ThrowNew(exClass, message);
+}
 
+jint throwNoClassDefFoundError(JNIEnv *env, const char *message) {
+    const char *className = "java/lang/NoClassDefFoundError";
+    jclass exClass = env->FindClass(className);
+    if (exClass == NULL) {
+        return throwNoClassDefFoundError(env, className);
+    }
+    return env->ThrowNew(exClass, message);
+}
+
+jint throwNoSuchMethodError(JNIEnv *env, const char *className, const char *methodName, const char *signature) {
+    const char *exClassName = "java/lang/NoSuchMethodError" ;
+    jclass exClass = env->FindClass(exClassName);
+    if (exClass == NULL) {
+        return throwNoClassDefFoundError(env, exClassName);
+    }
+    std::stringstream message;
+    message << className << '.' << methodName << " ("  << signature <<  ")";
+    return env->ThrowNew(exClass, const_cast<char *>(message.str().c_str()));
+}
+
+/*
+jint throwNoSuchFieldError(JNIEnv *env, const char *message) {
+    const char *className = "java/lang/NoSuchFieldError" ;
+    jclass exClass = env->FindClass(env, className);
+    if (exClass == NULL) {
+        return throwNoClassDefFoundError(env, className);
+    }
+
+    return env->ThrowNew( env, exClass, message );
+}
+
+jint throwOutOfMemoryError(JNIEnv *env, const char *message) {
+    const char *className = "java/lang/OutOfMemoryError" ;
+    jclass exClass = env->FindClass(className);
+    if (exClass == NULL) {
+        return throwNoClassDefFoundError(env, className);
+    }
+    return env->ThrowNew(exClass, message);
+}
+*/

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
@@ -25,6 +25,7 @@ package uk.ac.manchester.tornado.drivers.opencl;
 
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
 import uk.ac.manchester.tornado.api.common.Event;
+import uk.ac.manchester.tornado.api.common.TornadoExecutionHandler;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResult;
 import uk.ac.manchester.tornado.drivers.opencl.mm.OCLMemoryManager;
@@ -59,6 +60,8 @@ public interface OCLDeviceContextInterface extends TornadoDeviceContext {
     OCLMemoryManager getMemoryManager();
 
     void sync();
+
+    void sync(TornadoExecutionHandler handler);
 
     int enqueueBarrier();
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -120,7 +120,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
 
         int task;
         if (meta == null) {
-            task = deviceContext.enqueueNDRangeKernel(kernel, 1, null, singleThreadGlobalWorkSize, singleThreadLocalWorkSize, internalEvents);
+            task = deviceContext.enqueueNDRangeKernel(kernel, 1, null, singleThreadGlobalWorkSize, singleThreadLocalWorkSize, null);
             deviceContext.flush();
             deviceContext.finish();
         } else {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -41,6 +41,7 @@ import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.Event;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
+import uk.ac.manchester.tornado.api.common.TornadoExecutionHandler;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
@@ -585,7 +586,7 @@ public class OCLTornadoDevice implements TornadoAcceleratorDevice {
 
         if (BENCHMARKING_MODE || !state.hasContents()) {
             state.setContents(true);
-            return state.getBuffer().enqueueWrite(object, batchSize, offset, events, events == null);
+            return state.getBuffer().enqueueWrite(object, batchSize, offset, events, true/*events == null*/);
         }
         return null;
     }
@@ -596,17 +597,23 @@ public class OCLTornadoDevice implements TornadoAcceleratorDevice {
             ensureAllocated(object, batchSize, state);
         }
         state.setContents(true);
-        return state.getBuffer().enqueueWrite(object, batchSize, offset, events, events == null);
+        return state.getBuffer().enqueueWrite(object, batchSize, offset, events, true/*events == null*/);
     }
 
     @Override
     public int streamOut(Object object, long offset, TornadoDeviceObjectState state, int[] events) {
-        TornadoInternalError.guarantee(state.isValid(), "invalid variable");
-        int event = state.getBuffer().enqueueRead(object, offset, events, events == null);
-        if (events != null) {
-            return event;
+        if (state.isAtomicRegionPresent()) {
+            int eventID = state.getBuffer().enqueueRead(null, 0, null, false);
+            if (object instanceof AtomicInteger) {
+                int[] arr = getAtomic().getIntBuffer();
+                int indexFromGlobalRegion = mappingAtomics.get(object);
+                ((AtomicInteger) object).set(arr[indexFromGlobalRegion]);
+            }
+            return eventID;
+        } else {
+            TornadoInternalError.guarantee(state.isValid(), "invalid variable");
+            return state.getBuffer().enqueueRead(object, offset, events, true/*events == null*/);
         }
-        return -1;
     }
 
     @Override
@@ -661,6 +668,11 @@ public class OCLTornadoDevice implements TornadoAcceleratorDevice {
     @Override
     public void sync() {
         getDeviceContext().sync();
+    }
+
+    @Override
+    public void sync(TornadoExecutionHandler handler) {
+        getDeviceContext().sync(handler);
     }
 
     @Override

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
@@ -25,6 +25,8 @@ package uk.ac.manchester.tornado.drivers.opencl.virtual;
 
 import uk.ac.manchester.tornado.api.common.Event;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
+import uk.ac.manchester.tornado.api.common.TornadoExecutionHandler;
+import uk.ac.manchester.tornado.api.enums.TornadoExecutionStatus;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.drivers.opencl.OCLCodeCache;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContextInterface;
@@ -112,6 +114,12 @@ public class VirtualOCLDeviceContext extends TornadoLogger implements Initialisa
 
     @Override
     public void sync() {}
+
+    @Override
+    public void sync(TornadoExecutionHandler handler) {
+        sync();
+        handler.handle(TornadoExecutionStatus.COMPLETE, null);
+    }
 
     @Override
     public int enqueueBarrier() {

--- a/drivers/ptx-jni/src/main/cpp/CMakeLists.txt
+++ b/drivers/ptx-jni/src/main/cpp/CMakeLists.txt
@@ -4,7 +4,7 @@ project (Tornado)
 find_package(JNI REQUIRED)
 
 set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fpermissive -rdynamic -fPIC ")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fpermissive -export-dynamic -fPIC ")
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include_directories(
@@ -31,7 +31,9 @@ FIND_PACKAGE(CUDA)
 if(CUDA_FOUND)
     include_directories(${CUDA_INCLUDE_DIRS})
     link_directories(tornado-ptx ${CUDA_TOOLKIT_ROOT_DIR})
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} $ENV{PTX_LDFLAGS}")
     target_link_libraries(tornado-ptx ${JNI_LIB_DIRS} -lcuda)
+    set_target_properties(tornado-ptx PROPERTIES PREFIX "")
 else(CUDA_FOUND)
     message("CUDA is not installed on this system.")
 endif()

--- a/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
@@ -278,7 +278,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayDtoH__JJ_3IJ_3B
         (JNIEnv * env, jclass klass, jlong device_ptr, jlong length, jintArray array, jlong host_offset, jbyteArray stream_wrapper) {
-    WRITE_DEVICE_TO_HOST_BLOCKING(Int, int);
+    WRITE_DEVICE_TO_HOST_BLOCKING(Int, jint);
 }
 
 /*
@@ -298,7 +298,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayDtoH__JJ_3FJ_3B
         (JNIEnv * env, jclass klass, jlong device_ptr, jlong length, jfloatArray array, jlong host_offset, jbyteArray stream_wrapper) {
-    WRITE_DEVICE_TO_HOST_BLOCKING(Float, float);
+    WRITE_DEVICE_TO_HOST_BLOCKING(Float, jfloat);
 }
 
 /*
@@ -308,7 +308,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayDtoH__JJ_3DJ_3B
         (JNIEnv * env, jclass klass, jlong device_ptr, jlong length, jdoubleArray array, jlong host_offset, jbyteArray stream_wrapper) {
-    WRITE_DEVICE_TO_HOST_BLOCKING(Double, double);
+    WRITE_DEVICE_TO_HOST_BLOCKING(Double, jdouble);
 }
 
 /*
@@ -328,7 +328,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayDtoHAsync__JJ_3SJ_3B
         (JNIEnv * env, jclass klass, jlong devicePtr, jlong length, jshortArray array, jlong hostOffset, jbyteArray stream_wrapper) {
-    WRITE_DEVICE_TO_HOST_ASYNC(short);
+    WRITE_DEVICE_TO_HOST_ASYNC(jshort);
 }
 
 /*
@@ -338,7 +338,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayDtoHAsync__JJ_3CJ_3B
         (JNIEnv * env, jclass klass, jlong devicePtr, jlong length, jcharArray array, jlong hostOffset, jbyteArray stream_wrapper) {
-    WRITE_DEVICE_TO_HOST_ASYNC(char);
+    WRITE_DEVICE_TO_HOST_ASYNC(jchar);
 }
 
 /*
@@ -348,7 +348,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayDtoHAsync__JJ_3IJ_3B
         (JNIEnv * env, jclass klass, jlong devicePtr, jlong length, jintArray array, jlong hostOffset, jbyteArray stream_wrapper) {
-    WRITE_DEVICE_TO_HOST_ASYNC(int);
+    WRITE_DEVICE_TO_HOST_ASYNC(jint);
 }
 
 /*
@@ -358,7 +358,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayDtoHAsync__JJ_3JJ_3B
         (JNIEnv * env, jclass klass, jlong devicePtr, jlong length, jlongArray array, jlong hostOffset, jbyteArray stream_wrapper) {
-    WRITE_DEVICE_TO_HOST_ASYNC(long);
+    WRITE_DEVICE_TO_HOST_ASYNC(jlong);
 }
 
 /*
@@ -368,7 +368,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayDtoHAsync__JJ_3FJ_3B
         (JNIEnv * env, jclass klass, jlong devicePtr, jlong length, jfloatArray array, jlong hostOffset, jbyteArray stream_wrapper) {
-    WRITE_DEVICE_TO_HOST_ASYNC(float);
+    WRITE_DEVICE_TO_HOST_ASYNC(jfloat);
 }
 
 /*
@@ -378,7 +378,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayDtoHAsync__JJ_3DJ_3B
         (JNIEnv * env, jclass klass, jlong devicePtr, jlong length, jdoubleArray array, jlong hostOffset, jbyteArray stream_wrapper) {
-    WRITE_DEVICE_TO_HOST_ASYNC(double);
+    WRITE_DEVICE_TO_HOST_ASYNC(jdouble);
 }
 
 #define TRANSFER_FROM_HOST_TO_DEVICE_BLOCKING(TYPE, JAVATYPE)           \
@@ -499,7 +499,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayHtoDAsync__JJ_3SJ_3B
         (JNIEnv *env, jclass klass, jlong device_ptr, jlong length, jshortArray array, jlong host_offset, jbyteArray stream_wrapper) {
-    TRANSFER_FROM_HOST_TO_DEVICE_ASYNC(Short, short);
+    TRANSFER_FROM_HOST_TO_DEVICE_ASYNC(Short, jshort);
 }
 
 /*
@@ -519,7 +519,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayHtoDAsync__JJ_3IJ_3B
         (JNIEnv *env, jclass klass, jlong device_ptr, jlong length, jintArray array, jlong host_offset, jbyteArray stream_wrapper) {
-    TRANSFER_FROM_HOST_TO_DEVICE_ASYNC(Int, int);
+    TRANSFER_FROM_HOST_TO_DEVICE_ASYNC(Int, jint);
 }
 
 /*
@@ -529,7 +529,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayHtoDAsync__JJ_3JJ_3B
         (JNIEnv *env, jclass klass, jlong device_ptr, jlong length, jlongArray array, jlong host_offset, jbyteArray stream_wrapper) {
-    TRANSFER_FROM_HOST_TO_DEVICE_ASYNC(Long, long);
+    TRANSFER_FROM_HOST_TO_DEVICE_ASYNC(Long, jlong);
 }
 
 /*
@@ -539,7 +539,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayHtoDAsync__JJ_3FJ_3B
         (JNIEnv *env, jclass klass, jlong device_ptr, jlong length, jfloatArray array, jlong host_offset, jbyteArray stream_wrapper) {
-    TRANSFER_FROM_HOST_TO_DEVICE_ASYNC(Float, float);
+    TRANSFER_FROM_HOST_TO_DEVICE_ASYNC(Float, jfloat);
 }
 
 /*
@@ -549,7 +549,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
  */
 JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStream_writeArrayHtoDAsync__JJ_3DJ_3B
         (JNIEnv *env, jclass klass, jlong device_ptr, jlong length, jdoubleArray array, jlong host_offset, jbyteArray stream_wrapper) {
-    TRANSFER_FROM_HOST_TO_DEVICE_ASYNC(Double, double);
+    TRANSFER_FROM_HOST_TO_DEVICE_ASYNC(Double, jdouble);
 }
 
 /*

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplicationAsync2D.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplicationAsync2D.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package uk.ac.manchester.tornado.examples.compute;
+
+import java.util.Random;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.CountDownLatch;
+
+import uk.ac.manchester.tornado.api.TaskSchedule;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.collections.types.Matrix2DFloat;
+
+public class MatrixMultiplicationAsync2D {
+
+    private static final int WARMING_UP_ITERATIONS = 15;
+
+    private static void matrixMultiplication(Matrix2DFloat A, Matrix2DFloat B, Matrix2DFloat C, final int size) {
+        for (@Parallel int i = 0; i < size; i++) {
+            for (@Parallel int j = 0; j < size; j++) {
+                float sum = 0.0f;
+                for (int k = 0; k < size; k++) {
+                    sum += A.get(i, k) * B.get(k, j);
+                }
+                C.set(i, j, sum);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        int xsize = 512;
+        if (args.length >= 1) {
+            try {
+                xsize = Integer.parseInt(args[0]);
+            } catch (NumberFormatException nfe) {
+                xsize = 512;
+            }
+        }
+        int size = xsize;
+
+        System.out.println("Computing MxM of " + size + "x" + size);
+
+        Matrix2DFloat matrixA = new Matrix2DFloat(size, size);
+        Matrix2DFloat matrixB = new Matrix2DFloat(size, size);
+        Matrix2DFloat matrixC = new Matrix2DFloat(size, size);
+        Matrix2DFloat resultSeq = new Matrix2DFloat(size, size);
+
+        Random r = new Random();
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < size; j++) {
+                matrixA.set(i, j, r.nextFloat());
+                matrixB.set(i, j, r.nextFloat());
+            }
+        }
+
+        //@formatter:off
+        TaskSchedule t = new TaskSchedule("s0")
+                .task("t0", MatrixMultiplicationAsync2D::matrixMultiplication, matrixA, matrixB, matrixC, size)
+                .streamOut(matrixC);
+        //@formatter:on
+
+        ForkJoinPool.commonPool().execute(() -> {int z = 3/3;} );
+        double flops = 2 * Math.pow(size, 3);
+
+        CountDownLatch latch = new CountDownLatch(1); 
+
+        // 1. Warm up Tornado
+        for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {
+            t.execute();
+        }
+
+        // 2. Run parallel on the GPU with Tornado
+        long start = System.currentTimeMillis();
+        t.executeAsync().thenRunAsync(() -> {
+        ///------------------------
+            long end = System.currentTimeMillis();
+            long msecGPUElapsedTime = (end - start);
+            double gpuGigaFlops = (1.0E-9 * flops) / (msecGPUElapsedTime / 1000.0f);
+            String formatGPUFGlops = String.format("%.2f", gpuGigaFlops);
+
+            System.out.println("Resuming in thread: " + Thread.currentThread());
+            System.out.println("\tGPU Execution: " + formatGPUFGlops + " GFlops, Total Time = " + (end - start) + " ms");
+
+            // Run sequential
+            // 1. Warm up sequential
+            for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {
+                matrixMultiplication(matrixA, matrixB, resultSeq, size);
+            }
+
+            // 2. Run the sequential code
+            long startSequential = System.currentTimeMillis();
+            matrixMultiplication(matrixA, matrixB, resultSeq, size);
+            long endSequential = System.currentTimeMillis();
+
+            // Compute Gigaflops and performance
+            long msecCPUElaptedTime = (endSequential - startSequential);
+            double cpuGigaFlops = (1.0E-9 * flops) / (msecCPUElaptedTime / 1000.0f);
+            double speedup = (double) (endSequential - startSequential) / (double) (end - start);
+
+            String formatCPUFGlops = String.format("%.2f", cpuGigaFlops);
+
+            System.out.println("\tCPU Execution: " + formatCPUFGlops + " GFlops, Total time = " + (endSequential - startSequential) + " ms");
+            System.out.println("\tSpeedup: " + speedup + "x");
+            System.out.println("\tVerification " + verify(matrixC, resultSeq, size));
+            latch.countDown();
+        });
+        long msecStartlapsedTime = (System.currentTimeMillis() - start);
+        System.out.println("\tStart time: " + msecStartlapsedTime + " ms");
+        latch.await();
+    }
+
+    private static boolean verify(Matrix2DFloat par, Matrix2DFloat seq, int size) {
+        boolean check = true;
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < size; j++) {
+                if (Math.abs(par.get(i, j) - seq.get(i, j)) > 0.1f) {
+                    check = false;
+                    break;
+                }
+            }
+        }
+        return check;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,8 @@
                 <platform>windows-i386</platform>
                 <build.type>debug</build.type>
                 <cmake.classifier>windows-i386</cmake.classifier>
-                <cmake.generator>Visual Studio 14 2015</cmake.generator>
+                <!--cmake.generator>Visual Studio 14 2015</cmake.generator-->
+                <cmake.generator>Unix Makefiles</cmake.generator>
                 <cmake.config>${build.type}</cmake.config>
                 <!--
                         CMake interprets the lack of a generator architecture ("-A<platform>") as x86. There doesn't
@@ -96,7 +97,8 @@
                 <platform>windows-i386</platform>
                 <build.type>release</build.type>
                 <cmake.classifier>windows-i386</cmake.classifier>
-                <cmake.generator>Visual Studio 14 2015</cmake.generator>
+                <!--cmake.generator>Visual Studio 14 2015</cmake.generator-->
+                <cmake.generator>Unix Makefiles</cmake.generator>
                 <cmake.config>${build.type}</cmake.config>
                 <!--
                         CMake interprets the lack of a generator architecture ("-A<platform>") as x86. There doesn't
@@ -110,7 +112,8 @@
                 <platform>windows-amd64</platform>
                 <build.type>debug</build.type>
                 <cmake.classifier>windows-amd64</cmake.classifier>
-                <cmake.generator>Visual Studio 14 2015</cmake.generator>
+                <!--cmake.generator>Visual Studio 14 2015</cmake.generator-->
+                <cmake.generator>Unix Makefiles</cmake.generator>
                 <!--<cmake.options>-Ax64</cmake.options>-->
                 <cmake.config>${build.type}</cmake.config>
             </properties>
@@ -131,7 +134,8 @@
                 <platform>windows-amd64</platform>
                 <build.type>release</build.type>
                 <cmake.classifier>windows-amd64</cmake.classifier>
-                <cmake.generator>Visual Studio 14 2015</cmake.generator>
+                <!--cmake.generator>Visual Studio 14 2015</cmake.generator-->
+                <cmake.generator>Unix Makefiles</cmake.generator>
                 <!--<cmake.options>-Ax64</cmake.options>-->
                 <cmake.config>${build.type}</cmake.config>
             </properties>

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoExecutionFuture.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoExecutionFuture.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework: 
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.runtime.tasks;
+
+import java.util.concurrent.CompletableFuture;
+
+import uk.ac.manchester.tornado.api.AbstractTaskGraph;
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+
+class TornadoExecutionFuture extends CompletableFuture<AbstractTaskGraph> {
+    @Override 
+    public boolean complete(AbstractTaskGraph result) {
+        throw new UnsupportedOperationException("Explicit completion of " + getClass().getName() + " is forbidden");
+    }
+
+    @Override 
+    public boolean completeExceptionally(Throwable error) {
+        throw new UnsupportedOperationException("Explicit completion of " + getClass().getName() + " is forbidden");
+    }
+
+    boolean success(AbstractTaskGraph result) {
+        return super.complete(result);
+    }
+
+    boolean failure(Throwable error) {
+        return super.completeExceptionally(null == error ? new TornadoRuntimeException("Error executing task graph") : error);
+    }
+
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/AbstractTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/AbstractTaskGraph.java
@@ -41,6 +41,9 @@
  */
 package uk.ac.manchester.tornado.api;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
 
 import uk.ac.manchester.tornado.api.common.Access;
@@ -83,6 +86,12 @@ public interface AbstractTaskGraph extends ProfileInterface {
     void clearProfiles();
 
     void waitOn();
+
+    default CompletableFuture<AbstractTaskGraph> waitAsyncOn() {
+        return waitAsyncOn(ForkJoinPool.commonPool());
+    } 
+ 
+    CompletableFuture<AbstractTaskGraph> waitAsyncOn(Executor executor);
 
     void streamInInner(Object... objects);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskSchedule.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskSchedule.java
@@ -41,6 +41,9 @@
  */
 package uk.ac.manchester.tornado.api;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.common.TaskPackage;
@@ -272,8 +275,28 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     }
 
     @Override
+    public CompletableFuture<TornadoAPI> executeAsync() {
+        return selfFuture(taskScheduleImpl.schedule().waitAsyncOn());
+    }
+
+    @Override
+    public CompletableFuture<TornadoAPI> executeAsync(Executor executor) {
+        return selfFuture(taskScheduleImpl.schedule().waitAsyncOn(executor));
+    }
+
+    @Override
     public void execute(GridTask gridTask) {
         taskScheduleImpl.schedule(gridTask).waitOn();
+    }
+
+    @Override
+    public CompletableFuture<TornadoAPI> executeAsync(GridTask gridTask) {
+        return selfFuture(taskScheduleImpl.schedule(gridTask).waitAsyncOn());
+    }
+
+    @Override
+    public CompletableFuture<TornadoAPI> executeAsync(GridTask gridTask, Executor executor) {
+        return selfFuture(taskScheduleImpl.schedule(gridTask).waitAsyncOn(executor));
     }
 
     @Override
@@ -435,5 +458,9 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     @Override
     public boolean isFinished() {
         return taskScheduleImpl.isFinished();
+    }
+
+    private CompletableFuture<TornadoAPI> selfFuture(CompletableFuture<?> any) {
+        return any.thenApply(__ -> this);     
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoAPI.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoAPI.java
@@ -41,6 +41,9 @@
  */
 package uk.ac.manchester.tornado.api;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.common.TaskPackage;
@@ -603,7 +606,15 @@ public interface TornadoAPI {
      */
     void execute();
 
+    CompletableFuture<TornadoAPI> executeAsync();
+
+    CompletableFuture<TornadoAPI> executeAsync(Executor executor);
+
     void execute(GridTask gridTask);
+
+    CompletableFuture<TornadoAPI> executeAsync(GridTask gridTask);
+
+    CompletableFuture<TornadoAPI> executeAsync(GridTask gridTask, Executor executor);
 
     /**
      * Run with dynamic reconfiguration with an input policy

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
 import uk.ac.manchester.tornado.api.TornadoTargetDevice;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
+import uk.ac.manchester.tornado.api.enums.TornadoExecutionStatus;
 import uk.ac.manchester.tornado.api.mm.TornadoDeviceObjectState;
 import uk.ac.manchester.tornado.api.mm.TornadoMemoryProvider;
 
@@ -167,6 +168,10 @@ public interface TornadoDevice {
     int enqueueMarker(int[] events);
 
     void sync();
+    default void sync(TornadoExecutionHandler handler) {
+        sync();
+        handler.handle(TornadoExecutionStatus.COMPLETE, null);
+    }
 
     void flush();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoExecutionHandler.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoExecutionHandler.java
@@ -43,10 +43,6 @@ package uk.ac.manchester.tornado.api.common;
 
 import uk.ac.manchester.tornado.api.enums.TornadoExecutionStatus;
 
-public interface Event extends ProfiledAction, SynchronisationPoint {
-    default void waitOn(TornadoExecutionHandler handler) {
-        waitOn();
-        handler.handle(TornadoExecutionStatus.COMPLETE, null);
-    }
-    void waitForEvents();
+public interface TornadoExecutionHandler {
+    void handle(TornadoExecutionStatus status, Throwable deviceSpecificError);
 }


### PR DESCRIPTION
1. Root `pom.xml` is modified to use Unix `cmake.generator` on Windows (MingW64 GCC build is assumed)
2.  `CMakeLists.txt` is modified to replace `-rdynamic` with `-export-dynamic` flag (recognizable by MingW64 GCC) and to exclude any prefixes generated by MingW64 to target DLL names
3. In `opencl-jni` the file `OCLContext.cpp` is modified to use `_aligned_malloc` function instead of Unix-only `posix_memalign`
4. In `ptx-jni` the file `PTXStream.cpp` is fixed to use correct JNI types like `jint`, `jlong`, `jdouble` instead of native C types `int`, `long`, `double`
5. `tornado` in `assemby` now has no unused environment variable `EXTERNAL_DIRS` , otherwise external Java library path is set incorrectly on Windows

Signed-off-by: vsilaev <vsilaev@gmail.com>