### PR TITLE
[refactor] GridTask renamed to GridScheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ public class Compute {
         // When using the kernel-parallel API, we need to create a Grid and a Worker
 
         WorkerGrid workerGrid = new WorkerGrid2D(size, size);    // Create a 2D Worker
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);   // Attach the worker to the Grid
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);  // Attach the worker to the Grid
         KernelContext context = new KernelContext();             // Create a context
         workerGrid.setLocalWork(32, 32, 1);                      // Set the local-group size
 
@@ -123,7 +123,7 @@ public class Compute {
                 .streamIn(A, B)                                 // Stream data from host to device
                 .task("t0", Compute::mxmKernel, context, A, B, C, size)  // Each task points to an existing Java method
                 .streamOut(C);                                  // sync arrays with the host side
-        ts.execute(gridTask);   // Execute with a GridTask
+        ts.execute(gridScheduler);   // Execute with a GridScheduler
     }
 }
 ```

--- a/assembly/src/docs/21_KERNEL_CONTEXT.md
+++ b/assembly/src/docs/21_KERNEL_CONTEXT.md
@@ -88,14 +88,14 @@ public static void matrixMultiplication(KernelContext context,
 
 2. A TornadoVM program that uses the `KernelContext` must use the context with a `WorkerGrid` (1D/2D/3D). This is
    necessary in order to obtain awareness about the dimensions and the sizes of the threads that will be deployed.
-   **Therefore, `KernelContext` can only work with GridTasks.**
+   **Therefore, `KernelContext` can only work with tasks that are linked with a `GridScheduler`.**
 
 ```java
 // Create 2D Grid of Threads with a 2D Worker
 WorkerGrid workerGrid = new WorkerGrid2D(size, size);
 
-// Create a GridTask that associates a task-ID with a worker grid
-GridTask gridTask = new GridTask("s0.t0", workerGrid);
+// Create a GridScheduler that associates a task-ID with a worker grid
+GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
 
 // Create the TornadoVM Context
 KernelContext context = new KernelContext();
@@ -111,7 +111,7 @@ TaskSchedule t = new TaskSchedule("s0")
         .task("t0",MxM::compute,context, matrixA, matrixB, matrixC, size)
         .streamOut(matrixC);
 
-t.execute(gridTask);    // Pass the GridTask in the execute method
+t.execute(gridScheduler);    // Pass the GridScheduler in the execute method
 ```
 
 ## Multiple Tasks in a TaskSchedule with a `WorkerGrid` and `KernelContext`
@@ -128,12 +128,12 @@ The TornadoVM Task-Schedule can be composed of multiple tasks which can either e
 WorkerGrid workerT0 = new WorkerGrid1D(size);
 WorkerGrid workerT1 = new WorkerGrid1D(size);
 
-// Create a unique GridTask per TaskSchedule
-GridTask gridTask = new GridTask();
+// Create a unique GridScheduler per TaskSchedule
+GridScheduler gridScheduler = new GridScheduler();
 
 // Associate a worker per task within the task-scheduler
-gridTask.setWorkerGrid("s0.t0", workerT0);
-gridTask.setWorkerGrid("s0.t1", workerT1);
+gridScheduler.setWorkerGrid("s0.t0", workerT0);
+gridScheduler.setWorkerGrid("s0.t1", workerT1);
 
 // Create the KernelContext
 KernelContext context = new KernelContext();
@@ -147,7 +147,7 @@ TaskSchedule s0 = new TaskSchedule("s0")
         .streamOut(cTornado);
 
 // Execute the application
-s0.execute(gridTask);
+s0.execute(gridScheduler);
 
 // Change the Grid for the next round
 workerT0.setGlobalWork(size, 1, 1);
@@ -155,8 +155,8 @@ workerT0.setLocalWork(size/2, 1, 1);
 workerT1.setGlobalWork(size, 1, 1);
 workerT1.setLocalWorkToNull();
 
-s0.execute(gridTask);
+s0.execute(gridScheduler);
 ```
 
-In this test case, each of the first two tasks uses a separate `WorkerGrid`. The third task does not use a `WorkerGrid`, and it relies on the TornadoVM Runtime for the scheduling of the threads. The execution of the whole TaskSchedule is invoked by `s0.execute(gridTask);`.
+In this test case, each of the first two tasks uses a separate `WorkerGrid`. The third task does not use a `WorkerGrid`, and it relies on the TornadoVM Runtime for the scheduling of the threads. The execution of the whole TaskSchedule is invoked by `s0.execute(gridScheduler);`.
 

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication1D.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication1D.java
@@ -20,7 +20,7 @@ package uk.ac.manchester.tornado.examples.compute;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
@@ -67,7 +67,7 @@ public class MatrixMultiplication1D {
         });
 
         WorkerGrid workerGrid = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         // [Optional] Set the global work size
         workerGrid.setGlobalWork(size, 1, 1);
         // [Optional] Set the local work group
@@ -81,12 +81,12 @@ public class MatrixMultiplication1D {
 
         // 1. Warm up Tornado
         for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {
-            t.execute(gridTask);
+            t.execute(gridScheduler);
         }
 
         // 2. Run parallel on the GPU with Tornado
         long start = System.currentTimeMillis();
-        t.execute(gridTask);
+        t.execute(gridScheduler);
         long end = System.currentTimeMillis();
 
         // Run sequential

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication2D.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication2D.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.examples.compute;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid2D;
@@ -70,7 +70,7 @@ public class MatrixMultiplication2D {
         }
 
         WorkerGrid workerGrid = new WorkerGrid2D(size, size);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         // [Optional] Set the global work size
         workerGrid.setGlobalWork(size, size, 1);
         // [Optional] Set the local work group to be 32x32
@@ -84,12 +84,12 @@ public class MatrixMultiplication2D {
 
         // 1. Warm up Tornado
         for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {
-            t.execute(gridTask);
+            t.execute(gridScheduler);
         }
 
         // 2. Run parallel on the GPU with Tornado
         long start = System.currentTimeMillis();
-        t.execute(gridTask);
+        t.execute(gridScheduler);
         long end = System.currentTimeMillis();
 
         // Run sequential

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/NBody.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/compute/NBody.java
@@ -20,7 +20,7 @@ package uk.ac.manchester.tornado.examples.compute;
 
 import java.util.Arrays;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
@@ -132,7 +132,7 @@ public class NBody {
         System.out.println(resultsIterations.toString());
 
         WorkerGrid workerGrid = new WorkerGrid1D(numBodies);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         // [Optional] Set the global work group
         workerGrid.setGlobalWork(numBodies, 1, 1);
         // [Optional] Set the local work group
@@ -148,7 +148,7 @@ public class NBody {
         for (int i = 0; i < iterations; i++) {
             System.gc();
             start = System.nanoTime();
-            t0.execute(gridTask);
+            t0.execute(gridScheduler);
             end = System.nanoTime();
             uk.ac.manchester.tornado.api.profiler.ChromeEventTracer.enqueueTaskIfEnabled("nbody accelerated", start, end);
             resultsIterations.append("\tTornado execution time of iteration " + i + " is: " + (end - start) + " ns");

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/fpga/VectorAddIntGridScheduler.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/fpga/VectorAddIntGridScheduler.java
@@ -19,10 +19,10 @@ package uk.ac.manchester.tornado.examples.fpga;
 
 import java.util.Arrays;
 
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
-import uk.ac.manchester.tornado.api.GridTask;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 
 /**
@@ -52,7 +52,7 @@ public class VectorAddIntGridScheduler {
         Arrays.fill(b, 20);
 
         WorkerGrid workerGrid = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         workerGrid.setGlobalWork(size, 1, 1);
         workerGrid.setLocalWork(size / 2, 1, 1);
 
@@ -63,7 +63,7 @@ public class VectorAddIntGridScheduler {
         //@formatter:on
 
         for (int idx = 0; idx < 10; idx++) {
-            graph.execute(gridTask);
+            graph.execute(gridScheduler);
             vectorAdd(a, b, result);
 
             boolean wrongResult = false;

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/BFS.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/BFS.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -217,7 +217,7 @@ public class BFS {
         currentDepth = new int[] { 0 };
 
         WorkerGrid workerGrid = new WorkerGrid2D(numNodes, numNodes);
-        GridTask gridTask = new GridTask("s1.t1", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s1.t1", workerGrid);
         KernelContext context = new KernelContext();
         // [Optional] Set the global work group
         workerGrid.setGlobalWork(numNodes, numNodes, 1);
@@ -235,7 +235,7 @@ public class BFS {
             boolean allDone = true;
             System.out.println("Current Depth: " + currentDepth[0]);
             runBFS(verticesJava, adjacencyMatrix, numNodes, modifyJava, currentDepth);
-            s1.execute(gridTask);
+            s1.execute(gridScheduler);
             currentDepth[0]++;
 
             if (VALIDATION) {

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/BlackAndWhiteTransform.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/BlackAndWhiteTransform.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import javax.imageio.ImageIO;
 import javax.swing.*;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -65,7 +65,7 @@ public class BlackAndWhiteTransform {
         private static TaskSchedule tornadoTask;
 
         private static WorkerGrid workerGrid;
-        private static GridTask gridTask;
+        private static GridScheduler gridScheduler;
 
         LoadImage() {
             try {
@@ -136,7 +136,7 @@ public class BlackAndWhiteTransform {
 
                 if (tornadoTask == null) {
                     workerGrid = new WorkerGrid2D(w, s);
-                    gridTask = new GridTask("s0.t0", workerGrid);
+                    gridScheduler = new GridScheduler("s0.t0", workerGrid);
                     KernelContext context = new KernelContext();
 
                     tornadoTask = new TaskSchedule("s0");
@@ -147,7 +147,7 @@ public class BlackAndWhiteTransform {
                 workerGrid.setGlobalWork(w, s, 1);
 
                 taskStart = System.nanoTime();
-                tornadoTask.execute(gridTask);
+                tornadoTask.execute(gridScheduler);
                 taskEnd = System.nanoTime();
 
                 // unmarshall

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Euler.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Euler.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.examples.kernelcontext.compute;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -185,7 +185,7 @@ public class Euler {
         long[] outputE = new long[size];
 
         WorkerGrid workerGrid = new WorkerGrid2D(size, size);
-        GridTask gridTask = new GridTask("s0.s0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.s0", workerGrid);
         KernelContext context = new KernelContext();
         // [Optional] Set the global work group
         workerGrid.setGlobalWork(size, size, 1);
@@ -197,7 +197,7 @@ public class Euler {
         // Sequential
         for (int i = 0; i < ITERATIONS; i++) {
             long start = System.nanoTime();
-            ts.execute(gridTask);
+            ts.execute(gridScheduler);
             long end = System.nanoTime();
             System.out.println("Parallel: " + (end - start));
         }

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/HilbertMatrix.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/HilbertMatrix.java
@@ -18,7 +18,7 @@
 
 package uk.ac.manchester.tornado.examples.kernelcontext.compute;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -49,7 +49,7 @@ public class HilbertMatrix {
         float[] output = new float[NROWS * NCOLS];
 
         WorkerGrid workerGrid = new WorkerGrid2D(NROWS, NCOLS);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         KernelContext context = new KernelContext();
         // [Optional] Set the global work group
         workerGrid.setGlobalWork(NROWS, NCOLS, 1);
@@ -61,7 +61,7 @@ public class HilbertMatrix {
                 .streamOut(output);
         // @formatter:on
 
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         if (CHECK_RESULT) {
             float[] seq = new float[NROWS * NCOLS];

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Mandelbrot.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Mandelbrot.java
@@ -30,7 +30,7 @@ import java.io.File;
 import javax.imageio.ImageIO;
 import javax.swing.JFrame;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -141,7 +141,7 @@ public class Mandelbrot {
                 short[] result = new short[SIZE * SIZE];
 
                 WorkerGrid workerGrid = new WorkerGrid2D(SIZE, SIZE);
-                GridTask gridTask = new GridTask("s0.t0", workerGrid);
+                GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
                 KernelContext context = new KernelContext();
                 // [Optional] Set the global work group
                 workerGrid.setGlobalWork(SIZE, SIZE, 1);
@@ -151,7 +151,7 @@ public class Mandelbrot {
                 TaskSchedule s0 = new TaskSchedule("s0");
 
                 s0.task("t0", MandelbrotImage::mandelbrotTornado, context, SIZE, result);
-                s0.streamOut(result).execute(gridTask);
+                s0.streamOut(result).execute(gridScheduler);
                 this.image = writeFile(result, SIZE);
             }
             // draw the image

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/MatrixMultiplication1D.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/MatrixMultiplication1D.java
@@ -20,7 +20,7 @@ package uk.ac.manchester.tornado.examples.kernelcontext.compute;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -78,7 +78,7 @@ public class MatrixMultiplication1D {
         });
 
         WorkerGrid workerGrid = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         KernelContext context = new KernelContext();
         // [Optional] Set the global work size
         workerGrid.setGlobalWork(size, 1, 1);
@@ -93,12 +93,12 @@ public class MatrixMultiplication1D {
 
         // 1. Warm up Tornado
         for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {
-            t.execute(gridTask);
+            t.execute(gridScheduler);
         }
 
         // 2. Run parallel on the GPU with Tornado
         long start = System.currentTimeMillis();
-        t.execute(gridTask);
+        t.execute(gridScheduler);
         long end = System.currentTimeMillis();
 
         // Run sequential

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/MatrixMultiplication2DV1.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/MatrixMultiplication2DV1.java
@@ -19,7 +19,7 @@ package uk.ac.manchester.tornado.examples.kernelcontext.compute;
 
 import java.util.stream.IntStream;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -89,7 +89,7 @@ public class MatrixMultiplication2DV1 {
         });
 
         WorkerGrid workerGrid = new WorkerGrid2D(size, size);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         KernelContext context = new KernelContext();
         // The local work group is configured to be 32x32
         workerGrid.setLocalWork(32, 32, 1);
@@ -102,12 +102,12 @@ public class MatrixMultiplication2DV1 {
 
         // 1. Warm up Tornado
         for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {
-            t.execute(gridTask);
+            t.execute(gridScheduler);
         }
 
         // 2. Run parallel on the GPU with Tornado
         long start = System.currentTimeMillis();
-        t.execute(gridTask);
+        t.execute(gridScheduler);
         long end = System.currentTimeMillis();
 
         // Run sequential

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/MatrixMultiplication2DV2.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/MatrixMultiplication2DV2.java
@@ -19,7 +19,7 @@ package uk.ac.manchester.tornado.examples.kernelcontext.compute;
 
 import java.util.stream.IntStream;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -115,7 +115,7 @@ public class MatrixMultiplication2DV2 {
         });
 
         WorkerGrid workerGrid = new WorkerGrid2D(size, size);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         KernelContext context = new KernelContext();
         // The local work group is configured to be TSxTS, to match the Tile Size (TS)
         workerGrid.setLocalWork(TS, TS, 1);
@@ -128,12 +128,12 @@ public class MatrixMultiplication2DV2 {
 
         // 1. Warm up Tornado
         for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {
-            t.execute(gridTask);
+            t.execute(gridScheduler);
         }
 
         // 2. Run parallel on the GPU with Tornado
         long start = System.currentTimeMillis();
-        t.execute(gridTask);
+        t.execute(gridScheduler);
         long end = System.currentTimeMillis();
 
         // Run sequential

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Montecarlo.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Montecarlo.java
@@ -18,7 +18,7 @@
 
 package uk.ac.manchester.tornado.examples.kernelcontext.compute;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -84,7 +84,7 @@ public class Montecarlo {
         float[] seq = new float[size];
 
         WorkerGrid workerGrid = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         KernelContext context = new KernelContext();
         // [Optional] Set the global work size
         workerGrid.setGlobalWork(size, 1, 1);
@@ -94,7 +94,7 @@ public class Montecarlo {
         TaskSchedule t0 = new TaskSchedule("s0").task("t0", Montecarlo::computeMontecarlo, context, output, size).streamOut(output);
 
         long start = System.nanoTime();
-        t0.execute(gridTask);
+        t0.execute(gridScheduler);
         long end = System.nanoTime();
         long tornadoTime = (end - start);
 

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/NBody.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/NBody.java
@@ -20,7 +20,7 @@ package uk.ac.manchester.tornado.examples.kernelcontext.compute;
 
 import java.util.Arrays;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -163,7 +163,7 @@ public class NBody {
         System.out.println(resultsIterations.toString());
 
         WorkerGrid workerGrid = new WorkerGrid1D(numBodies);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         KernelContext context = new KernelContext();
         // [Optional] Set the global work group
         workerGrid.setGlobalWork(numBodies, 1, 1);
@@ -180,7 +180,7 @@ public class NBody {
         for (int i = 0; i < iterations; i++) {
             System.gc();
             start = System.nanoTime();
-            t0.execute(gridTask);
+            t0.execute(gridScheduler);
             end = System.nanoTime();
             ChromeEventTracer.enqueueTaskIfEnabled("nbody accelerated", start, end);
             resultsIterations.append("\tTornado execution time of iteration " + i + " is: " + (end - start) + " ns");

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/RenderTrack.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/RenderTrack.java
@@ -20,7 +20,7 @@ package uk.ac.manchester.tornado.examples.kernelcontext.compute;
 import java.util.ArrayList;
 import java.util.Random;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -122,7 +122,7 @@ public class RenderTrack {
         }
 
         WorkerGrid workerGrid = new WorkerGrid2D(n, m);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
         KernelContext context = new KernelContext();
         // [Optional] Set the global work group
         workerGrid.setGlobalWork(n, m, 1);
@@ -134,7 +134,7 @@ public class RenderTrack {
         // task.warmup();
         for (int i = 0; i < 10; i++) {
             long start = System.nanoTime();
-            task.execute(gridTask);
+            task.execute(gridScheduler);
             long end = System.nanoTime();
             timers.add((end - start));
         }

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/MatrixMul2DLocalMemory.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/MatrixMul2DLocalMemory.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.OptionalDouble;
 import java.util.stream.IntStream;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.TornadoDriver;
@@ -144,7 +144,7 @@ public class MatrixMul2DLocalMemory {
         });
 
         WorkerGrid workerCUDAOld = new WorkerGrid2D(N, N);
-        GridTask gridTaskCUDAOld = new GridTask("cuda_old_api.t0", workerCUDAOld);
+        GridScheduler gridSchedulerCUDAOld = new GridScheduler("cuda_old_api.t0", workerCUDAOld);
         TaskSchedule scheduleCUDA = new TaskSchedule("cuda_old_api").task("t0", MatrixMul2DLocalMemory::matrixMultiplication, matrixA, matrixB, matrixCCUDA, N).streamOut(matrixCCUDA);
 
         TornadoDriver cudaDriver = TornadoRuntime.getTornadoRuntime().getDriver(0);
@@ -155,7 +155,7 @@ public class MatrixMul2DLocalMemory {
 
         // Warm up CUDA
         for (int i = 0; i < WARMUP_ITERATIONS; i++) {
-            scheduleCUDA.execute(gridTaskCUDAOld);
+            scheduleCUDA.execute(gridSchedulerCUDAOld);
         }
 
         // Time CUDA
@@ -163,7 +163,7 @@ public class MatrixMul2DLocalMemory {
         long[] execTimesCUDA = new long[EXECUTE_ITERATIONS];
         for (int i = 0; i < execTimesCUDA.length; i++) {
             start = System.currentTimeMillis();
-            scheduleCUDA.execute(gridTaskCUDAOld);
+            scheduleCUDA.execute(gridSchedulerCUDAOld);
             stop = System.currentTimeMillis();
             execTimesCUDA[i] = stop - start;
         }
@@ -176,7 +176,7 @@ public class MatrixMul2DLocalMemory {
             throw new Exception("Could not get average execution time");
 
         WorkerGrid workerOpenCLOld = new WorkerGrid2D(N, N);
-        GridTask gridTaskOpenCLOld = new GridTask("ocl_old_api.t0", workerOpenCLOld);
+        GridScheduler gridSchedulerOpenCLOld = new GridScheduler("ocl_old_api.t0", workerOpenCLOld);
 
         TaskSchedule scheduleOCL = new TaskSchedule("ocl_old_api").task("t0", MatrixMul2DLocalMemory::matrixMultiplication, matrixA, matrixB, matrixCOCL, N).streamOut(matrixCOCL);
 
@@ -199,14 +199,14 @@ public class MatrixMul2DLocalMemory {
 
         // Warm up OpenCL
         for (int i = 0; i < WARMUP_ITERATIONS; i++) {
-            scheduleOCL.execute(gridTaskOpenCLOld);
+            scheduleOCL.execute(gridSchedulerOpenCLOld);
         }
 
         // Time OpenCL
         long[] execTimesOCL = new long[EXECUTE_ITERATIONS];
         for (int i = 0; i < execTimesOCL.length; i++) {
             start = System.currentTimeMillis();
-            scheduleOCL.execute(gridTaskOpenCLOld);
+            scheduleOCL.execute(gridSchedulerOpenCLOld);
             stop = System.currentTimeMillis();
             execTimesOCL[i] = stop - start;
         }
@@ -220,7 +220,7 @@ public class MatrixMul2DLocalMemory {
 
         // Time New API OpenCL
         WorkerGrid workerOpenCLNew = new WorkerGrid2D(N, N);
-        GridTask gridTaskOpenCLNew = new GridTask("ocl_advanced_api.t0", workerOpenCLNew);
+        GridScheduler gridSchedulerOpenCLNew = new GridScheduler("ocl_advanced_api.t0", workerOpenCLNew);
         KernelContext context = new KernelContext();
 
         TaskSchedule oclNewApiTask = new TaskSchedule("ocl_advanced_api") //
@@ -233,7 +233,7 @@ public class MatrixMul2DLocalMemory {
 
         // Warmup New Api OPENCL
         for (int i = 0; i < WARMUP_ITERATIONS; i++) {
-            oclNewApiTask.execute(gridTaskOpenCLNew);
+            oclNewApiTask.execute(gridSchedulerOpenCLNew);
         }
 
         // Time OPENCL
@@ -241,7 +241,7 @@ public class MatrixMul2DLocalMemory {
 
         for (int i = 0; i < EXECUTE_ITERATIONS; i++) {
             start = System.currentTimeMillis();
-            oclNewApiTask.execute(gridTaskOpenCLNew);
+            oclNewApiTask.execute(gridSchedulerOpenCLNew);
             stop = System.currentTimeMillis();
             execTimesOCLNewApi[i] = stop - start;
         }
@@ -255,7 +255,7 @@ public class MatrixMul2DLocalMemory {
 
         // Time New API CUDA
         WorkerGrid workerCudaNew = new WorkerGrid2D(N, N);
-        GridTask gridTaskCudaNew = new GridTask("cuda_advanced_api.t0", workerCudaNew);
+        GridScheduler gridSchedulerCudaNew = new GridScheduler("cuda_advanced_api.t0", workerCudaNew);
         KernelContext contextCUDA = new KernelContext();
 
         TaskSchedule cudaNewApiTask = new TaskSchedule("cuda_advanced_api") //
@@ -268,7 +268,7 @@ public class MatrixMul2DLocalMemory {
 
         // Warmup New Api OPENCL
         for (int i = 0; i < WARMUP_ITERATIONS; i++) {
-            cudaNewApiTask.execute(gridTaskCudaNew);
+            cudaNewApiTask.execute(gridSchedulerCudaNew);
         }
 
         // Time OPENCL
@@ -276,7 +276,7 @@ public class MatrixMul2DLocalMemory {
 
         for (int i = 0; i < EXECUTE_ITERATIONS; i++) {
             start = System.currentTimeMillis();
-            cudaNewApiTask.execute(gridTaskCudaNew);
+            cudaNewApiTask.execute(gridSchedulerCudaNew);
             stop = System.currentTimeMillis();
             execTimesCUDANewApi[i] = stop - start;
         }

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsGlobalMemory.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsGlobalMemory.java
@@ -19,7 +19,7 @@ package uk.ac.manchester.tornado.examples.kernelcontext.reductions;
 
 import java.util.stream.IntStream;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -69,13 +69,13 @@ public class ReductionsGlobalMemory {
         float sequential = computeSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0").streamIn(input).task("t0", ReductionsGlobalMemory::reduction, input, reduce, context).task("t1", ReductionsGlobalMemory::rAdd, reduce, size)
                 .streamOut(reduce);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         float finalSum = reduce[0];

--- a/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsLocalMemory.java
+++ b/examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsLocalMemory.java
@@ -19,7 +19,7 @@ package uk.ac.manchester.tornado.examples.kernelcontext.reductions;
 
 import java.util.stream.IntStream;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -72,15 +72,15 @@ public class ReductionsLocalMemory {
         float sequential = computeSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0").streamIn(input, localSize).task("t0", ReductionsLocalMemory::reductionLocal, input, reduce, localSize, context)
                 .task("t1", ReductionsLocalMemory::rAdd, reduce, (size / localSize)).streamOut(reduce);
         // Change the Grid
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         float finalSum = reduce[0];

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -25,22 +25,7 @@
  */
 package uk.ac.manchester.tornado.runtime;
 
-import static uk.ac.manchester.tornado.api.enums.TornadoExecutionStatus.COMPLETE;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.ENABLE_PROFILING;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.USE_VM_FLUSH;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.VM_USE_DEPS;
-import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEVICE_ENABLED;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.Arrays;
-import java.util.BitSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.common.Access;
@@ -68,6 +53,21 @@ import uk.ac.manchester.tornado.runtime.tasks.GlobalObjectState;
 import uk.ac.manchester.tornado.runtime.tasks.PrebuiltTask;
 import uk.ac.manchester.tornado.runtime.tasks.TornadoTaskSchedule;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static uk.ac.manchester.tornado.api.enums.TornadoExecutionStatus.COMPLETE;
+import static uk.ac.manchester.tornado.runtime.common.Tornado.ENABLE_PROFILING;
+import static uk.ac.manchester.tornado.runtime.common.Tornado.USE_VM_FLUSH;
+import static uk.ac.manchester.tornado.runtime.common.Tornado.VM_USE_DEPS;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEVICE_ENABLED;
 
 /**
  * TornadoVM: it includes a bytecode interpreter (Tornado bytecodes), a memory
@@ -110,7 +110,7 @@ public class TornadoVM extends TornadoLogger {
     private boolean finishedWarmup;
     private boolean doUpdate;
 
-    private GridTask gridTask;
+    private GridScheduler gridScheduler;
 
     public TornadoVM(TornadoExecutionContext graphContext, byte[] code, int limit, TornadoProfiler timeProfiler) {
 
@@ -435,7 +435,7 @@ public class TornadoVM extends TornadoLogger {
         task.setBatchThreads(batchThreads);
         task.enableDefaultThreadScheduler(graphContext.useDefaultThreadScheduler());
 
-        if (gridTask != null && gridTask.get(task.getId()) != null) {
+        if (gridScheduler != null && gridScheduler.get(task.getId()) != null) {
             task.setGridScheduler(true);
         }
 
@@ -509,8 +509,8 @@ public class TornadoVM extends TornadoLogger {
         }
 
         HashMap<Integer, Integer> map = new HashMap<>();
-        if (gridTask != null && gridTask.get(task.getId()) != null) {
-            WorkerGrid workerGrid = gridTask.get(task.getId());
+        if (gridScheduler != null && gridScheduler.get(task.getId()) != null) {
+            WorkerGrid workerGrid = gridScheduler.get(task.getId());
             long[] global = workerGrid.getGlobalWork();
             int i = 0;
             for (long maxThread : global) {
@@ -594,7 +594,7 @@ public class TornadoVM extends TornadoLogger {
         }
         // We attach the profiler
         metadata.attachProfiler(timeProfiler);
-        metadata.setGridTask(gridTask);
+        metadata.setGridScheduler(gridScheduler);
 
         int lastEvent;
         try {
@@ -804,8 +804,8 @@ public class TornadoVM extends TornadoLogger {
         }
     }
 
-    public void setGridTask(GridTask gridTask) {
-        this.gridTask = gridTask;
+    public void setGridScheduler(GridScheduler gridScheduler) {
+        this.gridScheduler = gridScheduler;
     }
 
     public void printTimes() {

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
@@ -25,16 +25,8 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks.meta;
 
-import static java.lang.Boolean.parseBoolean;
-import static java.lang.Integer.parseInt;
-import static uk.ac.manchester.tornado.runtime.tasks.meta.MetaDataUtils.resolveDevice;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-
 import jdk.vm.ci.meta.ResolvedJavaMethod;
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.common.TornadoEvents;
@@ -45,6 +37,14 @@ import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.DeviceBuffer;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoAcceleratorDevice;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
+import static uk.ac.manchester.tornado.runtime.tasks.meta.MetaDataUtils.resolveDevice;
 
 public abstract class AbstractMetaData implements TaskMetaDataInterface {
 
@@ -59,7 +59,7 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
     private final HashSet<String> openCLBuiltOptions = new HashSet<>(Arrays.asList("-cl-single-precision-constant", "-cl-denorms-are-zero", "-cl-opt-disable", "-cl-strict-aliasing", "-cl-mad-enable",
             "-cl-no-signed-zeros", "-cl-unsafe-math-optimizations", "-cl-finite-math-only", "-cl-fast-relaxed-math", "-w", "-cl-std=CL2.0"));
     private TornadoProfiler profiler;
-    private GridTask gridTask;
+    private GridScheduler gridScheduler;
     private long[] ptxBlockDim;
     private long[] ptxGridDim;
 
@@ -461,16 +461,16 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
         openclUseDriverScheduling = use;
     }
 
-    public void setGridTask(GridTask gridTask) {
-        this.gridTask = gridTask;
+    public void setGridScheduler(GridScheduler gridScheduler) {
+        this.gridScheduler = gridScheduler;
     }
 
     public boolean isWorkerGridAvailable() {
-        return (gridTask != null && gridTask.get(getId()) != null);
+        return (gridScheduler != null && gridScheduler.get(getId()) != null);
     }
 
     public WorkerGrid getWorkerGrid(String taskName) {
-        return gridTask.get(taskName);
+        return gridScheduler.get(taskName);
     }
 
     public long[] getPTXBlockDim() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/AbstractTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/AbstractTaskGraph.java
@@ -108,7 +108,7 @@ public interface AbstractTaskGraph extends ProfileInterface {
 
     AbstractTaskGraph schedule();
 
-    AbstractTaskGraph schedule(GridTask gridTask);
+    AbstractTaskGraph schedule(GridScheduler gridScheduler);
 
     AbstractTaskGraph scheduleWithProfile(Policy policy);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/GridScheduler.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/GridScheduler.java
@@ -43,15 +43,15 @@ package uk.ac.manchester.tornado.api;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-public class GridTask {
+public class GridScheduler {
 
     private final ConcurrentHashMap<String, WorkerGrid> gridTaskMap;
 
-    public GridTask() {
+    public GridScheduler() {
         gridTaskMap = new ConcurrentHashMap<>();
     }
 
-    public GridTask(String taskName, WorkerGrid workerGrid) {
+    public GridScheduler(String taskName, WorkerGrid workerGrid) {
         gridTaskMap = new ConcurrentHashMap<>();
         gridTaskMap.put(taskName, workerGrid);
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
@@ -62,7 +62,7 @@ import uk.ac.manchester.tornado.api.annotations.TornadoVMIntrinsic;
  * translated to both OpenCL and PTX by the TornadoVM JIT compiler. The main
  * difference with the {@link TaskSchedule} API is that the tasks within a
  * {@link TaskSchedule} that use {@link KernelContext} must be
- * {@link GridTask}.</li>
+ * {@link GridScheduler}.</li>
  * </ul>
  * </p>
  */

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskSchedule.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskSchedule.java
@@ -302,8 +302,8 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     }
 
     @Override
-    public void execute(GridTask gridTask) {
-        taskScheduleImpl.schedule(gridTask).waitOn();
+    public void execute(GridScheduler gridScheduler) {
+        taskScheduleImpl.schedule(gridScheduler).waitOn();
     }
 
     @Override
@@ -467,9 +467,9 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
      * 
      * Arrays can be of different sizes.
      * 
-     * If a {@link GridTask} is not passed in the {@link #execute()} method, then it
-     * will also trigger recompilation. Otherwise TornadoVM will not recompile the
-     * code, since the first compilation was generic.
+     * If a {@link GridScheduler} is not passed in the {@link #execute()} method,
+     * then it will also trigger recompilation. Otherwise TornadoVM will not
+     * recompile the code, since the first compilation was generic.
      * 
      * 
      * @param oldRef

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoAPI.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoAPI.java
@@ -603,7 +603,7 @@ public interface TornadoAPI {
      */
     void execute();
 
-    void execute(GridTask gridTask);
+    void execute(GridScheduler gridScheduler);
 
     /**
      * Run with dynamic reconfiguration with an input policy

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/dynsize/Resize.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/dynsize/Resize.java
@@ -19,7 +19,7 @@
 package uk.ac.manchester.tornado.unittests.dynsize;
 
 import org.junit.Test;
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
@@ -167,13 +167,13 @@ public class Resize {
         float[] b = createArray(256);
 
         WorkerGrid workerGrid = new WorkerGrid1D(256);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
 
         TaskSchedule ts = new TaskSchedule("s0") //
                 .streamIn(a) //
                 .task("t0", Resize::resize02, a, b) //
                 .streamOut(b); //
-        ts.execute(gridTask);
+        ts.execute(gridScheduler);
 
         float[] aux = createArray(256);
 
@@ -181,13 +181,13 @@ public class Resize {
         ts.updateReference(b, aux);
         ts.updateReference(a, b);
         ts.updateReference(aux, a);
-        ts.execute(gridTask);
+        ts.execute(gridScheduler);
 
         // Interchange again
         ts.updateReference(b, aux);
         ts.updateReference(a, b);
         ts.updateReference(aux, a);
-        ts.execute(gridTask);
+        ts.execute(gridScheduler);
 
         for (float v : b) {
             assertEquals(40.0f, v, 0.001f);
@@ -200,20 +200,21 @@ public class Resize {
         float[] b = createArray(256);
 
         WorkerGrid workerGrid = new WorkerGrid1D(256);
-        GridTask gridTask = new GridTask("s0.t0", workerGrid);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
 
         // Do not stream in 'a'
         TaskSchedule ts = new TaskSchedule("s0") //
                 .task("t0", Resize::resize02, a, b) //
                 .streamOut(b); //
-        ts.execute(gridTask);
+        ts.execute(gridScheduler);
 
         float[] aux = createArray(256);
         Arrays.fill(aux, 15);
 
-        // Update copy in variable 'a'. It should invalidate the buffer state on the device and copy in the 'aux' array.
+        // Update copy in variable 'a'. It should invalidate the buffer state on the
+        // device and copy in the 'aux' array.
         ts.updateReference(a, aux);
-        ts.execute(gridTask);
+        ts.execute(gridScheduler);
 
         for (float v : b) {
             assertEquals(25.0f, v, 0.001f);

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGrid.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGrid.java
@@ -18,7 +18,7 @@
 package uk.ac.manchester.tornado.unittests.grid;
 
 import org.junit.Test;
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.WorkerGrid2D;
@@ -75,12 +75,12 @@ public class TestGrid extends TornadoTestBase {
 
         // Set the Grid with 4096 threads
         WorkerGrid1D worker = new WorkerGrid1D(4096);
-        GridTask gridTask = new GridTask("s0.t0", worker);
-        ts.execute(gridTask);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        ts.execute(gridScheduler);
 
         // Change the Grid
         worker.setGlobalWork(512, 1, 1);
-        ts.execute(gridTask);
+        ts.execute(gridScheduler);
 
         for (int i = 0; i < c.length; i++) {
             assertEquals(a[i] + b[i], c[i], 0.01f);
@@ -106,11 +106,11 @@ public class TestGrid extends TornadoTestBase {
                 .streamOut(c); //
 
         WorkerGrid2D worker = new WorkerGrid2D(numElements, numElements);
-        GridTask gridTask = new GridTask("s0.t1", worker);
-        ts.execute(gridTask);
+        GridScheduler gridScheduler = new GridScheduler("s0.t1", worker);
+        ts.execute(gridScheduler);
 
         worker.setGlobalWork(512, 512, 1);
-        ts.execute(gridTask);
+        ts.execute(gridScheduler);
 
         matrixMultiplication(a, b, seq, numElements);
 
@@ -137,8 +137,8 @@ public class TestGrid extends TornadoTestBase {
                 .streamOut(matrixB);
 
         WorkerGrid2D worker = new WorkerGrid2D(X, Y);
-        GridTask gridTask = new GridTask("foo.bar", worker);
-        ts.execute(gridTask);
+        GridScheduler gridScheduler = new GridScheduler("foo.bar", worker);
+        ts.execute(gridScheduler);
 
         for (int i = 0; i < X; i++) {
             for (int j = 0; j < Y; j++) {
@@ -175,13 +175,13 @@ public class TestGrid extends TornadoTestBase {
 
         // Set the Grid with 4096 threads
         WorkerGrid1D worker = new WorkerGrid1D(4096);
-        GridTask gridTask = new GridTask("s0.t0", worker);
-        gridTask.setWorkerGrid("s0.t1", worker); // share the same worker
-        ts.execute(gridTask);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        gridScheduler.setWorkerGrid("s0.t1", worker); // share the same worker
+        ts.execute(gridScheduler);
 
         // Change the Grid
         worker.setGlobalWork(512, 1, 1);
-        ts.execute(gridTask);
+        ts.execute(gridScheduler);
 
         for (int i = 0; i < c.length; i++) {
             assertEquals(a[i] + b[i], c[i], 0.01f);
@@ -206,10 +206,10 @@ public class TestGrid extends TornadoTestBase {
                 .streamOut(matrixC);
 
         WorkerGrid2D worker = new WorkerGrid2D(N, N);
-        GridTask gridTask = new GridTask("s0.mxm", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.mxm", worker);
         worker.setGlobalWork(N, N, 1);
         worker.setLocalWork(256, 256, 1);
 
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
     }
 }

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGridScheduler.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGridScheduler.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.stream.IntStream;
 
 import org.junit.Test;
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
@@ -66,14 +66,14 @@ public class TestGridScheduler {
         float sequential = computeSequential(a, b, sequentialC);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
 
         TaskSchedule s0 = new TaskSchedule("s0").streamIn(a, b, size).task("t0", TestGridScheduler::vectorAddFloat, a, b, tornadoC).task("t1", TestGridScheduler::reduceAdd, tornadoC, size)
                 .streamOut(tornadoC);
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(1, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         float finalSum = tornadoC[0];
@@ -92,7 +92,7 @@ public class TestGridScheduler {
         float sequential = computeSequential(a, b, sequentialC);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
 
         TaskSchedule s0 = new TaskSchedule("s0") //
                 .streamIn(a, b, size) //
@@ -102,7 +102,7 @@ public class TestGridScheduler {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(1, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         TaskSchedule s1 = new TaskSchedule("s1").streamIn(tornadoC, size).task("t0", TestGridScheduler::reduceAdd, tornadoC, size).streamOut(tornadoC);
         s1.execute();

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestCombinedTaskSchedule.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestCombinedTaskSchedule.java
@@ -23,7 +23,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -148,7 +148,7 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
 
     /**
      * In this test, all tasks use the TaskSchedule API, and only t0 uses the
-     * {@link GridTask} and {@link WorkerGrid} to deploy a specific number of
+     * {@link GridScheduler} and {@link WorkerGrid} to deploy a specific number of
      * threads.
      */
     @Test
@@ -163,7 +163,7 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
         IntStream.range(0, b.length).sequential().forEach(i -> b[i] = i);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s01.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s01.t0", worker);
 
         TaskSchedule s01 = new TaskSchedule("s01") //
                 .streamIn(a, b) //
@@ -174,7 +174,7 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(size, 1, 1);
-        s01.execute(gridTask);
+        s01.execute(gridScheduler);
 
         vectorAddV1(a, b, cJava);
         vectorMulV1(cJava, b, cJava);
@@ -187,8 +187,8 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
 
     /**
      * In this test, all tasks use the {@link KernelContext} within the TaskSchedule
-     * API, and all tasks share the same {@link GridTask} and {@link WorkerGrid} to
-     * deploy a specific number of threads.
+     * API, and all tasks share the same {@link GridScheduler} and
+     * {@link WorkerGrid} to deploy a specific number of threads.
      */
     @Test
     public void combinedAPI02() {
@@ -202,10 +202,10 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
         IntStream.range(0, b.length).sequential().forEach(i -> b[i] = i);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s02.t0", worker);
-        gridTask.setWorkerGrid("s02.t1", worker);
-        gridTask.setWorkerGrid("s02.t2", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s02.t0", worker);
+        gridScheduler.setWorkerGrid("s02.t1", worker);
+        gridScheduler.setWorkerGrid("s02.t2", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s02 = new TaskSchedule("s02") //
@@ -214,7 +214,7 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
                 .task("t1", TestCombinedTaskSchedule::vectorMulV2, context, cTornado, b, cTornado) //
                 .task("t2", TestCombinedTaskSchedule::vectorSubV2, context, cTornado, b, cTornado) //
                 .streamOut(cTornado);
-        s02.execute(gridTask);
+        s02.execute(gridScheduler);
 
         vectorAddV1(a, b, cJava);
         vectorMulV1(cJava, b, cJava);
@@ -227,7 +227,7 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
 
     /**
      * In this test, all tasks use the {@link KernelContext} within the TaskSchedule
-     * API, and tasks t1 and t2 share the same {@link GridTask} and
+     * API, and tasks t1 and t2 share the same {@link GridScheduler} and
      * {@link WorkerGrid} to deploy a specific number of threads.
      */
     @Test
@@ -242,9 +242,9 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
         IntStream.range(0, b.length).sequential().forEach(i -> b[i] = i);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s03.t1", worker);
-        gridTask.setWorkerGrid("s03.t2", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s03.t1", worker);
+        gridScheduler.setWorkerGrid("s03.t2", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s03 = new TaskSchedule("s03") //
@@ -253,7 +253,7 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
                 .task("t1", TestCombinedTaskSchedule::vectorMulV2, context, cTornado, b, cTornado) //
                 .task("t2", TestCombinedTaskSchedule::vectorSubV2, context, cTornado, b, cTornado) //
                 .streamOut(cTornado);
-        s03.execute(gridTask);
+        s03.execute(gridScheduler);
 
         vectorAddV1(a, b, cJava);
         vectorMulV1(cJava, b, cJava);
@@ -266,8 +266,8 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
 
     /**
      * In this test, t0 and t1 use the {@link KernelContext} within the TaskSchedule
-     * API, and share the same {@link GridTask} and {@link WorkerGrid} to deploy a
-     * specific number of threads. While, t2 uses the TaskSchedule API.
+     * API, and share the same {@link GridScheduler} and {@link WorkerGrid} to
+     * deploy a specific number of threads. While, t2 uses the TaskSchedule API.
      */
     @Test
     public void combinedAPI04() {
@@ -281,9 +281,9 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
         IntStream.range(0, b.length).sequential().forEach(i -> b[i] = i);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s04.t0", worker);
-        gridTask.setWorkerGrid("s04.t1", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s04.t0", worker);
+        gridScheduler.setWorkerGrid("s04.t1", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s04 = new TaskSchedule("s04") //
@@ -292,7 +292,7 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
                 .task("t1", TestCombinedTaskSchedule::vectorMulV2, context, cTornado, b, cTornado) //
                 .task("t2", TestCombinedTaskSchedule::vectorSubV1, cTornado, b, cTornado) //
                 .streamOut(cTornado);
-        s04.execute(gridTask);
+        s04.execute(gridScheduler);
 
         vectorAddV1(a, b, cJava);
         vectorMulV1(cJava, b, cJava);
@@ -305,7 +305,7 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
 
     /**
      * In this test, t0 and t1 use the {@link KernelContext} within the TaskSchedule
-     * API, and use separate {@link GridTask} and {@link WorkerGrid} to deploy
+     * API, and use separate {@link GridScheduler} and {@link WorkerGrid} to deploy
      * different number of threads. While, t2 uses the TaskSchedule API.
      */
     @Test
@@ -321,9 +321,9 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
 
         WorkerGrid workerT0 = new WorkerGrid1D(size);
         WorkerGrid workerT1 = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s05.t0", workerT0);
-        gridTask.setWorkerGrid("s05.t1", workerT1);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s05.t0", workerT0);
+        gridScheduler.setWorkerGrid("s05.t1", workerT1);
         KernelContext context = new KernelContext();
 
         TaskSchedule s05 = new TaskSchedule("s05") //
@@ -337,7 +337,7 @@ public class TestCombinedTaskSchedule extends TornadoTestBase {
         workerT0.setLocalWork(size / 2, 1, 1);
         workerT1.setGlobalWork(size, 1, 1);
         workerT1.setLocalWorkToNull();
-        s05.execute(gridTask);
+        s05.execute(gridScheduler);
 
         vectorAddV1(a, b, cJava);
         vectorMulV1(cJava, b, cJava);

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestVectorAdditionKernelContext.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestVectorAdditionKernelContext.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -57,7 +57,7 @@ public class TestVectorAdditionKernelContext extends TornadoTestBase {
         Arrays.fill(b, 20);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -67,7 +67,7 @@ public class TestVectorAdditionKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWorkToNull();
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         vectorAddJava(a, b, cJava);
 
@@ -92,15 +92,15 @@ public class TestVectorAdditionKernelContext extends TornadoTestBase {
         Arrays.fill(b, 20);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
                 .streamIn(a, b) //
                 .task("t0", TestVectorAdditionKernelContext::vectorAdd, a, context, b, cTornado) //
                 .streamOut(cTornado);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         vectorAddJava(a, b, cJava);
 
@@ -125,15 +125,15 @@ public class TestVectorAdditionKernelContext extends TornadoTestBase {
         Arrays.fill(b, 20);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
                 .streamIn(a, b) //
                 .task("t0", TestVectorAdditionKernelContext::vectorAdd, a, b, context, cTornado) //
                 .streamOut(cTornado);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         vectorAddJava(a, b, cJava);
 
@@ -158,15 +158,15 @@ public class TestVectorAdditionKernelContext extends TornadoTestBase {
         Arrays.fill(b, 20);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
                 .streamIn(a, b) //
                 .task("t0", TestVectorAdditionKernelContext::vectorAdd, a, b, cTornado, context) //
                 .streamOut(cTornado);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         vectorAddJava(a, b, cJava);
 

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestMatrixMultiplicationKernelContext.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestMatrixMultiplicationKernelContext.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -77,14 +77,14 @@ public class TestMatrixMultiplicationKernelContext extends TornadoTestBase {
         Arrays.fill(b, 4);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
                 .streamIn(a, b) //
                 .task("t0", TestMatrixMultiplicationKernelContext::matrixMultiplication1D, context, a, b, cTornado, size) //
                 .streamOut(cTornado);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         matrixMultiplicationJava(a, b, cJava, size);
 
@@ -116,15 +116,15 @@ public class TestMatrixMultiplicationKernelContext extends TornadoTestBase {
         Arrays.fill(b, 4);
 
         WorkerGrid worker = new WorkerGrid2D(size, size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
                 .streamIn(a, b) //
                 .task("t0", TestMatrixMultiplicationKernelContext::matrixMultiplication2D01, context, a, b, cTornado, size) //
                 .streamOut(cTornado);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         matrixMultiplicationJava(a, b, cJava, size);
 
@@ -181,8 +181,8 @@ public class TestMatrixMultiplicationKernelContext extends TornadoTestBase {
         Arrays.fill(b, 4);
 
         WorkerGrid worker = new WorkerGrid2D(size, size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -192,7 +192,7 @@ public class TestMatrixMultiplicationKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, size, 1);
         worker.setLocalWork(TS, TS, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         matrixMultiplicationJava(a, b, cJava, size);
 

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsDoublesKernelContext.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsDoublesKernelContext.java
@@ -17,19 +17,18 @@
  */
 package uk.ac.manchester.tornado.unittests.kernelcontext.reductions;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.stream.IntStream;
-
 import org.junit.Test;
-
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.collections.math.TornadoMath;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * The unit-tests in this class implement reduce-operations such as add, max,
@@ -94,8 +93,8 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         // Create a 1D worker
         WorkerGrid worker = new WorkerGrid1D(size);
 
-        // Attach the Worker to the GridTask
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        // Attach the Worker to the GridScheduler
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
 
         // Create a KernelContext with its own worker
         KernelContext context = new KernelContext();
@@ -106,7 +105,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
                 .streamOut(reduce);
 
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final Reduction
         double finalSum = 0;
@@ -171,7 +170,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         double sequential = computeAddSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -181,7 +180,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         double finalSum = 0;
@@ -227,7 +226,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         double sequential = computeMaxSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -237,7 +236,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         double finalSum = 0;
@@ -277,7 +276,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         double sequential = computeMaxSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -287,7 +286,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         double finalSum = 0;
@@ -333,7 +332,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         double sequential = computeMinSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -343,7 +342,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         double finalSum = 0;
@@ -383,7 +382,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         double sequential = computeMinSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -393,7 +392,7 @@ public class TestReductionsDoublesKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         double finalSum = 0;

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsFloatsKernelContext.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsFloatsKernelContext.java
@@ -23,7 +23,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -75,7 +75,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         float sequential = computeAddSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -85,7 +85,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         float finalSum = 0;
@@ -125,7 +125,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         float sequential = computeAddSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -135,7 +135,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         float finalSum = 0;
@@ -181,7 +181,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         float sequential = computeMaxSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -191,7 +191,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         float finalSum = 0;
@@ -231,7 +231,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         float sequential = computeMaxSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -241,7 +241,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         float finalSum = 0;
@@ -287,7 +287,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         float sequential = computeMinSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -297,7 +297,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         float finalSum = 0;
@@ -337,7 +337,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         float sequential = computeMinSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -347,7 +347,7 @@ public class TestReductionsFloatsKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         float finalSum = 0;

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsIntegersKernelContext.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsIntegersKernelContext.java
@@ -23,7 +23,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -75,7 +75,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         int sequential = computeAddSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -85,7 +85,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         int finalSum = 0;
@@ -125,7 +125,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         int sequential = computeAddSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -135,7 +135,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         int finalSum = 0;
@@ -181,7 +181,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         int sequential = computeMaxSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -191,7 +191,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         int finalSum = 0;
@@ -231,7 +231,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         int sequential = computeMaxSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -241,7 +241,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         int finalSum = 0;
@@ -287,7 +287,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         int sequential = computeMinSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -297,7 +297,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         int finalSum = 0;
@@ -337,7 +337,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         int sequential = computeMinSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -347,7 +347,7 @@ public class TestReductionsIntegersKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         int finalSum = 0;

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsLongKernelContext.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsLongKernelContext.java
@@ -23,7 +23,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
-import uk.ac.manchester.tornado.api.GridTask;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskSchedule;
 import uk.ac.manchester.tornado.api.WorkerGrid;
@@ -75,7 +75,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         long sequential = computeAddSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -85,7 +85,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         long finalSum = 0;
@@ -125,8 +125,8 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         long sequential = computeAddSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask();
-        gridTask.setWorkerGrid("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -136,7 +136,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         long finalSum = 0;
@@ -182,7 +182,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         long sequential = computeMaxSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -192,7 +192,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         long finalSum = 0;
@@ -232,7 +232,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         long sequential = computeMaxSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -242,7 +242,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         long finalSum = 0;
@@ -288,7 +288,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         long sequential = computeMinSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -298,7 +298,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         long finalSum = 0;
@@ -338,7 +338,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         long sequential = computeMinSequential(input);
 
         WorkerGrid worker = new WorkerGrid1D(size);
-        GridTask gridTask = new GridTask("s0.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskSchedule s0 = new TaskSchedule("s0") //
@@ -348,7 +348,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);
         worker.setLocalWork(localSize, 1, 1);
-        s0.execute(gridTask);
+        s0.execute(gridScheduler);
 
         // Final SUM
         long finalSum = 0;


### PR DESCRIPTION
#### Description

This PR applies a change that we have discussed internally regarding the name of the `GridTask`. The fact that we can have multiple tasks that use the same `GridTask` object, has made us think that the naming is not appropriate as it makes developers think that one task corresponds to a `GridTask`.

Therefore we have agreed to rename the `GridTask` to `GridScheduler`. Here is an example of usage:
```java
        WorkerGrid worker = new WorkerGrid1D(size);
        GridScheduler gridScheduler = new GridScheduler();
        gridScheduler.setWorkerGrid("s02.t0", worker);
        gridScheduler.setWorkerGrid("s02.t1", worker);
        gridScheduler.setWorkerGrid("s02.t2", worker);
        KernelContext context = new KernelContext();

        TaskSchedule s0 = new TaskSchedule("s0") //
                .streamIn(a, b) //
                .task("t0", TestCombinedTaskSchedule::vectorAddV2, context, a, b, cTornado) //
                .task("t1", TestCombinedTaskSchedule::vectorMulV2, context, cTornado, b, cTornado) //
                .task("t2", TestCombinedTaskSchedule::vectorSubV2, context, cTornado, b, cTornado) //
                .streamOut(cTornado);
        s0.execute(gridScheduler);
```

No functional code has changed in this PR.

#### Backend/s tested

- [x] OpenCL
- [x] PTX

#### OS tested

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

No need to test. For sanity check, you can use:
```bash
grep -nr "GridTask" .
```
