### PR TITLE
Remove redundant parameter table from the PTXLIRGenerator

### DIFF
--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
@@ -221,7 +221,6 @@ public class PTXBackend extends TornadoBackend<PTXProviders> implements FrameMap
         emitPrintfPrototype(crb);
         if (crb.isKernel()) {
             emitKernelFunction(asm, crb.compilationResult.getName());
-            emitParamVariableDefs(asm, lirGenRes);
             emitVariableDefs(asm, lirGenRes);
         } else {
             emitFunctionHeader(asm, method, lirGenRes);
@@ -289,18 +288,6 @@ public class PTXBackend extends TornadoBackend<PTXProviders> implements FrameMap
 
     private void emitKernelFunction(PTXAssembler asm, String methodName) {
         asm.emitLine("%s %s %s(%s) {", PTXAssemblerConstants.EXTERNALLY_VISIBLE, PTXAssemblerConstants.KERNEL_ENTRYPOINT, methodName, architecture.getABI());
-    }
-
-    private void emitParamVariableDefs(PTXAssembler asm, PTXLIRGenerationResult lirGenRes) {
-        Map<PTXKind, Set<Variable>> kindToVariable = lirGenRes.getParamTable();
-
-        for (PTXKind type : kindToVariable.keySet()) {
-            Set<Variable> vars = kindToVariable.get(type);
-            if (vars.size() != 0) {
-                asm.emitLine("\t.param .%s %sParam<%d>;", type, type.getRegisterTypeString(), vars.size() + 1);
-            }
-        }
-
     }
 
     private void emitVariableDefs(PTXAssembler asm, PTXLIRGenerationResult lirGenRes) {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXLIRGenerationResult.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXLIRGenerationResult.java
@@ -51,14 +51,12 @@ public class PTXLIRGenerationResult extends LIRGenerationResult {
     }
 
     private final Map<PTXKind, Set<VariableData>> variableTable;
-    private final Map<PTXKind, Set<Variable>> paramTable;
     private final Map<PTXKind, Variable> returnVariables;
 
     public PTXLIRGenerationResult(CompilationIdentifier identifier, LIR lir, FrameMapBuilder frameMapBuilder, RegisterAllocationConfig registerAllocationConfig, CallingConvention callingConvention) {
         super(identifier, lir, frameMapBuilder, registerAllocationConfig, callingConvention);
 
         variableTable = new HashMap<>();
-        paramTable = new HashMap<>();
         returnVariables = new HashMap<>();
     }
 
@@ -73,18 +71,6 @@ public class PTXLIRGenerationResult extends LIRGenerationResult {
 
     public Map<PTXKind, Set<VariableData>> getVariableTable() {
         return variableTable;
-    }
-
-    public int insertParameterAndGetIndex(Variable var) {
-        guarantee(var.getPlatformKind() instanceof PTXKind, "invalid variable kind %s", var.getValueKind());
-        PTXKind kind = (PTXKind) var.getPlatformKind();
-
-        paramTable.computeIfAbsent(kind, k -> new HashSet<>()).add(var);
-        return paramTable.get(kind).size() - 1;
-    }
-
-    public Map<PTXKind, Set<Variable>> getParamTable() {
-        return paramTable;
     }
 
     public void setReturnVariable(Variable var) {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXLIRGenerator.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXLIRGenerator.java
@@ -77,8 +77,8 @@ import static uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt.ExprStmt
 import static uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCodeGenerator.trace;
 
 public class PTXLIRGenerator extends LIRGenerator {
-    private PTXGenTool ptxGenTool;
-    private PTXBuiltinTool ptxBuiltinTool;
+    private final PTXGenTool ptxGenTool;
+    private final PTXBuiltinTool ptxBuiltinTool;
 
     private final Map<String, Variable> parameterAllocations;
 
@@ -407,26 +407,6 @@ public class PTXLIRGenerator extends LIRGenerator {
         } else {
             var.setName(kind.getRegisterTypeString() + indexForType);
         }
-
-        return var;
-    }
-
-    public Variable newParamVariable(ValueKind<?> lirKind) {
-        PlatformKind pk = lirKind.getPlatformKind();
-        ValueKind<?> actualLIRKind = lirKind;
-        PTXKind kind = PTXKind.ILLEGAL;
-        if (pk instanceof PTXKind) {
-            kind = (PTXKind) pk;
-        } else {
-            shouldNotReachHere();
-        }
-
-        final Variable var = super.newVariable(actualLIRKind);
-        trace("newParamVariable: %s <- %s (%s)", var.toString(), actualLIRKind.toString(), actualLIRKind.getClass().getName());
-
-        PTXLIRGenerationResult res = (PTXLIRGenerationResult) getResult();
-        int indexForType = res.insertParameterAndGetIndex(var);
-        var.setName(kind.getRegisterTypeString() + "Param" + indexForType);
 
         return var;
     }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PrintfNode.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PrintfNode.java
@@ -78,8 +78,6 @@ public class PrintfNode extends FixedWithNextNode implements LIRLowerable, Itera
         PTXLIRGenerator genTool = (PTXLIRGenerator) gen.getLIRGeneratorTool();
 
         Value stack = gen.operand(argumentStack);
-        Variable formatParam = genTool.newParamVariable(LIRKind.value(PTXKind.B64));
-        Variable stackParam = genTool.newParamVariable(LIRKind.value(PTXKind.B64));
 
         Value[] globalIDs = new Value[3];
         globalIDs[0] = gen.operand(xDim);
@@ -95,14 +93,13 @@ public class PrintfNode extends FixedWithNextNode implements LIRLowerable, Itera
         genTool.append(new PTXLIRStmt.StoreStmt(
                 new PTXUnary.MemoryAccess(PTXArchitecture.localSpace, stack, new ConstantValue(LIRKind.value(PTXKind.S32), JavaConstant.forInt(2 * PTXKind.S32.getSizeInBytes()))), globalIDs[2]));
 
-        Variable globalAddr = genTool.newVariable(LIRKind.value(PTXKind.B64));
-        genTool.append(new PTXLIRStmt.ConvertAddressStmt(globalAddr, format, PTXMemorySpace.GLOBAL));
-        genTool.append(new PTXLIRStmt.StoreStmt(new PTXUnary.MemoryAccess(PTXArchitecture.paramSpace, formatParam, null), globalAddr));
+        Variable globalAddrFormat = genTool.newVariable(LIRKind.value(PTXKind.B64));
+        Variable globalAddrStack = genTool.newVariable(LIRKind.value(PTXKind.B64));
+        genTool.append(new PTXLIRStmt.ConvertAddressStmt(globalAddrFormat, format, PTXMemorySpace.GLOBAL));
 
-        genTool.append(new PTXLIRStmt.ConvertAddressStmt(globalAddr, stack, PTXMemorySpace.LOCAL));
-        genTool.append(new PTXLIRStmt.StoreStmt(new PTXUnary.MemoryAccess(PTXArchitecture.paramSpace, stackParam, null), globalAddr));
+        genTool.append(new PTXLIRStmt.ConvertAddressStmt(globalAddrStack, stack, PTXMemorySpace.LOCAL));
 
-        genTool.append(new PTXLIRStmt.ExprStmt(new PTXPrintf(formatParam, stackParam)));
+        genTool.append(new PTXLIRStmt.ExprStmt(new PTXPrintf(globalAddrFormat, globalAddrStack)));
     }
 
 }


### PR DESCRIPTION
#### Description

This PR cleans the `PTXLIRGenerationResult` and the related classes. We were using `.param` variables in the kernel only for `printf` calls. I realised we can pass `.reg` parameters instead, and therefore there is no need for a `paramTable` now.

Previous call to `printf`:
```
        .global .b8 rbbArr0[28] = {116, 111, 114, 110, 97, 100, 111, 91, 37, 117, 44, 32, 37, 117, 44, 32, 37, 117, 93, 62, 32, 104, 101, 108, 108, 111, 10, 0};
        st.local.s32    [rbiArr0], rsi0;
        st.local.s32    [rbiArr0+4], rsi2;
        st.local.s32    [rbiArr0+8], rsi3;
        cvta.global.u64 rbd0, rbbArr0;                <-- convert global state space address to generic address space 
        st.param.b64    [rbdParam0], rbd0;        <-- store generic address into .param variable
        cvta.local.u64 rbd0, rbiArr0;
        st.param.b64    [rbdParam1], rbd0;
        call (_), vprintf, (rbdParam0, rbdParam1);

```

New call to `printf`:
```
        .global .b8 rbbArr0[28] = {116, 111, 114, 110, 97, 100, 111, 91, 37, 117, 44, 32, 37, 117, 44, 32, 37, 117, 93, 62, 32, 104, 101, 108, 108, 111, 10, 0};
        st.local.s32    [rbiArr0], rsi0;
        st.local.s32    [rbiArr0+4], rsi2;
        st.local.s32    [rbiArr0+8], rsi3;
        cvta.global.u64 rbd0, rbbArr0;        <-- only convert global state space address to generic address space.
        cvta.local.u64 rbd1, rbiArr0;
        call (_), vprintf, (rbd0, rbd1);          <-- No need to use .param variables. Can directly pass the .reg variables to the call 
```

#### Backend/s tested

- [X] OpenCL
- [X] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Run the Hello World test with the PTX backend . 
`tornado-test.py --verbose uk.ac.manchester.tornado.unittests.TestHello#testHello`
