### PR TITLE
[fix] FMA LIR Type fixed for ternary nodes

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLArithmeticTool.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLArithmeticTool.java
@@ -462,7 +462,7 @@ public class OCLArithmeticTool extends ArithmeticLIRGenerator {
     }
 
     public Value emitFMAInstruction(Value op1, Value op2, Value op3) {
-        LIRKind resultKind = LIRKind.combine(op1, op2);
+        LIRKind resultKind = LIRKind.combine(op1, op2, op3);
         Variable result = getGen().newVariable(resultKind);
         OCLAssembler.OCLTernaryOp operation = OCLTernaryIntrinsic.FMA;
         getGen().append(new OCLLIRStmt.AssignStmt(result, new OCLTernary.Expr(operation, resultKind, op1, op2, op3)));

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXArithmeticTool.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXArithmeticTool.java
@@ -22,22 +22,25 @@
 
 package uk.ac.manchester.tornado.drivers.ptx.graal.lir;
 
-import jdk.vm.ci.meta.PlatformKind;
-import jdk.vm.ci.meta.Value;
-import jdk.vm.ci.meta.ValueKind;
+import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
+import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
+import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
+import static uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCodeGenerator.trace;
+
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.calc.FloatConvert;
 import org.graalvm.compiler.lir.LIRFrameState;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.ArithmeticLIRGenerator;
+
+import jdk.vm.ci.meta.PlatformKind;
+import jdk.vm.ci.meta.Value;
+import jdk.vm.ci.meta.ValueKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXLIRKindTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler;
 import uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXBinaryOp;
 import uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXTernaryOp;
 import uk.ac.manchester.tornado.drivers.ptx.graal.compiler.PTXLIRGenerator;
-
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.*;
-import static uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCodeGenerator.trace;
 
 public class PTXArithmeticTool extends ArithmeticLIRGenerator {
     @Override
@@ -322,7 +325,7 @@ public class PTXArithmeticTool extends ArithmeticLIRGenerator {
 
     public Value emitMultiplyAdd(Value op1, Value op2, Value op3) {
         trace("emitMultiplyAdd op1=%s op2=%s op3=%s", op1, op2, op3);
-        LIRKind resultKind = LIRKind.combine(op1, op2);
+        LIRKind resultKind = LIRKind.combine(op1, op2, op3);
         Variable result = getGen().newVariable(resultKind);
         PTXTernaryOp op = ((PTXKind) resultKind.getPlatformKind()).isFloating() ? PTXTernaryOp.MAD : PTXTernaryOp.MAD_LO;
         getGen().append(new PTXLIRStmt.AssignStmt(result, new PTXTernary.Expr(op, resultKind, op1, op2, op3)));

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestMath.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestMath.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertArrayEquals;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import uk.ac.manchester.tornado.api.TaskSchedule;
@@ -134,6 +133,18 @@ public class TestMath extends TornadoTestBase {
     public static void testRemainder(int[] a, int[] b) {
         for (@Parallel int i = 0; i < a.length; i++) {
             b[i] = b[i] % a[i];
+        }
+    }
+
+    public static void testFMA(float[] a, float[] b) {
+        for (@Parallel int i = 0; i < a.length; i++) {
+            b[i] = a[i] + b[i] * a[i];
+        }
+    }
+
+    public static void testFMA2(float[] a, double[] b) {
+        for (@Parallel int i = 0; i < a.length; i++) {
+            b[i] = a[i] + b[i] * a[i];
         }
     }
 
@@ -416,4 +427,49 @@ public class TestMath extends TornadoTestBase {
         testRemainder(a, seq);
         assertArrayEquals(b, seq);
     }
+
+    @Test
+    public void testFMA() {
+        Random r = new Random();
+        final int size = 8192;
+        float[] a = new float[size];
+        float[] b = new float[size];
+        float[] seq = new float[size];
+
+        IntStream.range(0, size).forEach(i -> {
+            a[i] = r.nextFloat();
+            b[i] = r.nextFloat();
+            seq[i] = b[i];
+        });
+
+        TaskSchedule s0 = new TaskSchedule("s0");
+        s0.task("t0", TestMath::testFMA, a, b).streamOut(b).execute();
+
+        testFMA(a, seq);
+
+        assertArrayEquals(b, seq, 0.01f);
+    }
+
+    @Test
+    public void testFMA2() {
+        Random r = new Random();
+        final int size = 8192;
+        float[] a = new float[size];
+        double[] b = new double[size];
+        double[] seq = new double[size];
+
+        IntStream.range(0, size).forEach(i -> {
+            a[i] = r.nextFloat();
+            b[i] = r.nextFloat();
+            seq[i] = b[i];
+        });
+
+        TaskSchedule s0 = new TaskSchedule("s0");
+        s0.task("t0", TestMath::testFMA2, a, b).streamOut(b).execute();
+
+        testFMA2(a, seq);
+
+        assertArrayEquals(b, seq, 0.01f);
+    }
+
 }

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
@@ -347,7 +347,6 @@ public class TestTornadoMathCollection extends TornadoTestBase {
 
     }
 
-
     @Test
     public void testTornadoMathPI() {
         final int size = 128;


### PR DESCRIPTION
Ternary nodes should infer the LIR type using the three operands. LIR types for `FMA` instructions were getting the LIR with the first two values, instead of the 3 operands. This patch fixes that. 

#### Backend/s tested

- [X] OpenCL
- [X] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash 
make tests
tornado-test.py -pk --debug -V -J"-Ds0.t0.device=0:0" --fast uk.ac.manchester.tornado.unittests.matrices.TestMatrices#testMatrixMultiplication
```
