### PR TITLE
[fix] ByteBuffer in the OCL event from static to non-static

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEvent.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEvent.java
@@ -92,23 +92,19 @@ public class OCLEvent extends TornadoLogger implements Event {
 
     private static final long[] internalBuffer = new long[2];
 
-    private OCLEventsWrapper eventsWrapper;
     private OCLCommandQueue queue;
     private int localId;
     private long oclEventID;
-    private static final ByteBuffer buffer = ByteBuffer.allocate(8);
+    private final ByteBuffer buffer = ByteBuffer.allocate(8);
     private String name;
     private int status;
 
-    static {
+    OCLEvent() {
         buffer.order(OpenCL.BYTE_ORDER);
     }
 
-    OCLEvent() {
-    }
-
     OCLEvent(final OCLEventsWrapper eventsWrapper, final OCLCommandQueue queue, final int event, final long oclEventID) {
-        this.eventsWrapper = eventsWrapper;
+        this();
         this.queue = queue;
         this.localId = event;
         this.oclEventID = oclEventID;

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEvent.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEvent.java
@@ -90,7 +90,7 @@ public class OCLEvent extends TornadoLogger implements Event {
     protected static final int DESC_SYNC_BARRIER = 15;
     protected static final int EVENT_NONE = 16;
 
-    private static final long[] internalBuffer = new long[2];
+    private final long[] internalBuffer = new long[2];
 
     private OCLCommandQueue queue;
     private int localId;


### PR DESCRIPTION
Minor fix. As reported in #52, the `ByteBuffer` in `OCLEvent` should be a non-static field. 


