### PR TITLE
[Fix] OCLKind/PTXKind inconsistency in code gen

### DIFF
--- a/assembly/src/examples/generated/virtualDevice/virtualDeviceKernelGPU.cl
+++ b/assembly/src/examples/generated/virtualDevice/virtualDeviceKernelGPU.cl
@@ -26,7 +26,7 @@ __kernel void maxReduction(__global uchar *_heap_base, ulong _frame_base, __cons
   // BLOCK 0
   ul_0  =  (ulong) _frame[3];
   ul_1  =  (ulong) _frame[4];
-  __local float ul_2[1024];
+  __local float f_2[1024];
   i_3  =  get_global_id(0);
   // BLOCK 1 MERGES [0 7 ]
   i_4  =  i_3;
@@ -39,7 +39,7 @@ __kernel void maxReduction(__global uchar *_heap_base, ulong _frame_base, __cons
     l_9  =  l_8 + 24L;
     ul_10  =  ul_0 + l_9;
     f_11  =  *((__global float *) ul_10);
-    ul_2[i_5]  =  f_11;
+    f_2[i_5]  =  f_11;
     i_12  =  i_6 >> 31;
     i_13  =  i_12 + i_6;
     i_14  =  i_13 >> 1;
@@ -53,11 +53,11 @@ __kernel void maxReduction(__global uchar *_heap_base, ulong _frame_base, __cons
       if(z_17)
       {
         // BLOCK 9
-        f_18  =  ul_2[i_5];
+        f_18  =  f_2[i_5];
         i_19  =  i_15 + i_5;
-        f_20  =  ul_2[i_19];
+        f_20  =  f_2[i_19];
         f_21  =  fmax(f_18, f_20);
-        ul_2[i_5]  =  f_21;
+        f_2[i_5]  =  f_21;
         f_18  =  f_21;
       }  // B9
       else
@@ -76,7 +76,7 @@ __kernel void maxReduction(__global uchar *_heap_base, ulong _frame_base, __cons
     if(z_25)
     {
       // BLOCK 5
-      f_26  =  ul_2[0];
+      f_26  =  f_2[0];
       i_27  =  get_group_id(0);
       i_28  =  i_27 + 1;
       l_29  =  (long) i_28;

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLKind.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLKind.java
@@ -114,9 +114,18 @@ public enum OCLKind implements PlatformKind {
     public static OCLKind fromResolvedJavaType(ResolvedJavaType type) {
         if (!type.isArray()) {
             for (OCLKind k : OCLKind.values()) {
-                if (k.javaClass != null && k.javaClass.getSimpleName().equals(type.getUnqualifiedName())) {
+                if (k.javaClass != null && (k.javaClass.getSimpleName().equalsIgnoreCase(type.getJavaKind().name()) || k.javaClass.getSimpleName().equals(type.getUnqualifiedName()))) {
                     return k;
                 }
+            }
+        }
+        return ILLEGAL;
+    }
+
+    public static OCLKind fromResolvedJavaKind(JavaKind javaKind) {
+        for (OCLKind k : OCLKind.values()) {
+            if (k.javaClass != null && k.javaClass.getSimpleName().equalsIgnoreCase(javaKind.name())) {
+                return k;
             }
         }
         return ILLEGAL;

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/LocalArrayNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/LocalArrayNode.java
@@ -53,33 +53,28 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
     @Input
     protected ConstantNode length;
 
-    protected OCLKind elementKind;
+    private OCLKind kind;
     protected OCLArchitecture.OCLMemoryBase memoryRegister;
-    protected ResolvedJavaType elementType;
     protected OCLAssembler.OCLBinaryTemplate arrayTemplate;
 
     public LocalArrayNode(OCLArchitecture.OCLMemoryBase memoryRegister, ResolvedJavaType elementType, ConstantNode length) {
         super(TYPE, StampFactory.objectNonNull(TypeReference.createTrustedWithoutAssumptions(elementType.getArrayClass())));
         this.memoryRegister = memoryRegister;
         this.length = length;
-        this.elementType = elementType;
-        this.elementKind = OCLKind.fromResolvedJavaType(elementType);
+        this.kind = OCLKind.fromResolvedJavaType(elementType);
         this.arrayTemplate = OCLKind.resolveTemplateType(elementType);
     }
 
-    public LocalArrayNode(OCLArchitecture.OCLMemoryBase memoryRegister, JavaKind elementType, ConstantNode length) {
+    public LocalArrayNode(OCLArchitecture.OCLMemoryBase memoryRegister, JavaKind elementKind, ConstantNode length) {
         super(TYPE, StampFactory.forKind(JavaKind.Object));
         this.memoryRegister = memoryRegister;
         this.length = length;
-        this.arrayTemplate = OCLKind.resolveTemplateType(elementType);
+        this.kind = OCLKind.fromResolvedJavaKind(elementKind);
+        this.arrayTemplate = OCLKind.resolveTemplateType(elementKind);
     }
 
     public OCLArchitecture.OCLMemoryBase getMemoryRegister() {
         return memoryRegister;
-    }
-
-    public ResolvedJavaType getElementType() {
-        return elementType;
     }
 
     public ConstantNode getLength() {
@@ -90,7 +85,7 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
     public void generate(NodeLIRBuilderTool gen) {
         final Value lengthValue = gen.operand(length);
 
-        LIRKind lirKind = LIRKind.value(gen.getLIRGeneratorTool().target().arch.getWordKind());
+        LIRKind lirKind = LIRKind.value(kind);
         final Variable variable = gen.getLIRGeneratorTool().newVariable(lirKind);
         final OCLBinary.Expr declaration = new OCLBinary.Expr(arrayTemplate, lirKind, variable, lengthValue);
 

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXKind.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXKind.java
@@ -142,6 +142,15 @@ public enum PTXKind implements PlatformKind {
         return ILLEGAL;
     }
 
+    public static PTXKind fromResolvedJavaKind(JavaKind javaKind) {
+        for (PTXKind k : PTXKind.values()) {
+            if (k.javaClass != null && k.javaClass.getSimpleName().equalsIgnoreCase(javaKind.name())) {
+                return k;
+            }
+        }
+        return ILLEGAL;
+    }
+
     public static PTXAssembler.PTXBinaryTemplate resolveTemplateType(ResolvedJavaType type) {
         return resolveTemplateType(type.getJavaKind());
     }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/LocalArrayNode.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/LocalArrayNode.java
@@ -70,11 +70,12 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
         this.arrayTemplate = PTXKind.resolveTemplateType(elementType);
     }
 
-    public LocalArrayNode(PTXMemoryBase memoryRegister, JavaKind elementType, ConstantNode length) {
+    public LocalArrayNode(PTXMemoryBase memoryRegister, JavaKind elementKind, ConstantNode length) {
         super(TYPE, StampFactory.forKind(JavaKind.Object));
         this.memoryRegister = memoryRegister;
         this.length = length;
-        this.arrayTemplate = PTXKind.resolveTemplateType(elementType);
+        this.kind = PTXKind.fromResolvedJavaKind(elementKind);
+        this.arrayTemplate = PTXKind.resolveTemplateType(elementKind);
     }
 
     public PTXMemoryBase getMemoryRegister() {
@@ -90,7 +91,7 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
         trace("emitLocalArray length=%s kind=%s", length, kind);
         final Value lengthValue = gen.operand(length);
 
-        LIRKind lirKind = LIRKind.value(gen.getLIRGeneratorTool().target().arch.getWordKind());
+        LIRKind lirKind = LIRKind.value(kind);
         final Variable variable = ((PTXLIRGenerator) gen.getLIRGeneratorTool()).newVariable(lirKind, true);
         final PTXBinary.Expr declaration = new PTXBinary.Expr(arrayTemplate, lirKind, variable, lengthValue);
 


### PR DESCRIPTION
#### Description

This PR provides a patch that refactors the `OCLKind` and `PTXKind` to be resolved from the JavaKind. This includes a new method for each backend. This refactoring fixes the inconsistency between the two backends (OpenCL, PTX) regarding the `LocalArrayNode`, as mentioned in issue #89.

As it is shown in the under-review files, the refactored code of this patch fixes the generated GPU [kernel](https://github.com/beehive-lab/TornadoVM/blob/master/assembly/src/examples/generated/virtualDevice/virtualDeviceKernelGPU.cl) that is required for the `testVirtualDeviceKernel` unit-test to use an array name `f_2` instead of `ul_2` (line 29) for the float local array.

#### Backend/s tested

- [x] OpenCL
- [x] PTX

#### OS tested

- [x] Linux
- [x] OSx
- [x] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

- The patch has been tested for both backends (`OpenCL`, `PTX`) and the benchmarks, as follows:
```bash
$ make jdk-11-plus
$ make tests
$ tornado-benchmarks.py --jmh --medium
```

- You can run the following unit-test (but replace the paths, this unit-test assesses the change of the local array name)
```bash
$ tornado -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False  -Dtornado.device.desc=/home/thanos/repositories/tornado-stratika/bin/sdk/examples/virtual-device-GPU.json -Dtornado.print.kernel=True -Dtornado.virtual.device=True -Dtornado.print.kernel.dir=/home/thanos/repositories/tornado-stratika/bin/sdk/virtualKernelOut.out -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceKernel#testVirtualDeviceKernelGPU
```