### PR TITLE
[OCL][PTX] fix vector stores to parameters

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLIRGenerator.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLIRGenerator.java
@@ -77,8 +77,8 @@ import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public class OCLLIRGenerator extends LIRGenerator {
 
-    private OCLBuiltinTool oclBuiltinTool;
-    private OCLGenTool oclGenTool;
+    private final OCLBuiltinTool oclBuiltinTool;
+    private final OCLGenTool oclGenTool;
 
     public OCLLIRGenerator(CodeGenProviders providers, LIRGenerationResult res) {
         super(new OCLLIRKindTool((OCLTargetDescription) providers.getCodeCache().getTarget()), new OCLArithmeticTool(), new OCLMoveFactory(), providers, res);
@@ -401,6 +401,10 @@ public class OCLLIRGenerator extends LIRGenerator {
     protected JavaConstant zapValueForKind(PlatformKind pk) {
         unimplemented();
         return null;
+    }
+
+    public OCLGenTool getOclGenTool() {
+        return oclGenTool;
     }
 
 }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLGenTool.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLGenTool.java
@@ -55,9 +55,13 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLUnary.MemoryAccess;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLUnary.OCLAddressCast;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.vector.VectorUtil;
 
+import java.util.HashMap;
+
 public class OCLGenTool {
 
     protected OCLLIRGenerator gen;
+
+    private final HashMap<ParameterNode, Variable> parameterToVariable = new HashMap<>();
 
     public OCLGenTool(OCLLIRGenerator gen) {
         this.gen = gen;
@@ -83,6 +87,7 @@ public class OCLGenTool {
 
         Variable result = (oclKind.isVector()) ? gen.newVariable(LIRKind.value(oclTarget.getOCLKind(JavaKind.Object))) : gen.newVariable(lirKind);
         emitParameterLoad(result, index);
+        parameterToVariable.put(paramNode, result);
 
         if (oclKind.isVector()) {
 
@@ -131,5 +136,9 @@ public class OCLGenTool {
         LIRKind lirKind = LIRKind.value(oclKind);
         final OCLUnaryOp op = getParameterLoadOp(oclKind);
         gen.append(new AssignStmt(dst, new OCLUnary.Expr(op, lirKind, new ConstantValue(LIRKind.value(OCLKind.INT), JavaConstant.forInt(index + OCLAssemblerConstants.STACK_BASE_OFFSET)))));
+    }
+
+    public HashMap<ParameterNode, Variable> getParameterToVariable() {
+        return parameterToVariable;
     }
 }

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/vector/VectorAddNode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/vector/VectorAddNode.java
@@ -31,6 +31,7 @@ import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.BinaryNode;
 import org.graalvm.compiler.nodes.spi.CanonicalizerTool;
@@ -56,6 +57,10 @@ public class VectorAddNode extends BinaryNode implements LIRLowerable, VectorOp 
 
     @Override
     public Stamp foldStamp(Stamp stampX, Stamp stampY) {
+        Stamp currentStamp = stamp(NodeView.DEFAULT);
+        if (currentStamp instanceof OCLStamp) {
+            return currentStamp;
+        }
         return (stampX instanceof OCLStamp) ? stampX.join(stampY) : stampY.join(stampX);
     }
 

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXVectorPlugins.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXVectorPlugins.java
@@ -44,6 +44,8 @@ import org.graalvm.compiler.nodes.java.StoreIndexedNode;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.compiler.nodes.memory.address.AddressNode;
+import org.graalvm.compiler.nodes.memory.address.OffsetAddressNode;
 import uk.ac.manchester.tornado.api.type.annotations.Vector;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXStampFactory;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
@@ -52,6 +54,7 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector.LoadIndexedVector
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector.VectorAddNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector.VectorLoadElementNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector.VectorStoreElementProxyNode;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector.VectorStoreGlobalMemory;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector.VectorValueNode;
 
 public final class PTXVectorPlugins {
@@ -143,6 +146,19 @@ public final class PTXVectorPlugins {
                 final VectorLoadElementNode loadElement = new VectorLoadElementNode(vectorKind.getElementKind(), receiver.get(), laneId);
                 b.push(javaElementKind, b.append(loadElement));
                 return true;
+            }
+        });
+
+        r.register2("set", Receiver.class, vectorKind.getJavaClass(), new InvocationPlugin() {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                if (receiver.get() instanceof ParameterNode) {
+                    final AddressNode address = new OffsetAddressNode(receiver.get(), null);
+                    final VectorStoreGlobalMemory store = new VectorStoreGlobalMemory(vectorKind, address, value);
+                    b.add(b.append(store));
+                    return true;
+                }
+                return false;
             }
         });
 

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXGenTool.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXGenTool.java
@@ -40,6 +40,8 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler;
 import uk.ac.manchester.tornado.drivers.ptx.graal.compiler.PTXLIRGenerator;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXUnary.MemoryAccess;
 
+import java.util.HashMap;
+
 import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXArchitecture.globalSpace;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssemblerConstants.STACK_BASE_OFFSET;
 import static uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCodeGenerator.trace;
@@ -47,6 +49,8 @@ import static uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCodeGenerat
 public class PTXGenTool {
 
     protected PTXLIRGenerator gen;
+
+    private final HashMap<ParameterNode, Variable> parameterToVariable = new HashMap<>();
 
     public PTXGenTool(PTXLIRGenerator generator) {
         gen = generator;
@@ -68,6 +72,7 @@ public class PTXGenTool {
 
         Variable result = (kind.isVector()) ? gen.newVariable(LIRKind.value(target.getPTXKind(JavaKind.Object))) : gen.newVariable(lirKind);
         emitParameterLoad(result, paramOffset);
+        parameterToVariable.put(paramNode, result);
 
         if (kind.isVector()) {
             Variable vector = gen.newVariable(lirKind);
@@ -85,6 +90,10 @@ public class PTXGenTool {
         ConstantValue stackIndex = new ConstantValue(LIRKind.value(PTXKind.S32), JavaConstant.forInt((index + STACK_BASE_OFFSET) * PTXKind.U64.getSizeInBytes()));
 
         gen.append(new PTXLIRStmt.LoadStmt(new MemoryAccess(globalSpace, gen.getParameterAllocation(PTXArchitecture.STACK_POINTER), stackIndex), (Variable) dst, PTXAssembler.PTXNullaryOp.LDU));
+    }
+
+    public HashMap<ParameterNode, Variable> getParameterToVariable() {
+        return parameterToVariable;
     }
 
 }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/vector/VectorAddNode.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/vector/VectorAddNode.java
@@ -29,6 +29,7 @@ import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.BinaryNode;
 import org.graalvm.compiler.nodes.spi.CanonicalizerTool;
@@ -54,6 +55,10 @@ public class VectorAddNode extends BinaryNode implements LIRLowerable, VectorOp 
 
     @Override
     public Stamp foldStamp(Stamp stampX, Stamp stampY) {
+        Stamp currentStamp = stamp(NodeView.DEFAULT);
+        if (currentStamp instanceof PTXStamp) {
+            return currentStamp;
+        }
         return (stampX instanceof PTXStamp) ? stampX.join(stampY) : stampY.join(stampX);
     }
 

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/vector/VectorStoreGlobalMemory.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/vector/VectorStoreGlobalMemory.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -16,8 +17,6 @@
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- * Authors: James Clarkson
  *
  */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector;

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/vector/VectorStoreGlobalMemory.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/vector/VectorStoreGlobalMemory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Authors: James Clarkson
+ *
+ */
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector;
+
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+
+import uk.ac.manchester.tornado.drivers.ptx.graal.PTXStampFactory;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.runtime.graal.phases.MarkVectorStore;
+
+/**
+ * The {@code VectorStoreGlobalMemory} represents a vector-write to global memory.
+ */
+@NodeInfo(nameTemplate = "VectorStoreGlobalMemory")
+public final class VectorStoreGlobalMemory extends FixedWithNextNode implements LIRLowerable, MarkVectorStore {
+
+    public static final NodeClass<VectorStoreGlobalMemory> TYPE = NodeClass.create(VectorStoreGlobalMemory.class);
+
+    @Input ValueNode value;
+    @Input ValueNode address;
+
+    public VectorStoreGlobalMemory(PTXKind vectorKind, ValueNode address, ValueNode value) {
+        super(TYPE, PTXStampFactory.getStampFor(vectorKind));
+        this.value = value;
+        this.address = address;
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool gen) {
+        LIRKind writeKind = gen.getLIRGeneratorTool().getLIRKind(stamp);
+        gen.getLIRGeneratorTool().getArithmetic().emitStore(writeKind, gen.operand(address), gen.operand(value), null);
+    }
+}

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/MarkVectorStore.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/MarkVectorStore.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *
+ */
+
+package uk.ac.manchester.tornado.runtime.graal.phases;
+
+/**
+ * This interface is used for accessing the Vector Store node type outside the
+ * scope of drivers package
+ */
+public interface MarkVectorStore {
+}

--- a/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoDataflowAnalysis.java
+++ b/runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoDataflowAnalysis.java
@@ -45,6 +45,7 @@ import org.graalvm.compiler.nodes.java.LoadFieldNode;
 import org.graalvm.compiler.nodes.java.LoadIndexedNode;
 import org.graalvm.compiler.nodes.java.StoreFieldNode;
 import org.graalvm.compiler.nodes.java.StoreIndexedNode;
+import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.phases.BasePhase;
 
 import jdk.vm.ci.meta.Constant;
@@ -52,7 +53,6 @@ import jdk.vm.ci.meta.MetaAccessProvider;
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.StoreAtomicIndexedNode;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class TornadoDataflowAnalysis extends BasePhase<TornadoSketchTierContext> {
 
@@ -215,11 +215,13 @@ public class TornadoDataflowAnalysis extends BasePhase<TornadoSketchTierContext>
                 isWrittenTrueCondition = meta.isWrittenTrueCondition();
                 isWrittenFalseCondition = meta.isWrittenFalseCondition();
                 isWritten = true;
+            } else if (currentNode instanceof MarkVectorStore) {
+                isWritten = true;
             } else if (isNodeFromKnownObject(currentNode)) {
                 // All objects are passed by reference -> R/W
                 isRead = true;
                 isWritten = true;
-            } else if (currentNode instanceof PiNode) {
+            } else if (currentNode instanceof PiNode || currentNode instanceof AddressNode) {
                 currentNode.usages().forEach(nf::add);
             }
         }

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestMultipleFunctions.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestMultipleFunctions.java
@@ -20,6 +20,7 @@ package uk.ac.manchester.tornado.unittests.tasks;
 import org.junit.Assert;
 import org.junit.Test;
 import uk.ac.manchester.tornado.api.TaskSchedule;
+import uk.ac.manchester.tornado.api.collections.types.Float4;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 import java.util.Random;
@@ -226,6 +227,53 @@ public class TestMultipleFunctions extends TornadoTestBase {
         ts.execute();
 
         Assert.assertEquals(-1, arr[0]);
+    }
+
+    /**
+     * Test to check we can generate vector types for the method signature and
+     * non-main kernel functions.
+     */
+    @Test
+    public void testVector01() {
+
+        Float4 a = new Float4(1, 2, 3, 4);
+        Float4 b = new Float4(4, 3, 2, 1);
+        Float4 c = new Float4();
+
+        //@formatter:off
+        new TaskSchedule("s0")
+                .streamIn(a, b)
+                .task("t0", TestMultipleFunctions::vectorTypes, a, b, c)
+                .streamOut(c)
+                .execute();
+        //@formatter:on
+
+        Float4 result = Float4.add(foo(a),bar(b));
+
+        float[] cArray = c.getArray();
+        float[] resultArray = result.getArray();
+
+        Assert.assertArrayEquals(resultArray, cArray, 0.1f);
+    }
+
+    /**
+     * Test to check we can generate vector types for the method signature and
+     * non-main kernel functions.
+     *
+     * @param a
+     * @param b
+     * @param c
+     */
+    public static void vectorTypes(Float4 a, Float4 b, Float4 c) {
+        c.set(Float4.add(foo(a), bar(b)));
+    }
+
+    private static Float4 foo(Float4 a) {
+        return Float4.add(a, a);
+    }
+
+    private static Float4 bar(Float4 a) {
+        return Float4.mult(a, a);
     }
 
 }


### PR DESCRIPTION
#### Description

This PR fixes vector stores to method parameters when calling the `set` method. Previously the test from `TestMultipleFunctions::testVector01` was failing with a compile time error.

The ideal graph generated before the patch is:
![image](https://user-images.githubusercontent.com/7903443/135862379-ebba6fb7-98bc-4d08-b15b-b18852574f65.png)

The ideal graph generated after the patch is:
![image](https://user-images.githubusercontent.com/7903443/135862438-cb131979-ae63-455e-82a6-3cdf2f48de33.png)

The new node `VectorStoreGlobalMemory` performs a single `vstore` operation to global memory. 

```
__kernel void vectorTypes(__global uchar *_heap_base, ulong _frame_base, __constant uchar *_constant_region, __local uchar *_local_region, __global int *_atomics)
{
  ulong ul_2, ul_0, ul_4; 
  float f_10, f_9, f_8, f_7; 
  float4 v4f_6, v4f_5, v4f_11, v4f_12, v4f_3, v4f_1; 

  __global ulong *_frame = (__global ulong *) &_heap_base[_frame_base];


  // BLOCK 0
  ul_0  =  (ulong) _frame[3];
  v4f_1  =  vload4(0, (__global float *) ul_0);
  ul_2  =  (ulong) _frame[4];
  v4f_3  =  vload4(0, (__global float *) ul_2);
  ul_4  =  (ulong) _frame[5];
  v4f_5  =  vload4(0, (__global float *) ul_4);
  v4f_6  =  v4f_1 + v4f_1;
  f_7  =  v4f_3.s0 * v4f_3.s0;
  f_8  =  v4f_3.s1 * v4f_3.s1;
  f_9  =  v4f_3.s2 * v4f_3.s2;
  f_10  =  v4f_3.s3 * v4f_3.s3;
  v4f_11  =  (float4)(f_7, f_8, f_9, f_10);
  v4f_12  =  v4f_6 + v4f_11;
  vstore4(v4f_12, 0, (__global float *) ul_4);
  return;
}  //  kernel
```

#### Backend/s tested

- [X] OpenCL
- [X] PTX

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

`tornado-test.py -J"-Dtornado.print.bytecodes=True" --debug --verbose --printKernel uk.ac.manchester.tornado.unittests.tasks.TestMultipleFunctions#testVector01`
