### PR TITLE
[FPGA] Enhancement of Xilinx OpenCL backend

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -27,13 +27,16 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl;
 
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
-import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLBuildStatus.CL_BUILD_SUCCESS;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.getProperty;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
+import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.drivers.opencl.enums.OCLBuildStatus;
+import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
+import uk.ac.manchester.tornado.drivers.opencl.exceptions.OCLException;
+import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
+import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
+import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -50,16 +53,13 @@ import java.util.StringJoiner;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 
-import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
-import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
-import uk.ac.manchester.tornado.drivers.opencl.enums.OCLBuildStatus;
-import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
-import uk.ac.manchester.tornado.drivers.opencl.exceptions.OCLException;
-import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
-import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
-import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
+import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLBuildStatus.CL_BUILD_SUCCESS;
+import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
+import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
+import static uk.ac.manchester.tornado.runtime.common.Tornado.getProperty;
+import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
+import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 
 public class OCLCodeCache {
 
@@ -214,7 +214,7 @@ public class OCLCodeCache {
         if (flag.contains("--config")) {
             String fileString = resolveAbsoluteDirectory(tokenizer.nextToken(" ="));
             resolvedFlags = buildFlags.append(flag).append(" ").append(fileString).toString();
-        } else if (flag.contains("--nk")) {
+        } else if (flag.contains("--")) {
             String fileString = tokenizer.nextToken(" =");
             resolvedFlags = buildFlags.append(flag).append(" ").append(fileString).toString();
         } else {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -211,8 +211,11 @@ public class OCLCodeCache {
 
     private String resolveCompilationFlags(StringTokenizer tokenizer, StringBuilder buildFlags, String flag) {
         String resolvedFlags;
-        if (flag.contains("--")) {
+        if (flag.contains("--config")) {
             String fileString = resolveAbsoluteDirectory(tokenizer.nextToken(" ="));
+            resolvedFlags = buildFlags.append(flag).append(" ").append(fileString).toString();
+        } else if (flag.contains("--nk")) {
+            String fileString = tokenizer.nextToken(" =");
             resolvedFlags = buildFlags.append(flag).append(" ").append(fileString).toString();
         } else {
             resolvedFlags = buildFlags.append(flag).toString();

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -27,6 +27,24 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl;
 
+import uk.ac.manchester.tornado.api.common.Event;
+import uk.ac.manchester.tornado.api.common.SchedulableTask;
+import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
+import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
+import uk.ac.manchester.tornado.drivers.opencl.enums.OCLMemFlags;
+import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResult;
+import uk.ac.manchester.tornado.drivers.opencl.mm.OCLMemoryManager;
+import uk.ac.manchester.tornado.drivers.opencl.runtime.OCLTornadoDevice;
+import uk.ac.manchester.tornado.runtime.common.Initialisable;
+import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+
+import java.nio.ByteOrder;
+import java.util.Comparator;
+import java.util.List;
+
 import static uk.ac.manchester.tornado.drivers.opencl.OCLCommandQueue.EMPTY_EVENT;
 import static uk.ac.manchester.tornado.drivers.opencl.OCLEvent.DEFAULT_TAG;
 import static uk.ac.manchester.tornado.drivers.opencl.OCLEvent.DESC_PARALLEL_KERNEL;
@@ -46,24 +64,6 @@ import static uk.ac.manchester.tornado.drivers.opencl.OCLEvent.DESC_WRITE_LONG;
 import static uk.ac.manchester.tornado.drivers.opencl.OCLEvent.DESC_WRITE_SHORT;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.USE_SYNC_FLUSH;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.getProperty;
-
-import java.nio.ByteOrder;
-import java.util.Comparator;
-import java.util.List;
-
-import uk.ac.manchester.tornado.api.common.Event;
-import uk.ac.manchester.tornado.api.common.SchedulableTask;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
-import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
-import uk.ac.manchester.tornado.drivers.opencl.enums.OCLMemFlags;
-import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
-import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResult;
-import uk.ac.manchester.tornado.drivers.opencl.mm.OCLMemoryManager;
-import uk.ac.manchester.tornado.drivers.opencl.runtime.OCLTornadoDevice;
-import uk.ac.manchester.tornado.runtime.common.Initialisable;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
-import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class OCLDeviceContext extends TornadoLogger implements Initialisable, OCLDeviceContextInterface {
 
@@ -439,6 +439,11 @@ public class OCLDeviceContext extends TornadoLogger implements Initialisable, OC
     public boolean isPlatformFPGA() {
         return getDevice().getDeviceType() == OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR
                 && (getPlatformContext().getPlatform().getName().toLowerCase().contains("fpga") || getPlatformContext().getPlatform().getName().toLowerCase().contains("xilinx"));
+    }
+
+    @Override
+    public boolean isPlatformXilinxFPGA() {
+        return getPlatformContext().getPlatform().getName().toLowerCase().contains("xilinx");
     }
 
     @Override

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLHighTier.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLHighTier.java
@@ -25,13 +25,7 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.graal.compiler;
 
-import static org.graalvm.compiler.core.common.GraalOptions.ConditionalElimination;
-import static org.graalvm.compiler.core.common.GraalOptions.ImmutableCode;
-import static org.graalvm.compiler.core.common.GraalOptions.OptConvertDeoptsToGuards;
-import static org.graalvm.compiler.core.common.GraalOptions.PartialEscapeAnalysis;
-import static org.graalvm.compiler.core.phases.HighTier.Options.Inline;
-import static org.graalvm.compiler.phases.common.DeadCodeEliminationPhase.Optionality.Optional;
-
+import jdk.vm.ci.meta.MetaAccessProvider;
 import org.graalvm.compiler.loop.phases.ConvertDeoptimizeToGuardPhase;
 import org.graalvm.compiler.loop.phases.LoopFullUnrollPhase;
 import org.graalvm.compiler.nodes.loop.DefaultLoopPolicies;
@@ -46,13 +40,11 @@ import org.graalvm.compiler.phases.common.RemoveValueProxyPhase;
 import org.graalvm.compiler.phases.common.inlining.InliningPhase;
 import org.graalvm.compiler.phases.schedule.SchedulePhase;
 import org.graalvm.compiler.virtual.phases.ea.PartialEscapePhase;
-
-import jdk.vm.ci.meta.MetaAccessProvider;
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
+import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoFPGAPragmas;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoNewArrayDevirtualizationReplacement;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoOpenCLIntrinsicsReplacements;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoParallelScheduler;
-import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoPragmaUnroll;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoTaskSpecialisation;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoThreadScheduler;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
@@ -64,6 +56,13 @@ import uk.ac.manchester.tornado.runtime.graal.phases.TornadoLocalMemoryAllocatio
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoPartialInliningPolicy;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoShapeAnalysis;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoValueTypeCleanup;
+
+import static org.graalvm.compiler.core.common.GraalOptions.ConditionalElimination;
+import static org.graalvm.compiler.core.common.GraalOptions.ImmutableCode;
+import static org.graalvm.compiler.core.common.GraalOptions.OptConvertDeoptsToGuards;
+import static org.graalvm.compiler.core.common.GraalOptions.PartialEscapeAnalysis;
+import static org.graalvm.compiler.core.phases.HighTier.Options.Inline;
+import static org.graalvm.compiler.phases.common.DeadCodeEliminationPhase.Optionality.Optional;
 
 public class OCLHighTier extends TornadoHighTier {
 
@@ -115,7 +114,7 @@ public class OCLHighTier extends TornadoHighTier {
         appendPhase(new TornadoParallelScheduler());
         appendPhase(new SchedulePhase(SchedulePhase.SchedulingStrategy.EARLIEST));
         if (deviceContext.isPlatformFPGA()) {
-            appendPhase(new TornadoPragmaUnroll());
+            appendPhase(new TornadoFPGAPragmas(deviceContext));
             appendPhase(new TornadoThreadScheduler());
         } else {
             LoopPolicies loopPolicies = new DefaultLoopPolicies();

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLNodeLIRBuilder.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLNodeLIRBuilder.java
@@ -103,9 +103,9 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.ExprStmt;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLNullary;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLReturnSlot;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLUnary;
-import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.PragmaUnrollNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.IntelUnrollPragmaNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.ThreadConfigurationNode;
-import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.XilinxPipelineAttribute;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.XilinxPipeliningPragmaNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.logic.LogicalAndNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.logic.LogicalEqualsNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.logic.LogicalNotNode;
@@ -560,7 +560,7 @@ public class OCLNodeLIRBuilder extends NodeLIRBuilder {
             emitLoopExit((LoopExitNode) node);
         } else if (node instanceof ShortCircuitOrNode) {
             emitShortCircuitOrNode((ShortCircuitOrNode) node);
-        } else if (node instanceof PragmaUnrollNode || node instanceof XilinxPipelineAttribute || node instanceof ThreadConfigurationNode) {
+        } else if (node instanceof IntelUnrollPragmaNode || node instanceof XilinxPipeliningPragmaNode || node instanceof ThreadConfigurationNode) {
             // ignore emit-action
         } else {
             super.emitNode(node);
@@ -624,7 +624,7 @@ public class OCLNodeLIRBuilder extends NodeLIRBuilder {
 
     private void emitPragmaLoopUnroll(Block blk) {
         for (ValueNode tempDomBlockNode : blk.getNodes()) {
-            if (tempDomBlockNode instanceof PragmaUnrollNode || tempDomBlockNode instanceof XilinxPipelineAttribute) {
+            if (tempDomBlockNode instanceof IntelUnrollPragmaNode || tempDomBlockNode instanceof XilinxPipeliningPragmaNode) {
                 super.emitNode(tempDomBlockNode);
             }
         }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLNodeLIRBuilder.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLNodeLIRBuilder.java
@@ -25,15 +25,13 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.graal.compiler;
 
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
-import static uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind.ILLEGAL;
-import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
-import static uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCodeGenerator.trace;
-
-import java.util.Collection;
-import java.util.List;
-
+import jdk.vm.ci.code.CallingConvention;
+import jdk.vm.ci.meta.AllocatableValue;
+import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.Local;
+import jdk.vm.ci.meta.PrimitiveConstant;
+import jdk.vm.ci.meta.ResolvedJavaType;
+import jdk.vm.ci.meta.Value;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.calc.Condition;
 import org.graalvm.compiler.core.common.cfg.BlockMap;
@@ -86,14 +84,6 @@ import org.graalvm.compiler.nodes.calc.IsNullNode;
 import org.graalvm.compiler.nodes.cfg.Block;
 import org.graalvm.compiler.nodes.extended.SwitchNode;
 import org.graalvm.compiler.options.OptionValues;
-
-import jdk.vm.ci.code.CallingConvention;
-import jdk.vm.ci.meta.AllocatableValue;
-import jdk.vm.ci.meta.JavaConstant;
-import jdk.vm.ci.meta.Local;
-import jdk.vm.ci.meta.PrimitiveConstant;
-import jdk.vm.ci.meta.ResolvedJavaType;
-import jdk.vm.ci.meta.Value;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLStampFactory;
@@ -115,11 +105,21 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLReturnSlot;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLUnary;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.PragmaUnrollNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.ThreadConfigurationNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.XilinxPipelineAttribute;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.logic.LogicalAndNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.logic.LogicalEqualsNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.logic.LogicalNotNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.logic.LogicalOrNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.vector.VectorValueNode;
+
+import java.util.Collection;
+import java.util.List;
+
+import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
+import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
+import static uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind.ILLEGAL;
+import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
+import static uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCodeGenerator.trace;
 
 public class OCLNodeLIRBuilder extends NodeLIRBuilder {
 
@@ -560,7 +560,7 @@ public class OCLNodeLIRBuilder extends NodeLIRBuilder {
             emitLoopExit((LoopExitNode) node);
         } else if (node instanceof ShortCircuitOrNode) {
             emitShortCircuitOrNode((ShortCircuitOrNode) node);
-        } else if (node instanceof PragmaUnrollNode || node instanceof ThreadConfigurationNode) {
+        } else if (node instanceof PragmaUnrollNode || node instanceof XilinxPipelineAttribute || node instanceof ThreadConfigurationNode) {
             // ignore emit-action
         } else {
             super.emitNode(node);
@@ -624,7 +624,7 @@ public class OCLNodeLIRBuilder extends NodeLIRBuilder {
 
     private void emitPragmaLoopUnroll(Block blk) {
         for (ValueNode tempDomBlockNode : blk.getNodes()) {
-            if (tempDomBlockNode instanceof PragmaUnrollNode) {
+            if (tempDomBlockNode instanceof PragmaUnrollNode || tempDomBlockNode instanceof XilinxPipelineAttribute) {
                 super.emitNode(tempDomBlockNode);
             }
         }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/IntelUnrollPragmaNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/IntelUnrollPragmaNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * Copyright (c) 2018, 2020, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -18,6 +18,8 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
+ * Authors: Michalis Papadimitriou
+ *
  * */
 
 package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
@@ -33,21 +35,21 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
 
 @NodeInfo
-public class XilinxPipelineAttribute extends FixedWithNextNode implements LIRLowerable {
+public class IntelUnrollPragmaNode extends FixedWithNextNode implements LIRLowerable {
 
     @Successor
     LoopBeginNode loopBgNd;
-    public static final NodeClass<XilinxPipelineAttribute> TYPE = NodeClass.create(XilinxPipelineAttribute.class);
+    public static final NodeClass<IntelUnrollPragmaNode> TYPE = NodeClass.create(IntelUnrollPragmaNode.class);
 
-    private int initiationIntervalValue;
+    private int unroll;
 
-    public XilinxPipelineAttribute(int initiationIntervalValue) {
+    public IntelUnrollPragmaNode(int unroll) {
         super(TYPE, StampFactory.forVoid());
-        this.initiationIntervalValue = initiationIntervalValue;
+        this.unroll = unroll;
     }
 
     @Override
     public void generate(NodeLIRBuilderTool nodeLIRBuilderTool) {
-        nodeLIRBuilderTool.getLIRGeneratorTool().append(new OCLLIRStmt.PragmaExpr(new XclPipelineAttribute(initiationIntervalValue)));
+        nodeLIRBuilderTool.getLIRGeneratorTool().append(new OCLLIRStmt.PragmaExpr(new OCLPragmaUnroll(unroll)));
     }
 }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/XclPipelineAttribute.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/XclPipelineAttribute.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, APT Group, School of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
+
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.lir.Opcode;
+
+import uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler;
+import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResultBuilder;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIROp;
+
+@Opcode("XclPipelineAttribute")
+public class XclPipelineAttribute extends OCLLIROp {
+
+    private int initiationIntervalValue;
+
+    public XclPipelineAttribute(int initiationIntervalValue) {
+        super(LIRKind.Illegal);
+        this.initiationIntervalValue = initiationIntervalValue;
+    }
+
+    @Override
+    public void emit(OCLCompilationResultBuilder crb, OCLAssembler asm) {
+        asm.emitLine(" __attribute__((xcl_pipeline_loop(" + initiationIntervalValue + ")))");
+    }
+}

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/XclPipelineAttribute.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/XclPipelineAttribute.java
@@ -40,6 +40,6 @@ public class XclPipelineAttribute extends OCLLIROp {
 
     @Override
     public void emit(OCLCompilationResultBuilder crb, OCLAssembler asm) {
-        asm.emitLine(" __attribute__((xcl_pipeline_loop(" + initiationIntervalValue + ")))");
+        asm.emitLine("__attribute__((xcl_pipeline_loop(" + initiationIntervalValue + ")))");
     }
 }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/XilinxPipelineAttribute.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/XilinxPipelineAttribute.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * */
+
+package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
+
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.LoopBeginNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
+
+@NodeInfo
+public class XilinxPipelineAttribute extends FixedWithNextNode implements LIRLowerable {
+
+    @Successor
+    LoopBeginNode loopBgNd;
+    public static final NodeClass<XilinxPipelineAttribute> TYPE = NodeClass.create(XilinxPipelineAttribute.class);
+
+    private int initiationIntervalValue;
+
+    public XilinxPipelineAttribute(int initiationIntervalValue) {
+        super(TYPE, StampFactory.forVoid());
+        this.initiationIntervalValue = initiationIntervalValue;
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool nodeLIRBuilderTool) {
+        nodeLIRBuilderTool.getLIRGeneratorTool().append(new OCLLIRStmt.PragmaExpr(new XclPipelineAttribute(initiationIntervalValue)));
+    }
+}

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/XilinxPipeliningPragmaNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/XilinxPipeliningPragmaNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -18,8 +18,6 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Authors: Michalis Papadimitriou
- *
  * */
 
 package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
@@ -35,21 +33,21 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
 
 @NodeInfo
-public class PragmaUnrollNode extends FixedWithNextNode implements LIRLowerable {
+public class XilinxPipeliningPragmaNode extends FixedWithNextNode implements LIRLowerable {
 
     @Successor
     LoopBeginNode loopBgNd;
-    public static final NodeClass<PragmaUnrollNode> TYPE = NodeClass.create(PragmaUnrollNode.class);
+    public static final NodeClass<XilinxPipeliningPragmaNode> TYPE = NodeClass.create(XilinxPipeliningPragmaNode.class);
 
-    private int unroll;
+    private int initiationIntervalValue;
 
-    public PragmaUnrollNode(int unroll) {
+    public XilinxPipeliningPragmaNode(int initiationIntervalValue) {
         super(TYPE, StampFactory.forVoid());
-        this.unroll = unroll;
+        this.initiationIntervalValue = initiationIntervalValue;
     }
 
     @Override
     public void generate(NodeLIRBuilderTool nodeLIRBuilderTool) {
-        nodeLIRBuilderTool.getLIRGeneratorTool().append(new OCLLIRStmt.PragmaExpr(new OCLPragmaUnroll(unroll)));
+        nodeLIRBuilderTool.getLIRGeneratorTool().append(new OCLLIRStmt.PragmaExpr(new XclPipelineAttribute(initiationIntervalValue)));
     }
 }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoFPGAPragmas.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoFPGAPragmas.java
@@ -53,7 +53,19 @@ import static org.graalvm.compiler.nodes.loop.DefaultLoopPolicies.Options.FullUn
 
 public class TornadoFPGAPragmas extends BasePhase<TornadoHighTierContext> {
 
+    /*
+     * The default factor number for loop unrolling is 4, because this number
+     * yielded higher performance on Intel FPGAs.
+     */
     private static final int UNROLL_FACTOR_NUMBER = 4;
+    /**
+     * The default initiation interval number for loop pipelining is 1, because this
+     * number has been indicated as the default by Xilinx HLS for full pipelining.
+     *
+     * @see <a href=
+     *      "https://www.xilinx.com/html_docs/xilinx2020_2/vitis_doc/openclattributes.html#sgo1504034359903__ad410982"
+     *      * >Vitis 2020.2 Documentation</a>.
+     */
     private static final int XILINX_PIPELINING_II_NUMBER = 1;
     private TornadoDeviceContext deviceContext;
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoFPGAPragmas.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoFPGAPragmas.java
@@ -53,9 +53,13 @@ import static org.graalvm.compiler.nodes.loop.DefaultLoopPolicies.Options.FullUn
 
 public class TornadoFPGAPragmas extends BasePhase<TornadoHighTierContext> {
 
-    /*
-     * The default factor number for loop unrolling is 4, because this number
-     * yielded higher performance on Intel FPGAs.
+    /**
+     * The default factor number for loop unrolling is 4, as this number yielded the
+     * same performance with full unrolling on an Intel Arria 10 FPGA.
+     * 
+     * @see <a href= "https://arxiv.org/ftp/arxiv/papers/2010/2010.16304.pdf">
+     *      Transparent Compiler and Runtime Specializations for Accelerating
+     *      Managed Languages on FPGAs</a>.
      */
     private static final int UNROLL_FACTOR_NUMBER = 4;
     /**

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoFPGAPragmas.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoFPGAPragmas.java
@@ -40,8 +40,8 @@ import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.compiler.phases.BasePhase;
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
-import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.PragmaUnrollNode;
-import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.XilinxPipelineAttribute;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.IntelUnrollPragmaNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.XilinxPipeliningPragmaNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.TornadoLoopsData;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
 
@@ -114,11 +114,11 @@ public class TornadoFPGAPragmas extends BasePhase<TornadoHighTierContext> {
                             idx++;
                             if (idx == 2) {
                                 if (deviceContext.isPlatformXilinxFPGA()) {
-                                    XilinxPipelineAttribute pipelineAttribute = graph.addOrUnique(new XilinxPipelineAttribute(XILINX_PIPELINING_II_NUMBER));
-                                    graph.addBeforeFixed(end, pipelineAttribute);
+                                    XilinxPipeliningPragmaNode pipeliningPragmaNode = graph.addOrUnique(new XilinxPipeliningPragmaNode(XILINX_PIPELINING_II_NUMBER));
+                                    graph.addBeforeFixed(end, pipeliningPragmaNode);
                                 } else {
-                                    PragmaUnrollNode unroll = graph.addOrUnique(new PragmaUnrollNode(UNROLL_FACTOR_NUMBER));
-                                    graph.addBeforeFixed(end, unroll);
+                                    IntelUnrollPragmaNode unrollPragmaNode = graph.addOrUnique(new IntelUnrollPragmaNode(UNROLL_FACTOR_NUMBER));
+                                    graph.addBeforeFixed(end, unrollPragmaNode);
                                 }
                             }
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
@@ -190,6 +190,11 @@ public class VirtualOCLDeviceContext extends TornadoLogger implements Initialisa
     }
 
     @Override
+    public boolean isPlatformXilinxFPGA() {
+        return getPlatformContext().getPlatform().getName().toLowerCase().contains("xilinx");
+    }
+
+    @Override
     public int getDeviceIndex() {
         return device.getIndex();
     }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -23,13 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx;
 
-import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernelName;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.Arrays;
-import java.util.List;
-
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.common.Event;
@@ -47,6 +40,13 @@ import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+
+import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernelName;
 
 public class PTXDeviceContext extends TornadoLogger implements Initialisable, TornadoDeviceContext {
 
@@ -89,6 +89,11 @@ public class PTXDeviceContext extends TornadoLogger implements Initialisable, To
 
     @Override
     public boolean isPlatformFPGA() {
+        return false;
+    }
+
+    @Override
+    public boolean isPlatformXilinxFPGA() {
         return false;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceContext.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceContext.java
@@ -56,6 +56,8 @@ public interface TornadoDeviceContext {
 
     boolean isPlatformFPGA();
 
+    boolean isPlatformXilinxFPGA();
+
     boolean useRelativeAddresses();
 
     boolean isCached(String methodName, SchedulableTask task);


### PR DESCRIPTION
#### Description

This PR provides enhancements for the generated code that target Xilinx FPGAs.

In particular two features are introduced:
- The ability to instantiate multiple compute units for the same kernel.
- The transparent addition of the `__attribute__((xcl_pipeline_loop(1)))`. (1 is the default initiation interval value (II) used by Xilinx HLS tools).

#### Problem description

1. With regards to the first feature, we have seen up to 2.5x performance improvement when fitting multiple compute units on the FPGA. In particular for the DFT and 65536 input size, we managed to fit up to 12 kernels on the Xilinx KCU1500 FPGA. The problem that did not allow this flag to work was due to an inability in the `OCLCodeCache` to parse the `--nk computeDft:2` as a flag in the FPGA configuration file.
This flag is tested with SDAccel compiler `xocc` and resulted in 2.5x speedup for `DFTDynamic`.

2. Regarding the second feature, TornadoVM currently supports the loop unrolling for Intel FPGAs. This PR has added the addition of the Xilinx OpenCL pipelining attribute for loops, as this attribute can contribute to up to 2.2x performance increase. The XIlinx OpenCL loop unrolling attribute did not result in any performance change.

#### Backend/s tested

- [x] OpenCL
- [ ] PTX

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [x] Yes
- [ ] No

#### How to test the new patch?

I tested the PR in the Intel FPGAs to ensure that it does not break the code generation. In addition, I tested it on the Xilinx KCU1500 FPGA using SDAccel 2018.2 and on emulation mode with Vitis 2020.2. Here is the output of the execution with the generated code:

```bash
$ tornado --printKernel --debug --igv -Ds0.t0.device=0:1 uk.ac.manchester.tornado.examples.dynamic.DFTDynamic 512 tornado 1

__kernel void lookupBufferAddress(__global uchar *_heap_base, ulong _frame_base, __constant uchar *_constant_region, __local uchar *_local_region, __global int *_atomics)
{

  __global ulong *_frame = (__global ulong *) &_heap_base[_frame_base];


  // BLOCK 0
  _frame[0]  =  (ulong) _heap_base;
}  //  kernel

Initialization time:  759578609 ns

__kernel void lookupBufferAddress(__global uchar *_heap_base, ulong _frame_base, __constant uchar *_constant_region, __local uchar *_local_region, __global int *_atomics)
{

  __global ulong *_frame = (__global ulong *) &_heap_base[_frame_base];


  // BLOCK 0
  _frame[0]  =  (ulong) _heap_base;
}  //  kernel

[DEBUG] JIT compilation for the FPGA
Warning: -Dtornado.opencl.userelative was set to False. TornadoVM changed it to True because it is required for FPGA execution.
__attribute__((reqd_work_group_size(64,1,1)))
__kernel void computeDft(__global uchar *_heap_base, ulong _frame_base, __constant uchar *_constant_region, __local uchar *_local_region, __global int *_atomics)
{
  long l_11, l_30, l_32, l_31, l_10, l_9; 
  float f_28, f_27, f_26, f_25, f_24, f_7, f_6, f_15, f_13, f_23, f_22, f_21, f_20, f_19, f_18, f_17, f_16; 
  ulong ul_12, ul_14, ul_0, ul_2, ul_34, ul_1, ul_33, ul_3; 
  int i_8, i_29, i_35, i_5, i_4, i_36; 

  __global ulong *_frame = (__global ulong *) &_heap_base[_frame_base];


  // BLOCK 0
  ul_0  =  (ulong) _frame[3];
  ul_1  =  (ulong) _frame[4];
  ul_2  =  (ulong) _frame[5];
  ul_3  =  (ulong) _frame[6];
  i_4  =  get_global_id(0);
  // BLOCK 1 MERGES [0 5 ]
  i_5  =  i_4;
  // BLOCK 2
  // BLOCK 3 MERGES [2 4 ]
  f_6  =  0.0F;
  f_7  =  0.0F;
  i_8  =  0;
  __attribute__((xcl_pipeline_loop(1)))
  for(;i_8 < 512;)
  {
    // BLOCK 4
    l_9  =  (long) i_8;
    l_10  =  l_9 << 2;
    l_11  =  l_10 + 24L;
    ul_12  =  ul_0 + l_11;
    f_13  =  *((__global float *) &_heap_base[ul_12]);
    ul_14  =  ul_1 + l_11;
    f_15  =  *((__global float *) &_heap_base[ul_14]);
    f_16  =  (float) i_8;
    f_17  =  f_16 * 6.2831855F;
    f_18  =  (float) i_5;
    f_19  =  f_17 * f_18;
    f_20  =  f_19 / 512.0F;
    f_21  =  sin(f_20);
    f_22  =  cos(f_20);
    f_23  =  f_22 * f_15;
    f_24  =  fma(f_21, f_13, f_23);
    f_25  =  f_7 - f_24;
    f_26  =  f_21 * f_15;
    f_27  =  fma(f_22, f_13, f_26);
    f_28  =  f_6 + f_27;
    i_29  =  i_8 + 1;
    f_6  =  f_28;
    f_7  =  f_25;
    i_8  =  i_29;
  }  // B4
  // BLOCK 5
  l_30  =  (long) i_5;
  l_31  =  l_30 << 2;
  l_32  =  l_31 + 24L;
  ul_33  =  ul_2 + l_32;
  *((__global float *) &_heap_base[ul_33])  =  f_6;
  ul_34  =  ul_3 + l_32;
  *((__global float *) &_heap_base[ul_34])  =  f_7;
  i_35  =  get_global_size(0);
  i_36  =  i_35 + i_5;
  i_5  =  i_36;
  // BLOCK 6
  return;
}  //  kernel

Task info: s0.t0
	Backend           : OpenCL
	Device            : xilinx_u50_gen3x16_xdma_201920_3 CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 1
	Global work offset: [0]
	Global work size  : [512]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : [8]

Total time:  58947809342 ns 

Is valid?: true

Validation: SUCCESS 
```

Provide instructions about how to test the new patch. 
