### PR TITLE
Runtime error when two tasks have the same name

### DIFF
--- a/assembly/src/bin/tornado-test.py
+++ b/assembly/src/bin/tornado-test.py
@@ -5,9 +5,7 @@
 # This file is part of Tornado: A heterogeneous programming framework:
 # https://github.com/beehive-lab/tornadovm
 #
-# Copyright (c) 2020, APT Group, Department of Computer Science,
-# Department of Engineering, The University of Manchester. All rights reserved.
-# Copyright (c) 2013-2019, APT Group, Department of Computer Science,
+# Copyright (c) 2013-2021, 2021 APT Group, Department of Computer Science,
 # The University of Manchester. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -86,6 +84,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.reductions.MultipleReductions"),
     TestEntry("uk.ac.manchester.tornado.unittests.bitsets.BitSetTests"),
     TestEntry("uk.ac.manchester.tornado.unittests.fails.TestFails"),
+    TestEntry("uk.ac.manchester.tornado.unittests.fails.RuntimeFail"),
     TestEntry("uk.ac.manchester.tornado.unittests.math.TestTornadoMathCollection"),
     TestEntry("uk.ac.manchester.tornado.unittests.arrays.TestNewArrays"),
     TestEntry("uk.ac.manchester.tornado.unittests.dynsize.Resize"),

--- a/assembly/src/docs/15_FAQ.md
+++ b/assembly/src/docs/15_FAQ.md
@@ -2,10 +2,12 @@
 
 ## 1. What can TornadoVM do?
 
-TornadoVM accelerates parts of your Java applications on heterogeneous hardware devices such as multicore CPUs, GPUs, and FPGAs.
+TornadoVM accelerates parts of your Java applications on heterogeneous hardware devices such as multicore CPUs, GPUs,
+and FPGAs.
 
-TornadoVM is currently being used to accelerate machine learning and deep learning applications, computer vision, physics simulations, financial applications, computational photography, natural language processing and signal processing.
-
+TornadoVM is currently being used to accelerate machine learning and deep learning applications, computer vision,
+physics simulations, financial applications, computational photography, natural language processing and signal
+processing.
 
 ## 2. How can I use it?
 
@@ -13,11 +15,12 @@ TornadoVM is currently being used to accelerate machine learning and deep learni
 
 TornadoVM can be currently executed with the following two configurations:
 
-  * TornadoVM with JDK 8 with JVMCI support: see the installation guide [here](11_INSTALL_WITH_JDK8.md).
-  * TornadoVM with GraalVM (either with JDK 8 or JDK 11): see the installation guide [here](10_INSTALL_WITH_GRAALVM.md).
-  * TornadoVM with JDK11+ (e.g. OpenJDK, Red Hat Mandrel, Amazon Corretto): see the installation guide [here](12_INSTALL_WITH_JDK11_PLUS.md).
+* TornadoVM with JDK 8 with JVMCI support: see the installation guide [here](11_INSTALL_WITH_JDK8.md).
+* TornadoVM with GraalVM (either with JDK 8 or JDK 11): see the installation guide [here](10_INSTALL_WITH_GRAALVM.md).
+* TornadoVM with JDK11+ (e.g. OpenJDK, Red Hat Mandrel, Amazon Corretto, Windows JDK 11): see the installation
+  guide [here](12_INSTALL_WITH_JDK11_PLUS.md).
 
-Note: To run TornadoVM on ARM Mali, install TornadoVM with GraalVM and JDK 11. More information [here](18_MALI.md).
+Note: To run TornadoVM on ARM Mali GPUs, install TornadoVM with GraalVM and JDK 11. More information [here](18_MALI.md).
 
 #### Usage
 
@@ -26,78 +29,84 @@ Note: To run TornadoVM on ARM Mali, install TornadoVM with GraalVM and JDK 11. M
 
 ## 3. Which programming languages does TornadoVM support?
 
-TornadoVM primarily supports Java. However, with the integration with GraalVM you can call your TornadoVM-compatible Java code through other programming languages supported by GraalVM's polyglot runtime (e.g., Python, R, Ruby, Javascript, Node.js, etc).
+TornadoVM primarily supports Java. However, with the integration with GraalVM you can call your TornadoVM-compatible
+Java code through other programming languages supported by GraalVM's polyglot runtime (e.g., Python, R, Ruby,
+Javascript, Node.js, etc).
 
-[Here](https://github.com/beehive-lab/TornadoVM/tree/master/examples/src/main/java/uk/ac/manchester/tornado/examples/polyglot) you can find examples of how to use TornadoVM with GraalVM Polyglot.
-
+[Here](https://github.com/beehive-lab/TornadoVM/tree/master/examples/src/main/java/uk/ac/manchester/tornado/examples/polyglot)
+you can find examples of how to use TornadoVM with GraalVM Polyglot.
 
 ## 4. Is TornadoVM a DSL?
 
 No, TornadoVM is not a DSL. It compiles a subset of Java code to OpenCL and PTX.
 
-The TornadoVM API only provides two Java annotations (`@Parallel` and `@Reduce`) plus a light API to create task-schedules (groups of Java methods to be accelerated by TornadoVM).
+The TornadoVM API only provides two Java annotations (`@Parallel` and `@Reduce`) plus a light API to create
+task-schedules (groups of Java methods to be accelerated by TornadoVM).
 
 ## 5. Does it support the whole Java Language?
 
-No, TornadoVM supports a subset of the Java programming language.
-A list of unsupported features along with the reasoning behind it can be found [here](Unsupported.md).
+No, TornadoVM supports a subset of the Java programming language. A list of unsupported features along with the
+reasoning behind it can be found [here](Unsupported.md).
 
 ## 6. Can TornadoVM degrade the performance of my application?
 
-No, TornadoVM can only increase the performance of your application because it can dynamically change the execution of a program at runtime onto another device.
-If a particular code segment cannot be accelerated, then execution falls back to the host JVM which will execute your code on the CPU as it would normally do.
+No, TornadoVM can only increase the performance of your application because it can dynamically change the execution of a
+program at runtime onto another device. If a particular code segment cannot be accelerated, then execution falls back to
+the host JVM which will execute your code on the CPU as it would normally do.
 
-Also with the **Dynamic Reconfiguration**, TornadoVM discovers the fastest possible device for a particular code segment completely transparently to the user.
+Also with the **Dynamic Reconfiguration**, TornadoVM discovers the fastest possible device for a particular code segment
+completely transparently to the user.
 
 ## 7. Dynamic Reconfiguration? What is this?
 
-It is a novel feature of TornadoVM, in which the user selects a metric on which the system decides how to map a specific computation on a particular device.
-Further details and instructions on how to enable this feature can be found here:
+It is a novel feature of TornadoVM, in which the user selects a metric on which the system decides how to map a specific
+computation on a particular device. Further details and instructions on how to enable this feature can be found here:
 
-* Dynamic reconfiguration: [https://dl.acm.org/doi/10.1145/3313808.3313819](https://dl.acm.org/doi/10.1145/3313808.3313819)
+* Dynamic
+  reconfiguration: [https://dl.acm.org/doi/10.1145/3313808.3313819](https://dl.acm.org/doi/10.1145/3313808.3313819)
 
-## 8. Is TornadoVM supported by a company?
+## 8. Does TornadoVM support only OpenCL devices?
 
-No, TornadoVM has been developed in the Beehive-Lab of the Advanced Processor Technology Group ([APT](http://apt.cs.manchester.ac.uk/)) at The University of Manchester.
+No. Currently, TornadoVM supports two compiler backends and therefore, it is able to generate OpenCL and PTX code
+depending on the hardware configuration.
 
+## 9. Why is it called a VM?
 
-## 9. Does TornadoVM support only OpenCL devices?
+The VM name is used because TornadoVM implements its own set of bytecodes for handling heterogeneous execution. These
+bytecodes are used for handling JIT compilation, device exploration, data management and live task-migration for
+heterogeneous devices (multi-core CPUs, GPUs, and FPGAs). We sometimes refer to a VM inside a VM (nested VM). The main
+VM is the Java Virtual Machine, and TornadoVM sits on top of that.
 
-No. Currently, TornadoVM supports two compiler backends and therefore, it is able to generate OpenCL and PTX code depending on the hardware configuration.
+You can find more information
+here: [https://dl.acm.org/doi/10.1145/3313808.3313819](https://dl.acm.org/doi/10.1145/3313808.3313819)
 
-## 10. Why is it called a VM?
+## 10. How it interacts with OpenJDK?
 
-The VM name is used because TornadoVM implements its own set of bytecodes for handling heterogeneous execution. These bytecodes are used for handling JIT compilation, device exploration, data management and live task-migration for heterogeneous devices (multi-core CPUs, GPUs, and FPGAs). We sometimes refer to a VM inside a VM (nested VM). The main VM is the Java Virtual Machine, and TornadoVM sits on top of that.
+TornadoVM makes use of the Java Virtual Machine Common Interface (JVMCI) that is included from Java 9 to compile Java
+bytecode to OpenCL C / PTX at runtime. As a JVMCI implementation, TornadoVM uses Graal (it extends the Graal IR and
+includes new backends for OpenCL C and PTX code generation).
 
-You can find more information here: [https://dl.acm.org/doi/10.1145/3313808.3313819](https://dl.acm.org/doi/10.1145/3313808.3313819)
+## 11. How do I know which parts of my application are suitable for acceleration?
 
+Workloads with for-loops that do not have dependencies between iterations are very good candidates to offload on
+accelerators. Examples of this pattern are NBody computation, Black-scholes, DFT, KMeans, etc.
 
-## 11. How it interacts with OpenJDK?
+Besides, matrix-type applications are good candidates, such as matrix-multiplication widely used in machine and deep
+learning.
 
-TornadoVM makes use of the Java Virtual Machine Common Interface (JVMCI) that is included from Java 9 to compile Java bytecode to OpenCL C / PTX at runtime. As a JVMCI implementation, TornadoVM uses Graal (it extends the Graal IR and includes new backends for OpenCL C and PTX code generation).
+## 12. How can I contribute to TornadoVM?
 
-## 12. How do I know which parts of my application are suitable for acceleration?
-Workloads with for-loops that do not have dependencies between iterations are very good candidates to offload on accelerators. Examples of this pattern are NBody computation, Black-scholes, DFT, KMeans, etc.
+TornadoVM is an open-source project, and, as such, we welcome contributions from all levels.
 
-Besides, matrix-type applications are good candidates, such as matrix-multiplication widely used in machine and deep learning.
+* **Solve [issues](https://github.com/beehive-lab/TornadoVM/issues)** reported on the Github page. 
+* **New proposals**: We welcome new proposals and ideas. To work on a new proposal, use
+  the [discussion](https://github.com/beehive-lab/TornadoVM/discussions) page on Github. Alternatively, you can open a
+  shared document (e.g., a shared Google doc) where we can discuss and analyse your proposal.
 
+[Here](https://github.com/beehive-lab/TornadoVM/blob/master/CONTRIBUTING.md) you can find more information about how to
+contribute, code conventions, and tasks.
 
-## 13. How can I contribute to TornadoVM?
+## 13. Does TornadoVM support calls to standard Java libraries?
 
-TornadoVM is an open-source project, and, as such, we welcome contributions.
-
-* Look at Github issues tagged with [good first issue](https://github.com/beehive-lab/TornadoVM/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
-* **Documentation**: you can help to improve install documentation, testing platforms, and scripts to easy deploy TornadoVM.
-* **TornadoVM use-cases**: Develop use cases that use TornadoVM for acceleration: block-chain, graphical version of NBody, filters for photography, etc.
-* **TornadoVM Development / Improvements**: If you would like to contribute to the TornadoVM internals, here is a list of pending tasks/improvements:
-
-    - Port all Python-2 scripts to Python-3.
-    - Implement a performance plot suite when running the benchmark runner. This should plot speedups against serial Java as well as stacked bars with breakdown analysis (e.g. time spent on compilation, execution, and data transfers).
-    - Port TornadoVM to Windows 10 - port bash scripts and adapt Python scripts to build with Windows 10.
-
-[Here](https://github.com/beehive-lab/TornadoVM/blob/master/CONTRIBUTING.md) you can find more information about how to contribute, code conventions, and tasks.
-
-
-## 14. Does TornadoVM support calls to standard Java libraries?
-
-Partially yes. TornadoVM currently supports calls to the Math library. However, invocations that imply I/O are not supported.
+Partially yes. TornadoVM currently supports calls to the Math library. However, invocations that imply I/O are not
+supported.

--- a/assembly/src/docs/15_FAQ.md
+++ b/assembly/src/docs/15_FAQ.md
@@ -80,7 +80,7 @@ VM is the Java Virtual Machine, and TornadoVM sits on top of that.
 You can find more information
 here: [https://dl.acm.org/doi/10.1145/3313808.3313819](https://dl.acm.org/doi/10.1145/3313808.3313819)
 
-## 10. How it interacts with OpenJDK?
+## 10. How does it interact with OpenJDK?
 
 TornadoVM makes use of the Java Virtual Machine Common Interface (JVMCI) that is included from Java 9 to compile Java
 bytecode to OpenCL C / PTX at runtime. As a JVMCI implementation, TornadoVM uses Graal (it extends the Graal IR and

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskSchedule.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskSchedule.java
@@ -41,6 +41,8 @@
  */
 package uk.ac.manchester.tornado.api;
 
+import java.util.HashSet;
+
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.common.TaskPackage;
@@ -61,6 +63,7 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task6;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task7;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task8;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task9;
+import uk.ac.manchester.tornado.api.exceptions.TornadoTaskRuntimeException;
 import uk.ac.manchester.tornado.api.profiler.ProfileInterface;
 import uk.ac.manchester.tornado.api.runtime.TornadoAPIProvider;
 
@@ -76,10 +79,19 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     private final String taskScheduleName;
     private AbstractTaskGraph taskScheduleImpl;
+    private HashSet<String> taskNames;
 
     public TaskSchedule(String name) {
         this.taskScheduleName = name;
         taskScheduleImpl = TornadoAPIProvider.loadScheduleRuntime(name);
+        taskNames = new HashSet<>();
+    }
+
+    private void checkTaskName(String id) {
+        if (taskNames.contains(id)) {
+            throw new TornadoTaskRuntimeException("Error. More than 1 task with the same task-name");
+        }
+        taskNames.add(id);
     }
 
     @Override
@@ -90,6 +102,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     @Override
     public TaskSchedule task(String id, Task code) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -97,6 +110,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     @Override
     public <T1> TaskSchedule task(String id, Task1<T1> code, T1 arg) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -104,6 +118,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     @Override
     public <T1, T2> TaskSchedule task(String id, Task2<T1, T2> code, T1 arg1, T2 arg2) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -111,6 +126,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     @Override
     public <T1, T2, T3> TaskSchedule task(String id, Task3<T1, T2, T3> code, T1 arg1, T2 arg2, T3 arg3) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -118,6 +134,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     @Override
     public <T1, T2, T3, T4> TaskSchedule task(String id, Task4<T1, T2, T3, T4> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -125,6 +142,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     @Override
     public <T1, T2, T3, T4, T5> TaskSchedule task(String id, Task5<T1, T2, T3, T4, T5> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -132,6 +150,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     @Override
     public <T1, T2, T3, T4, T5, T6> TaskSchedule task(String id, Task6<T1, T2, T3, T4, T5, T6> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -139,6 +158,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     @Override
     public <T1, T2, T3, T4, T5, T6, T7> TaskSchedule task(String id, Task7<T1, T2, T3, T4, T5, T6, T7> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -146,6 +166,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8> TaskSchedule task(String id, Task8<T1, T2, T3, T4, T5, T6, T7, T8> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -154,6 +175,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9> TaskSchedule task(String id, Task9<T1, T2, T3, T4, T5, T6, T7, T8, T9> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8,
             T9 arg9) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -162,6 +184,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> TaskSchedule task(String id, Task10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7,
             T8 arg8, T9 arg9, T10 arg10) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -170,6 +193,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> TaskSchedule task(String id, Task11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6,
             T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -178,6 +202,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> TaskSchedule task(String id, Task12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
             T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -186,6 +211,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> TornadoAPI task(String id, Task13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
             T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -194,6 +220,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> TornadoAPI task(String id, Task14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> code, T1 arg1, T2 arg2, T3 arg3,
             T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -202,6 +229,7 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> TaskSchedule task(String id, Task15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> code, T1 arg1,
             T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15) {
+        checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
         taskScheduleImpl.addTask(taskPackage);
         return this;
@@ -209,12 +237,14 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
 
     @Override
     public TaskSchedule prebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
+        checkTaskName(id);
         taskScheduleImpl.addPrebuiltTask(id, entryPoint, filename, args, accesses, device, dimensions);
         return this;
     }
 
     @Override
     public TaskSchedule prebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions, int[] atomics) {
+        checkTaskName(id);
         taskScheduleImpl.addPrebuiltTask(id, entryPoint, filename, args, accesses, device, dimensions, atomics);
         return this;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoTaskRuntimeException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoTaskRuntimeException.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * GNU Classpath is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * GNU Classpath is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Classpath; see the file COPYING.  If not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA.
+ *
+ * Linking this library statically or dynamically with other modules is
+ * making a combined work based on this library.  Thus, the terms and
+ * conditions of the GNU General Public License cover the whole
+ * combination.
+ *
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent
+ * modules, and to copy and distribute the resulting executable under
+ * terms of your choice, provided that you also meet, for each linked
+ * independent module, the terms and conditions of the license of that
+ * module.  An independent module is a module which is not derived from
+ * or based on this library.  If you modify this library, you may extend
+ * this exception to your version of the library, but you are not
+ * obligated to do so.  If you do not wish to do so, delete this
+ * exception statement from your version.
+ *
+ */
+package uk.ac.manchester.tornado.api.exceptions;
+
+public class TornadoTaskRuntimeException extends RuntimeException {
+
+    private final String message;
+    private Exception e;
+    final String RESET = "\u001B[0m";
+    final String RED = "\u001B[31m";
+
+    public TornadoTaskRuntimeException(final String msg) {
+        message = RED + msg + RESET;
+    }
+
+    public TornadoTaskRuntimeException(final String msg, Exception e) {
+        message = RED + msg + RESET;
+        this.e = e;
+    }
+
+    public Exception getException() {
+        return this.e;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -92,4 +92,5 @@ public abstract class TornadoTestBase {
             throw new PTXNotSupported("Test not supported for the PTX backend");
         }
     }
+
 }

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/RuntimeFail.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/RuntimeFail.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.fails;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.TaskSchedule;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.exceptions.TornadoTaskRuntimeException;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+public class RuntimeFail extends TornadoTestBase {
+
+    public static void vectorAdd(float[] a, float[] b, float[] c) {
+        for (@Parallel int i = 0; i < a.length; i++) {
+            c[i] = a[i] * b[i];
+        }
+    }
+
+    public static void square(float[] a) {
+        for (@Parallel int i = 0; i < a.length; i++) {
+            a[i] = a[i] * a[i];
+        }
+    }
+
+    /**
+     * This test sets the same task-name for two different tasks. This triggers an
+     * error and TornadoVM exits execution.
+     * 
+     * How to run?
+     * 
+     * <code>
+     *     tornado-test.py -V -pk --debug uk.ac.manchester.tornado.unittests.fails.RuntimeFail#test01
+     * </code>
+     */
+    @Test(expected = TornadoTaskRuntimeException.class)
+    public void test01() {
+        float[] x = new float[8192];
+        float[] y = new float[8192];
+        float[] z = new float[8192];
+
+        Arrays.fill(x, 2.0f);
+        Arrays.fill(y, 8.0f);
+
+        TaskSchedule ts = new TaskSchedule("s0") //
+                .task("t0", RuntimeFail::vectorAdd, x, y, z) //
+                .task("t0", RuntimeFail::square, z) //
+                .streamOut(z);
+        ts.execute();
+    }
+
+}


### PR DESCRIPTION
Throw an exception when at least two tasks within the same task-scheduler have the same name. 

Developers much provide a unique task-id per task within the same task-scheduler, otherwise, TornadoVM will fail to obtain the right binary from the code cache. However, prior to this PR there was no exception or help to guide the user. 

Github issue #569 (Internal)

#### OS tested

This is at the API level. So it should not matter the backend and the OS. 

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ tornado-test.py -V -pk --debug uk.ac.manchester.tornado.unittests.fails.RuntimeFail#test01
```

The test launches an exception `TornadoTaskRuntimeException` that is watched in the unit test.

