### PR TITLE
Register Graal Compiler Plugin for accessing the global number of threads in OpenCL/PTX

### DIFF
--- a/assembly/src/bin/tornado-test.py
+++ b/assembly/src/bin/tornado-test.py
@@ -68,6 +68,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestAPI"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestCombinedTaskSchedule"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestVectorAdditionKernelContext"),
+    TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.KernelPluginsTests"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsIntegersKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsFloatsKernelContext"),

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
@@ -66,6 +66,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.OCLArchitecture;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.AtomicAddNodeTemplate;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.DecAtomicNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.GlobalThreadSizeNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.IncAtomicNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.LocalArrayNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.LocalThreadSizeNode;
@@ -234,6 +235,18 @@ public class OCLGraphBuilderPlugins {
         });
     }
 
+    private static void registerGlobalWorkGroupSize(Registration r) {
+        JavaKind returnedJavaKind = JavaKind.Int;
+        r.register2("getGlobalGroupSize", Receiver.class, int.class, new InvocationPlugin() {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
+                GlobalThreadSizeNode threadSize = new GlobalThreadSizeNode((ConstantNode) size);
+                b.push(returnedJavaKind, threadSize);
+                return true;
+            }
+        });
+    }
+
     private static void registerIntLocalArray(Registration r, JavaKind returnedJavaKind, JavaKind elementType) {
         r.register2("allocateIntLocalArray", Receiver.class, int.class, new InvocationPlugin() {
             @Override
@@ -309,6 +322,7 @@ public class OCLGraphBuilderPlugins {
         registerLocalBarrier(r);
         registerGlobalBarrier(r);
         localWorkGroupPlugin(r);
+        registerGlobalWorkGroupSize(r);
         localArraysPlugins(r);
     }
 

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
@@ -58,6 +58,7 @@ import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.exceptions.Debug;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXArchitecture;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.GlobalThreadSizeNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.LocalArrayNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.LocalThreadSizeNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXBarrierNode;
@@ -204,6 +205,18 @@ public class PTXGraphBuilderPlugins {
         });
     }
 
+    private static void registerGlobalWorkGroupSize(Registration r) {
+        JavaKind returnedJavaKind = JavaKind.Int;
+        r.register2("getGlobalGroupSize", InvocationPlugin.Receiver.class, int.class, new InvocationPlugin() {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
+                GlobalThreadSizeNode threadSize = new GlobalThreadSizeNode((ConstantNode) size);
+                b.push(returnedJavaKind, threadSize);
+                return true;
+            }
+        });
+    }
+
     private static void registerIntLocalArray(Registration r, JavaKind returnedJavaKind, JavaKind elementType) {
         r.register2("allocateIntLocalArray", InvocationPlugin.Receiver.class, int.class, new InvocationPlugin() {
             @Override
@@ -279,6 +292,7 @@ public class PTXGraphBuilderPlugins {
         registerLocalBarrier(r);
         registerGlobalBarrier(r);
         localWorkGroupPlugin(r);
+        registerGlobalWorkGroupSize(r);
         localArraysPlugins(r);
     }
 

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/KernelPluginsTests.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/KernelPluginsTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.kernelcontext.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskSchedule;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * How to execute:
+ * 
+ * <code>
+ *     tornado-test.py --threadInfo --printKernel --fast -V uk.ac.manchester.tornado.unittests.kernelcontext.api.KernelPluginsTests
+ * </code>
+ */
+public class KernelPluginsTests extends TornadoTestBase {
+
+    private static void apiTest(KernelContext context, int[] data) {
+        data[0] = context.getGlobalGroupSize(0);
+    }
+
+    @Test
+    public void test01() {
+
+        KernelContext context = new KernelContext();
+        GridScheduler grid = new GridScheduler();
+        WorkerGrid worker = new WorkerGrid1D(1024);
+        grid.setWorkerGrid("s0.t0", worker);
+
+        int[] data = new int[1024];
+        TaskSchedule ts = new TaskSchedule("s0").task("t0", KernelPluginsTests::apiTest, context, data).streamOut(data);
+        ts.execute(grid);
+        assertEquals(1024, data[0]);
+    }
+}


### PR DESCRIPTION
This PR enables the method `getGlobalThreadSize` as a compiler plugin. This method was missing from the initial implementation of the `KernelContext`. 

#### Backend/s tested

- [X] OpenCL
- [X] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

For both backends:

```bash
tornado-test.py --threadInfo --printKernel --fast -V uk.ac.manchester.tornado.unittests.kernelcontext.api.KernelPluginsTests
```

