### PR TITLE
Fix for toString method in the VectorAPI

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double2.java
@@ -127,7 +127,7 @@ public final class Double2 implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public String toString() {
-        return toString(DoubleOps.fmt2);
+        return toString(DoubleOps.FMT_2);
     }
 
     protected static Double2 loadFromArray(final double[] array, int index) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double3.java
@@ -149,7 +149,7 @@ public final class Double3 implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public String toString() {
-        return toString(DoubleOps.fmt3);
+        return toString(DoubleOps.FMT_3);
     }
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double4.java
@@ -147,7 +147,7 @@ public final class Double4 implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public String toString() {
-        return toString(DoubleOps.fmt4);
+        return toString(DoubleOps.FMT_4);
     }
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double6.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double6.java
@@ -173,7 +173,7 @@ public final class Double6 implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public String toString() {
-        return toString(DoubleOps.fmt6);
+        return toString(DoubleOps.FMT_6);
     }
 
     public static Double6 loadFromArray(final double[] array, int index) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Double8.java
@@ -190,7 +190,7 @@ public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public String toString() {
-        return toString(DoubleOps.fmt8);
+        return toString(DoubleOps.FMT_8);
     }
 
     protected static Double8 loadFromArray(final double[] array, int index) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/DoubleOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/DoubleOps.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -10,12 +10,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -25,7 +25,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -46,16 +46,16 @@ import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 public class DoubleOps {
 
     public static final double EPSILON = 1e-7f;
-    public static final String fmt = "%.3f";
-    public static final String fmt2 = "{%.3f,%.3f}";
-    public static final String fmt3 = "{%.3f,%.3f,%.3f}";
-    public static final String fmt3e = "{%.4e,%.4e,%.4e}";
-    public static final String fmt4 = "{%.3f,%.3f,%.3f,%.3f}";
-    public static final String fmt4m = "%.3f,%.3f,%.3f,%.3f";
-    public static final String fmt4em = "%.3e,%.3e,%.3e,%.3e";
-    public static final String fmt6 = "{%.3f,%.3f,%.3f,%.3f,%.3f,%.3f}";
-    public static final String fmt8 = "{%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f}";
-    public static final String fmt6e = "{%e,%e,%e,%e,%e,%e}";
+    public static final String FMT = "%.3f";
+    public static final String FMT_2 = "{%.3f,%.3f}";
+    public static final String FMT_3 = "{%.3f,%.3f,%.3f}";
+    public static final String FMT_3_E = "{%.4e,%.4e,%.4e}";
+    public static final String FMT_4 = "{%.3f,%.3f,%.3f,%.3f}";
+    public static final String FMT_4_M = "%.3f,%.3f,%.3f,%.3f";
+    public static final String FMT_4_EM = "%.3e,%.3e,%.3e,%.3e";
+    public static final String FMT_6 = "{%.3f,%.3f,%.3f,%.3f,%.3f,%.3f}";
+    public static final String FMT_8 = "{%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f}";
+    public static final String FMT_6_E = "{%e,%e,%e,%e,%e,%e}";
 
     public static boolean compareBits(double a, double b) {
         long ai = Double.doubleToRawLongBits(a);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float2.java
@@ -127,7 +127,7 @@ public final class Float2 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public String toString() {
-        return toString(FloatOps.fmt2);
+        return toString(FloatOps.FMT_2);
     }
 
     protected static Float2 loadFromArray(final float[] array, int index) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float3.java
@@ -161,7 +161,7 @@ public final class Float3 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public String toString() {
-        return toString(FloatOps.fmt3);
+        return toString(FloatOps.FMT_3);
     }
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float4.java
@@ -147,7 +147,7 @@ public final class Float4 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public String toString() {
-        return toString(FloatOps.fmt4);
+        return toString(FloatOps.FMT_4);
     }
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float6.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float6.java
@@ -173,7 +173,7 @@ public final class Float6 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public String toString() {
-        return toString(FloatOps.fmt6);
+        return toString(FloatOps.FMT_6);
     }
 
     public static Float6 loadFromArray(final float[] array, int index) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Float8.java
@@ -190,7 +190,7 @@ public final class Float8 implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public String toString() {
-        return toString(FloatOps.fmt8);
+        return toString(FloatOps.FMT_8);
     }
 
     protected static Float8 loadFromArray(final float[] array, int index) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/FloatOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/FloatOps.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -10,12 +10,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -25,7 +25,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -46,16 +46,16 @@ import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 public class FloatOps {
 
     public static final float EPSILON = 1e-7f;
-    public static final String fmt = "%.3f";
-    public static final String fmt2 = "{%.3f,%.3f}";
-    public static final String fmt3 = "{%.3f,%.3f,%.3f}";
-    public static final String fmt3e = "{%.4e,%.4e,%.4e}";
-    public static final String fmt4 = "{%.3f,%.3f,%.3f,%.3f}";
-    public static final String fmt4m = "%.3f,%.3f,%.3f,%.3f";
-    public static final String fmt4em = "%.3e,%.3e,%.3e,%.3e";
-    public static final String fmt6 = "{%.3f,%.3f,%.3f,%.3f,%.3f,%.3f}";
-    public static final String fmt8 = "{%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f}";
-    public static final String fmt6e = "{%e,%e,%e,%e,%e,%e}";
+    public static final String FMT = "%.3f";
+    public static final String FMT_2 = "{%.3f,%.3f}";
+    public static final String FMT_3 = "{%.3f,%.3f,%.3f}";
+    public static final String FMT_3_E = "{%.4e,%.4e,%.4e}";
+    public static final String FMT_4 = "{%.3f,%.3f,%.3f,%.3f}";
+    public static final String FMT_4_M = "%.3f,%.3f,%.3f,%.3f";
+    public static final String FMT_4_EM = "%.3e,%.3e,%.3e,%.3e";
+    public static final String FMT_6 = "{%.3f,%.3f,%.3f,%.3f,%.3f,%.3f}";
+    public static final String FMT_8 = "{%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f}";
+    public static final String FMT_6_E = "{%e,%e,%e,%e,%e,%e}";
 
     public static boolean compareBits(float a, float b) {
         long ai = Float.floatToRawIntBits(a);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageByte3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageByte3.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -10,12 +10,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -25,7 +25,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -42,6 +42,7 @@
 package uk.ac.manchester.tornado.api.collections.types;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
 
@@ -69,12 +70,9 @@ public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
     /**
      * Storage format for matrix
      *
-     * @param width
-     *            number of rows
-     * @param height
-     *            number of columns
-     * @param array
-     *            array reference which contains data
+     * @param width  number of rows
+     * @param height number of columns
+     * @param array  array reference which contains data
      */
     public ImageByte3(int width, int height, byte[] array) {
         storage = array;
@@ -86,10 +84,8 @@ public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
     /**
      * Storage format for matrix
      *
-     * @param width
-     *            number of rows
-     * @param height
-     *            number of columns
+     * @param width  number of rows
+     * @param height number of columns
      */
     public ImageByte3(int width, int height) {
         this(width, height, new byte[width * height * elementSize]);
@@ -134,9 +130,7 @@ public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
     }
 
     public void fill(byte value) {
-        for (int i = 0; i < storage.length; i++) {
-            storage[i] = value;
-        }
+        Arrays.fill(storage, value);
     }
 
     public ImageByte3 duplicate() {
@@ -146,19 +140,17 @@ public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
     }
 
     public void set(ImageByte3 m) {
-        for (int i = 0; i < storage.length; i++) {
-            storage[i] = m.storage[i];
-        }
+        System.arraycopy(storage, 0, m.storage, 0, storage.length);
     }
 
     public String toString(String fmt) {
-        String str = "";
+        StringBuilder str = new StringBuilder();
         for (int i = 0; i < Y; i++) {
             for (int j = 0; j < X; j++) {
-                str += get(j, i).toString(fmt) + "\n";
+                str.append(get(j, i).toString(fmt)).append("\n");
             }
         }
-        return str;
+        return str.toString();
     }
 
     public String toString() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat.java
@@ -186,7 +186,7 @@ public class ImageFloat implements PrimitiveStorage<FloatBuffer> {
     public String toString() {
         String result = String.format("ImageFloat <%d x %d>", X, Y);
         if (Y < 16 && X < 16) {
-            result += "\n" + toString(FloatOps.fmt);
+            result += "\n" + toString(FloatOps.FMT);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat.java
@@ -167,20 +167,18 @@ public class ImageFloat implements PrimitiveStorage<FloatBuffer> {
     }
 
     public void set(ImageFloat m) {
-        for (int i = 0; i < storage.length; i++) {
-            storage[i] = m.storage[i];
-        }
+        System.arraycopy(storage, 0, m.storage, 0, storage.length);
     }
 
     public String toString(String fmt) {
-        String str = "";
+        StringBuilder str = new StringBuilder();
         for (int i = 0; i < Y; i++) {
             for (int j = 0; j < X; j++) {
-                str += String.format(fmt, get(j, i)) + " ";
+                str.append(String.format(fmt, get(j, i))).append(" ");
             }
-            str += "\n";
+            str.append("\n");
         }
-        return str;
+        return str.toString();
     }
 
     public String toString() {
@@ -199,24 +197,24 @@ public class ImageFloat implements PrimitiveStorage<FloatBuffer> {
 
     public float mean() {
         float result = 0f;
-        for (int i = 0; i < storage.length; i++) {
-            result += storage[i];
+        for (float v : storage) {
+            result += v;
         }
         return result / (float) (X * Y);
     }
 
     public float min() {
         float result = Float.MAX_VALUE;
-        for (int i = 0; i < storage.length; i++) {
-            result = Math.min(result, storage[i]);
+        for (float v : storage) {
+            result = Math.min(result, v);
         }
         return result;
     }
 
     public float max() {
         float result = Float.MIN_VALUE;
-        for (int i = 0; i < storage.length; i++) {
-            result = Math.max(result, storage[i]);
+        for (float v : storage) {
+            result = Math.max(result, v);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat3.java
@@ -42,6 +42,7 @@
 package uk.ac.manchester.tornado.api.collections.types;
 
 import java.nio.FloatBuffer;
+import java.util.Arrays;
 
 public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
 
@@ -134,9 +135,7 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public void fill(float value) {
-        for (int i = 0; i < storage.length; i++) {
-            storage[i] = value;
-        }
+        Arrays.fill(storage,value);
     }
 
     public ImageFloat3 duplicate() {
@@ -146,21 +145,19 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public void set(ImageFloat3 m) {
-        for (int i = 0; i < storage.length; i++) {
-            storage[i] = m.storage[i];
-        }
+        System.arraycopy(storage, 0, m.storage, 0, storage.length);
     }
 
     public String toString(String fmt) {
-        String str = "";
+        StringBuilder str = new StringBuilder();
 
         for (int i = 0; i < Y; i++) {
             for (int j = 0; j < X; j++) {
-                str += get(j, i).toString(fmt) + "\n";
+                str.append(get(j, i).toString(fmt)).append("\n");
             }
         }
 
-        return str;
+        return str.toString();
     }
 
     @Override
@@ -221,11 +218,7 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
 
         return Float3.sqrt(varience);
     }
-
-    public String summerise() {
-        return String.format("ImageFloat3<%dx%d>: min=%s, max=%s, mean=%s, sd=%s", X, Y, min(), max(), mean(), stdDev());
-    }
-
+    
     @Override
     public void loadFromBuffer(FloatBuffer buffer) {
         asBuffer().put(buffer);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat3.java
@@ -167,7 +167,7 @@ public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
     public String toString() {
         String result = String.format("ImageFloat3 <%d x %d>", X, Y);
         if (X <= 8 && Y <= 8) {
-            result += "\n" + toString(FloatOps.fmt3);
+            result += "\n" + toString(FloatOps.FMT_3);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat4.java
@@ -167,7 +167,7 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
     public String toString() {
         String result = String.format("ImageFloat4 <%d x %d>", X, Y);
         if (X <= 8 && Y <= 8) {
-            result += "\n" + toString(FloatOps.fmt3);
+            result += "\n" + toString(FloatOps.FMT_3);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat4.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -10,12 +10,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -25,7 +25,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -42,6 +42,7 @@
 package uk.ac.manchester.tornado.api.collections.types;
 
 import java.nio.FloatBuffer;
+import java.util.Arrays;
 
 public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
 
@@ -68,13 +69,10 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
 
     /**
      * Storage format for matrix
-     * 
-     * @param width
-     *            number of rows
-     * @param height
-     *            number of columns
-     * @param array
-     *            array reference which contains data
+     *
+     * @param width  number of rows
+     * @param height number of columns
+     * @param array  array reference which contains data
      */
     public ImageFloat4(int width, int height, float[] array) {
         storage = array;
@@ -85,11 +83,9 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
 
     /**
      * Storage format for matrix
-     * 
-     * @param width
-     *            number of rows
-     * @param height
-     *            number of column
+     *
+     * @param width  number of rows
+     * @param height number of column
      */
     public ImageFloat4(int width, int height) {
         this(width, height, new float[width * height * elementSize]);
@@ -134,9 +130,7 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public void fill(float value) {
-        for (int i = 0; i < storage.length; i++) {
-            storage[i] = value;
-        }
+        Arrays.fill(storage,value);
     }
 
     public ImageFloat4 duplicate() {
@@ -146,28 +140,26 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public void set(ImageFloat4 m) {
-        for (int i = 0; i < storage.length; i++) {
-            storage[i] = m.storage[i];
-        }
+        System.arraycopy(storage, 0, m.storage, 0, storage.length);
     }
 
     public String toString(String fmt) {
-        String str = "";
+        StringBuilder str = new StringBuilder();
 
         for (int i = 0; i < Y; i++) {
             for (int j = 0; j < X; j++) {
-                str += get(j, i).toString(fmt) + "\n";
+                str.append(get(j, i).toString(fmt)).append("\n");
             }
         }
 
-        return str;
+        return str.toString();
     }
 
     @Override
     public String toString() {
         String result = String.format("ImageFloat4 <%d x %d>", X, Y);
         if (X <= 8 && Y <= 8) {
-            result += "\n" + toString(FloatOps.FMT_3);
+            result += "\n" + toString(FloatOps.FMT_4);
         }
         return result;
     }
@@ -191,7 +183,6 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
                 result = Float4.min(result, get(col, row));
             }
         }
-
         return result;
     }
 
@@ -203,7 +194,6 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
                 result = Float4.max(result, get(col, row));
             }
         }
-
         return result;
     }
 
@@ -220,10 +210,6 @@ public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
         }
 
         return Float4.sqrt(varience);
-    }
-
-    public String summerise() {
-        return String.format("ImageFloat4<%dx%d>: min=%s, max=%s, mean=%s, sd=%s", X, Y, min(), max(), mean(), stdDev());
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ImageFloat8.java
@@ -172,7 +172,7 @@ public class ImageFloat8 implements PrimitiveStorage<FloatBuffer>, Container<Flo
     public String toString() {
         String result = String.format("ImageFloat8 <%d x %d>", X, Y);
         if (X <= 4 && Y <= 4) {
-            result += "\n" + toString(FloatOps.fmt8);
+            result += "\n" + toString(FloatOps.FMT_8);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Int4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Int4.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -10,12 +10,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -25,7 +25,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -52,25 +52,25 @@ public final class Int4 implements PrimitiveStorage<IntBuffer> {
 
     public static final Class<Int4> TYPE = Int4.class;
 
-    private static final String numberFormat = "{ x=%-7d, y=%-7d, z=%-7d, w=%-7d }";
+    private static final String NUMBER_FORMAT = "{ x=%-7d, y=%-7d, z=%-7d, w=%-7d }";
 
     /**
      * backing array
      */
     @Payload
-    final protected int[] storage;
+    protected final int[] storage;
 
     /**
      * number of elements in the storage
      */
-    final private static int numElements = 4;
+    static final private int NUM_ELEMENTS = 4;
 
     public Int4(int[] storage) {
         this.storage = storage;
     }
 
     public Int4() {
-        this(new int[numElements]);
+        this(new int[NUM_ELEMENTS]);
     }
 
     public Int4(int x, int y, int z, int w) {
@@ -157,7 +157,7 @@ public final class Int4 implements PrimitiveStorage<IntBuffer> {
 
     @Override
     public String toString() {
-        return toString(numberFormat);
+        return toString(NUMBER_FORMAT);
     }
 
     protected static Int4 loadFromArray(final int[] array, int index) {
@@ -188,7 +188,7 @@ public final class Int4 implements PrimitiveStorage<IntBuffer> {
 
     @Override
     public int size() {
-        return numElements;
+        return NUM_ELEMENTS;
     }
 
     /*

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DDouble.java
@@ -205,7 +205,7 @@ public class Matrix2DDouble implements PrimitiveStorage<DoubleBuffer> {
     public String toString() {
         String result = String.format("MatrixDouble <%d x %d>", M, N);
         if (M < 16 && N < 16) {
-            result += "\n" + toString(DoubleOps.fmt);
+            result += "\n" + toString(DoubleOps.FMT);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat.java
@@ -45,7 +45,7 @@ import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.nio.FloatBuffer.wrap;
 import static java.util.Arrays.copyOfRange;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt;
+import static uk.ac.manchester.tornado.api.collections.types.FloatOps.FMT;
 import static uk.ac.manchester.tornado.api.collections.types.StorageFormats.toRowMajor;
 
 import java.nio.FloatBuffer;
@@ -211,7 +211,7 @@ public class Matrix2DFloat implements PrimitiveStorage<FloatBuffer> {
     public String toString() {
         String result = format("MatrixFloat <%d x %d>", M, N);
         if (M < 16 && N < 16) {
-            result += "\n" + toString(fmt);
+            result += "\n" + toString(FMT);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix2DFloat4.java
@@ -219,7 +219,7 @@ public class Matrix2DFloat4 implements PrimitiveStorage<FloatBuffer> {
     public String toString() {
         String result = String.format("MatrixFloat <%d x %d>", M, N);
         if (M < 16 && N < 16) {
-            result += "\n" + toString(FloatOps.fmt);
+            result += "\n" + toString(FloatOps.FMT);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat.java
@@ -163,7 +163,7 @@ public class Matrix3DFloat implements PrimitiveStorage<FloatBuffer> {
     public String toString() {
         String result = String.format("Matrix3DFloat <%d x %d x %d>", X, Y, Z);
         if (X < 16 && Y < 16 && Z < 16) {
-            result += "\n" + toString(FloatOps.fmt);
+            result += "\n" + toString(FloatOps.FMT);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix3DFloat4.java
@@ -174,7 +174,7 @@ public class Matrix3DFloat4 implements PrimitiveStorage<FloatBuffer> {
     public String toString() {
         String result = String.format("MatrixFloat <%d x %d x %d>", X, Y, Z);
         if (X < 16 && Y < 16 && Z < 16) {
-            result += "\n" + toString(FloatOps.fmt);
+            result += "\n" + toString(FloatOps.FMT);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix4x4Float.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Matrix4x4Float.java
@@ -178,7 +178,7 @@ public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
 
     public String toString() {
         String result = String.format("MatrixFloat <%d x %d>", M, N);
-        result += "\n" + toString(FloatOps.fmt4m);
+        result += "\n" + toString(FloatOps.FMT_4_M);
         return result;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Short2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/Short2.java
@@ -127,7 +127,7 @@ public final class Short2 implements PrimitiveStorage<ShortBuffer> {
 
     @Override
     public String toString() {
-        return toString(ShortOps.fmt2);
+        return toString(ShortOps.FMT_2);
     }
 
     protected static Short2 loadFromArray(final short[] array, int index) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ShortOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/ShortOps.java
@@ -43,9 +43,9 @@ package uk.ac.manchester.tornado.api.collections.types;
 
 public class ShortOps {
 
-    public static final String fmt = "%3d";
-    public static final String fmt2 = "{%3d,%3d}";
-    public static final String fmt3 = "{%3d,%3d,%.3d}";
+    public static final String FMT = "%3d";
+    public static final String FMT_2 = "{%3d,%3d}";
+    public static final String FMT_3 = "{%3d,%3d,%.3d}";
 
     public static boolean compare(short a, short b) {
         return Short.compare(a, b) == 0;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble.java
@@ -230,7 +230,7 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
     public String toString() {
         String str = String.format("VectorDouble <%d>", numElements);
         if (numElements < 32) {
-            str += toString(DoubleOps.fmt);
+            str += toString(DoubleOps.FMT);
         }
         return str;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble2.java
@@ -7,12 +7,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -22,7 +22,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -93,7 +93,6 @@ public class VectorDouble2 implements PrimitiveStorage<DoubleBuffer> {
      * Returns the float at the given index of this vector
      *
      * @param index
-     *
      * @return value
      */
     public Double2 get(int index) {
@@ -150,29 +149,15 @@ public class VectorDouble2 implements PrimitiveStorage<DoubleBuffer> {
         return vector;
     }
 
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     *
-     * @return
-     */
-    public String toString(String fmt) {
-        String str = "";
-
-        for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
-        }
-
-        return str;
-    }
-
     public String toString() {
-        if (numElements > 4) {
-            return format("VectorDouble2 <%d>", numElements);
-        } else {
-            return toString(fmt3);
+        if (this.numElements > elementSize) {
+            return String.format("VectorDouble2 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Double2 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble2.java
@@ -41,7 +41,6 @@ package uk.ac.manchester.tornado.api.collections.types;
 import static java.lang.String.format;
 import static uk.ac.manchester.tornado.api.collections.types.Double2.add;
 import static uk.ac.manchester.tornado.api.collections.types.Double2.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
 
 import java.nio.DoubleBuffer;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble3.java
@@ -41,7 +41,6 @@ package uk.ac.manchester.tornado.api.collections.types;
 import static java.lang.String.format;
 import static uk.ac.manchester.tornado.api.collections.types.Double3.add;
 import static uk.ac.manchester.tornado.api.collections.types.Double3.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
 
 import java.nio.DoubleBuffer;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble3.java
@@ -7,12 +7,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -22,7 +22,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -93,7 +93,6 @@ public class VectorDouble3 implements PrimitiveStorage<DoubleBuffer> {
      * Returns the float at the given index of this vector
      *
      * @param index
-     *
      * @return value
      */
     public Double3 get(int index) {
@@ -154,7 +153,6 @@ public class VectorDouble3 implements PrimitiveStorage<DoubleBuffer> {
      * Prints the vector using the specified format string
      *
      * @param fmt
-     *
      * @return
      */
     public String toString(String fmt) {
@@ -168,11 +166,14 @@ public class VectorDouble3 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString() {
-        if (numElements > elementSize) {
-            return format("VectorDouble3 <%d>", numElements);
-        } else {
-            return toString(fmt3);
+        if (this.numElements > elementSize) {
+            return String.format("VectorDouble3 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Double3 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble3.java
@@ -149,22 +149,6 @@ public class VectorDouble3 implements PrimitiveStorage<DoubleBuffer> {
         return vector;
     }
 
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     * @return
-     */
-    public String toString(String fmt) {
-        String str = "";
-
-        for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
-        }
-
-        return str;
-    }
-
     public String toString() {
         if (this.numElements > elementSize) {
             return String.format("VectorDouble3 <%d>", this.numElements);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble4.java
@@ -149,22 +149,6 @@ public class VectorDouble4 implements PrimitiveStorage<DoubleBuffer> {
         return vector;
     }
 
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     * @return
-     */
-    public String toString(String fmt) {
-        String str = "";
-
-        for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
-        }
-
-        return str;
-    }
-
     public String toString() {
         if (this.numElements > elementSize) {
             return String.format("VectorDouble4 <%d>", this.numElements);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble4.java
@@ -41,7 +41,6 @@ package uk.ac.manchester.tornado.api.collections.types;
 import static java.lang.String.format;
 import static uk.ac.manchester.tornado.api.collections.types.Double4.add;
 import static uk.ac.manchester.tornado.api.collections.types.Double4.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
 
 import java.nio.DoubleBuffer;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble4.java
@@ -7,12 +7,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -22,7 +22,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -93,7 +93,6 @@ public class VectorDouble4 implements PrimitiveStorage<DoubleBuffer> {
      * Returns the float at the given index of this vector
      *
      * @param index
-     *
      * @return value
      */
     public Double4 get(int index) {
@@ -154,7 +153,6 @@ public class VectorDouble4 implements PrimitiveStorage<DoubleBuffer> {
      * Prints the vector using the specified format string
      *
      * @param fmt
-     *
      * @return
      */
     public String toString(String fmt) {
@@ -168,11 +166,14 @@ public class VectorDouble4 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString() {
-        if (numElements > elementSize) {
-            return format("VectorDouble4 <%d>", numElements);
-        } else {
-            return toString(fmt3);
+        if (this.numElements > elementSize) {
+            return String.format("VectorDouble4 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Double4 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble8.java
@@ -7,12 +7,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -22,7 +22,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -93,7 +93,6 @@ public class VectorDouble8 implements PrimitiveStorage<DoubleBuffer> {
      * Returns the float at the given index of this vector
      *
      * @param index
-     *
      * @return value
      */
     public Double8 get(int index) {
@@ -148,22 +147,6 @@ public class VectorDouble8 implements PrimitiveStorage<DoubleBuffer> {
         VectorDouble8 vector = new VectorDouble8(numElements);
         vector.set(this);
         return vector;
-    }
-
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     *
-     * @return
-     */
-    public String toString(String fmt) {
-        String str = "";
-        for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
-        }
-
-        return str;
     }
 
     public String toString() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble8.java
@@ -167,11 +167,14 @@ public class VectorDouble8 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString() {
-        if (numElements > elementSize) {
-            return format("VectorDouble8 <%d>", numElements);
-        } else {
-            return toString(fmt3);
+        if (this.numElements > elementSize) {
+            return String.format("VectorDouble8 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Double8 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble8.java
@@ -41,7 +41,6 @@ package uk.ac.manchester.tornado.api.collections.types;
 import static java.lang.String.format;
 import static uk.ac.manchester.tornado.api.collections.types.Double8.add;
 import static uk.ac.manchester.tornado.api.collections.types.Double8.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
 
 import java.nio.DoubleBuffer;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat.java
@@ -226,7 +226,7 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
     public String toString() {
         String str = String.format("VectorFloat <%d>", numElements);
         if (numElements < 32) {
-            str += toString(FloatOps.fmt);
+            str += toString(FloatOps.FMT);
         }
         return str;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat2.java
@@ -7,12 +7,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -22,7 +22,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -94,7 +94,6 @@ public class VectorFloat2 implements PrimitiveStorage<FloatBuffer> {
      * Returns the float at the given index of this vector
      *
      * @param index
-     *
      * @return value
      */
     public Float2 get(int index) {
@@ -151,29 +150,15 @@ public class VectorFloat2 implements PrimitiveStorage<FloatBuffer> {
         return vector;
     }
 
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     *
-     * @return
-     */
-    public String toString(String fmt) {
-        String str = "";
-
-        for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
-        }
-
-        return str;
-    }
-
     public String toString() {
-        if (numElements > elementSize) {
-            return format("VectorFloat2 <%d>", numElements);
-        } else {
-            return toString(fmt3);
+        if (this.numElements > elementSize) {
+            return String.format("VectorFloat2 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Float2 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat2.java
@@ -42,7 +42,6 @@ import static java.lang.String.format;
 import static java.nio.FloatBuffer.wrap;
 import static uk.ac.manchester.tornado.api.collections.types.Float2.add;
 import static uk.ac.manchester.tornado.api.collections.types.Float2.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
 
 import java.nio.FloatBuffer;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat3.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -10,12 +10,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -25,7 +25,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -59,10 +59,8 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Creates a vector using the provided backing array
      *
-     * @param numElements
-     *            Number of elements
-     * @param array
-     *            array to be copied
+     * @param numElements Number of elements
+     * @param array       array to be copied
      */
     protected VectorFloat3(int numElements, float[] array) {
         this.numElements = numElements;
@@ -83,8 +81,7 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Creates an empty vector with
      *
-     * @param numElements
-     *            Number of elements
+     * @param numElements Number of elements
      */
     public VectorFloat3(int numElements) {
         this(numElements, new float[numElements * elementSize]);
@@ -97,8 +94,7 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Returns the float at the given index of this vector
      *
-     * @param index
-     *            Position
+     * @param index Position
      * @return {@link Float3}
      */
     public Float3 get(int index) {
@@ -108,10 +104,8 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Sets the float at the given index of this vector
      *
-     * @param index
-     *            Position
-     * @param value
-     *            Value to be set
+     * @param index Position
+     * @param value Value to be set
      */
     public void set(int index, Float3 value) {
         value.storeToArray(storage, toIndex(index));
@@ -120,8 +114,7 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Sets the elements of this vector to that of the provided vector
      *
-     * @param values
-     *            set an input array into the internal array
+     * @param values set an input array into the internal array
      */
     public void set(VectorFloat3 values) {
         for (int i = 0; i < numElements; i++) {
@@ -132,8 +125,7 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Sets the elements of this vector to that of the provided array
      *
-     * @param values
-     *            set an input array into the internal array
+     * @param values set an input array into the internal array
      */
     public void set(float[] values) {
         VectorFloat3 vector = new VectorFloat3(values);
@@ -162,8 +154,7 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Prints the vector using the specified format string
      *
-     * @param fmt
-     *            String Format
+     * @param fmt String Format
      * @return String
      */
     public String toString(String fmt) {
@@ -177,11 +168,14 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public String toString() {
-        if (numElements > elementSize) {
-            return String.format("VectorFloat3 <%d>", numElements);
-        } else {
-            return toString(FloatOps.fmt3);
+        if (this.numElements > elementSize) {
+            return String.format("VectorFloat3 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Float3 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat3.java
@@ -151,22 +151,6 @@ public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
         return vector;
     }
 
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt String Format
-     * @return String
-     */
-    public String toString(String fmt) {
-        StringBuffer sb = new StringBuffer("[");
-        sb.append("[ ");
-        for (int i = 0; i < numElements; i++) {
-            sb.append(String.format(fmt, get(i)) + " ");
-        }
-        sb.append("]");
-        return sb.toString();
-    }
-
     public String toString() {
         if (this.numElements > elementSize) {
             return String.format("VectorFloat3 <%d>", this.numElements);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat4.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -10,12 +10,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -25,7 +25,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -59,10 +59,8 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Creates a vector using the provided backing array
      *
-     * @param numElements
-     *            Number of elements
-     * @param array
-     *            Array to be stored
+     * @param numElements Number of elements
+     * @param array       Array to be stored
      */
     protected VectorFloat4(int numElements, float[] array) {
         this.numElements = numElements;
@@ -79,8 +77,7 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Creates an empty vector with
      *
-     * @param numElements
-     *            Number of elements
+     * @param numElements Number of elements
      */
     public VectorFloat4(int numElements) {
         this(numElements, new float[numElements * elementSize]);
@@ -97,8 +94,7 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Returns the float at the given index of this vector
      *
-     * @param index
-     *            Position
+     * @param index Position
      * @return value
      */
     public Float4 get(int index) {
@@ -108,10 +104,8 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Sets the float at the given index of this vector
      *
-     * @param index
-     *            position
-     * @param value
-     *            value to be stored
+     * @param index position
+     * @param value value to be stored
      */
     public void set(int index, Float4 value) {
         value.storeToArray(storage, toIndex(index));
@@ -120,8 +114,7 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Sets the elements of this vector to that of the provided vector
      *
-     * @param values
-     *            set a {@link VectorFloat4} into the internal array
+     * @param values set a {@link VectorFloat4} into the internal array
      */
     public void set(VectorFloat4 values) {
         for (int i = 0; i < numElements; i++) {
@@ -132,8 +125,7 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
     /**
      * Sets the elements of this vector to that of the provided array
      *
-     * @param values
-     *            set an input array into the internal array
+     * @param values set an input array into the internal array
      */
     public void set(float[] values) {
         VectorFloat4 vector = new VectorFloat4(values);
@@ -157,23 +149,6 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
         VectorFloat4 vector = new VectorFloat4(numElements);
         vector.set(this);
         return vector;
-    }
-
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     *            String Format
-     * @return String
-     */
-    public String toString(String fmt) {
-        StringBuffer sb = new StringBuffer("[");
-        sb.append("[ ");
-        for (int i = 0; i < numElements; i++) {
-            sb.append(String.format(fmt, get(i)) + " ");
-        }
-        sb.append("]");
-        return sb.toString();
     }
 
     public String toString() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat4.java
@@ -177,11 +177,14 @@ public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public String toString() {
-        if (numElements > elementSize) {
-            return String.format("VectorFloat4 <%d>", numElements);
-        } else {
-            return toString(FloatOps.fmt4);
+        if (this.numElements > elementSize) {
+            return String.format("VectorFloat4 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Float4 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat8.java
@@ -173,11 +173,14 @@ public class VectorFloat8 implements PrimitiveStorage<FloatBuffer> {
     }
 
     public String toString() {
-        if (numElements > elementSize) {
-            return format("VectorFloat8 <%d>", numElements);
-        } else {
-            return toString(fmt4);
+        if (this.numElements > elementSize) {
+            return String.format("VectorFloat8 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Float8 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat8.java
@@ -42,11 +42,9 @@
 package uk.ac.manchester.tornado.api.collections.types;
 
 import static java.lang.String.format;
-import static java.lang.System.out;
 import static java.nio.FloatBuffer.wrap;
 import static uk.ac.manchester.tornado.api.collections.types.Float8.add;
 import static uk.ac.manchester.tornado.api.collections.types.Float8.loadFromArray;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt4;
 
 import java.nio.FloatBuffer;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat8.java
@@ -155,23 +155,6 @@ public class VectorFloat8 implements PrimitiveStorage<FloatBuffer> {
         return vector;
     }
 
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     *
-     * @return
-     */
-    public String toString(String fmt) {
-        String str = "";
-        out.printf("has %d elements\n", numElements);
-        for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
-        }
-
-        return str;
-    }
-
     public String toString() {
         if (this.numElements > elementSize) {
             return String.format("VectorFloat8 <%d>", this.numElements);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt2.java
@@ -150,29 +150,15 @@ public class VectorInt2 implements PrimitiveStorage<DoubleBuffer> {
         return vector;
     }
 
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     *
-     * @return
-     */
-    public String toString(String fmt) {
-        String str = "";
-
-        for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
-        }
-
-        return str;
-    }
-
     public String toString() {
-        if (numElements > elementSize) {
-            return format("VectorInt2 <%d>", numElements);
-        } else {
-            return toString(fmt3);
+        if (this.numElements > elementSize) {
+            return String.format("VectorInt2 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Int2 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt2.java
@@ -39,7 +39,6 @@
 package uk.ac.manchester.tornado.api.collections.types;
 
 import static java.lang.String.format;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
 import static uk.ac.manchester.tornado.api.collections.types.Int2.add;
 import static uk.ac.manchester.tornado.api.collections.types.Int2.loadFromArray;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt3.java
@@ -39,7 +39,6 @@
 package uk.ac.manchester.tornado.api.collections.types;
 
 import static java.lang.String.format;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
 import static uk.ac.manchester.tornado.api.collections.types.Int3.add;
 import static uk.ac.manchester.tornado.api.collections.types.Int3.loadFromArray;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt3.java
@@ -150,23 +150,6 @@ public class VectorInt3 implements PrimitiveStorage<DoubleBuffer> {
         return vector;
     }
 
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     *
-     * @return
-     */
-    public String toString(String fmt) {
-        String str = "";
-
-        for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
-        }
-
-        return str;
-    }
-
     public String toString() {
         if (this.numElements > elementSize) {
             return String.format("VectorInt3 <%d>", this.numElements);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt3.java
@@ -168,11 +168,14 @@ public class VectorInt3 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString() {
-        if (numElements > elementSize) {
-            return format("VectorInt3 <%d>", numElements);
-        } else {
-            return toString(fmt3);
+        if (this.numElements > elementSize) {
+            return String.format("VectorInt3 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Int3 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt4.java
@@ -150,23 +150,6 @@ public class VectorInt4 implements PrimitiveStorage<DoubleBuffer> {
         return vector;
     }
 
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     *
-     * @return
-     */
-    public String toString(String fmt) {
-        String str = "";
-
-        for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
-        }
-
-        return str;
-    }
-
     public String toString() {
         if (this.numElements > elementSize) {
             return String.format("VectorInt4 <%d>", this.numElements);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt4.java
@@ -39,7 +39,6 @@
 package uk.ac.manchester.tornado.api.collections.types;
 
 import static java.lang.String.format;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
 import static uk.ac.manchester.tornado.api.collections.types.Int4.add;
 import static uk.ac.manchester.tornado.api.collections.types.Int4.loadFromArray;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt4.java
@@ -168,11 +168,14 @@ public class VectorInt4 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString() {
-        if (numElements > elementSize) {
-            return format("VectorInt4 <%d>", numElements);
-        } else {
-            return toString(fmt3);
+        if (this.numElements > elementSize) {
+            return String.format("VectorInt4 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Int4 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt8.java
@@ -168,11 +168,14 @@ public class VectorInt8 implements PrimitiveStorage<DoubleBuffer> {
     }
 
     public String toString() {
-        if (numElements > elementSize) {
-            return format("VectorInt8 <%d>", numElements);
-        } else {
-            return toString(fmt3);
+        if (this.numElements > elementSize) {
+            return String.format("VectorInt8 <%d>", this.numElements);
         }
+        StringBuilder tempString = new StringBuilder();
+        for (int i = 0; i < numElements; i++) {
+            tempString.append(" ").append(this.get(i).toString());
+        }
+        return tempString.toString();
     }
 
     public Int8 sum() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt8.java
@@ -39,7 +39,6 @@
 package uk.ac.manchester.tornado.api.collections.types;
 
 import static java.lang.String.format;
-import static uk.ac.manchester.tornado.api.collections.types.FloatOps.fmt3;
 import static uk.ac.manchester.tornado.api.collections.types.Int8.add;
 import static uk.ac.manchester.tornado.api.collections.types.Int8.loadFromArray;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt8.java
@@ -150,22 +150,6 @@ public class VectorInt8 implements PrimitiveStorage<DoubleBuffer> {
         return vector;
     }
 
-    /**
-     * Prints the vector using the specified format string
-     *
-     * @param fmt
-     *
-     * @return
-     */
-    public String toString(String fmt) {
-        String str = "";
-
-        for (int i = 0; i < numElements; i++) {
-            str += get(i).toString() + " ";
-        }
-
-        return str;
-    }
 
     public String toString() {
         if (this.numElements > elementSize) {

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
@@ -1,25 +1,26 @@
 /*
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
  * The University of Manchester.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 
 package uk.ac.manchester.tornado.unittests.vectortypes;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.IllegalFormatConversionException;
 import java.util.Random;
 
 import org.junit.Ignore;
@@ -55,9 +56,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::dotMethodFloat2, a, b, output)
-            .streamOut(output)
-            .execute();
+                .task("t0", TestFloats::dotMethodFloat2, a, b, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         assertEquals(7, output.get(0), 0.001);
@@ -76,9 +77,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::dotMethodFloat3, a, b, output)
-            .streamOut(output)
-            .execute();        
+                .task("t0", TestFloats::dotMethodFloat3, a, b, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         assertEquals(10, output.get(0), 0.001f);
@@ -97,9 +98,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::dotMethodFloat4, a, b, output)
-            .streamOut(output)
-            .execute();
+                .task("t0", TestFloats::dotMethodFloat4, a, b, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         assertEquals(20, output.get(0), 0.001f);
@@ -118,9 +119,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::dotMethodFloat6, a, b, output)
-            .streamOut(output)
-            .execute();
+                .task("t0", TestFloats::dotMethodFloat6, a, b, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         assertEquals(56, output.get(0), 0.001f);
@@ -139,9 +140,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::dotMethodFloat8, a, b, output)
-            .streamOut(output)
-            .execute();
+                .task("t0", TestFloats::dotMethodFloat8, a, b, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         assertEquals(120, output.get(0), 0.001f);
@@ -173,9 +174,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::testFloat3Add, a, b, output)
-            .streamOut(output)
-            .execute();
+                .task("t0", TestFloats::testFloat3Add, a, b, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         for (int i = 0; i < size; i++) {
@@ -187,7 +188,7 @@ public class TestFloats extends TornadoTestBase {
 
     /**
      * Test using the {@link Float} Java Wrapper class
-     * 
+     *
      * @param a
      * @param b
      * @param result
@@ -213,9 +214,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::addFloat, a, b, output)
-            .streamOut(output)
-            .execute();
+                .task("t0", TestFloats::addFloat, a, b, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         for (int i = 0; i < size; i++) {
@@ -225,7 +226,7 @@ public class TestFloats extends TornadoTestBase {
 
     /**
      * Test using the {@link Float2} Tornado wrapper class
-     * 
+     *
      * @param a
      * @param b
      * @param result
@@ -251,9 +252,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::addFloat2, a, b, output)
-            .streamOut(output)
-            .execute();
+                .task("t0", TestFloats::addFloat2, a, b, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         for (int i = 0; i < size; i++) {
@@ -305,7 +306,7 @@ public class TestFloats extends TornadoTestBase {
 
     /**
      * Test using Tornado {@link VectorFloat3} data type
-     * 
+     *
      * @param a
      * @param b
      * @param results
@@ -318,7 +319,6 @@ public class TestFloats extends TornadoTestBase {
 
     @Test
     public void testVectorFloat3() {
-
         int size = 8;
 
         VectorFloat3 a = new VectorFloat3(size);
@@ -332,9 +332,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::addVectorFloat3, a, b, output)
-            .streamOut(output)
-            .execute();
+                .task("t0", TestFloats::addVectorFloat3, a, b, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         for (int i = 0; i < size; i++) {
@@ -345,9 +345,33 @@ public class TestFloats extends TornadoTestBase {
         }
     }
 
+
+    @Test
+    public void testVectorFloat3toString() {
+        int size = 2;
+
+        VectorFloat3 a = new VectorFloat3(size);
+        VectorFloat3 b = new VectorFloat3(size);
+        VectorFloat3 output = new VectorFloat3(size);
+
+        for (int i = 0; i < size; i++) {
+            a.set(i, new Float3(i, i, i));
+            b.set(i, new Float3((float) size - i, (float) size - i, (float) size - i));
+        }
+
+        //@formatter:off
+        new TaskSchedule("s0")
+                .task("t0", TestFloats::addVectorFloat3, a, b, output)
+                .streamOut(output)
+                .execute();
+        //@formatter:on
+
+        System.out.println(" Test Output " + output.toString());
+    }
+
     /**
      * Test using Tornado {@link VectorFloat4} data type
-     * 
+     *
      * @param a
      * @param b
      * @param results
@@ -374,9 +398,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::addVectorFloat4, a, b, output)
-            .streamOut(output)
-            .execute();
+                .task("t0", TestFloats::addVectorFloat4, a, b, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         for (int i = 0; i < size; i++) {
@@ -467,10 +491,10 @@ public class TestFloats extends TornadoTestBase {
         // Parallel computation with Tornado
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0-MAP", TestFloats::dotProductFunctionMap, a, b, outputMap)
-            .task("t1-REDUCE", TestFloats::dotProductFunctionReduce, outputMap, outputReduce)
-            .streamOut(outputReduce)
-            .execute();
+                .task("t0-MAP", TestFloats::dotProductFunctionMap, a, b, outputMap)
+                .task("t1-REDUCE", TestFloats::dotProductFunctionReduce, outputMap, outputReduce)
+                .streamOut(outputReduce)
+                .execute();
         //@formatter:on
 
         assertEquals(seqReduce[0], outputReduce[0], 0.001);
@@ -494,9 +518,9 @@ public class TestFloats extends TornadoTestBase {
 
         //@formatter:off
         new TaskSchedule("s0")
-            .task("t0", TestFloats::vectorPhiTest, input, output)
-            .streamOut(output)
-            .execute();
+                .task("t0", TestFloats::vectorPhiTest, input, output)
+                .streamOut(output)
+                .execute();
         //@formatter:on
 
         assertEquals(8.0f, output.get(0).getS0(), 0.001);


### PR DESCRIPTION
#### Description
This bug provides a fix for issue #60.
Also, provides minor refactoring by removing deprecated `toString()` methods in the VectorAPI.

#### Problem description

The issue is due to incorrect formating on  `Vector` objects available for various lengths (i.e, 2,3,4, and 8).
Previously, the `toString()` method will cause the following error:

```
Exception in thread "main" java.util.IllegalFormatConversionException: f != uk.ac.manchester.tornado.api.collections.types.Float3
	at java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4302)
	at java.util.Formatter$FormatSpecifier.printFloat(Formatter.java:2806)
	at java.util.Formatter$FormatSpecifier.print(Formatter.java:2753)
	at java.util.Formatter.format(Formatter.java:2520)
	at java.util.Formatter.format(Formatter.java:2455)
	at java.lang.String.format(String.java:2940)
	at uk.ac.manchester.tornado.api.collections.types.VectorFloat3.toString(VectorFloat3.java:175)
	at uk.ac.manchester.tornado.api.collections.types.VectorFloat3.toString(VectorFloat3.java:193)
	at uk.ac.manchester.tornado.examples.vectors.VectorAddTest.main(VectorAddTest.java:41)
```


#### Backend/s tested

- [x] OpenCL
- [x] PTX

#### OS tested

- [x] Linux
- [x] OSx
- [x] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

`make backend=opencl,ptx && tornado -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False  uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.vectortypes.TestFloats#testVectorFloat3toString
`