### PR TITLE
[fix] failing virtual devices tests when another device is selected

### DIFF
--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -54,7 +54,10 @@ public abstract class TornadoTestBase {
             }
         }
 
-        if (!wasDeviceInspected) {
+        /* Virtual devices support a single device. Therefore, it doesn't make sense to change the device even if
+           a different device is set through the 'tornado.unittests.device' property
+        */
+        if (!wasDeviceInspected && !getVirtualDeviceEnabled()) {
             Tuple2<Integer, Integer> pairDriverDevice = getDriverAndDeviceIndex();
             int driverIndex = pairDriverDevice.f0();
             if (driverIndex != 0) {
@@ -69,6 +72,10 @@ public abstract class TornadoTestBase {
             }
             wasDeviceInspected = true;
         }
+    }
+
+    private boolean getVirtualDeviceEnabled() {
+        return Boolean.parseBoolean(System.getProperty("tornado.virtual.device", "False"));
     }
 
     private Tuple2<Integer, Integer> getDriverAndDeviceIndex() {

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -54,9 +54,11 @@ public abstract class TornadoTestBase {
             }
         }
 
-        /* Virtual devices support a single device. Therefore, it doesn't make sense to change the device even if
-           a different device is set through the 'tornado.unittests.device' property
-        */
+        /*
+         * Virtual Device execution assumes an environment with a single device.
+         * Therefore, there is no need to change the device even if a different device
+         * is set through the 'tornado.unittests.device' property
+         */
         if (!wasDeviceInspected && !getVirtualDeviceEnabled()) {
             Tuple2<Integer, Integer> pairDriverDevice = getDriverAndDeviceIndex();
             int driverIndex = pairDriverDevice.f0();


### PR DESCRIPTION
Fixes virtual device tests when selecting a different physical device: `tornado-test.py --ea --verbose -J"-Dtornado.unittests.device=0:1" `

Before, we had this stacktrace:
```

2021/03/29 09:24:14
Test: class uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceKernel#testVirtualDeviceKernelCPU
	Running test: [34mtestVirtualDeviceKernelCPU[0m ................ [31m [FAILED] [0m
		\_[REASON] 1
	java.lang.ArrayIndexOutOfBoundsException: 1
	at uk.ac.manchester.tornado.drivers.opencl.OCLDriver.swapDefaultDevice(OCLDriver.java:112)
	at uk.ac.manchester.tornado.drivers.opencl.OCLDriver.setDefaultDevice(OCLDriver.java:80)
	at uk.ac.manchester.tornado.unittests.common.TornadoTestBase.before(TornadoTestBase.java:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.RunBefores.invokeMethod(RunBefores.java:33)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at uk.ac.manchester.tornado.unittests.tools.TornadoHelper.runTestVerbose(TornadoHelper.java:148)
	at uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner.main(TornadoTestRunner.java:36)

```

#### Backend/s tested

- [x] OpenCL
- [x] PTX

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [x] No
