### PR TITLE
Fixup/unit-tests/amd

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLAMDScheduler.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLAMDScheduler.java
@@ -23,6 +23,7 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl;
 
+import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class OCLAMDScheduler extends OCLKernelScheduler {
@@ -40,7 +41,15 @@ public class OCLAMDScheduler extends OCLKernelScheduler {
 
     @Override
     public int launch(OCLKernel kernel, TaskMetaData meta, int[] waitEvents, long batchThreads) {
-        return deviceContext.enqueueNDRangeKernel(kernel, meta.getDims(), meta.getGlobalOffset(), meta.getGlobalWork(), null, waitEvents);
+        if (meta.isWorkerGridAvailable()) {
+            WorkerGrid grid = meta.getWorkerGrid(meta.getId());
+            long[] global = grid.getGlobalWork();
+            long[] offset = grid.getGlobalOffset();
+            long[] local = grid.getLocalWork();
+            return deviceContext.enqueueNDRangeKernel(kernel, grid.dimension(), offset, global, local, waitEvents);
+        } else {
+            return deviceContext.enqueueNDRangeKernel(kernel, meta.getDims(), meta.getGlobalOffset(), meta.getGlobalWork(), null, waitEvents);
+        }
     }
 
     @Override

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLAMDScheduler.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLAMDScheduler.java
@@ -89,6 +89,9 @@ public class OCLAMDScheduler extends OCLKernelScheduler {
             maxBlockSize /= 4;
         }
         int value = (int) Math.min(Math.max(maxBlockSize, customBlockSize), globalWorkSize);
+        if (value == 0) {
+            return 1;
+        }
         while (globalWorkSize % value != 0) {
             value--;
         }

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
@@ -63,15 +63,15 @@ public class TestProfiler extends TornadoTestBase {
         assertTrue(ts.getTotalTime() > 0);
         assertTrue(ts.getTornadoCompilerTime() > 0);
         assertTrue(ts.getCompileTime() > 0);
-        assertTrue(ts.getDataTransfersTime() > 0);
-        assertTrue(ts.getReadTime() > 0);
-        assertTrue(ts.getWriteTime() > 0);
+        assertTrue(ts.getDataTransfersTime() >= 0);
+        assertTrue(ts.getReadTime() >= 0);
+        assertTrue(ts.getWriteTime() >= 0);
         // We do not support dispatch time on the PTX backend
         if (!"PTX".equals(TornadoRuntime.getTornadoRuntime().getDriver(driverIndex).getName())) {
             assertTrue(ts.getDispatchTime() > 0);
         }
-        assertTrue(ts.getDeviceReadTime() > 0);
-        assertTrue(ts.getDeviceWriteTime() > 0);
+        assertTrue(ts.getDeviceReadTime() >= 0);
+        assertTrue(ts.getDeviceWriteTime() >= 0);
         assertTrue(ts.getDeviceKernelTime() > 0);
 
         assertEquals(ts.getWriteTime() + ts.getReadTime(), ts.getDataTransfersTime());


### PR DESCRIPTION
#### Description
This PR aims to fix the problem with some unit-tests that fail on AMD GPUs.
In particular, it fixes the following unit-tests: 
- `TestGrid`
- `TestProfiler`
- `CodeFail`, which is expected to fail but it was failing due to an arithmetic exception in the AMDScheduler.

#### Problem description
1. The main issues were that the `AMDScheduler` class was not updated to support the Grid and GridScheduler features. This was responsible for the failure of the `TestGrid`.
2. In addition, the `TestProfiler` was failing because the value that is returned from the events  `CL_PROFILING_COMMAND_END`, `CL_PROFILING_COMMAND_START` is zero. 
These two flags are used by the OpenCL standard to return **[a 64-bit value that describes the current device time counter in nanoseconds](https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/clGetEventProfilingInfo.html)**. This was triggering the tests to fail.
From our understanding, when we execute on the AMD GPU of our server, the reporting `TOTAL_KERNEL_TIME` from the TornadoVM profiler includes also the copy_in and copy_out times for the data transfers. And the AMD driver (2766.4) returns zero for the events.
3. The third problem was that the `codeFail01` unit-test, which was triggering an arithmetic exception when running on AMD.
```
Test: class uk.ac.manchester.tornado.unittests.fails.CodeFail
	Running test: codeFail01                 ................  [FAILED] 
		\_[REASON] Bailout is disabled. 
Reason: uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException: Bailout from LAUNCH Bytecode: 
Reason: java.lang.ArithmeticException: / by zero
	uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException: Bailout is disabled. 
Reason: uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException: Bailout from LAUNCH Bytecode: 
Reason: java.lang.ArithmeticException: / by zero
```

To run all unit-tests:
```
tornado-test.py --ea --verbose -J"-Dtornado.unittests.device=0:2"
```

#### Backend/s tested

- [x] OpenCL
- [ ] PTX

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Commit id: 
AMD Driver: 2766.4
OS: Ubuntu 18.04
GPU: Radeon RX Vega gfx900

In my case, the AMD device has id 0:2.
To test this patch, run:

```
tornado -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.device=0:2 uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.profiler.TestProfiler

tornado -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.device=0:2 uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.grid.TestGrid

tornado -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.device=0:2 uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.fails.CodeFail
```