### PR TITLE
Hotfix for disabling FixReads to make kfusion run on Nvidia GPUs

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLowTier.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLowTier.java
@@ -73,6 +73,7 @@ public class OCLLowTier extends TornadoLowTier {
             appendPhase(new IterativeConditionalEliminationPhase(canonicalizer, false));
         }
 
+        // TODO Investigate why FixReads break kfusion on Nvidia GPUs
         if (TornadoOptions.ENABLE_FIX_READS) {
             appendPhase(new FixReadsPhase(true, new SchedulePhase(SchedulePhase.SchedulingStrategy.LATEST_OUT_OF_LOOPS)));
         }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLowTier.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLowTier.java
@@ -73,7 +73,9 @@ public class OCLLowTier extends TornadoLowTier {
             appendPhase(new IterativeConditionalEliminationPhase(canonicalizer, false));
         }
 
-        appendPhase(new FixReadsPhase(true, new SchedulePhase(SchedulePhase.SchedulingStrategy.LATEST_OUT_OF_LOOPS)));
+        if (TornadoOptions.ENABLE_FIX_READS) {
+            appendPhase(new FixReadsPhase(true, new SchedulePhase(SchedulePhase.SchedulingStrategy.LATEST_OUT_OF_LOOPS)));
+        }
 
         appendPhase(new AddressLoweringPhase(addressLowering));
 

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -73,6 +73,11 @@ public class TornadoOptions {
     public static final boolean ENABLE_FMA = getBooleanValue("tornado.enable.fma", "True");
 
     /**
+     * Enable/Disable Fix Reads Optimization. True by default.
+     */
+    public static final boolean ENABLE_FIX_READS = getBooleanValue("tornado.enable.fix.reads", "True");
+
+    /**
      * Enable/Disable events dumping on program finish. False by default.
      */
     public final static boolean DUMP_EVENTS = Boolean.parseBoolean(getProperty("tornado.events.dump", "False"));


### PR DESCRIPTION
#### Description

This PR provides a hotfix for making kfusion running on Nvidia GPUs (OpenCL), as it is reported in issue #104. This is not a solution for why `fix-reads` break kfusion on Nvidia GPUs, but a hotfix. I have also added a `TODO` comment.

The PR introduces a new flag in the TornadoOptions class, which can be used by any user programs that need the `fix-reads` disabled. The default value is `True`. This flag is being used to deactivate fix-reads only for OpenCL, as this phase seems to work when I tested the PTX backend for `unit-tests`, `benchmarks`, `kfusion`).

#### Backend/s tested

- [x] OpenCL
- [x] PTX

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
## Pass Unittests using the OpenCL backend
$ make
$ make tests

## Pass unittests using the PTX backend
$ make BACKEND=ptx,opencl
$ make tests # It will select the PTX by default 
```

I also run `kfusion` in both GUI and benchmarking modes. To reproduce, run:
```bash
$ source sources.env
$ mvn clean install -DskipTests
$ kfusion kfusion.tornado.Benchmark conf/bm-traj2.settings
```

 and got the following output:
```
: Reading configuration file: /home/thanos/.kfusion_tornado/living_room_traj2_loop.raw
frame	acquisition	preprocessing	tracking	integration	raycasting	rendering	computation	total    	X          	Y          	Z         	tracked   	integrated
0	0.005837	0.067432	0.031135	0.011988	0.000000	0.002608	0.110555	0.119001	0.000000	0.000000	0.000000	0	1
1	0.000424	0.000529	0.002138	0.001439	0.000000	0.000000	0.004107	0.004531	0.000000	0.000000	0.000000	0	1
2	0.000372	0.000505	0.002115	0.001435	0.000000	0.000000	0.004056	0.004429	0.000000	0.000000	0.000000	0	1
...
881	0.001556	0.000353	0.006821	0.000001	0.000435	0.000000	0.007610	0.009166	-0.566813	0.149231	1.172933	1	0
Summary: time=9.32, frames=882, FPS=94.64
```
