### PR TITLE
[CodeGen] Fix kernel name for Lambda Expressions

### DIFF
--- a/assembly/src/docs/TORNADOVM_TESTED_DRIVERS.md
+++ b/assembly/src/docs/TORNADOVM_TESTED_DRIVERS.md
@@ -21,6 +21,7 @@
 
 The following drivers have been tested on Linux >= CentOS 7.3
 
+* 21.15.19533: OK  ( OpenCL 3.0 )
 * 21.14.19498: OK  ( OpenCL 3.0 )
 * 21.13.19438: OK  ( OpenCL 3.0 )  -- This update gets Correct LookupBuffer for SPIRV kernels (experimental)
 * 21.12.19358: OK  ( OpenCL 3.0 )

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -48,13 +48,11 @@ import static uk.ac.manchester.tornado.runtime.common.Tornado.USE_SYNC_FLUSH;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.getProperty;
 
 import java.nio.ByteOrder;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
 import uk.ac.manchester.tornado.api.common.Event;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
-import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLMemFlags;
@@ -497,7 +495,15 @@ public class OCLDeviceContext extends TornadoLogger implements Initialisable, OC
         return installCode(result.getMeta(), result.getId(), result.getName(), result.getTargetCode());
     }
 
+    public static String checkKernelName(String entryPoint) {
+        if (entryPoint.contains("$")) {
+            return entryPoint.replace("$", "_");
+        }
+        return entryPoint;
+    }
+
     public OCLInstalledCode installCode(TaskMetaData meta, String id, String entryPoint, byte[] code) {
+        entryPoint = checkKernelName(entryPoint);
         return codeCache.installSource(meta, id, entryPoint, code);
     }
 
@@ -506,15 +512,18 @@ public class OCLDeviceContext extends TornadoLogger implements Initialisable, OC
     }
 
     public boolean isCached(String id, String entryPoint) {
+        entryPoint = checkKernelName(entryPoint);
         return codeCache.isCached(id + "-" + entryPoint);
     }
 
     @Override
     public boolean isCached(String methodName, SchedulableTask task) {
+        methodName = checkKernelName(methodName);
         return codeCache.isCached(task.getId() + "-" + methodName);
     }
 
     public OCLInstalledCode getInstalledCode(String id, String entryPoint) {
+        entryPoint = checkKernelName(entryPoint);
         return codeCache.getInstalledCode(id, entryPoint);
     }
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
@@ -83,6 +83,7 @@ import jdk.vm.ci.meta.ProfilingInfo;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.TriState;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
+import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.drivers.opencl.OCLTargetDescription;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLProviders;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLSuitesProvider;
@@ -435,7 +436,8 @@ public class OCLCompiler {
         OptimisticOptimizations optimisticOpts = OptimisticOptimizations.ALL;
         ProfilingInfo profilingInfo = resolvedMethod.getProfilingInfo();
 
-        OCLCompilationResult kernelCompResult = new OCLCompilationResult(task.getId(), resolvedMethod.getName(), taskMeta, backend);
+        String kernelName = OCLDeviceContext.checkKernelName(resolvedMethod.getName());
+        OCLCompilationResult kernelCompResult = new OCLCompilationResult(task.getId(), kernelName, taskMeta, backend);
         CompilationResultBuilderFactory factory = CompilationResultBuilderFactory.Default;
 
         Set<ResolvedJavaMethod> methods = new HashSet<>();
@@ -458,7 +460,8 @@ public class OCLCompiler {
             Sketch currentSketch = TornadoSketcher.lookup(currentMethod, task.meta().getDriverIndex(), task.meta().getDeviceIndex());
             final StructuredGraph graph = (StructuredGraph) currentSketch.getGraph().getMutableCopy(null);
 
-            final OCLCompilationResult compResult = new OCLCompilationResult(task.getId(), currentMethod.getName(), taskMeta, backend);
+            String subKernelName = OCLDeviceContext.checkKernelName(currentMethod.getName());
+            final OCLCompilationResult compResult = new OCLCompilationResult(task.getId(), subKernelName, taskMeta, backend);
 
             Request<OCLCompilationResult> methodCompilationRequest = new Request<>(graph, currentMethod, //
                     null, null, providers, backend, suitesProvider.getGraphBuilderSuite(), //


### PR DESCRIPTION
When using Lambdas, the `ResolvedJavaMethod` uses the `$` symbol as part of the method name. This causes a problem on AMD devices using the ROCm driver. 

This patch fixes the issue by replacing the `$` with a `_`.


#### Backend/s tested

- [x] OpenCL on AMD, NVIDIA, Intel CPU, Intel HD Graphics
- [ ] PTX

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [] Yes
- [X] No

#### How to test the new patch?

```bash
## Assuming AMD Device is in Index 0:2
$ tornado --printKernel -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.device=0:2 uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.functional.TestLambdas
```

Report using the ROCm driver: 2766.4 

```bash

==================================================
              Unit tests report 
==================================================

{'[FAILED]': 0, '[PASS]': 375}
Coverage: 100.0%

==================================================

Total Time(s): 167.080966949
```
