### PR TITLE
Unload PTX/CUDA modules when resetting the code cache

### DIFF
--- a/drivers/ptx-jni/src/main/cpp/source/PTXModule.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/PTXModule.cpp
@@ -69,6 +69,22 @@ JNIEXPORT jbyteArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXModule
 
 /*
  * Class:     uk_ac_manchester_tornado_drivers_ptx_PTXModule
+ * Method:    cuModuleUnload
+ * Signature: ([B)J
+ */
+JNIEXPORT jbyteArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXModule_cuModuleUnload
+  (JNIEnv *env, jclass clazz, jbyteArray module_wrapper) {
+    CUresult result;
+    CUmodule module;
+    array_to_module(env, &module, module_wrapper);
+
+    result = cuModuleUnload(module);
+    LOG_PTX_AND_VALIDATE("cuModuleUnload", result);
+    return (jlong) result;
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_ptx_PTXModule
  * Method:    cuOccupancyMaxPotentialBlockSize
  * Signature: ([BLjava/lang/String;)I
  */

--- a/drivers/ptx-jni/src/main/cpp/source/PTXModule.h
+++ b/drivers/ptx-jni/src/main/cpp/source/PTXModule.h
@@ -44,6 +44,14 @@ JNIEXPORT jbyteArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXModule
 
 /*
  * Class:     uk_ac_manchester_tornado_drivers_ptx_PTXModule
+ * Method:    cuModuleUnload
+ * Signature: ([B)J
+ */
+JNIEXPORT jbyteArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXModule_cuModuleUnload
+        (JNIEnv *, jclass, jbyteArray);
+
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_ptx_PTXModule
  * Method:    cuOccupancyMaxPotentialBlockSize
  * Signature: ([BLjava/lang/String;)I
  */

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXCodeCache.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXCodeCache.java
@@ -69,6 +69,9 @@ public class PTXCodeCache {
     }
 
     public void reset() {
+        for (PTXInstalledCode code : cache.values()) {
+            code.invalidate();
+        }
         cache.clear();
     }
 }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXModule.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXModule.java
@@ -44,6 +44,8 @@ public class PTXModule {
 
     private native static byte[] cuModuleLoadData(byte[] source);
 
+    private native static long cuModuleUnload(byte[] module);
+
     private native static int cuOccupancyMaxPotentialBlockSize(byte[] module, String funcName);
 
     public int getMaxThreadBlocks() {
@@ -59,5 +61,9 @@ public class PTXModule {
 
     public boolean isPTXJITSuccess() {
         return moduleWrapper.length != 0;
+    }
+
+    public void unload() {
+        cuModuleUnload(moduleWrapper);
     }
 }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXInstalledCode.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXInstalledCode.java
@@ -32,13 +32,15 @@ import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class PTXInstalledCode extends InstalledCode implements TornadoInstalledCode {
-    private PTXModule module;
-    private PTXDeviceContext deviceContext;
+    private final PTXModule module;
+    private final PTXDeviceContext deviceContext;
+    private boolean valid;
 
     public PTXInstalledCode(String name, PTXModule module, PTXDeviceContext deviceContext) {
         super(name);
         this.module = module;
         this.deviceContext = deviceContext;
+        valid = false;
     }
 
     @Override
@@ -54,5 +56,18 @@ public class PTXInstalledCode extends InstalledCode implements TornadoInstalledC
 
     public String getGeneratedSourceCode() {
         return new String(module.getSource());
+    }
+
+    @Override
+    public boolean isValid() {
+        return valid;
+    }
+
+    @Override
+    public void invalidate() {
+        if (valid) {
+            module.unload();
+            valid = false;
+        }
     }
 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -431,7 +431,7 @@ public class TornadoVM extends TornadoLogger {
             task.setGridScheduler(true);
         }
 
-        if (installedCodes[taskIndex] == null) {
+        if (shouldCompile(installedCodes[taskIndex])) {
             task.mapTo(device);
             try {
                 task.attachProfiler(timeProfiler);
@@ -452,6 +452,10 @@ public class TornadoVM extends TornadoLogger {
             }
         }
         return new ExecutionInfo(stack, waitList);
+    }
+
+    private boolean shouldCompile(TornadoInstalledCode installedCode) {
+        return installedCode == null || !installedCode.isValid();
     }
 
     private void setObjectOwnerShip(GlobalObjectState globalState, DeviceObjectState objectState, TornadoDevice device) {

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoInstalledCode.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoInstalledCode.java
@@ -33,4 +33,6 @@ public interface TornadoInstalledCode {
     int launchWithDependencies(CallStack stack, ObjectBuffer atomicSpace, TaskMetaData meta, long batchThreads, int[] waitEvents);
 
     int launchWithoutDependencies(CallStack stack, ObjectBuffer atomicSpace, TaskMetaData meta, long batchThreads);
+
+    boolean isValid();
 }


### PR DESCRIPTION
#### Description

The PTX modules from the code cache were never unloaded from the driver when the PTX device was reset. 
This PR fixes that.

#### Backend/s tested

- [X] OpenCL
- [X] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Run the unit tests on the PTX backend. `TornadoTestBase::before` resets devices before each test.

