### PR TITLE
Hotfix/673/thanos

### DIFF
--- a/assembly/src/docs/6_TORNADO_FLAGS.md
+++ b/assembly/src/docs/6_TORNADO_FLAGS.md
@@ -46,10 +46,13 @@ Enable profilling for OpenCL/CUDA events such as kernel times and data tranfers.
 Enable usage of relative addresses which is a prerequisite for using DMA tranfers on Altera/Intel FPGAs. Nonetheless, this flag can be used for any OpenCL device.
 
 * ```-Dtornado.precompiled.binary=PATH```:
- Provides the location of the bistream or pre-geneared OpenCL (.cl) kernel.
+ Provides the location of the bistream or pre-generated OpenCL (.cl) kernel.
 
 * ```-Dtornado.fpga.conf.file=FILE```:
  Provides the absolute path of the FPGA configuation file.
+
+* ```-Dtornado.fpgaDumpLog=true```:
+ Dumps the log information from the HLS compilation to the command prompt.
 
 * ```-Dtornado.opencl.blocking=true```:  
 Allows to force OpenCL API blocking calls.

--- a/assembly/src/docs/7_FPGA.md
+++ b/assembly/src/docs/7_FPGA.md
@@ -128,9 +128,10 @@ DIRECTORY_BITSTREAM = fpga-source-comp/ # Specify the directory
 
 ### 1. Full JIT Mode  
 
-This mode allows the compilation and execution of a given task for the FPGA. As it provides full end-to-end execution, the compilation is expected to take up to 2 hours due HLS bistream generation process.  
+This mode allows the compilation and execution of a given task for the FPGA. As it provides full end-to-end execution, the compilation is expected to take up to 2 hours due HLS bistream generation process.
 
-The generated FPGA bitstream as well as the the generated OpenCL code can be found in the `fpga-source-comp/` directory which is place in the local directory of execution.
+The log dumps from the HLS compilation are written in the `output.log` file, and potential emerging errors in the `error.log` file.
+The compilation dumps along with the generated FPGA bitstream and the generated OpenCL code can be found in the `fpga-source-comp/` directory which is defined in the FPGA configuration file (Step 1).
 
 Example:
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -375,7 +375,7 @@ public class OCLCodeCache {
     private void invokeShellCommand(String[] command) {
         try {
             if (command != null) {
-                RuntimeUtilities.systemCall(command, true);
+                RuntimeUtilities.systemCall(command, Tornado.FPGA_DUMP_LOG, directoryBitstream);
             }
         } catch (IOException e) {
             throw new TornadoRuntimeException(e);

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
@@ -59,8 +59,8 @@ public class RuntimeUtilities {
     public static final int ONE_MEGABYTE = 1 * 1024 * 1024;
     public static final int ONE_KILOBYTE = 1 * 1024;
 
-    public static final String FPGA_OUTPUT_FILENAME = "output.log";
-    public static final String FPGA_ERROR_FILENAME = "error.log";
+    public static final String FPGA_OUTPUT_FILENAME = "outputFPGA.log";
+    public static final String FPGA_ERROR_FILENAME = "errorFPGA.log";
 
     public static long parseSize(String size) {
         if (size.endsWith("B")) {

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -93,6 +93,7 @@ public final class Tornado implements TornadoCI {
     public static final boolean ENABLE_VECTORS = Boolean.parseBoolean(settings.getProperty("tornado.vectors.enable", "True"));
     public static final boolean TORNADO_ENABLE_BIFS = Boolean.parseBoolean(settings.getProperty("tornado.bifs.enable", "False"));
     public static final boolean DEBUG = Boolean.parseBoolean(settings.getProperty("tornado.debug", "False"));
+    public static final boolean FPGA_DUMP_LOG = Boolean.parseBoolean(settings.getProperty("tornado.fpgaDumpLog", "False"));
     public static final boolean FULL_DEBUG = Boolean.parseBoolean(settings.getProperty("tornado.fullDebug", "False"));
 
     public static final boolean SHOULD_LOAD_RMI = Boolean.parseBoolean(settings.getProperty("tornado.rmi.enable", "false"));
@@ -103,7 +104,8 @@ public final class Tornado implements TornadoCI {
     private static boolean isFPGAEmulation() {
         String cl_context_emulator_device_intelfpga = System.getenv("CL_CONTEXT_EMULATOR_DEVICE_INTELFPGA");
         String cl_context_emulator_device_xilinxfpga = System.getenv("XCL_EMULATION_MODE");
-        return (cl_context_emulator_device_intelfpga != null && (cl_context_emulator_device_intelfpga.equals("1"))) || (cl_context_emulator_device_xilinxfpga != null && (cl_context_emulator_device_xilinxfpga.equals("sw_emu")));
+        return (cl_context_emulator_device_intelfpga != null && (cl_context_emulator_device_intelfpga.equals("1")))
+                || (cl_context_emulator_device_xilinxfpga != null && (cl_context_emulator_device_xilinxfpga.equals("sw_emu")));
     }
 
     public static final TornadoLogger log = new TornadoLogger(Tornado.class);


### PR DESCRIPTION
#### Description

This PR addresses an internal issue (673). This issue is that for FPGA compilation all the HLS logs and error logs are being dumped to the terminal. The proposal is to dump them in two log files that will be stored in the user-defined directory where the bitstream will be stored. 

This PR addresses the issue by writing these dumps in two files: a) `output.log` that stores all the information about HLS compilation, and b) `error.log` that stores any error coming from the HLS compilation. In addition, a new flag is introduced that can be used by users to also dump the logs in the terminal (`-Dtornado.fpgaDumpLog`).

#### Backend/s tested

- [x] OpenCL
- [ ] PTX

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [x] Yes
- [ ] No

#### How to test the new patch?

Here follows an example for compiling `DFT` for FPGA execution:
- Command that dumps the logs in terminal. The output of compilation in FPGA emulation mode: 
[dumps_in_terminal.txt](https://github.com/beehive-lab/TornadoVM/files/6349333/dumps_in_terminal.txt)

```
tornado --printKernel --debug -Dtornado.fpgaDumpLog=True -Ds0.t0.device=0:1 uk.ac.manchester.tornado.examples.dynamic.DFTDynamic 1024 default 1
```
- Command that does not dump the logs in terminal. The output of compilation in FPGA emulation mode: 
[dumps_in_file.txt](https://github.com/beehive-lab/TornadoVM/files/6349339/dumps_in_file.txt)
[output.log](https://github.com/beehive-lab/TornadoVM/files/6349340/output.log)
[error.log](https://github.com/beehive-lab/TornadoVM/files/6349341/error.log)

```
tornado --printKernel --debug -Ds0.t0.device=0:1 uk.ac.manchester.tornado.examples.dynamic.DFTDynamic 1024 default 1
```
