### PR TITLE
Fix scheduling when multiple task schedules use the same Java method 

### DIFF
--- a/assembly/src/examples/generated/add.ptx
+++ b/assembly/src/examples/generated/add.ptx
@@ -1,5 +1,5 @@
 // kernel function
-.visible .entry add_int8_int8_int8(.param .u64 stack_pointer) {
+.visible .entry s0_t0_add_int8_int8_int8(.param .u64 stack_pointer) {
     // register declaration
 	.reg .u64 rud<9>;
 	.reg .s64 rsd<4>;

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXCodeUtil.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXCodeUtil.java
@@ -89,7 +89,8 @@ public class PTXCodeUtil {
     }
 
     public static String buildKernelName(String methodName, SchedulableTask task) {
-        StringBuilder sb = new StringBuilder(methodName);
+        StringBuilder sb = new StringBuilder(task.getId().replaceAll("[.\\-]", "_"));
+        sb.append('_').append(methodName);
 
         for (Object arg : task.getArguments()) {
             // Object is either array or primitive


### PR DESCRIPTION
#### Description

A single thread was scheduled for some tasks when running the `BlurFilterTornado` benchmark with the PTX backend.

This is a temporary fix that replicates what happens on the OpenCL backend. I think the ideal solution is to decouple the domain from any of the compiler phases.

#### Problem description

The issue is that multiple task schedules use the same entry in the code cache. This stops the `TornadoShapeAnalysis` phase from running and setting the domain in the task meta, causing a single thread to be scheduled for the kernel.

```
Task info: blur.red                                                                                      
        Backend           : PTX                                                                          
        Device            : GeForce GTX 1650 GPU                                                         
        Dims              : 2                                                                            
        Thread dimensions : [256, 256]              
        Blocks dimensions : [32, 32, 1]                                                                  
        Grids dimensions  : [8, 8, 1]                                                                                                                                                                              
                                                                                                         
Task info: blur.green                                                                                    
        Backend           : PTX                                                                          
        Device            : GeForce GTX 1650 GPU                                                         
        Dims              : 0                                                                            
        Thread dimensions : [1]                                                                                                                                                                                    
        Blocks dimensions : [1, 1, 1]               
        Grids dimensions  : [1, 1, 1]                                                                    
                                                                                                                                                                                                                   
Task info: blur.blue                                                                                                                                                                                               
        Backend           : PTX                                                                          
        Device            : GeForce GTX 1650 GPU
        Dims              : 0                                                                            
        Thread dimensions : [1]                                                                          
        Blocks dimensions : [1, 1, 1]                                                                    
        Grids dimensions  : [1, 1, 1]        
```

#### Backend/s tested

- [ ] OpenCL
- [X] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Run the benchmark on the PTX backend: 
`tornado --debug -Xms24G -Xmx24G -server -Dtornado.benchmarks.skipserial=True uk.ac.manchester.tornado.benchmarks.BenchmarkRunner blurFilter 5 256`

Numbers of threads running after the patch:
```
Task info: blur.red
        Backend           : PTX
        Device            : GeForce GTX 1650 GPU
        Dims              : 2
        Thread dimensions : [256, 256]
        Blocks dimensions : [32, 32, 1]
        Grids dimensions  : [8, 8, 1]

Task info: blur.green
        Backend           : PTX
        Device            : GeForce GTX 1650 GPU
        Dims              : 2
        Thread dimensions : [256, 256]
        Blocks dimensions : [32, 32, 1]
        Grids dimensions  : [8, 8, 1]

Task info: blur.blue
        Backend           : PTX
        Device            : GeForce GTX 1650 GPU
        Dims              : 2
        Thread dimensions : [256, 256]
        Blocks dimensions : [32, 32, 1]
        Grids dimensions  : [8, 8, 1]
```

