### PR TITLE
[fix] #155 (public) TaskSchedule return type for task13 and 14

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/AbstractWorkerGrid.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/AbstractWorkerGrid.java
@@ -48,7 +48,7 @@ public abstract class AbstractWorkerGrid implements WorkerGrid {
     protected long[] numOfWorkgroups;
     protected long[] globalOffset;
 
-    public AbstractWorkerGrid(long x, long y, long z) {
+    protected AbstractWorkerGrid(long x, long y, long z) {
         globalWork = new long[] { x, y, z };
         globalOffset = new long[] { 0, 0, 0 };
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/Policy.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/Policy.java
@@ -48,14 +48,14 @@ public enum Policy {
     LATENCY("Latency"), //
     ENERGY("Energy"); //
 
-    private final String policy;
+    private final String policyName;
 
-    Policy(String policy) {
-        this.policy = policy;
+    Policy(String policyName) {
+        this.policyName = policyName;
     }
 
     @Override
     public String toString() {
-        return policy;
+        return policyName;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskSchedule.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskSchedule.java
@@ -70,8 +70,8 @@ import uk.ac.manchester.tornado.api.runtime.TornadoAPIProvider;
 /**
  * Tornado Task Schedule API.
  * <p>
- * </> Task-based parallel API to express code to be compiled and executed from
- * Java to OpenCL a t runtime. The Tornado runtime executes the generated OpenCL
+ * Task-based parallel API to express code to be compiled and executed from Java
+ * to OpenCL a t runtime. The Tornado runtime executes the generated OpenCL
  * program on any OpenCL-compatible device.
  * </p>
  */
@@ -209,8 +209,8 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     }
 
     @Override
-    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> TornadoAPI task(String id, Task13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
-            T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13) {
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> TaskSchedule task(String id, Task13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> code, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13) {
         checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
         taskScheduleImpl.addTask(taskPackage);
@@ -218,8 +218,8 @@ public class TaskSchedule implements TornadoAPI, ProfileInterface {
     }
 
     @Override
-    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> TornadoAPI task(String id, Task14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> code, T1 arg1, T2 arg2, T3 arg3,
-            T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14) {
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> TaskSchedule task(String id, Task14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> code, T1 arg1, T2 arg2,
+            T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14) {
         checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
         taskScheduleImpl.addTask(taskPackage);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskSchedule.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskSchedule.java
@@ -70,9 +70,8 @@ import uk.ac.manchester.tornado.api.runtime.TornadoAPIProvider;
 /**
  * Tornado Task Schedule API.
  * <p>
- * Task-based parallel API to express code to be compiled and executed from Java
- * to OpenCL a t runtime. The Tornado runtime executes the generated OpenCL
- * program on any OpenCL-compatible device.
+ * Task-based parallel API to express methods to be accelerated
+ * on any OpenCL, PTX or SPIRV compatible device.
  * </p>
  */
 public class TaskSchedule implements TornadoAPI, ProfileInterface {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoVM_Intrinsics.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoVM_Intrinsics.java
@@ -52,7 +52,7 @@ public class TornadoVM_Intrinsics {
      * @param value
      * @return old value
      */
-    public synchronized static int atomic_add(int[] array, int index, int value) {
+    public static synchronized int atomic_add(int[] array, int index, int value) {
         int old = array[index];
         array[index] = array[index] + value;
         return old;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/runtime/TornadoAPIProvider.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/runtime/TornadoAPIProvider.java
@@ -50,7 +50,6 @@ import java.lang.reflect.Method;
 import uk.ac.manchester.tornado.api.AbstractFactoryDevice;
 import uk.ac.manchester.tornado.api.AbstractTaskGraph;
 import uk.ac.manchester.tornado.api.TornadoCI;
-import uk.ac.manchester.tornado.api.TornadoDriver;
 import uk.ac.manchester.tornado.api.TornadoRuntimeCI;
 
 public class TornadoAPIProvider {


### PR DESCRIPTION
TaskSchedules with 13 and 14 arguments returned a `TornadoAPI` object instead of a `TaskSchedule` object. 

This PR provides a fix and it removes old imports and some changes in the API to comply with Sonar tool. 

This PR solves issue #155 

#### Backend/s tested

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If possible, check your changes on FPGAs.

- [ ] Yes
- [X] No

All Unittests should pass.
