### PR TITLE
VM-wide default driver/device for TaskSchedule.

### DIFF
--- a/assembly/src/etc/tornado.properties
+++ b/assembly/src/etc/tornado.properties
@@ -1,35 +1,32 @@
 tornado.opencl.print = false
 tornado.debug = false
 #
-# Index of the default driver (OpenCL vs PTX) used for TaskSchedule.
-# Please check output of "tornado --devices" for the correct value.
+# Index of the default TornadoVM's driver (either OpenCL or PTX backend).
+# Please, check the output of the tornado --devices command for the desired value.
 tornado.driver = 0
 #
 # Index of the default default device within default driver 
-# used for TaskSchedule.
-# Please check output of "tornado --devices" for the correct value.
+# used in the TornadoVM TaskSchedule objects.
+# Please check output of "tornado --devices" for the desired value.
 tornado.device = 0
 tornado.events.log = false
 tornado.vectors.enable = true
 tornado.kernels.parallelise = true
 tornado.opencl.gpu.block.x = 512
 #
-# Index of the default platform (like AMD, Intel, NVIDIA etc)
-# used in OpenCL-specific applications.
-# Please note that this property does not affect default driver/device
-# settings for TaskSchedule.
+# Index of the default OpenCL platform (e.g., AMD, Intel, NVIDIA, Xilinx, ARM, etc)
+# This index corresponds to the OpenCL platform level that the Operating System sees.
+# Note that this property does not affect the default driver:device setting for the TaskSchedule.
 tornado.opencl.platform = 0
 #
-# Index of the default device withing default platform
-# used in OpenCL-specific applications.
-# Please note that this property does not affect default driver/device
-# settings for TaskSchedule.
+# Index of the default OpenCL device within a selected platform.
+# This index corresponds to the OpenCL device level that the Operating System sees within an OpenCL platform.
+# Note that this property does not affect the default driver:device setting for the TaskSchedule.
 tornado.opencl.device = 0
 #
-# Index of the default device used in PTX-specific applications.
-# There is no specific corrsponding settings for the platform (unlike with OpenCL)
-# while PTX backend has a single target platform - CUDA.
-# Please note that this property does not affect default driver/device
-# settings for TaskSchedule.
+# Index of the default PTX device.
+# There is no specific setting corresponding to the PTX platform (unlike the OpenCL).
+# This is because the PTX backend has a single platform. All GPUs are groups into the same platform.
+# Note that this property does not affect the default driver/device setting for TaskSchedules.
 tornado.ptx.device = 0
 

--- a/assembly/src/etc/tornado.properties
+++ b/assembly/src/etc/tornado.properties
@@ -1,8 +1,35 @@
 tornado.opencl.print = false
 tornado.debug = false
-tornado.platform = 0
+#
+# Index of the default driver (OpenCL vs PTX) used for TaskSchedule.
+# Please check output of "tornado --devices" for the correct value.
+tornado.driver = 0
+#
+# Index of the default default device within default driver 
+# used for TaskSchedule.
+# Please check output of "tornado --devices" for the correct value.
 tornado.device = 0
 tornado.events.log = false
 tornado.vectors.enable = true
 tornado.kernels.parallelise = true
 tornado.opencl.gpu.block.x = 512
+#
+# Index of the default platform (like AMD, Intel, NVIDIA etc)
+# used in OpenCL-specific applications.
+# Please note that this property does not affect default driver/device
+# settings for TaskSchedule.
+tornado.opencl.platform = 0
+#
+# Index of the default device withing default platform
+# used in OpenCL-specific applications.
+# Please note that this property does not affect default driver/device
+# settings for TaskSchedule.
+tornado.opencl.device = 0
+#
+# Index of the default device used in PTX-specific applications.
+# There is no specific corrsponding settings for the platform (unlike with OpenCL)
+# while PTX backend has a single target platform - CUDA.
+# Please note that this property does not affect default driver/device
+# settings for TaskSchedule.
+tornado.ptx.device = 0
+

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OpenCL.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OpenCL.java
@@ -145,8 +145,8 @@ public class OpenCL {
     }
 
     public static OCLTornadoDevice defaultDevice() {
-        final int platformIndex = Integer.parseInt(Tornado.getProperty("tornado.platform", "0"));
-        final int deviceIndex = Integer.parseInt(Tornado.getProperty("tornado.device", "0"));
+        final int platformIndex = Integer.parseInt(Tornado.getProperty("tornado.opencl.platform", "0"));
+        final int deviceIndex = Integer.parseInt(Tornado.getProperty("tornado.opencl.device", "0"));
         return new OCLTornadoDevice(platformIndex, deviceIndex);
     }
 

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
@@ -78,7 +78,7 @@ public class PTX {
     }
 
     public static PTXTornadoDevice defaultDevice() {
-        final int deviceIndex = Integer.parseInt(Tornado.getProperty("tornado.device", "0"));
+        final int deviceIndex = Integer.parseInt(Tornado.getProperty("tornado.ptx.device", "0"));
         return new PTXTornadoDevice(deviceIndex);
     }
 

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -56,6 +56,9 @@ public final class Tornado implements TornadoCI {
 
     private static final String TORNADO_SDK_VARIABLE = "TORNADO_SDK";
 
+    public static final int DEFAULT_DRIVER_INDEX = Integer.parseInt(Tornado.getProperty("tornado.driver", "0"));
+    public static final int DEFAULT_DEVICE_INDEX = Integer.parseInt(Tornado.getProperty("tornado.device", "0"));
+
     public static final int PTX_BACKEND_PRIORITY = Integer.parseInt(Tornado.getProperty("tornado.ptx.priority", "1"));
     public static final int OPENCL_BACKEND_PRIORITY = Integer.parseInt(Tornado.getProperty("tornado.opencl.priority", "0"));
 

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
@@ -386,7 +386,7 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
         return numThreads;
     }
 
-    AbstractMetaData(String id, int defaultDriver, int defaultIndex) {
+    AbstractMetaData(String id, AbstractMetaData parent) {
         this.id = id;
         shouldRecompile = true;
 
@@ -395,6 +395,9 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
             int[] a = MetaDataUtils.resolveDriverDeviceIndexes(getProperty(id + ".device"));
             driverIndex = a[0];
             deviceIndex = a[1];
+        } else if (null != parent) {
+            driverIndex = parent.getDriverIndex();
+            deviceIndex = parent.getDeviceIndex();
         } else {
             driverIndex = Tornado.DEFAULT_DRIVER_INDEX;
             deviceIndex = Tornado.DEFAULT_DEVICE_INDEX;

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
@@ -61,8 +61,6 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
     private TornadoProfiler profiler;
     private GridTask gridTask;
 
-    private static final int DEFAULT_DRIVER_INDEX = 0;
-    private static final int DEFAULT_DEVICE_INDEX = 0;
     private DeviceBuffer deviceBuffer;
     private ResolvedJavaMethod graph;
     private boolean useGridScheduler;
@@ -398,8 +396,8 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
             driverIndex = a[0];
             deviceIndex = a[1];
         } else {
-            driverIndex = defaultDriver;
-            deviceIndex = defaultIndex;
+            driverIndex = Tornado.DEFAULT_DRIVER_INDEX;
+            deviceIndex = Tornado.DEFAULT_DEVICE_INDEX;
         }
 
         debugKernelArgs = parseBoolean(getDefault("debug.kernelargs", id, "True"));

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleMetaData.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleMetaData.java
@@ -25,11 +25,9 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks.meta;
 
-import uk.ac.manchester.tornado.runtime.common.Tornado;
-
 public class ScheduleMetaData extends AbstractMetaData {
 
     public ScheduleMetaData(String id) {
-        super(id, Tornado.DEFAULT_DRIVER_INDEX, Tornado.DEFAULT_DEVICE_INDEX);
+        super(id, null);
     }
 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleMetaData.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleMetaData.java
@@ -25,12 +25,11 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks.meta;
 
+import uk.ac.manchester.tornado.runtime.common.Tornado;
+
 public class ScheduleMetaData extends AbstractMetaData {
 
-    private static final int DEFAULT_DRIVER_INDEX = 0;
-    private static final int DEFAULT_DEVICE_INDEX = 0;
-
     public ScheduleMetaData(String id) {
-        super(id, DEFAULT_DRIVER_INDEX, DEFAULT_DEVICE_INDEX);
+        super(id, Tornado.DEFAULT_DRIVER_INDEX, Tornado.DEFAULT_DEVICE_INDEX);
     }
 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
@@ -62,7 +62,7 @@ public class TaskMetaData extends AbstractMetaData {
     private boolean canAssumeExact;
 
     public TaskMetaData(ScheduleMetaData scheduleMetaData, String taskID, int numParameters) {
-        super(scheduleMetaData.getId() + "." + taskID, scheduleMetaData.getDriverIndex(), scheduleMetaData.getDeviceIndex());
+        super(scheduleMetaData.getId() + "." + taskID, scheduleMetaData);
         this.scheduleMetaData = scheduleMetaData;
         this.globalSize = 0;
         this.constantSize = 0;


### PR DESCRIPTION
This update provides an option to specify default driver / device to be used for TaskSchedule when no per-task settings are present. Without this option DRIVER=0 and DEVICE=0 is always used, and it's necessary to set device for each concrete task within schedule.

The PR is related to the issue https://github.com/beehive-lab/TornadoVM/issues/58 