### PR TITLE
[refactor] Misc fixes

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -437,8 +437,7 @@ public class OCLDeviceContext extends TornadoLogger implements Initialisable, OC
 
     @Override
     public boolean isPlatformFPGA() {
-        return getDevice().getDeviceType() == OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR
-                && (getPlatformContext().getPlatform().getName().toLowerCase().contains("fpga") || getPlatformContext().getPlatform().getName().toLowerCase().contains("xilinx"));
+        return getDevice().getDeviceType() == OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR && (getPlatformContext().getPlatform().getName().toLowerCase().contains("fpga") || isPlatformXilinxFPGA());
     }
 
     @Override

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
@@ -185,8 +185,7 @@ public class VirtualOCLDeviceContext extends TornadoLogger implements Initialisa
 
     @Override
     public boolean isPlatformFPGA() {
-        return getDevice().getDeviceType() == OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR
-                && (getPlatformContext().getPlatform().getName().toLowerCase().contains("fpga") || getPlatformContext().getPlatform().getName().toLowerCase().contains("xilinx"));
+        return getDevice().getDeviceType() == OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR && (getPlatformContext().getPlatform().getName().toLowerCase().contains("fpga") || isPlatformXilinxFPGA());
     }
 
     @Override

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -436,7 +436,7 @@ public class TornadoVM extends TornadoLogger {
         task.enableDefaultThreadScheduler(graphContext.useDefaultThreadScheduler());
 
         if (gridScheduler != null && gridScheduler.get(task.getId()) != null) {
-            task.setGridScheduler(true);
+            task.setUseGridScheduler(true);
         }
 
         if (shouldCompile(installedCodes[taskIndex])) {

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
@@ -25,9 +25,6 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks;
 
-import java.lang.reflect.Method;
-import java.util.Objects;
-
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
@@ -35,6 +32,9 @@ import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
 import uk.ac.manchester.tornado.runtime.common.TornadoAcceleratorDevice;
 import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
 
 public class CompilableTask implements SchedulableTask {
 
@@ -167,8 +167,8 @@ public class CompilableTask implements SchedulableTask {
     }
 
     @Override
-    public void setGridScheduler(boolean use) {
-        meta.setGridScheduler(use);
+    public void setUseGridScheduler(boolean use) {
+        meta.setUseGridScheduler(use);
     }
 
     @Override

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
@@ -25,8 +25,6 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks;
 
-import java.util.Objects;
-
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
@@ -35,6 +33,8 @@ import uk.ac.manchester.tornado.runtime.common.TornadoAcceleratorDevice;
 import uk.ac.manchester.tornado.runtime.domain.DomainTree;
 import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+
+import java.util.Objects;
 
 public class PrebuiltTask implements SchedulableTask {
 
@@ -192,8 +192,8 @@ public class PrebuiltTask implements SchedulableTask {
     }
 
     @Override
-    public void setGridScheduler(boolean use) {
-        meta.setGridScheduler(use);
+    public void setUseGridScheduler(boolean use) {
+        meta.setUseGridScheduler(use);
     }
 
     @Override

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
@@ -501,7 +501,7 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
         return graph;
     }
 
-    public void setGridScheduler(boolean use) {
+    public void setUseGridScheduler(boolean use) {
         this.useGridScheduler = use;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/SchedulableTask.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/SchedulableTask.java
@@ -76,7 +76,7 @@ public interface SchedulableTask {
 
     void enableDefaultThreadScheduler(boolean useDefaultScheduler);
 
-    void setGridScheduler(boolean use);
+    void setUseGridScheduler(boolean use);
 
     boolean isGridSchedulerEnabled();
 }


### PR DESCRIPTION
#### Description

This PR includes two complementary changes to PRs #121 and #122.

1. The fix of duplication with regards to the logic of `isPlatformXilinxFPGA()`.
2. The fix with regard to the renaming of the  method  `setGridScheduler(boolean use)` with `setUseGridScheduler(boolean use)`.

#### Backend/s tested

- [x] OpenCL
- [x] PTX

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

All unit-tests are passing. Try:
```bash
$ make 
$ make tests
$ make BACKEND=ptx
$ make tests
```
