### PR TITLE
Add option to inline during bytecode parsing

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
@@ -58,6 +58,7 @@ import org.graalvm.compiler.nodes.util.GraphUtil;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
+import org.graalvm.compiler.replacements.InlineDuringParsingPlugin;
 import uk.ac.manchester.tornado.api.TornadoVM_Intrinsics;
 import uk.ac.manchester.tornado.api.exceptions.Debug;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLArchitecture;
@@ -77,11 +78,16 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.SlotsBaseAddressNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.TPrintfNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.TornadoAtomicIntegerNode;
 import uk.ac.manchester.tornado.api.TornadoVMContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.directives.CompilerInternals;
 
 public class OCLGraphBuilderPlugins {
 
     public static void registerInvocationPlugins(final Plugins ps, final InvocationPlugins plugins) {
+        if (TornadoOptions.INLINE_DURING_BYTECODE_PARSING) {
+            ps.appendInlineInvokePlugin(new InlineDuringParsingPlugin());
+        }
+
         registerCompilerIntrinsicsPlugins(plugins);
         registerTornadoVMIntrinsicsPlugins(plugins);
         registerOpenCLBuiltinPlugins(plugins);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
@@ -53,6 +53,7 @@ import org.graalvm.compiler.nodes.util.GraphUtil;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
+import org.graalvm.compiler.replacements.InlineDuringParsingPlugin;
 import uk.ac.manchester.tornado.api.TornadoVMContext;
 import uk.ac.manchester.tornado.api.exceptions.Debug;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXArchitecture;
@@ -65,10 +66,15 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXIntBinaryIntrinsicNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXIntUnaryIntrinsicNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PrintfNode;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public class PTXGraphBuilderPlugins {
 
     public static void registerInvocationPlugins(final Plugins ps, final InvocationPlugins plugins) {
+        if (TornadoOptions.INLINE_DURING_BYTECODE_PARSING) {
+            ps.appendInlineInvokePlugin(new InlineDuringParsingPlugin());
+        }
+
         registerTornadoInstrinsicsPlugins(plugins);
         registerPTXBuiltinPlugins(plugins);
         PTXMathPlugins.registerTornadoMathPlugins(plugins);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -264,10 +264,6 @@ public class PTXTornadoDevice implements TornadoAcceleratorDevice {
     public int ensureAllocated(Object object, long batchSize, TornadoDeviceObjectState state) {
         if (!state.hasBuffer()) {
             reserveMemory(object, batchSize, state);
-        }
-
-        if (!state.hasBuffer()) {
-            reserveMemory(object, batchSize, state);
         } else {
             checkForResizeBuffer(object, batchSize, state);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <classifier>${platform}</classifier>
         <download.cmake>false</download.cmake>
-        <jmh.version>1.23</jmh.version>
+        <jmh.version>1.29</jmh.version>
         <uberjar.name>jmhbenchmarks</uberjar.name>
     </properties>
 

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -177,4 +177,9 @@ public class TornadoOptions {
      */
     public static final boolean FULL_INLINING = getBooleanValue("tornado.compiler.fullInlining", "False");;
 
+    /**
+     * It enables inlining during Java bytecode parsing. Default is False.
+     */
+    public static final boolean INLINE_DURING_BYTECODE_PARSING = getBooleanValue("tornado.compiler.bytecodeInlining", "False");
+
 }


### PR DESCRIPTION
#### Description

Graal performs inlining during bytecode parsing by default. Tornado does not have this capability so I added the option to enable this. 
On Graal, this option is enabled by default. In our case, the performance remains the same on slambench with the OpenCL backend, but there is a slowdown on PTX. Therefore, the option is disabled by default.

Also, I updated the JMH version to the latest and cleanup `PTXTornadoDevice::ensureAllocated`

#### Backend/s tested

- [X] OpenCL
- [X] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Run the unit tests on both backends and the JMH benchmarks.
`tornado-test.py --verbose -J"-Dtornado.{opencl,ptx}.priority=XXX -Dtornado.compiler.bytecodeInlining=True"`
`tornado-benchmarks.py --jmh`