### PR TITLE
Decouple task meta from the PTXModule

### DIFF
--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXCodeCache.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXCodeCache.java
@@ -40,13 +40,13 @@ public class PTXCodeCache {
         cache = new ConcurrentHashMap<>();
     }
 
-    public PTXInstalledCode installSource(String name, byte[] targetCode, TaskMetaData taskMeta, String resolvedMethodName) {
+    public PTXInstalledCode installSource(String name, byte[] targetCode, String resolvedMethodName) {
         String cacheKey = name;
 
         if (!cache.containsKey(cacheKey)) {
             RuntimeUtilities.maybePrintSource(targetCode);
 
-            PTXModule module = new PTXModule(resolvedMethodName, targetCode, name, taskMeta);
+            PTXModule module = new PTXModule(resolvedMethodName, targetCode, name);
 
             if (module.isPTXJITSuccess()) {
                 PTXInstalledCode code = new PTXInstalledCode(name, module, deviceContext);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -107,11 +107,11 @@ public class PTXDeviceContext extends TornadoLogger implements Initialisable, To
     }
 
     public TornadoInstalledCode installCode(PTXCompilationResult result, String resolvedMethodName) {
-        return codeCache.installSource(result.getName(), result.getTargetCode(), result.getTaskMeta(), resolvedMethodName);
+        return codeCache.installSource(result.getName(), result.getTargetCode(), resolvedMethodName);
     }
 
-    public TornadoInstalledCode installCode(String name, byte[] code, TaskMetaData taskMeta, String resolvedMethodName) {
-        return codeCache.installSource(name, code, taskMeta, resolvedMethodName);
+    public TornadoInstalledCode installCode(String name, byte[] code, String resolvedMethodName) {
+        return codeCache.installSource(name, code, resolvedMethodName);
     }
 
     public TornadoInstalledCode getInstalledCode(String name) {
@@ -194,11 +194,11 @@ public class PTXDeviceContext extends TornadoLogger implements Initialisable, To
         wasReset = true;
     }
 
-    public int enqueueKernelLaunch(PTXModule module, CallStack stack, long batchThreads) {
+    public int enqueueKernelLaunch(PTXModule module, CallStack stack, TaskMetaData taskMeta, long batchThreads) {
         int[] blockDimension = { 1, 1, 1 };
         int[] gridDimension = { 1, 1, 1 };
-        if (module.metaData.isWorkerGridAvailable()) {
-            WorkerGrid grid = module.metaData.getWorkerGrid(module.metaData.getId());
+        if (taskMeta.isWorkerGridAvailable()) {
+            WorkerGrid grid = taskMeta.getWorkerGrid(taskMeta.getId());
             int[] global = Arrays.stream(grid.getGlobalWork()).mapToInt(l -> (int) l).toArray();
 
             if (grid.getLocalWork() != null) {
@@ -214,13 +214,13 @@ public class PTXDeviceContext extends TornadoLogger implements Initialisable, To
                 System.out.println("Warning: TornadoVM changed the user-defined local size to the following: [" + blockDimension[0] + ", " + blockDimension[1] + ", " + blockDimension[2] + "].");
             }
             gridDimension = scheduler.calculateGridDimension(module.javaName, grid.dimension(), global, blockDimension);
-        } else if (module.metaData.isParallel()) {
-            scheduler.calculateGlobalWork(module.metaData, batchThreads);
-            blockDimension = scheduler.calculateBlockDimension(module);
-            gridDimension = scheduler.calculateGridDimension(module, blockDimension);
+        } else if (taskMeta.isParallel()) {
+            scheduler.calculateGlobalWork(taskMeta, batchThreads);
+            blockDimension = scheduler.calculateBlockDimension(module, taskMeta);
+            gridDimension = scheduler.calculateGridDimension(module, taskMeta, blockDimension);
         }
-        int kernelLaunchEvent = stream.enqueueKernelLaunch(module, writePTXStackOnDevice((PTXCallStack) stack), gridDimension, blockDimension);
-        updateProfiler(kernelLaunchEvent, module.metaData);
+        int kernelLaunchEvent = stream.enqueueKernelLaunch(module, taskMeta, writePTXStackOnDevice((PTXCallStack) stack), gridDimension, blockDimension);
+        updateProfiler(kernelLaunchEvent, taskMeta);
         return kernelLaunchEvent;
     }
 

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXModule.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXModule.java
@@ -23,21 +23,17 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx;
 
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
-
 public class PTXModule {
     public final byte[] moduleWrapper;
     public final String kernelFunctionName;
-    public final TaskMetaData metaData;
     private int maxBlockSize;
     public final String javaName;
     private final byte[] source;
 
-    public PTXModule(String name, byte[] source, String kernelFunctionName, TaskMetaData taskMetaData) {
+    public PTXModule(String name, byte[] source, String kernelFunctionName) {
         moduleWrapper = cuModuleLoadData(source);
         this.source = source;
         this.kernelFunctionName = kernelFunctionName;
-        metaData = taskMetaData;
         maxBlockSize = -1;
         javaName = name;
     }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
@@ -53,11 +53,11 @@ public class PTXScheduler {
         }
     }
 
-    public int[] calculateBlockDimension(PTXModule module) {
-        if (module.metaData.isLocalWorkDefined()) {
-            return Arrays.stream(module.metaData.getLocalWork()).mapToInt(l -> (int) l).toArray();
+    public int[] calculateBlockDimension(PTXModule module, TaskMetaData taskMeta) {
+        if (taskMeta.isLocalWorkDefined()) {
+            return Arrays.stream(taskMeta.getLocalWork()).mapToInt(l -> (int) l).toArray();
         }
-        return calculateBlockDimension(module.metaData.getGlobalWork(), module.getMaxThreadBlocks(), module.metaData.getDims(), module.javaName);
+        return calculateBlockDimension(taskMeta.getGlobalWork(), module.getMaxThreadBlocks(), taskMeta.getDims(), module.javaName);
     }
 
     public int[] calculateBlockDimension(long[] globalWork, int maxThreadBlocks, int dimension, String javaName) {
@@ -100,9 +100,9 @@ public class PTXScheduler {
         return value;
     }
 
-    public int[] calculateGridDimension(PTXModule module, int[] blockDimension) {
-        int[] globalWork = Arrays.stream(module.metaData.getGlobalWork()).mapToInt(l -> (int) l).toArray();
-        return calculateGridDimension(module.javaName, module.metaData.getDims(), globalWork, blockDimension);
+    public int[] calculateGridDimension(PTXModule module, TaskMetaData taskMeta, int[] blockDimension) {
+        int[] globalWork = Arrays.stream(taskMeta.getGlobalWork()).mapToInt(l -> (int) l).toArray();
+        return calculateGridDimension(module.javaName, taskMeta.getDims(), globalWork, blockDimension);
     }
 
     public int[] calculateGridDimension(String javaName, int dimension, int[] globalWork, int[] blockDimension) {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
@@ -47,6 +47,7 @@ import uk.ac.manchester.tornado.api.common.Event;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class PTXStream extends TornadoLogger {
 
@@ -180,16 +181,16 @@ public class PTXStream extends TornadoLogger {
         PTXEvent.waitForEventArray((PTXEvent[]) events.toArray());
     }
 
-    public int enqueueKernelLaunch(PTXModule module, byte[] kernelParams, int[] gridDim, int[] blockDim) {
+    public int enqueueKernelLaunch(PTXModule module, TaskMetaData taskMeta, byte[] kernelParams, int[] gridDim, int[] blockDim) {
         assert Arrays.stream(gridDim).filter(i -> i <= 0).count() == 0;
         assert Arrays.stream(blockDim).filter(i -> i <= 0).count() == 0;
 
-        if (module.metaData.isDebug()) {
+        if (taskMeta.isDebug()) {
             long[] blockDims = Arrays.stream(blockDim).mapToLong(i -> i).toArray();
             long[] gridDims = Arrays.stream(gridDim).mapToLong(i -> i).toArray();
-            module.metaData.setPtxBlockDim(blockDims);
-            module.metaData.setPtxGridDim(gridDims);
-            module.metaData.printThreadDims();
+            taskMeta.setPtxBlockDim(blockDims);
+            taskMeta.setPtxGridDim(gridDims);
+            taskMeta.printThreadDims();
         }
 
         return registerEvent(cuLaunchKernel(module.moduleWrapper, module.kernelFunctionName, gridDim[0], gridDim[1], gridDim[2], blockDim[0], blockDim[1], blockDim[2], DYNAMIC_SHARED_MEMORY_BYTES,

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXInstalledCode.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXInstalledCode.java
@@ -49,7 +49,7 @@ public class PTXInstalledCode extends InstalledCode implements TornadoInstalledC
 
     @Override
     public int launchWithoutDependencies(CallStack stack, ObjectBuffer atomicSpace, TaskMetaData meta, long batchThreads) {
-        return deviceContext.enqueueKernelLaunch(module, stack, batchThreads);
+        return deviceContext.enqueueKernelLaunch(module, stack, meta, batchThreads);
     }
 
     public String getGeneratedSourceCode() {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompilationResult.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompilationResult.java
@@ -25,7 +25,6 @@ package uk.ac.manchester.tornado.drivers.ptx.graal.compiler;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import org.graalvm.compiler.code.CompilationResult;
 import uk.ac.manchester.tornado.drivers.ptx.graal.backend.PTXBackend;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -36,11 +35,9 @@ import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.getCodeWith
 public class PTXCompilationResult extends CompilationResult {
 
     private Set<ResolvedJavaMethod> nonInlinedMethods;
-    private TaskMetaData taskMetaData;
 
-    public PTXCompilationResult(String functionName, TaskMetaData taskMetaData) {
+    public PTXCompilationResult(String functionName) {
         super(functionName);
-        this.taskMetaData = taskMetaData;
     }
 
     public void setNonInlinedMethods(Set<ResolvedJavaMethod> value) {
@@ -59,9 +56,5 @@ public class PTXCompilationResult extends CompilationResult {
     public void addPTXHeader(PTXBackend backend) {
         byte[] newCode = getCodeWithAttachedPTXHeader(getTargetCode(), backend);
         setTargetCode(newCode, newCode.length);
-    }
-
-    public TaskMetaData getTaskMeta() {
-        return taskMetaData;
     }
 }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
@@ -421,7 +421,7 @@ public class PTXCompiler {
         OptimisticOptimizations optimisticOpts = OptimisticOptimizations.ALL;
         ProfilingInfo profilingInfo = resolvedMethod.getProfilingInfo();
 
-        PTXCompilationResult kernelCompResult = new PTXCompilationResult(buildKernelName(resolvedMethod.getName(), task), taskMeta);
+        PTXCompilationResult kernelCompResult = new PTXCompilationResult(buildKernelName(resolvedMethod.getName(), task));
         CompilationResultBuilderFactory factory = CompilationResultBuilderFactory.Default;
 
         Set<ResolvedJavaMethod> methods = new HashSet<>();
@@ -446,7 +446,7 @@ public class PTXCompiler {
         while (!worklist.isEmpty()) {
             final ResolvedJavaMethod currentMethod = worklist.pop();
             Sketch currentSketch = TornadoSketcher.lookup(currentMethod, task.meta().getDriverIndex(), task.meta().getDeviceIndex());
-            final PTXCompilationResult compResult = new PTXCompilationResult(currentMethod.getName(), taskMeta);
+            final PTXCompilationResult compResult = new PTXCompilationResult(currentMethod.getName());
             final StructuredGraph graph = (StructuredGraph) currentSketch.getGraph().getMutableCopy(null);
 
             PTXCompilationRequest methodCompilationRequest = PTXCompilationRequest.PTXCompilationRequestBuilder.getInstance().withGraph(graph).withCodeOwner(currentMethod).withProviders(providers)
@@ -507,7 +507,7 @@ public class PTXCompiler {
         OptimisticOptimizations optimisticOpts = OptimisticOptimizations.ALL;
         ProfilingInfo profilingInfo = resolvedMethod.getProfilingInfo();
 
-        PTXCompilationResult kernelCompResult = new PTXCompilationResult(resolvedMethod.getName(), meta);
+        PTXCompilationResult kernelCompResult = new PTXCompilationResult(resolvedMethod.getName());
         CompilationResultBuilderFactory factory = CompilationResultBuilderFactory.Default;
 
         final PTXSuitesProvider suitesProvider = (PTXSuitesProvider) providers.getSuitesProvider();
@@ -522,7 +522,7 @@ public class PTXCompiler {
 
         while (!workList.isEmpty()) {
             final ResolvedJavaMethod currentMethod = workList.pop();
-            final PTXCompilationResult compResult = new PTXCompilationResult(currentMethod.getName(), meta);
+            final PTXCompilationResult compResult = new PTXCompilationResult(currentMethod.getName());
             StructuredGraph.Builder builder1 = new StructuredGraph.Builder(TornadoCoreRuntime.getOptions(), getDebugContext(), StructuredGraph.AllowAssumptions.YES);
             builder1.method(resolvedMethod);
             builder1.compilationId(id);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -190,7 +190,7 @@ public class PTXTornadoDevice implements TornadoAcceleratorDevice {
                 profiler.stop(ProfilerType.TASK_COMPILE_GRAAL_TIME, taskMeta.getId());
                 profiler.sum(ProfilerType.TOTAL_GRAAL_COMPILE_TIME, profiler.getTaskTimer(ProfilerType.TASK_COMPILE_GRAAL_TIME, taskMeta.getId()));
             } else {
-                result = new PTXCompilationResult(buildKernelName(resolvedMethod.getName(), executable), taskMeta);
+                result = new PTXCompilationResult(buildKernelName(resolvedMethod.getName(), executable));
             }
 
             profiler.start(ProfilerType.TASK_COMPILE_DRIVER_TIME, taskMeta.getId());
@@ -219,7 +219,7 @@ public class PTXTornadoDevice implements TornadoAcceleratorDevice {
         try {
             byte[] source = Files.readAllBytes(path);
             source = PTXCodeUtil.getCodeWithAttachedPTXHeader(source, getBackend());
-            return deviceContext.installCode(functionName, source, executable.meta(), executable.getEntryPoint());
+            return deviceContext.installCode(functionName, source, executable.getEntryPoint());
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXTornadoCompiler.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXTornadoCompiler.java
@@ -86,13 +86,11 @@ public class TestPTXTornadoCompiler {
 
         TornadoCoreRuntime tornadoRuntime = TornadoCoreRuntime.getTornadoRuntime();
         PTXBackend backend = tornadoRuntime.getDriver(PTXDriver.class).getDefaultBackend();
-        ScheduleMetaData scheduleMeta = new ScheduleMetaData("ptxBackend");
-        TaskMetaData meta = new TaskMetaData(scheduleMeta, "add");
-        new PTXCompilationResult("add", meta);
+        new PTXCompilationResult("add");
 
         byte[] source = PTX_KERNEL.getBytes();
         source = PTXCodeUtil.getCodeWithAttachedPTXHeader(source, backend);
-        PTXInstalledCode code = codeCache.installSource("add", source, meta, "add");
+        PTXInstalledCode code = codeCache.installSource("add", source, "add");
 
         String generatedSourceCode = code.getGeneratedSourceCode();
         if (PRINT_KERNEL) {


### PR DESCRIPTION
#### Description

This PR decouples the `TaskMetaData` from the `PTXModule`.

#### Problem description

The code cache will store `PTXModule`s and therefore also store `TaskMetaData`. If the same `PTXModule` is used for different tasks, then Tornado will use the task metadata from the cache (from the previous task) instead of the current task meta. This can break scheduling.

#### Backend/s tested

- [X] OpenCL
- [X] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

I don't think it's possible to replicate this bug with the current code cache strategy `PTXCodeUtil::buildKernelName`.
