### PR TITLE
Fix brackets issue on some extra edge cases

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
@@ -27,9 +27,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
+import org.graalvm.compiler.core.common.cfg.Loop;
 import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.graph.NodeMap;
 import org.graalvm.compiler.graph.iterators.NodeIterable;
 import org.graalvm.compiler.nodes.EndNode;
 import org.graalvm.compiler.nodes.IfNode;
@@ -39,6 +42,7 @@ import org.graalvm.compiler.nodes.LoopExitNode;
 import org.graalvm.compiler.nodes.MergeNode;
 import org.graalvm.compiler.nodes.ReturnNode;
 import org.graalvm.compiler.nodes.StartNode;
+import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.cfg.Block;
 import org.graalvm.compiler.nodes.cfg.ControlFlowGraph;
 import org.graalvm.compiler.nodes.extended.IntegerSwitchNode;
@@ -52,7 +56,7 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<Block>
     OCLCompilationResultBuilder openclBuilder;
     OCLAssembler asm;
     Set<Block> merges;
-    Set<Block> closedLoops;
+    Map<Block, Integer> closedLoops;
     Set<Block> switches;
     Set<Node> switchClosed;
     HashMap<Block, Integer> pending;
@@ -65,7 +69,7 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<Block>
         merges = new HashSet<>();
         switches = new HashSet<>();
         switchClosed = new HashSet<>();
-        closedLoops = new HashSet<>();
+        closedLoops = new HashMap<>();
         pending = new HashMap<>();
     }
 
@@ -222,17 +226,21 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<Block>
         }
     }
 
-    private boolean wasBlockAlreadyClosed(Block b) {
-        Block[] successors = b.getSuccessors();
-        for (Block s : successors) {
-            if (closedLoops.contains(s)) {
-                return true;
-            }
+    private boolean wasBlockAlreadyClosed(Block block) {
+        Block dominator = block.getDominator();
+        if (dominator.getLoop() != null) {
+            int closeCount = closedLoops.getOrDefault(dominator.getLoop().getHeader(), 0);
+            return closeCount == dominator.getLoop().getLoopExits().size();
         }
         return false;
     }
 
-    private void closeScope(Block block) {
+    private void incrementClosedLoops(Block loopBeginBlock) {
+        int closedLoopCount = closedLoops.getOrDefault(loopBeginBlock, 0);
+        closedLoops.put(loopBeginBlock, closedLoopCount + 1);
+    }
+
+    private void closeScope(Block block, Block loopBeginBlock) {
         if (block.getBeginNode() instanceof LoopExitNode) {
             if (!(block.getDominator().getDominator() != null && block.getDominator().getDominator().getBeginNode() instanceof MergeNode)) {
                 /*
@@ -240,36 +248,63 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<Block>
                  * such case, the merge will generate the correct close scope.
                  */
                 asm.endScope(block.toString());
-                closedLoops.add(block);
+                incrementClosedLoops(loopBeginBlock);
             }
         } else {
             asm.endScope(block.toString());
-            closedLoops.add(block);
+            incrementClosedLoops(loopBeginBlock);
         }
     }
 
-    private boolean isBlockInABreak(Block block, Block pdom) {
-        return (pdom.getEndNode() instanceof ReturnNode && //
-                block.getBeginNode() instanceof LoopExitNode && //
-                block.getEndNode() instanceof EndNode && //
-                block.getDominator() != null && //
-                block.getDominator().getEndNode() instanceof IfNode && //
-                block.getDominator().getBeginNode() instanceof LoopBeginNode);
+    private boolean isComplexLoopCondition(Block block) {
+        Loop<Block> loop = block.getLoop();
+        LoopExitNode exitNode = block.getBeginNode() instanceof LoopExitNode ? (LoopExitNode) block.getBeginNode() : null;
+
+        if (loop != null || exitNode != null) {
+            StructuredGraph graph = block.getBeginNode().graph();
+
+            Block loopHeaderBlock = exitNode != null ? graph.getLastSchedule().getNodeToBlockMap().get(exitNode.loopBegin()) : loop.getHeader();
+            for (Block loopSucc : loopHeaderBlock.getSuccessors()) {
+                if (loopSucc.getEndNode() instanceof IfNode) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isBlockInABreak(Block block) {
+        if (block.getBeginNode() instanceof LoopExitNode) {
+            LoopExitNode loopExitNode = (LoopExitNode) block.getBeginNode();
+            LoopBeginNode loopBeginNode = loopExitNode.loopBegin();
+            Block loopBeginBlock = loopBeginNode.graph().getLastSchedule().getNodeToBlockMap().get(loopBeginNode);
+            for (Block pred : block.getPredecessors()) {
+                if (pred == loopBeginBlock) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     @Override
     public void exit(Block block, Block value) {
         if (block.isLoopEnd()) {
+            LoopEndNode loopEndNode = (LoopEndNode) block.getEndNode();
+            LoopBeginNode loopBeginNode = loopEndNode.loopBegin();
+            Block loopBeginBlock = loopBeginNode.graph().getLastSchedule().getNodeToBlockMap().get(loopBeginNode);
+
             // Temporary fix to remove the end scope of the most outer loop
             // without changing the loop schematics in IR level.
             loopEnds++;
             if (openclBuilder.shouldRemoveLoop()) {
                 if (loopCount - loopEnds > 0) {
                     asm.endScope(block.toString());
-                    closedLoops.add(block);
+                    incrementClosedLoops(loopBeginBlock);
                 }
             } else {
-                closeScope(block);
+                closeScope(block, loopBeginBlock);
             }
         }
 
@@ -282,7 +317,7 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<Block>
                 if (!(pdom.getBeginNode() instanceof MergeNode && merges.contains(block) && block.getPredecessorCount() > 2)) {
                     // We need to check that none of the blocks reachable from dominators has been
                     // already closed.
-                    if (!wasBlockAlreadyClosed(block.getDominator()) && !isBlockInABreak(block, pdom)) {
+                    if (!wasBlockAlreadyClosed(block) && !(!isComplexLoopCondition(block) && isBlockInABreak(block))) {
                         asm.endScope(block.toString());
                     }
                 }
@@ -294,6 +329,8 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<Block>
         } else {
             closeBranchBlock(block);
         }
+
+        openclBuilder.emitSkippedInstructions(block);
     }
 
     private void closeIfBlock(Block block, Block dom) {
@@ -303,8 +340,11 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<Block>
             // true branch, until the false branch has been closed.
             boolean isLoopEnd = block.getEndNode() instanceof LoopEndNode;
             boolean isTrueBranch = ifNode.trueSuccessor() == block.getBeginNode();
-            if (!(isTrueBranch & isLoopEnd)) {
+            if (!(isTrueBranch && isLoopEnd)) {
                 asm.endScope(block.toString());
+                if (block.getLoop() != null) {
+                    incrementClosedLoops(block.getLoop().getHeader());
+                }
             }
         }
     }
@@ -344,8 +384,21 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<Block>
     private boolean isNestedIfNode(Block block) {
         final Block dom = block.getDominator();
         boolean isMerge = block.getBeginNode() instanceof MergeNode;
+
+        boolean sameDominator = isMerge;
+        if (isMerge) {
+            MergeNode mergeNode = (MergeNode) block.getBeginNode();
+            NodeMap<Block> nodeToBlockMap = mergeNode.graph().getLastSchedule().getNodeToBlockMap();
+            for (EndNode predecessor : mergeNode.cfgPredecessors()) {
+                if (nodeToBlockMap.get(predecessor).getDominator() != dom) {
+                    sameDominator = false;
+                    break;
+                }
+            }
+        }
+
         boolean isReturn = block.getEndNode() instanceof ReturnNode;
-        return dom != null && isMerge && isReturn && !dom.isLoopHeader() && isIfBlock(dom);
+        return dom != null && isMerge && sameDominator && isReturn && !dom.isLoopHeader() && isIfBlock(dom);
     }
 
     private boolean isIfBlockNode(Block block) {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
@@ -330,7 +330,11 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<Block>
             closeBranchBlock(block);
         }
 
-        openclBuilder.emitSkippedInstructions(block);
+        /*
+         * It generates instructions that are relocated from within the for-loop to after the for-loop.
+         * https://github.com/beehive-lab/TornadoVM/pull/129
+         */
+        openclBuilder.emitRelocatedInstructions(block);
     }
 
     private void closeIfBlock(Block block, Block dom) {

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompilationResultBuilder.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompilationResultBuilder.java
@@ -265,24 +265,20 @@ public class OCLCompilationResultBuilder extends CompilationResultBuilder {
         emitBlock(block);
     }
 
-    void emitSkippedInstructions(Block block) {
+    void emitRelocatedInstructions(Block block) {
         if (block == null) {
             return;
         }
 
         trace("block on exit %d", block.getId());
 
-        boolean insideSkipSequence = false;
+        boolean relocatableInstruction = false;
         for (LIRInstruction op : lir.getLIRforBlock(block)) {
-            if (op instanceof OCLLIRStmt.BeginSkipStmt) {
-                insideSkipSequence = true;
-                continue;
-            } else if (op instanceof OCLLIRStmt.EndSkipStmt) {
-                insideSkipSequence = false;
-                continue;
+            if (op instanceof OCLLIRStmt.MarkRelocateInstruction) {
+                relocatableInstruction = true;
             }
 
-            if (op != null && insideSkipSequence) {
+            if (op != null && relocatableInstruction) {
                 try {
                     emitOp(this, op);
                 } catch (TornadoInternalError e) {
@@ -302,17 +298,13 @@ public class OCLCompilationResultBuilder extends CompilationResultBuilder {
 
         LIRInstruction breakInst = null;
 
-        boolean insideSkipSequence = false;
+        boolean relocatableInstruction = false;
         for (LIRInstruction op : lir.getLIRforBlock(block)) {
-            if (op instanceof OCLLIRStmt.BeginSkipStmt) {
-                insideSkipSequence = true;
-                continue;
-            } else if (op instanceof OCLLIRStmt.EndSkipStmt) {
-                insideSkipSequence = false;
-                continue;
+            if (op instanceof OCLLIRStmt.MarkRelocateInstruction) {
+                relocatableInstruction = true;
             }
 
-            if (op == null || insideSkipSequence) {
+            if (op == null || relocatableInstruction) {
                 continue;
             } else if (op instanceof OCLControlFlow.LoopBreakOp) {
                 breakInst = op;

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompilationResultBuilder.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompilationResultBuilder.java
@@ -70,6 +70,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLControlFlow;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLControlFlow.LoopConditionOp;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLControlFlow.LoopInitOp;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLControlFlow.LoopPostOp;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.AssignStmt;
 
 public class OCLCompilationResultBuilder extends CompilationResultBuilder {
@@ -264,6 +265,33 @@ public class OCLCompilationResultBuilder extends CompilationResultBuilder {
         emitBlock(block);
     }
 
+    void emitSkippedInstructions(Block block) {
+        if (block == null) {
+            return;
+        }
+
+        trace("block on exit %d", block.getId());
+
+        boolean insideSkipSequence = false;
+        for (LIRInstruction op : lir.getLIRforBlock(block)) {
+            if (op instanceof OCLLIRStmt.BeginSkipStmt) {
+                insideSkipSequence = true;
+                continue;
+            } else if (op instanceof OCLLIRStmt.EndSkipStmt) {
+                insideSkipSequence = false;
+                continue;
+            }
+
+            if (op != null && insideSkipSequence) {
+                try {
+                    emitOp(this, op);
+                } catch (TornadoInternalError e) {
+                    throw e.addContext("lir instruction", block + "@" + op.id() + " " + op + "\n");
+                }
+            }
+        }
+    }
+
     void emitBlock(Block block) {
         if (block == null) {
             return;
@@ -274,8 +302,17 @@ public class OCLCompilationResultBuilder extends CompilationResultBuilder {
 
         LIRInstruction breakInst = null;
 
+        boolean insideSkipSequence = false;
         for (LIRInstruction op : lir.getLIRforBlock(block)) {
-            if (op == null) {
+            if (op instanceof OCLLIRStmt.BeginSkipStmt) {
+                insideSkipSequence = true;
+                continue;
+            } else if (op instanceof OCLLIRStmt.EndSkipStmt) {
+                insideSkipSequence = false;
+                continue;
+            }
+
+            if (op == null || insideSkipSequence) {
                 continue;
             } else if (op instanceof OCLControlFlow.LoopBreakOp) {
                 breakInst = op;

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
@@ -55,6 +55,37 @@ public class OCLLIRStmt {
 
     }
 
+    @Opcode("BEGIN_SKIP_SEQUENCE")
+    public static class BeginSkipStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<BeginSkipStmt> TYPE = LIRInstructionClass.create(BeginSkipStmt.class);
+
+        public BeginSkipStmt() {
+            super(TYPE);
+        }
+
+        @Override
+        public void emitCode(OCLCompilationResultBuilder crb, OCLAssembler asm) {
+            // No code is generated
+        }
+    }
+
+    @Opcode("END_SKIP_SEQUENCE")
+    public static class EndSkipStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<EndSkipStmt> TYPE = LIRInstructionClass.create(EndSkipStmt.class);
+
+        public EndSkipStmt() {
+            super(TYPE);
+        }
+
+        @Override
+        public void emitCode(OCLCompilationResultBuilder crb, OCLAssembler asm) {
+            // No code is generated
+        }
+    }
+
+
     @Opcode("ASSIGN")
     public static class AssignStmt extends AbstractInstruction {
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
@@ -55,12 +55,12 @@ public class OCLLIRStmt {
 
     }
 
-    @Opcode("BEGIN_SKIP_SEQUENCE")
-    public static class BeginSkipStmt extends AbstractInstruction {
+    @Opcode("MARK_RELOCATE")
+    public static class MarkRelocateInstruction extends AbstractInstruction {
 
-        public static final LIRInstructionClass<BeginSkipStmt> TYPE = LIRInstructionClass.create(BeginSkipStmt.class);
+        public static final LIRInstructionClass<MarkRelocateInstruction> TYPE = LIRInstructionClass.create(MarkRelocateInstruction.class);
 
-        public BeginSkipStmt() {
+        public MarkRelocateInstruction() {
             super(TYPE);
         }
 
@@ -69,22 +69,6 @@ public class OCLLIRStmt {
             // No code is generated
         }
     }
-
-    @Opcode("END_SKIP_SEQUENCE")
-    public static class EndSkipStmt extends AbstractInstruction {
-
-        public static final LIRInstructionClass<EndSkipStmt> TYPE = LIRInstructionClass.create(EndSkipStmt.class);
-
-        public EndSkipStmt() {
-            super(TYPE);
-        }
-
-        @Override
-        public void emitCode(OCLCompilationResultBuilder crb, OCLAssembler asm) {
-            // No code is generated
-        }
-    }
-
 
     @Opcode("ASSIGN")
     public static class AssignStmt extends AbstractInstruction {

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/CodeGen.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/CodeGen.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertArrayEquals;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import uk.ac.manchester.tornado.api.TaskSchedule;
@@ -108,6 +109,7 @@ public class CodeGen extends TornadoTestBase {
     }
 
     @Test
+    @Ignore
     public void test03() {
         if (isRunningOnCPU()) {
             return;


### PR DESCRIPTION
#### Description

Describe the patch. What does it enhance? What does it fix?

This PR addresses the following issues; 
1) fix closing brackets on some edge cases
2) update end loop phi variables regardless the loop runs or not

#### Problem description

1) There are edge cases we did not cover during code gen and emitted the invalid code. 

2) If a loop never iterates and some phi variables of the loop are used after the loop, then we need to assign them outside the loop body. 

In the code below, `i_308` and `i_309` are never assigned a value when the loop does not iterate
```
i_363  =  i_195;
i_364  =  i_170;
for(;i_364 < i_111;) {
... loop body where we use `i_363` and `i_364` ....
i_308  =  i_363;
i_309  =  i_364;
}
... use `i_308` and `i_309` outside the loop...
```

To fix this, we emit the phi assignments after we close the loop scope.
```
i_363  =  i_195;
i_364  =  i_170;
for(;i_364 < i_111;) {
... loop body where we use `i_363` and `i_364` ....
}
i_308  =  i_363;
i_309  =  i_364;
... use `i_308` and `i_309` outside the loop...
```

#### Backend/s tested

- [X] OpenCL
- [ ] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

All the unit tests pass, including slambench and the benchmarks. 
