### PR TITLE
Unsafe access removed from TornadoVMConfig and use JVMCI metaAccessProvider instead

### DIFF
--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
@@ -39,7 +39,6 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -105,6 +104,7 @@ public class TornadoCoreRuntime extends TornadoLogger implements TornadoRuntimeC
     }
 
     private static DebugContext debugContext = null;
+
     public static DebugContext getDebugContext() {
         if (debugContext == null) {
             debugContext = new DebugContext.Builder(getOptions(), new GraalDebugHandlersFactory(new TornadoSnippetReflectionProvider())).build();
@@ -147,7 +147,7 @@ public class TornadoCoreRuntime extends TornadoLogger implements TornadoRuntimeC
         }
         vmRuntime = (HotSpotJVMCIRuntime) JVMCI.getRuntime();
         vmBackend = vmRuntime.getHostJVMCIBackend();
-        vmConfig = new TornadoVMConfig(vmRuntime.getConfigStore());
+        vmConfig = new TornadoVMConfig(vmRuntime.getConfigStore(), vmBackend.getMetaAccess());
         drivers = loadDrivers();
     }
 

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
@@ -2,9 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2020, APT Group, Department of Computer Science,
- * School of Engineering, The University of Manchester. All rights reserved.
- * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2021, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVMConfig.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVMConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2018, 2021, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -23,19 +23,14 @@
  */
 package uk.ac.manchester.tornado.runtime;
 
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
-
 import jdk.vm.ci.hotspot.HotSpotVMConfigAccess;
 import jdk.vm.ci.hotspot.HotSpotVMConfigStore;
 import jdk.vm.ci.meta.JavaKind;
-import sun.misc.Unsafe;
+import jdk.vm.ci.meta.MetaAccessProvider;
 
-@SuppressWarnings("restriction")
 public class TornadoVMConfig extends HotSpotVMConfigAccess {
 
-    TornadoVMConfig(HotSpotVMConfigStore store) {
-        super(store);
-    }
+    private MetaAccessProvider metaAccessProvider;
 
     private final boolean useCompressedClassPointers = getFlag("UseCompressedClassPointers", Boolean.class);
     private final int arrayOopDescSize = getFieldValue("CompilerToVM::Data::sizeof_arrayOopDesc", Integer.class, "int");
@@ -43,60 +38,21 @@ public class TornadoVMConfig extends HotSpotVMConfigAccess {
     private final int narrowKlassSize = getFieldValue("CompilerToVM::Data::sizeof_narrowKlass", Integer.class, "int");
     public final int instanceKlassFieldsOffset = getFieldOffset("InstanceKlass::_fields", Integer.class, "Array<u2>*");
 
+    public TornadoVMConfig(HotSpotVMConfigStore store, MetaAccessProvider metaAccessProvider) {
+        super(store);
+        this.metaAccessProvider = metaAccessProvider;
+    }
+
     public final int arrayOopDescLengthOffset() {
         return useCompressedClassPointers ? hubOffset + narrowKlassSize : arrayOopDescSize;
     }
 
     public int getArrayBaseOffset(JavaKind kind) {
-        switch (kind) {
-            case Boolean:
-                return Unsafe.ARRAY_BOOLEAN_BASE_OFFSET;
-            case Byte:
-                return Unsafe.ARRAY_BYTE_BASE_OFFSET;
-            case Char:
-                return Unsafe.ARRAY_CHAR_BASE_OFFSET;
-            case Short:
-                return Unsafe.ARRAY_SHORT_BASE_OFFSET;
-            case Int:
-                return Unsafe.ARRAY_INT_BASE_OFFSET;
-            case Long:
-                return Unsafe.ARRAY_LONG_BASE_OFFSET;
-            case Float:
-                return Unsafe.ARRAY_FLOAT_BASE_OFFSET;
-            case Double:
-                return Unsafe.ARRAY_DOUBLE_BASE_OFFSET;
-            case Object:
-                return Unsafe.ARRAY_OBJECT_BASE_OFFSET;
-            case Void:
-            case Illegal:
-            default:
-                throw shouldNotReachHere();
-        }
+        return metaAccessProvider.getArrayBaseOffset(kind);
     }
 
     public int getArrayIndexScale(JavaKind kind) {
-        switch (kind) {
-            case Boolean:
-                return Unsafe.ARRAY_BOOLEAN_INDEX_SCALE;
-            case Byte:
-                return Unsafe.ARRAY_BYTE_INDEX_SCALE;
-            case Char:
-                return Unsafe.ARRAY_CHAR_INDEX_SCALE;
-            case Short:
-                return Unsafe.ARRAY_SHORT_INDEX_SCALE;
-            case Int:
-                return Unsafe.ARRAY_INT_INDEX_SCALE;
-            case Long:
-                return Unsafe.ARRAY_LONG_INDEX_SCALE;
-            case Float:
-                return Unsafe.ARRAY_FLOAT_INDEX_SCALE;
-            case Double:
-                return Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
-            case Object:
-                return Unsafe.ARRAY_OBJECT_INDEX_SCALE;
-            default:
-                throw shouldNotReachHere();
-        }
+        return metaAccessProvider.getArrayIndexScale(kind);
     }
 
 }


### PR DESCRIPTION
Resolves #59 

#### Backend/s tested

- [X] OpenCL
- [X] PTX

JDK 8 and 11 

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make tests
```
