### PR TITLE
[docs] Minor updates in README.md & 15_FAQ.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Previous Releases can be found [here](assembly/src/docs/Releases.md)
 ## 1. Installation
 
 In Linux and Mac OSx, TornadoVM can be installed by the [installer](https://github.com/beehive-lab/tornadovm-installer).
-Althernatively, TornadoVM can be installed either [from source](INSTALL.md) or 
+Alternatively, TornadoVM can be installed either [from source](INSTALL.md) or 
 by [using Docker](assembly/src/docs/13_INSTALL_WITH_DOCKER.md).
 
 You can also run TornadoVM on Amazon AWS CPUs, GPUs, and FPGAs following the

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Previous Releases can be found [here](assembly/src/docs/Releases.md)
 
 ## 1. Installation
 
-In Linux and Mac OSx, TornadoVM can be installed with the [installer](https://github.com/beehive-lab/tornadovm-installer).
+In Linux and Mac OSx, TornadoVM can be installed by the [installer](https://github.com/beehive-lab/tornadovm-installer).
 Althernatively, TornadoVM can be installed either [from source](INSTALL.md) or 
 by [using Docker](assembly/src/docs/13_INSTALL_WITH_DOCKER.md).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Previous Releases can be found [here](assembly/src/docs/Releases.md)
 
 ## 1. Installation
 
-TornadoVM can be installed either [from source](INSTALL.md) or
+In Linux and Mac OSx, TornadoVM can be installed with the [installer](https://github.com/beehive-lab/tornadovm-installer).
+Althernatively, TornadoVM can be installed either [from source](INSTALL.md) or 
 by [using Docker](assembly/src/docs/13_INSTALL_WITH_DOCKER.md).
 
 You can also run TornadoVM on Amazon AWS CPUs, GPUs, and FPGAs following the

--- a/assembly/src/docs/15_FAQ.md
+++ b/assembly/src/docs/15_FAQ.md
@@ -11,8 +11,8 @@ processing.
 
 ## 2. How can I use it?
 
-In Linux and Mac OSx, TornadoVM can be automatically installed with the [installer](https://github.com/beehive-lab/tornadovm-installer).
-Althernatively, TornadoVM can be manually installed either [from source](INSTALL.md) or by [using Docker](13_INSTALL_WITH_DOCKER.md).
+In Linux and Mac OSx, TornadoVM can be installed with the [installer](https://github.com/beehive-lab/tornadovm-installer).
+Althernatively, TornadoVM can be installed either [from source](1_INSTALL.md) or by [using Docker](13_INSTALL_WITH_DOCKER.md).
 
 #### List of compatible JDKs
 

--- a/assembly/src/docs/15_FAQ.md
+++ b/assembly/src/docs/15_FAQ.md
@@ -12,7 +12,7 @@ processing.
 ## 2. How can I use it?
 
 In Linux and Mac OSx, TornadoVM can be installed by the [installer](https://github.com/beehive-lab/tornadovm-installer).
-Althernatively, TornadoVM can be installed either [from source](1_INSTALL.md) or by [using Docker](13_INSTALL_WITH_DOCKER.md).
+Alternatively, TornadoVM can be installed either [from source](1_INSTALL.md) or by [using Docker](13_INSTALL_WITH_DOCKER.md).
 
 #### List of compatible JDKs
 

--- a/assembly/src/docs/15_FAQ.md
+++ b/assembly/src/docs/15_FAQ.md
@@ -11,7 +11,7 @@ processing.
 
 ## 2. How can I use it?
 
-In Linux and Mac OSx, TornadoVM can be installed with the [installer](https://github.com/beehive-lab/tornadovm-installer).
+In Linux and Mac OSx, TornadoVM can be installed by the [installer](https://github.com/beehive-lab/tornadovm-installer).
 Althernatively, TornadoVM can be installed either [from source](1_INSTALL.md) or by [using Docker](13_INSTALL_WITH_DOCKER.md).
 
 #### List of compatible JDKs

--- a/assembly/src/docs/15_FAQ.md
+++ b/assembly/src/docs/15_FAQ.md
@@ -11,16 +11,16 @@ processing.
 
 ## 2. How can I use it?
 
-TornadoVM can be installed either [from source](INSTALL.md) or by [using Docker](13_INSTALL_WITH_DOCKER.md).
+In Linux and Mac OSx, TornadoVM can be automatically installed with the [installer](https://github.com/beehive-lab/tornadovm-installer).
+Althernatively, TornadoVM can be manually installed either [from source](INSTALL.md) or by [using Docker](13_INSTALL_WITH_DOCKER.md).
 
 #### List of compatible JDKs
 
 TornadoVM can be currently executed with the following three configurations:
 
 * TornadoVM with JDK 8 with JVMCI support: see the installation guide [here](11_INSTALL_WITH_JDK8.md).
-* TornadoVM with GraalVM (either with JDK 8 or JDK 11): see the installation guide [here](10_INSTALL_WITH_GRAALVM.md).
-* TornadoVM with JDK11+ (e.g. OpenJDK, Red Hat Mandrel, Amazon Corretto, Windows JDK 11): see the installation
-  guide [here](12_INSTALL_WITH_JDK11_PLUS.md).
+* TornadoVM with GraalVM (JDK 8, JDK 11, JDK 16): see the installation guide [here](10_INSTALL_WITH_GRAALVM.md).
+* TornadoVM with JDK11+ (e.g. OpenJDK 11, OpenJDK 16, Red Hat Mandrel 11, Amazon Corretto 11, Amazon Corretto 16, Windows JDK 11, Windows JDK 16): see the installation guide [here](12_INSTALL_WITH_JDK11_PLUS.md).
 
 Note: To run TornadoVM on ARM Mali GPUs, install TornadoVM with GraalVM and JDK 11. More information [here](18_MALI.md).
 
@@ -100,9 +100,9 @@ learning.
 
 TornadoVM is an open-source project, and, as such, we welcome contributions from all levels.
 
-* **Solve [issues](https://github.com/beehive-lab/TornadoVM/issues)** reported on the Github page. 
+* **Solve [issues](https://github.com/beehive-lab/TornadoVM/issues)** reported on the GitHub page. 
 * **New proposals**: We welcome new proposals and ideas. To work on a new proposal, use
-  the [discussion](https://github.com/beehive-lab/TornadoVM/discussions) page on Github. Alternatively, you can open a
+  the [discussion](https://github.com/beehive-lab/TornadoVM/discussions) page on GitHub. Alternatively, you can open a
   shared document (e.g., a shared Google doc) where we can discuss and analyse your proposal.
 
 [Here](https://github.com/beehive-lab/TornadoVM/blob/master/CONTRIBUTING.md) you can find more information about how to


### PR DESCRIPTION
#### Description

This PR contains minor updates in terms of documentation. In particular, it contains the following changes:

- Update JDK 16 in the list of JDKs that TornadoVM can be installed with.
- Minor typos.
- Addition of a reference to the TornadoVM [installer](https://github.com/beehive-lab/tornadovm-installer) for Linux and Mac OSx.