### PR TITLE
[refactor] event.getExecutionTime -> event.getElapsedTime

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEvent.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEvent.java
@@ -229,7 +229,7 @@ public class OCLEvent extends TornadoLogger implements Event {
     }
 
     @Override
-    public long getExecutionTime() {
+    public long getElapsedTime() {
         return (getCLEndTime() - getCLStartTime());
     }
 
@@ -239,13 +239,13 @@ public class OCLEvent extends TornadoLogger implements Event {
     }
 
     @Override
-    public double getExecutionTimeInSeconds() {
+    public double getElapsedTimeInSeconds() {
         return RuntimeUtilities.elapsedTimeInSeconds(getCLStartTime(), getCLEndTime());
     }
 
     @Override
     public double getTotalTimeInSeconds() {
-        return getExecutionTimeInSeconds();
+        return getElapsedTimeInSeconds();
     }
 
     @Override

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLKernelScheduler.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLKernelScheduler.java
@@ -24,13 +24,13 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl;
 
+import java.util.Arrays;
+
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.common.Event;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
-
-import java.util.Arrays;
 
 public abstract class OCLKernelScheduler {
 
@@ -61,9 +61,9 @@ public abstract class OCLKernelScheduler {
             tornadoKernelEvent.waitForEvents();
             long timer = meta.getProfiler().getTimer(ProfilerType.TOTAL_KERNEL_TIME);
             // Register globalTime
-            meta.getProfiler().setTimer(ProfilerType.TOTAL_KERNEL_TIME, timer + tornadoKernelEvent.getExecutionTime());
+            meta.getProfiler().setTimer(ProfilerType.TOTAL_KERNEL_TIME, timer + tornadoKernelEvent.getElapsedTime());
             // Register the time for the task
-            meta.getProfiler().setTaskTimer(ProfilerType.TASK_KERNEL_TIME, meta.getId(), tornadoKernelEvent.getExecutionTime());
+            meta.getProfiler().setTaskTimer(ProfilerType.TASK_KERNEL_TIME, meta.getId(), tornadoKernelEvent.getElapsedTime());
             // Register the dispatch time of the kernel
             long dispatchValue = meta.getProfiler().getTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME);
             dispatchValue += tornadoKernelEvent.getDriverDispatchTime();

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -153,7 +153,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
             debug("\tstatus   : %s", event.getStatus());
 
             if (meta != null && meta.enableProfiling()) {
-                debug("\texecuting: %f seconds", event.getExecutionTimeInSeconds());
+                debug("\texecuting: %f seconds", event.getElapsedTimeInSeconds());
                 debug("\ttotal    : %f seconds", event.getTotalTimeInSeconds());
             }
         }
@@ -315,9 +315,9 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
             tornadoKernelEvent.waitForEvents();
             long timer = meta.getProfiler().getTimer(ProfilerType.TOTAL_KERNEL_TIME);
             // Register globalTime
-            meta.getProfiler().setTimer(ProfilerType.TOTAL_KERNEL_TIME, timer + tornadoKernelEvent.getExecutionTime());
+            meta.getProfiler().setTimer(ProfilerType.TOTAL_KERNEL_TIME, timer + tornadoKernelEvent.getElapsedTime());
             // Register the time for the task
-            meta.getProfiler().setTaskTimer(ProfilerType.TASK_KERNEL_TIME, meta.getId(), tornadoKernelEvent.getExecutionTime());
+            meta.getProfiler().setTaskTimer(ProfilerType.TASK_KERNEL_TIME, meta.getId(), tornadoKernelEvent.getElapsedTime());
             // Register the dispatch time of the kernel
             long dispatchValue = meta.getProfiler().getTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME);
             dispatchValue += tornadoKernelEvent.getDriverDispatchTime();
@@ -393,7 +393,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
             Event event = deviceContext.resolveEvent(stackWriteEventId);
             event.waitForEvents();
             long copyInTimer = meta.getProfiler().getTimer(ProfilerType.COPY_IN_TIME);
-            copyInTimer += event.getExecutionTime();
+            copyInTimer += event.getElapsedTime();
             profiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
             profiler.addValueToMetric(ProfilerType.TASK_COPY_IN_SIZE_BYTES, meta.getId(), stack.getSize());
 

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -23,6 +23,13 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx;
 
+import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernelName;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
+
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.common.Event;
@@ -40,13 +47,6 @@ import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.Arrays;
-import java.util.List;
-
-import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernelName;
 
 public class PTXDeviceContext extends TornadoLogger implements Initialisable, TornadoDeviceContext {
 
@@ -250,7 +250,7 @@ public class PTXDeviceContext extends TornadoLogger implements Initialisable, To
             Event event = resolveEvent(stackWriteEventId);
             event.waitForEvents();
             long copyInTimer = meta.getProfiler().getTimer(ProfilerType.COPY_IN_TIME);
-            copyInTimer += event.getExecutionTime();
+            copyInTimer += event.getElapsedTime();
             profiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
             profiler.addValueToMetric(ProfilerType.TASK_COPY_IN_SIZE_BYTES, meta.getId(), stack.getSize());
 
@@ -266,9 +266,9 @@ public class PTXDeviceContext extends TornadoLogger implements Initialisable, To
             tornadoKernelEvent.waitForEvents();
             long timer = meta.getProfiler().getTimer(ProfilerType.TOTAL_KERNEL_TIME);
             // Register globalTime
-            meta.getProfiler().setTimer(ProfilerType.TOTAL_KERNEL_TIME, timer + tornadoKernelEvent.getExecutionTime());
+            meta.getProfiler().setTimer(ProfilerType.TOTAL_KERNEL_TIME, timer + tornadoKernelEvent.getElapsedTime());
             // Register the time for the task
-            meta.getProfiler().setTaskTimer(ProfilerType.TASK_KERNEL_TIME, meta.getId(), tornadoKernelEvent.getExecutionTime());
+            meta.getProfiler().setTaskTimer(ProfilerType.TASK_KERNEL_TIME, meta.getId(), tornadoKernelEvent.getElapsedTime());
             // Register the dispatch time of the kernel
             long dispatchValue = meta.getProfiler().getTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME);
             dispatchValue += tornadoKernelEvent.getDriverDispatchTime();

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXEvent.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXEvent.java
@@ -166,7 +166,7 @@ public class PTXEvent extends TornadoLogger implements Event {
     }
 
     @Override
-    public long getExecutionTime() {
+    public long getElapsedTime() {
         return cuEventElapsedTime(eventWrapper);
     }
 
@@ -176,7 +176,7 @@ public class PTXEvent extends TornadoLogger implements Event {
     }
 
     @Override
-    public double getExecutionTimeInSeconds() {
+    public double getElapsedTimeInSeconds() {
         return RuntimeUtilities.elapsedTimeInSeconds(cuEventElapsedTime(eventWrapper));
     }
 
@@ -193,7 +193,7 @@ public class PTXEvent extends TornadoLogger implements Event {
 
     @Override
     public double getTotalTimeInSeconds() {
-        return getExecutionTimeInSeconds();
+        return getElapsedTimeInSeconds();
     }
 
     @Override

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/EmptyEvent.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/EmptyEvent.java
@@ -46,7 +46,7 @@ public class EmptyEvent implements Event {
     }
 
     @Override
-    public long getExecutionTime() {
+    public long getElapsedTime() {
         return 0;
     }
 
@@ -56,7 +56,7 @@ public class EmptyEvent implements Event {
     }
 
     @Override
-    public double getExecutionTimeInSeconds() {
+    public double getElapsedTimeInSeconds() {
         return 0;
     }
 

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -288,7 +288,7 @@ public class TornadoVM extends TornadoLogger {
                 Event event = device.resolveEvent(e);
                 event.waitForEvents();
                 long copyInTimer = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
-                copyInTimer += event.getExecutionTime();
+                copyInTimer += event.getElapsedTime();
                 timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
                 timeProfiler.addValueToMetric(ProfilerType.TASK_COPY_IN_SIZE_BYTES, tasks.get(contextIndex).getId(), objectState.getBuffer().size());
 
@@ -324,7 +324,7 @@ public class TornadoVM extends TornadoLogger {
                 Event event = device.resolveEvent(e);
                 event.waitForEvents();
                 long copyInTimer = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
-                copyInTimer += event.getExecutionTime();
+                copyInTimer += event.getElapsedTime();
                 timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
                 timeProfiler.addValueToMetric(ProfilerType.TASK_COPY_IN_SIZE_BYTES, tasks.get(contextIndex).getId(), objectState.getBuffer().size());
 
@@ -360,7 +360,7 @@ public class TornadoVM extends TornadoLogger {
             Event event = device.resolveEvent(lastEvent);
             event.waitForEvents();
             long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
-            value += event.getExecutionTime();
+            value += event.getElapsedTime();
             timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
             timeProfiler.addValueToMetric(ProfilerType.TASK_COPY_OUT_SIZE_BYTES, tasks.get(contextIndex).getId(), objectState.getBuffer().size());
             long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
@@ -393,7 +393,7 @@ public class TornadoVM extends TornadoLogger {
             Event event = device.resolveEvent(tornadoEventID);
             event.waitForEvents();
             long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
-            value += event.getExecutionTime();
+            value += event.getElapsedTime();
             timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
             timeProfiler.addValueToMetric(ProfilerType.TASK_COPY_OUT_SIZE_BYTES, tasks.get(contextIndex).getId(), objectState.getBuffer().size());
             long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
@@ -575,7 +575,7 @@ public class TornadoVM extends TornadoLogger {
                     Event event = device.resolveEvent(e);
                     event.waitForEvents();
                     long value = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
-                    value += event.getExecutionTime();
+                    value += event.getElapsedTime();
                     timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, value);
                 }
             }
@@ -855,7 +855,7 @@ public class TornadoVM extends TornadoLogger {
                     TornadoAcceleratorDevice device = (TornadoAcceleratorDevice) eventSet.getDevice();
                     final Event profile = device.resolveEvent(i);
                     if (profile.getStatus() == COMPLETE) {
-                        System.out.printf("task: %s %s %9d %9d %9d %9d %9d\n", device.getDeviceName(), meta.getId(), profile.getExecutionTime(), profile.getQueuedTime(), profile.getSubmitTime(),
+                        System.out.printf("task: %s %s %9d %9d %9d %9d %9d\n", device.getDeviceName(), meta.getId(), profile.getElapsedTime(), profile.getQueuedTime(), profile.getSubmitTime(),
                                 profile.getStartTime(), profile.getEndTime());
                     }
                 }

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -367,7 +367,7 @@ public class TornadoExecutionContext {
 
                 if (TornadoOptions.isProfilerEnabled()) {
                     long value = profiler.getTimer(ProfilerType.COPY_OUT_TIME_SYNC);
-                    value += event.getExecutionTime();
+                    value += event.getElapsedTime();
                     profiler.setTimer(ProfilerType.COPY_OUT_TIME_SYNC, value);
                     DeviceObjectState deviceObjectState = localState.getGlobalState().getDeviceState(meta().getLogicDevice());
                     profiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getBuffer().size());

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskSchedule.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskSchedule.java
@@ -816,7 +816,7 @@ public class TornadoTaskSchedule implements AbstractTaskGraph {
             timeProfiler.clean();
             for (int i = 0; i < events.length; i++) {
                 long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME_SYNC);
-                value += events[i].getExecutionTime();
+                value += events[i].getElapsedTime();
                 timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME_SYNC, value);
                 LocalObjectState localState = executionContext.getObjectState(objects[i]);
                 DeviceObjectState deviceObjectState = localState.getGlobalState().getDeviceState(meta().getLogicDevice());

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/ProfiledAction.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/ProfiledAction.java
@@ -55,11 +55,11 @@ public interface ProfiledAction {
 
     long getEndTime();
 
-    long getExecutionTime();
+    long getElapsedTime();
 
     long getDriverDispatchTime();
 
-    double getExecutionTimeInSeconds();
+    double getElapsedTimeInSeconds();
 
     TornadoExecutionStatus getStatus();
 


### PR DESCRIPTION
Refactor in the ProfilerAction class

* event.getExecutionTime -> event.getElapsedTime
* event.getExecutionTimeInSeconds -> getElapsedTimeInSeconds 

#### Backend/s tested

- [X] OpenCL
- [ ] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

All tests should run

``` 
$ make tests 
```
