### PR TITLE
Support for TornadoMath functions in reductions

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFMANode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFMANode.java
@@ -34,10 +34,10 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import jdk.vm.ci.meta.Value;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLArithmeticTool;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLFPIntrinsicsNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkFloatingPointIntrinsicsNode;
 
 @NodeInfo(shortName = "OCL-FMA")
-public class OCLFMANode extends FloatingNode implements ArithmeticLIRLowerable, MarkOCLFPIntrinsicsNode {
+public class OCLFMANode extends FloatingNode implements ArithmeticLIRLowerable, MarkFloatingPointIntrinsicsNode {
 
     public static final NodeClass<OCLFMANode> TYPE = NodeClass.create(OCLFMANode.class);
 
@@ -63,5 +63,10 @@ public class OCLFMANode extends FloatingNode implements ArithmeticLIRLowerable, 
 
         OCLArithmeticTool oclArithmeticTool = (OCLArithmeticTool) gen;
         builder.setResult(this, oclArithmeticTool.emitFMAInstruction(op1, op2, op3));
+    }
+
+    @Override
+    public String getOperation() {
+        return "FMA";
     }
 }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFPBinaryIntrinsicNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFPBinaryIntrinsicNode.java
@@ -47,10 +47,10 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLArithmeticTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLBuiltinTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLFPIntrinsicsNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkFloatingPointIntrinsicsNode;
 
 @NodeInfo(nameTemplate = "{p#operation/s}")
-public class OCLFPBinaryIntrinsicNode extends BinaryNode implements ArithmeticLIRLowerable, MarkOCLFPIntrinsicsNode {
+public class OCLFPBinaryIntrinsicNode extends BinaryNode implements ArithmeticLIRLowerable, MarkFloatingPointIntrinsicsNode {
 
     protected OCLFPBinaryIntrinsicNode(ValueNode x, ValueNode y, Operation op, JavaKind kind) {
         super(TYPE, StampFactory.forKind(kind), x, y);
@@ -59,6 +59,11 @@ public class OCLFPBinaryIntrinsicNode extends BinaryNode implements ArithmeticLI
 
     public static final NodeClass<OCLFPBinaryIntrinsicNode> TYPE = NodeClass.create(OCLFPBinaryIntrinsicNode.class);
     protected final Operation operation;
+
+    @Override
+    public String getOperation() {
+        return operation.toString();
+    }
 
     // @formatter:off
     public enum Operation {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFPTernaryIntrinsicNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFPTernaryIntrinsicNode.java
@@ -48,10 +48,10 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLArithmeticTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLBuiltinTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLFPIntrinsicsNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkFloatingPointIntrinsicsNode;
 
 @NodeInfo(nameTemplate = "{p#operation/s}")
-public class OCLFPTernaryIntrinsicNode extends TernaryNode implements ArithmeticLIRLowerable, MarkOCLFPIntrinsicsNode {
+public class OCLFPTernaryIntrinsicNode extends TernaryNode implements ArithmeticLIRLowerable, MarkFloatingPointIntrinsicsNode {
 
     protected OCLFPTernaryIntrinsicNode(ValueNode x, ValueNode y, ValueNode z, Operation op, JavaKind kind) {
         super(TYPE, StampFactory.forKind(kind), x, y, z);
@@ -64,6 +64,11 @@ public class OCLFPTernaryIntrinsicNode extends TernaryNode implements Arithmetic
     @Override
     public Stamp foldStamp(Stamp stampX, Stamp stampY, Stamp stampZ) {
         return stamp(NodeView.DEFAULT);
+    }
+
+    @Override
+    public String getOperation() {
+        return operation.toString();
     }
 
     public enum Operation {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFPUnaryIntrinsicNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFPUnaryIntrinsicNode.java
@@ -49,10 +49,10 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLArithmeticTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLBuiltinTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLFPIntrinsicsNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkFloatingPointIntrinsicsNode;
 
 @NodeInfo(nameTemplate = "{p#operation/s}")
-public class OCLFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRLowerable, MarkOCLFPIntrinsicsNode {
+public class OCLFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRLowerable, MarkFloatingPointIntrinsicsNode {
 
     protected OCLFPUnaryIntrinsicNode(ValueNode value, Operation op, JavaKind kind) {
         super(TYPE, StampFactory.forKind(kind), value);
@@ -62,6 +62,11 @@ public class OCLFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
 
     public static final NodeClass<OCLFPUnaryIntrinsicNode> TYPE = NodeClass.create(OCLFPUnaryIntrinsicNode.class);
     protected final Operation operation;
+
+    @Override
+    public String getOperation() {
+        return operation.toString();
+    }
 
     // @formatter:off
     public enum Operation {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLIntBinaryIntrinsicNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLIntBinaryIntrinsicNode.java
@@ -47,10 +47,10 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLArithmeticTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLBuiltinTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLIntIntrinsicNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkIntIntrinsicNode;
 
 @NodeInfo(nameTemplate = "{p#operation/s}")
-public class OCLIntBinaryIntrinsicNode extends BinaryNode implements ArithmeticLIRLowerable, MarkOCLIntIntrinsicNode {
+public class OCLIntBinaryIntrinsicNode extends BinaryNode implements ArithmeticLIRLowerable, MarkIntIntrinsicNode {
 
     protected OCLIntBinaryIntrinsicNode(ValueNode x, ValueNode y, Operation op, JavaKind kind) {
         super(TYPE, StampFactory.forKind(kind), x, y);
@@ -59,6 +59,11 @@ public class OCLIntBinaryIntrinsicNode extends BinaryNode implements ArithmeticL
 
     public static final NodeClass<OCLIntBinaryIntrinsicNode> TYPE = NodeClass.create(OCLIntBinaryIntrinsicNode.class);
     protected final Operation operation;
+
+    @Override
+    public String getOperation() {
+        return operation.toString();
+    }
 
     //@formatter:off
     public enum Operation {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLIntTernaryIntrinsicNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLIntTernaryIntrinsicNode.java
@@ -50,10 +50,10 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLArithmeticTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLBuiltinTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLIntIntrinsicNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkIntIntrinsicNode;
 
 @NodeInfo(nameTemplate = "{p#operation/s}")
-public class OCLIntTernaryIntrinsicNode extends TernaryNode implements ArithmeticLIRLowerable, MarkOCLIntIntrinsicNode {
+public class OCLIntTernaryIntrinsicNode extends TernaryNode implements ArithmeticLIRLowerable, MarkIntIntrinsicNode {
 
     protected OCLIntTernaryIntrinsicNode(ValueNode x, ValueNode y, ValueNode z, Operation op, JavaKind kind) {
         super(TYPE, StampFactory.forKind(kind), x, y, z);
@@ -66,6 +66,11 @@ public class OCLIntTernaryIntrinsicNode extends TernaryNode implements Arithmeti
     @Override
     public Stamp foldStamp(Stamp stampX, Stamp stampY, Stamp stampZ) {
         return stamp(NodeView.DEFAULT);
+    }
+
+    @Override
+    public String getOperation() {
+        return operation.toString();
     }
 
     public enum Operation {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLIntUnaryIntrinsicNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLIntUnaryIntrinsicNode.java
@@ -44,10 +44,10 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLArithmeticTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLBuiltinTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLIntIntrinsicNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkIntIntrinsicNode;
 
 @NodeInfo(nameTemplate = "{p#operation/s}")
-public class OCLIntUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRLowerable, MarkOCLIntIntrinsicNode {
+public class OCLIntUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRLowerable, MarkIntIntrinsicNode {
 
     protected OCLIntUnaryIntrinsicNode(ValueNode x, Operation op, JavaKind kind) {
         super(TYPE, StampFactory.forKind(kind), x);
@@ -56,6 +56,11 @@ public class OCLIntUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIR
 
     public static final NodeClass<OCLIntUnaryIntrinsicNode> TYPE = NodeClass.create(OCLIntUnaryIntrinsicNode.class);
     protected final Operation operation;
+
+    @Override
+    public String getOperation() {
+        return operation.toString();
+    }
 
     public enum Operation {
         ABS, CLZ, POPCOUNT

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXFPBinaryIntrinsicNode.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXFPBinaryIntrinsicNode.java
@@ -53,10 +53,10 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXBuiltinTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLFPIntrinsicsNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkFloatingPointIntrinsicsNode;
 
 @NodeInfo(nameTemplate = "{p#operation/s}")
-public class PTXFPBinaryIntrinsicNode extends BinaryNode implements ArithmeticLIRLowerable, MarkOCLFPIntrinsicsNode {
+public class PTXFPBinaryIntrinsicNode extends BinaryNode implements ArithmeticLIRLowerable, MarkFloatingPointIntrinsicsNode {
 
     protected PTXFPBinaryIntrinsicNode(ValueNode x, ValueNode y, Operation op, JavaKind kind) {
         super(TYPE, StampFactory.forKind(kind), x, y);
@@ -65,6 +65,11 @@ public class PTXFPBinaryIntrinsicNode extends BinaryNode implements ArithmeticLI
 
     public static final NodeClass<PTXFPBinaryIntrinsicNode> TYPE = NodeClass.create(PTXFPBinaryIntrinsicNode.class);
     protected final Operation operation;
+
+    @Override
+    public String getOperation() {
+        return operation.toString();
+    }
 
     public enum Operation {
         FMAX, //

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXFPUnaryIntrinsicNode.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXFPUnaryIntrinsicNode.java
@@ -50,10 +50,10 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXArithmeticTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXBuiltinTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLFPIntrinsicsNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkFloatingPointIntrinsicsNode;
 
 @NodeInfo(nameTemplate = "{p#operation/s}")
-public class PTXFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRLowerable, MarkOCLFPIntrinsicsNode {
+public class PTXFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRLowerable, MarkFloatingPointIntrinsicsNode {
 
     protected PTXFPUnaryIntrinsicNode(ValueNode value, Operation op, JavaKind kind) {
         super(TYPE, StampFactory.forKind(kind), value);
@@ -63,6 +63,11 @@ public class PTXFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
 
     public static final NodeClass<PTXFPUnaryIntrinsicNode> TYPE = NodeClass.create(PTXFPUnaryIntrinsicNode.class);
     protected final Operation operation;
+
+    @Override
+    public String getOperation() {
+        return operation.toString();
+    }
 
     // @formatter:off
     public enum Operation {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXIntBinaryIntrinsicNode.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXIntBinaryIntrinsicNode.java
@@ -44,10 +44,10 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXArithmeticTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXBuiltinTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLIntIntrinsicNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkIntIntrinsicNode;
 
 @NodeInfo(nameTemplate = "{p#operation/s}")
-public class PTXIntBinaryIntrinsicNode extends BinaryNode implements ArithmeticLIRLowerable, MarkOCLIntIntrinsicNode {
+public class PTXIntBinaryIntrinsicNode extends BinaryNode implements ArithmeticLIRLowerable, MarkIntIntrinsicNode {
 
     protected PTXIntBinaryIntrinsicNode(ValueNode x, ValueNode y, Operation op, JavaKind kind) {
         super(TYPE, StampFactory.forKind(kind), x, y);
@@ -56,6 +56,11 @@ public class PTXIntBinaryIntrinsicNode extends BinaryNode implements ArithmeticL
 
     public static final NodeClass<PTXIntBinaryIntrinsicNode> TYPE = NodeClass.create(PTXIntBinaryIntrinsicNode.class);
     protected final Operation operation;
+
+    @Override
+    public String getOperation() {
+        return operation.toString();
+    }
 
     public enum Operation {
         MAX, //

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXIntUnaryIntrinsicNode.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXIntUnaryIntrinsicNode.java
@@ -21,9 +21,9 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
-import jdk.vm.ci.meta.JavaKind;
-import jdk.vm.ci.meta.Value;
-import jdk.vm.ci.meta.ValueKind;
+import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
+import static uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCodeGenerator.trace;
+
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.Node;
@@ -37,18 +37,19 @@ import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.UnaryNode;
 import org.graalvm.compiler.nodes.spi.ArithmeticLIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Value;
+import jdk.vm.ci.meta.ValueKind;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXArithmeticTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXBuiltinTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.graal.phases.MarkOCLIntIntrinsicNode;
-
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
-import static uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCodeGenerator.trace;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkIntIntrinsicNode;
 
 @NodeInfo(nameTemplate = "{p#operation/s}")
-public class PTXIntUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRLowerable, MarkOCLIntIntrinsicNode {
+public class PTXIntUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRLowerable, MarkIntIntrinsicNode {
 
     protected PTXIntUnaryIntrinsicNode(ValueNode x, Operation op, JavaKind kind) {
         super(TYPE, StampFactory.forKind(kind), x);
@@ -57,6 +58,11 @@ public class PTXIntUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIR
 
     public static final NodeClass<PTXIntUnaryIntrinsicNode> TYPE = NodeClass.create(PTXIntUnaryIntrinsicNode.class);
     protected final Operation operation;
+
+    @Override
+    public String getOperation() {
+        return operation.toString();
+    }
 
     public enum Operation {
         ABS, POPCOUNT

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/ReduceCodeAnalysis.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/ReduceCodeAnalysis.java
@@ -67,12 +67,6 @@ import uk.ac.manchester.tornado.runtime.graal.phases.MarkFloatingPointIntrinsics
  */
 public class ReduceCodeAnalysis {
 
-    private static final String OCL_FP_BINARY_NODE = "OCLFPBinaryIntrinsicNode";
-    private static final String OCL_INT_BINARY_NODE = "OCLIntBinaryIntrinsicNode";
-
-    private static final String PTX_FP_BINARY_NODE = "PTXFPBinaryIntrinsicNode";
-    private static final String PTX_INT_BINARY_NODE = "PTXIntBinaryIntrinsicNode";
-
     // @formatter:off
     public enum REDUCE_OPERATION {
         ADD,
@@ -120,18 +114,15 @@ public class ReduceCodeAnalysis {
                 } else {
                     throw new TornadoRuntimeException("[ERROR] Automatic reduce operation not supported yet: " + operation);
                 }
-            } else if (operation instanceof MarkFloatingPointIntrinsicsNode) {
-                String currentNodeName = operation.getClass().getName();
-                if (currentNodeName.endsWith(OCL_FP_BINARY_NODE) || currentNodeName.endsWith(PTX_FP_BINARY_NODE)) {
-                    MarkFloatingPointIntrinsicsNode mark = (MarkFloatingPointIntrinsicsNode) operation;
-                    String op = mark.getOperation();
-                    if (op.equals("FMAX")) {
-                        operations.add(REDUCE_OPERATION.MAX);
-                    } else if (op.equals("FMIN")) {
-                        operations.add(REDUCE_OPERATION.MIN);
-                    } else {
-                        throw new TornadoRuntimeException("[ERROR] Automatic reduce operation not supported yet: " + operation);
-                    }
+            } else if (operation instanceof BinaryNode && operation instanceof MarkFloatingPointIntrinsicsNode) {
+                MarkFloatingPointIntrinsicsNode mark = (MarkFloatingPointIntrinsicsNode) operation;
+                String op = mark.getOperation();
+                if (op.equals("FMAX")) {
+                    operations.add(REDUCE_OPERATION.MAX);
+                } else if (op.equals("FMIN")) {
+                    operations.add(REDUCE_OPERATION.MIN);
+                } else {
+                    throw new TornadoRuntimeException("[ERROR] Automatic reduce operation not supported yet: " + operation);
                 }
             } else {
                 throw new TornadoRuntimeException("[ERROR] Automatic reduce operation not supported yet: " + operation);

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/ReduceCodeAnalysis.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/ReduceCodeAnalysis.java
@@ -61,6 +61,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.runtime.graal.nodes.StoreAtomicIndexedNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.TornadoReduceAddNode;
 import uk.ac.manchester.tornado.runtime.graal.phases.MarkFloatingPointIntrinsicsNode;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkIntIntrinsicNode;
 
 /**
  * Code analysis class for reductions in TornadoVM.
@@ -120,6 +121,16 @@ public class ReduceCodeAnalysis {
                 if (op.equals("FMAX")) {
                     operations.add(REDUCE_OPERATION.MAX);
                 } else if (op.equals("FMIN")) {
+                    operations.add(REDUCE_OPERATION.MIN);
+                } else {
+                    throw new TornadoRuntimeException("[ERROR] Automatic reduce operation not supported yet: " + operation);
+                }
+            } else if (operation instanceof BinaryNode && operation instanceof MarkIntIntrinsicNode) {
+                MarkIntIntrinsicNode mark = (MarkIntIntrinsicNode) operation;
+                String op = mark.getOperation();
+                if (op.equals("MAX")) {
+                    operations.add(REDUCE_OPERATION.MAX);
+                } else if (op.equals("MIN")) {
                     operations.add(REDUCE_OPERATION.MIN);
                 } else {
                     throw new TornadoRuntimeException("[ERROR] Automatic reduce operation not supported yet: " + operation);

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/MarkFloatingPointIntrinsicsNode.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/MarkFloatingPointIntrinsicsNode.java
@@ -28,13 +28,6 @@ package uk.ac.manchester.tornado.runtime.graal.phases;
  * This interface is used for accessing all dedicated nodes for FP OpenCL math
  * functions outside the scope of opencl-driver package
  */
-public interface MarkFloatingPointIntrinsicsNode {
+public interface MarkFloatingPointIntrinsicsNode extends MarkIntrinsicsNode {
 
-    /**
-     * Method used to return the intrinsic operation from the driver to the runtime
-     * without breaking the dependencies.
-     * 
-     * @return String
-     */
-    String getOperation();
 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/MarkFloatingPointIntrinsicsNode.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/MarkFloatingPointIntrinsicsNode.java
@@ -28,5 +28,13 @@ package uk.ac.manchester.tornado.runtime.graal.phases;
  * This interface is used for accessing all dedicated nodes for FP OpenCL math
  * functions outside the scope of opencl-driver package
  */
-public interface MarkOCLFPIntrinsicsNode {
+public interface MarkFloatingPointIntrinsicsNode {
+
+    /**
+     * Method used to return the intrinsic operation from the driver to the runtime
+     * without breaking the dependencies.
+     * 
+     * @return String
+     */
+    String getOperation();
 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/MarkIntIntrinsicNode.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/MarkIntIntrinsicNode.java
@@ -28,5 +28,13 @@ package uk.ac.manchester.tornado.runtime.graal.phases;
  * This interface is used for accessing all dedicated nodes for Int OpenCL math
  * functions outside the scope of opencl-driver package
  */
-public interface MarkOCLIntIntrinsicNode {
+public interface MarkIntIntrinsicNode {
+
+    /**
+     * Method used to return the intrinsic operation from the driver to the runtime
+     * without breaking the dependencies.
+     *
+     * @return String
+     */
+    String getOperation();
 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/MarkIntrinsicsNode.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/MarkIntrinsicsNode.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -24,10 +24,13 @@
  */
 package uk.ac.manchester.tornado.runtime.graal.phases;
 
-/**
- * This interface is used for accessing all dedicated nodes for Int OpenCL math
- * functions outside the scope of opencl-driver package
- */
-public interface MarkIntIntrinsicNode extends MarkIntrinsicsNode {
+public interface MarkIntrinsicsNode {
 
+    /**
+     * Method used to return the intrinsic operation from the driver to the runtime
+     * without breaking the dependencies.
+     *
+     * @return String
+     */
+    String getOperation();
 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoFeatureExtraction.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoFeatureExtraction.java
@@ -118,7 +118,7 @@ public class TornadoFeatureExtraction extends Phase {
                 updateCounter(irFeatures, ProfilerCodeFeatures.F_CMP);
             } else if (node instanceof MarkFloatingPointIntrinsicsNode || node instanceof UnaryArithmeticNode) {
                 updateCounter(irFeatures, ProfilerCodeFeatures.F_MATH);
-            } else if (node instanceof MarkOCLIntIntrinsicNode) {
+            } else if (node instanceof MarkIntIntrinsicNode) {
                 updateCounter(irFeatures, ProfilerCodeFeatures.I_MATH);
             }
         }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoFeatureExtraction.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoFeatureExtraction.java
@@ -116,7 +116,7 @@ public class TornadoFeatureExtraction extends Phase {
                 updateCounter(irFeatures, ProfilerCodeFeatures.CAST);
             } else if (node instanceof FloatLessThanNode) {
                 updateCounter(irFeatures, ProfilerCodeFeatures.F_CMP);
-            } else if (node instanceof MarkOCLFPIntrinsicsNode || node instanceof UnaryArithmeticNode) {
+            } else if (node instanceof MarkFloatingPointIntrinsicsNode || node instanceof UnaryArithmeticNode) {
                 updateCounter(irFeatures, ProfilerCodeFeatures.F_MATH);
             } else if (node instanceof MarkOCLIntIntrinsicNode) {
                 updateCounter(irFeatures, ProfilerCodeFeatures.I_MATH);

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoReduceReplacement.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoReduceReplacement.java
@@ -154,7 +154,7 @@ public class TornadoReduceReplacement extends BasePhase<TornadoSketchTierContext
                 array = obtainInputArray(value.getY(), outputArray);
             }
         } else if (currentNode instanceof BinaryNode) {
-            if (currentNode instanceof MarkFloatingPointIntrinsicsNode) {
+            if (currentNode instanceof MarkIntrinsicsNode) {
                 array = obtainInputArray(((BinaryNode) currentNode).getX(), outputArray);
                 if (array == null) {
                     array = obtainInputArray(((BinaryNode) currentNode).getY(), outputArray);

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoReduceReplacement.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoReduceReplacement.java
@@ -57,12 +57,6 @@ import uk.ac.manchester.tornado.runtime.graal.nodes.TornadoReduceSubNode;
 
 public class TornadoReduceReplacement extends BasePhase<TornadoSketchTierContext> {
 
-    private static final String OCL_FP_BINARY_NODE = "OCLFPBinaryIntrinsicNode";
-    private static final String OCL_INT_BINARY_NODE = "OCLIntBinaryIntrinsicNode";
-
-    private static final String PTX_FP_BINARY_NODE = "PTXFPBinaryIntrinsicNode";
-    private static final String PTX_INT_BINARY_NODE = "PTXIntBinaryIntrinsicNode";
-
     @Override
     protected void run(StructuredGraph graph, TornadoSketchTierContext context) {
         findParametersWithReduceAnnotations(graph);
@@ -146,7 +140,6 @@ public class TornadoReduceReplacement extends BasePhase<TornadoSketchTierContext
             this.inputArray = inputArray;
             this.startNode = startNode;
         }
-
     }
 
     private ValueNode obtainInputArray(ValueNode currentNode, ValueNode outputArray) {
@@ -161,8 +154,7 @@ public class TornadoReduceReplacement extends BasePhase<TornadoSketchTierContext
                 array = obtainInputArray(value.getY(), outputArray);
             }
         } else if (currentNode instanceof BinaryNode) {
-            String currentNodeName = currentNode.getClass().getName();
-            if (currentNodeName.endsWith(OCL_FP_BINARY_NODE) || currentNodeName.endsWith(PTX_FP_BINARY_NODE)) {
+            if (currentNode instanceof MarkFloatingPointIntrinsicsNode) {
                 array = obtainInputArray(((BinaryNode) currentNode).getX(), outputArray);
                 if (array == null) {
                     array = obtainInputArray(((BinaryNode) currentNode).getY(), outputArray);
@@ -205,8 +197,7 @@ public class TornadoReduceReplacement extends BasePhase<TornadoSketchTierContext
 
             // We need to compare with the name because it is loaded from inner core
             // (tornado-driver).
-            String storeValueName = storeValue.getClass().getName();
-            if (storeValueName.endsWith(OCL_FP_BINARY_NODE) || storeValueName.endsWith(PTX_FP_BINARY_NODE)) {
+            if (storeValue instanceof MarkFloatingPointIntrinsicsNode) {
                 accumulator = ((BinaryNode) storeValue).getY();
                 // TODO: Control getX case
             } else {
@@ -245,9 +236,9 @@ public class TornadoReduceReplacement extends BasePhase<TornadoSketchTierContext
                 arithmeticNode = reduce.getX();
             } else if (reduce.getY() instanceof BinaryArithmeticNode) {
                 arithmeticNode = reduce.getY();
-            } else if (reduce.getX().getClass().getName().endsWith(OCL_FP_BINARY_NODE) || reduce.getX().getClass().getName().endsWith(PTX_FP_BINARY_NODE)) {
+            } else if (reduce.getX() instanceof MarkFloatingPointIntrinsicsNode) {
                 arithmeticNode = reduce.getX();
-            } else if (reduce.getY().getClass().getName().endsWith(OCL_FP_BINARY_NODE) || reduce.getY().getClass().getName().endsWith(PTX_FP_BINARY_NODE)) {
+            } else if (reduce.getY() instanceof MarkFloatingPointIntrinsicsNode) {
                 arithmeticNode = reduce.getY();
             }
         }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoReduceReplacement.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoReduceReplacement.java
@@ -197,7 +197,7 @@ public class TornadoReduceReplacement extends BasePhase<TornadoSketchTierContext
 
             // We need to compare with the name because it is loaded from inner core
             // (tornado-driver).
-            if (storeValue instanceof MarkFloatingPointIntrinsicsNode) {
+            if (storeValue instanceof MarkFloatingPointIntrinsicsNode || storeValue instanceof MarkIntIntrinsicNode) {
                 accumulator = ((BinaryNode) storeValue).getY();
                 // TODO: Control getX case
             } else {

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsDoubles.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsDoubles.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.annotations.Reduce;
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.unittests.common.TornadoNotSupported;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
@@ -269,7 +270,7 @@ public class TestReductionsDoubles extends TornadoTestBase {
 
     private static void maxReductionAnnotation(double[] input, @Reduce double[] result) {
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.max(result[0], input[i]);
+            result[0] = TornadoMath.max(result[0], input[i]);
         }
     }
 
@@ -302,7 +303,7 @@ public class TestReductionsDoubles extends TornadoTestBase {
 
     private static void minReductionAnnotation(double[] input, @Reduce double[] result) {
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.min(result[0], input[i]);
+            result[0] = TornadoMath.min(result[0], input[i]);
         }
     }
 
@@ -334,7 +335,7 @@ public class TestReductionsDoubles extends TornadoTestBase {
     }
 
     private static void tornadoRemoveOutliers(final double[] values, @Reduce double[] result) {
-        final double sqrt = Math.sqrt(12.2321 / values.length);
+        final double sqrt = TornadoMath.sqrt(12.2321 / values.length);
         final double min = result[0] - (2 * sqrt);
         final double max = result[0] + (2 * sqrt);
 
@@ -415,7 +416,7 @@ public class TestReductionsDoubles extends TornadoTestBase {
     private static void computeStandardDeviation(final double[] values, final double[] sum, @Reduce final double[] std) {
         final double s = sum[0] / values.length;
         for (@Parallel int i = 0; i < values.length; i++) {
-            std[0] += Math.pow(values[i] - s, 2);
+            std[0] += TornadoMath.pow(values[i] - s, 2);
         }
     }
 
@@ -513,7 +514,7 @@ public class TestReductionsDoubles extends TornadoTestBase {
     private static void maxReductionAnnotation2(double[] input, @Reduce double[] result, double neutral) {
         result[0] = neutral;
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.max(result[0], input[i] * 100);
+            result[0] = TornadoMath.max(result[0], input[i] * 100);
         }
     }
 
@@ -545,7 +546,7 @@ public class TestReductionsDoubles extends TornadoTestBase {
     private static void minReductionAnnotation2(double[] input, @Reduce double[] result, double neutral) {
         result[0] = neutral;
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.min(result[0], input[i] * 50);
+            result[0] = TornadoMath.min(result[0], input[i] * 50);
         }
     }
 

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
@@ -368,7 +368,6 @@ public class TestReductionsFloats extends TornadoTestBase {
 
     private static void maxReductionAnnotation(float[] input, @Reduce float[] result) {
         for (@Parallel int i = 0; i < input.length; i++) {
-            // result[0] = Math.max(result[0], input[i]);
             result[0] = TornadoMath.max(result[0], input[i]);
         }
     }

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.annotations.Reduce;
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 public class TestReductionsFloats extends TornadoTestBase {
@@ -367,7 +368,8 @@ public class TestReductionsFloats extends TornadoTestBase {
 
     private static void maxReductionAnnotation(float[] input, @Reduce float[] result) {
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.max(result[0], input[i]);
+            // result[0] = Math.max(result[0], input[i]);
+            result[0] = TornadoMath.max(result[0], input[i]);
         }
     }
 

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
@@ -338,7 +338,7 @@ public class TestReductionsFloats extends TornadoTestBase {
     private static void computePi(float[] input, @Reduce float[] result) {
         result[0] = 0.0f;
         for (@Parallel int i = 1; i < input.length; i++) {
-            float value = input[i] + (float) (Math.pow(-1, i + 1) / (2 * i - 1));
+            float value = input[i] + (float) (TornadoMath.pow(-1, i + 1) / (2 * i - 1));
             result[0] += value;
         }
     }
@@ -398,7 +398,7 @@ public class TestReductionsFloats extends TornadoTestBase {
 
     private static void maxReductionAnnotation2(float[] input, @Reduce float[] result) {
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.max(result[0], input[i] * 100);
+            result[0] = TornadoMath.max(result[0], input[i] * 100);
         }
     }
 
@@ -429,7 +429,7 @@ public class TestReductionsFloats extends TornadoTestBase {
     private static void minReductionAnnotation(float[] input, @Reduce float[] result, float neutral) {
         result[0] = neutral;
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.min(result[0], input[i]);
+            result[0] = TornadoMath.min(result[0], input[i]);
         }
     }
 
@@ -461,7 +461,7 @@ public class TestReductionsFloats extends TornadoTestBase {
     private static void minReductionAnnotation2(float[] input, @Reduce float[] result, float neutral) {
         result[0] = neutral;
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.min(result[0], input[i] * 50);
+            result[0] = TornadoMath.min(result[0], input[i] * 50);
         }
     }
 

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsIntegers.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsIntegers.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.annotations.Reduce;
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 public class TestReductionsIntegers extends TornadoTestBase {
@@ -205,7 +206,7 @@ public class TestReductionsIntegers extends TornadoTestBase {
     private static void maxReductionAnnotation(int[] input, @Reduce int[] result, int neutral) {
         result[0] = neutral;
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.max(result[0], input[i]);
+            result[0] = TornadoMath.max(result[0], input[i]);
         }
     }
 
@@ -239,7 +240,7 @@ public class TestReductionsIntegers extends TornadoTestBase {
 
     private static void minReductionAnnotation(int[] input, @Reduce int[] result) {
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.min(result[0], input[i]);
+            result[0] = TornadoMath.min(result[0], input[i]);
         }
     }
 
@@ -570,7 +571,7 @@ public class TestReductionsIntegers extends TornadoTestBase {
     private static void maxReductionAnnotation2(int[] input, @Reduce int[] result, int neutral) {
         result[0] = neutral;
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.max(result[0], input[i] * 100);
+            result[0] = TornadoMath.max(result[0], input[i] * 100);
         }
     }
 
@@ -602,7 +603,7 @@ public class TestReductionsIntegers extends TornadoTestBase {
     private static void minReductionAnnotation2(int[] input, @Reduce int[] result, int neutral) {
         result[0] = neutral;
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.min(result[0], input[i] * 50);
+            result[0] = TornadoMath.min(result[0], input[i] * 50);
         }
     }
 

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsLong.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsLong.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.annotations.Reduce;
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 public class TestReductionsLong extends TornadoTestBase {
@@ -100,7 +101,7 @@ public class TestReductionsLong extends TornadoTestBase {
 
     private static void maxReductionAnnotation(long[] input, @Reduce long[] result) {
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.max(result[0], input[i]);
+            result[0] = TornadoMath.max(result[0], input[i]);
         }
     }
 
@@ -133,7 +134,7 @@ public class TestReductionsLong extends TornadoTestBase {
 
     private static void minReductionAnnotation(long[] input, @Reduce long[] result) {
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.min(result[0], input[i]);
+            result[0] = TornadoMath.min(result[0], input[i]);
         }
     }
 
@@ -163,7 +164,7 @@ public class TestReductionsLong extends TornadoTestBase {
     private static void maxReductionAnnotation2(long[] input, @Reduce long[] result) {
         result[0] = Long.MIN_VALUE + 1;
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.max(result[0], input[i] * 2);
+            result[0] = TornadoMath.max(result[0], input[i] * 2);
         }
     }
 
@@ -192,7 +193,7 @@ public class TestReductionsLong extends TornadoTestBase {
 
     private static void minReductionAnnotation2(long[] input, @Reduce long[] result) {
         for (@Parallel int i = 0; i < input.length; i++) {
-            result[0] = Math.min(result[0], input[i] * 50);
+            result[0] = TornadoMath.min(result[0], input[i] * 50);
         }
     }
 

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/tornadovmcontext/reductions/TestReductionsDoublesTornadoVMContext.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/tornadovmcontext/reductions/TestReductionsDoublesTornadoVMContext.java
@@ -28,6 +28,7 @@ import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.TornadoVMContext;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -194,7 +195,7 @@ public class TestReductionsDoublesTornadoVMContext extends TornadoTestBase {
     public static double computeMaxSequential(double[] input) {
         double acc = 0;
         for (double v : input) {
-            acc = Math.max(acc, v);
+            acc = TornadoMath.max(acc, v);
         }
         return acc;
     }
@@ -208,7 +209,7 @@ public class TestReductionsDoublesTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                a[id] = Math.max(a[id], a[id + stride]);
+                a[id] = TornadoMath.max(a[id], a[id + stride]);
             }
         }
         if (localIdx == 0) {
@@ -241,7 +242,7 @@ public class TestReductionsDoublesTornadoVMContext extends TornadoTestBase {
         // Final SUM
         double finalSum = 0;
         for (double v : reduce) {
-            finalSum = Math.max(finalSum, v);
+            finalSum = TornadoMath.max(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -258,7 +259,7 @@ public class TestReductionsDoublesTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                localA[localIdx] = Math.max(localA[localIdx], localA[localIdx + stride]);
+                localA[localIdx] = TornadoMath.max(localA[localIdx], localA[localIdx + stride]);
             }
         }
         if (localIdx == 0) {
@@ -291,7 +292,7 @@ public class TestReductionsDoublesTornadoVMContext extends TornadoTestBase {
         // Final SUM
         double finalSum = 0;
         for (double v : reduce) {
-            finalSum = Math.max(finalSum, v);
+            finalSum = TornadoMath.max(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -300,7 +301,7 @@ public class TestReductionsDoublesTornadoVMContext extends TornadoTestBase {
     public static double computeMinSequential(double[] input) {
         double acc = 0;
         for (double v : input) {
-            acc = Math.min(acc, v);
+            acc = TornadoMath.min(acc, v);
         }
         return acc;
     }
@@ -314,7 +315,7 @@ public class TestReductionsDoublesTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                a[id] = Math.min(a[id], a[id + stride]);
+                a[id] = TornadoMath.min(a[id], a[id + stride]);
             }
         }
         if (localIdx == 0) {
@@ -347,7 +348,7 @@ public class TestReductionsDoublesTornadoVMContext extends TornadoTestBase {
         // Final SUM
         double finalSum = 0;
         for (double v : reduce) {
-            finalSum = Math.min(finalSum, v);
+            finalSum = TornadoMath.min(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -364,7 +365,7 @@ public class TestReductionsDoublesTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                localA[localIdx] = Math.min(localA[localIdx], localA[localIdx + stride]);
+                localA[localIdx] = TornadoMath.min(localA[localIdx], localA[localIdx + stride]);
             }
         }
         if (localIdx == 0) {
@@ -397,7 +398,7 @@ public class TestReductionsDoublesTornadoVMContext extends TornadoTestBase {
         // Final SUM
         double finalSum = 0;
         for (double v : reduce) {
-            finalSum = Math.min(finalSum, v);
+            finalSum = TornadoMath.min(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/tornadovmcontext/reductions/TestReductionsFloatsTornadoVMContext.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/tornadovmcontext/reductions/TestReductionsFloatsTornadoVMContext.java
@@ -28,6 +28,7 @@ import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.TornadoVMContext;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -148,7 +149,7 @@ public class TestReductionsFloatsTornadoVMContext extends TornadoTestBase {
     public static float computeMaxSequential(float[] input) {
         float acc = 0;
         for (float v : input) {
-            acc = Math.max(acc, v);
+            acc = TornadoMath.max(acc, v);
         }
         return acc;
     }
@@ -162,7 +163,7 @@ public class TestReductionsFloatsTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                a[id] = Math.max(a[id], a[id + stride]);
+                a[id] = TornadoMath.max(a[id], a[id + stride]);
             }
         }
         if (localIdx == 0) {
@@ -195,7 +196,7 @@ public class TestReductionsFloatsTornadoVMContext extends TornadoTestBase {
         // Final SUM
         float finalSum = 0;
         for (float v : reduce) {
-            finalSum = Math.max(finalSum, v);
+            finalSum = TornadoMath.max(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -212,7 +213,7 @@ public class TestReductionsFloatsTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                localA[localIdx] = Math.max(localA[localIdx], localA[localIdx + stride]);
+                localA[localIdx] = TornadoMath.max(localA[localIdx], localA[localIdx + stride]);
             }
         }
         if (localIdx == 0) {
@@ -245,7 +246,7 @@ public class TestReductionsFloatsTornadoVMContext extends TornadoTestBase {
         // Final SUM
         float finalSum = 0;
         for (float v : reduce) {
-            finalSum = Math.max(finalSum, v);
+            finalSum = TornadoMath.max(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -254,7 +255,7 @@ public class TestReductionsFloatsTornadoVMContext extends TornadoTestBase {
     public static float computeMinSequential(float[] input) {
         float acc = 0;
         for (float v : input) {
-            acc = Math.min(acc, v);
+            acc = TornadoMath.min(acc, v);
         }
         return acc;
     }
@@ -268,7 +269,7 @@ public class TestReductionsFloatsTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                a[id] = Math.min(a[id], a[id + stride]);
+                a[id] = TornadoMath.min(a[id], a[id + stride]);
             }
         }
         if (localIdx == 0) {
@@ -301,7 +302,7 @@ public class TestReductionsFloatsTornadoVMContext extends TornadoTestBase {
         // Final SUM
         float finalSum = 0;
         for (float v : reduce) {
-            finalSum = Math.min(finalSum, v);
+            finalSum = TornadoMath.min(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -318,7 +319,7 @@ public class TestReductionsFloatsTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                localA[localIdx] = Math.min(localA[localIdx], localA[localIdx + stride]);
+                localA[localIdx] = TornadoMath.min(localA[localIdx], localA[localIdx + stride]);
             }
         }
         if (localIdx == 0) {
@@ -351,7 +352,7 @@ public class TestReductionsFloatsTornadoVMContext extends TornadoTestBase {
         // Final SUM
         float finalSum = 0;
         for (float v : reduce) {
-            finalSum = Math.min(finalSum, v);
+            finalSum = TornadoMath.min(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/tornadovmcontext/reductions/TestReductionsIntegersTornadoVMContext.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/tornadovmcontext/reductions/TestReductionsIntegersTornadoVMContext.java
@@ -28,6 +28,7 @@ import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.TornadoVMContext;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -148,7 +149,7 @@ public class TestReductionsIntegersTornadoVMContext extends TornadoTestBase {
     public static int computeMaxSequential(int[] input) {
         int acc = 0;
         for (int v : input) {
-            acc = Math.max(acc, v);
+            acc = TornadoMath.max(acc, v);
         }
         return acc;
     }
@@ -162,7 +163,7 @@ public class TestReductionsIntegersTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                a[id] = Math.max(a[id], a[id + stride]);
+                a[id] = TornadoMath.max(a[id], a[id + stride]);
             }
         }
         if (localIdx == 0) {
@@ -195,7 +196,7 @@ public class TestReductionsIntegersTornadoVMContext extends TornadoTestBase {
         // Final SUM
         int finalSum = 0;
         for (int v : reduce) {
-            finalSum = Math.max(finalSum, v);
+            finalSum = TornadoMath.max(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -212,7 +213,7 @@ public class TestReductionsIntegersTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                localA[localIdx] = Math.max(localA[localIdx], localA[localIdx + stride]);
+                localA[localIdx] = TornadoMath.max(localA[localIdx], localA[localIdx + stride]);
             }
         }
         if (localIdx == 0) {
@@ -245,7 +246,7 @@ public class TestReductionsIntegersTornadoVMContext extends TornadoTestBase {
         // Final SUM
         int finalSum = 0;
         for (int v : reduce) {
-            finalSum = Math.max(finalSum, v);
+            finalSum = TornadoMath.max(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -254,7 +255,7 @@ public class TestReductionsIntegersTornadoVMContext extends TornadoTestBase {
     public static int computeMinSequential(int[] input) {
         int acc = 0;
         for (int v : input) {
-            acc = Math.min(acc, v);
+            acc = TornadoMath.min(acc, v);
         }
         return acc;
     }
@@ -268,7 +269,7 @@ public class TestReductionsIntegersTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                a[id] = Math.min(a[id], a[id + stride]);
+                a[id] = TornadoMath.min(a[id], a[id + stride]);
             }
         }
         if (localIdx == 0) {
@@ -301,7 +302,7 @@ public class TestReductionsIntegersTornadoVMContext extends TornadoTestBase {
         // Final SUM
         int finalSum = 0;
         for (int v : reduce) {
-            finalSum = Math.min(finalSum, v);
+            finalSum = TornadoMath.min(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -318,7 +319,7 @@ public class TestReductionsIntegersTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                localA[localIdx] = Math.min(localA[localIdx], localA[localIdx + stride]);
+                localA[localIdx] = TornadoMath.min(localA[localIdx], localA[localIdx + stride]);
             }
         }
         if (localIdx == 0) {
@@ -351,7 +352,7 @@ public class TestReductionsIntegersTornadoVMContext extends TornadoTestBase {
         // Final SUM
         int finalSum = 0;
         for (int v : reduce) {
-            finalSum = Math.min(finalSum, v);
+            finalSum = TornadoMath.min(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/tornadovmcontext/reductions/TestReductionsLongTornadoVMContext.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/tornadovmcontext/reductions/TestReductionsLongTornadoVMContext.java
@@ -28,6 +28,7 @@ import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.TornadoVMContext;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -149,7 +150,7 @@ public class TestReductionsLongTornadoVMContext extends TornadoTestBase {
     public static long computeMaxSequential(long[] input) {
         long acc = 0;
         for (long v : input) {
-            acc = Math.max(acc, v);
+            acc = TornadoMath.max(acc, v);
         }
         return acc;
     }
@@ -163,7 +164,7 @@ public class TestReductionsLongTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                a[id] = Math.max(a[id], a[id + stride]);
+                a[id] = TornadoMath.max(a[id], a[id + stride]);
             }
         }
         if (localIdx == 0) {
@@ -196,7 +197,7 @@ public class TestReductionsLongTornadoVMContext extends TornadoTestBase {
         // Final SUM
         long finalSum = 0;
         for (long v : reduce) {
-            finalSum = Math.max(finalSum, v);
+            finalSum = TornadoMath.max(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -213,7 +214,7 @@ public class TestReductionsLongTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                localA[localIdx] = Math.max(localA[localIdx], localA[localIdx + stride]);
+                localA[localIdx] = TornadoMath.max(localA[localIdx], localA[localIdx + stride]);
             }
         }
         if (localIdx == 0) {
@@ -246,7 +247,7 @@ public class TestReductionsLongTornadoVMContext extends TornadoTestBase {
         // Final SUM
         long finalSum = 0;
         for (long v : reduce) {
-            finalSum = Math.max(finalSum, v);
+            finalSum = TornadoMath.max(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -255,7 +256,7 @@ public class TestReductionsLongTornadoVMContext extends TornadoTestBase {
     public static long computeMinSequential(long[] input) {
         long acc = 0;
         for (long v : input) {
-            acc = Math.min(acc, v);
+            acc = TornadoMath.min(acc, v);
         }
         return acc;
     }
@@ -269,7 +270,7 @@ public class TestReductionsLongTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                a[id] = Math.min(a[id], a[id + stride]);
+                a[id] = TornadoMath.min(a[id], a[id + stride]);
             }
         }
         if (localIdx == 0) {
@@ -302,7 +303,7 @@ public class TestReductionsLongTornadoVMContext extends TornadoTestBase {
         // Final SUM
         long finalSum = 0;
         for (long v : reduce) {
-            finalSum = Math.min(finalSum, v);
+            finalSum = TornadoMath.min(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);
@@ -319,7 +320,7 @@ public class TestReductionsLongTornadoVMContext extends TornadoTestBase {
         for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
             context.localBarrier();
             if (localIdx < stride) {
-                localA[localIdx] = Math.min(localA[localIdx], localA[localIdx + stride]);
+                localA[localIdx] = TornadoMath.min(localA[localIdx], localA[localIdx + stride]);
             }
         }
         if (localIdx == 0) {
@@ -352,7 +353,7 @@ public class TestReductionsLongTornadoVMContext extends TornadoTestBase {
         // Final SUM
         long finalSum = 0;
         for (long v : reduce) {
-            finalSum = Math.min(finalSum, v);
+            finalSum = TornadoMath.min(finalSum, v);
         }
 
         assertEquals(sequential, finalSum, 0);


### PR DESCRIPTION
TornadoMath functions supported in reduce operations. TornadoVM math
provides operations for floats and doubles, avoiding typecasting in the
OpenCL/PTX code.

This PR solves issue #79 (Public)

#### Backend/s tested

- [X] OpenCL
- [X] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ tornado-test.py -V -pk --debug uk.ac.manchester.tornado.unittests.reductions.TestReductionsFloats#testMaxReduction
```
