### PR TITLE
Release OCL events when calling device reset 

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventsWrapper.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventsWrapper.java
@@ -144,6 +144,13 @@ class OCLEventsWrapper {
     }
 
     protected void reset() {
+        for (int index = 0; index < events.length; index++) {
+            if (events[index] > 0) {
+                internalEvent.setEventId(index, events[index]);
+                releaseEvent(index);
+                internalEvent.release();
+            }
+        }
         Arrays.fill(events, 0);
         eventIndex = 0;
     }


### PR DESCRIPTION
#### Description

This PR fixes a memory leak caused by the way TornadoVM interacts with the OCL driver.

Events were marked as released in the runtime but calls to `clReleaseEvent` were not made when calling `device.reset()`.
For long-running processes, this caused increased memory usage. 

On the PTX backend, we perform the required driver calls. 

#### Backend/s tested

- [X] OpenCL
- [ ] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Running the unit tests should cover this. Between tests, we always call `device.reset()`.
