### PR TITLE
[fix/176] Implement IntegerTestMove operation in OpenCL, PTX, SPIRV

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLIRGenerator.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLIRGenerator.java
@@ -282,9 +282,20 @@ public class OCLLIRGenerator extends LIRGenerator {
     }
 
     @Override
-    public Variable emitIntegerTestMove(Value value, Value value1, Value value2, Value value3) {
-        unimplemented();
-        return null;
+    public Variable emitIntegerTestMove(Value left, Value right, Value trueValue, Value falseValue) {
+        Logger.traceBuildLIR(Logger.BACKEND.OpenCL, "emitIntegerTestMove");
+        assert left.getPlatformKind() == right.getPlatformKind() && ((OCLKind) left.getPlatformKind()).isInteger();
+
+        assert trueValue.getPlatformKind() == falseValue.getPlatformKind();
+
+        final OCLBinary.Expr condExpr = new OCLBinary.Expr(OCLBinaryOp.BITWISE_AND, null, left, right);
+        final OCLTernary.Select selectExpr = new OCLTernary.Select(LIRKind.combine(trueValue, falseValue), condExpr, trueValue, falseValue);
+
+        final Variable variable = newVariable(LIRKind.combine(trueValue, falseValue));
+        final AssignStmt assignStmt = new AssignStmt(variable, selectExpr);
+        append(assignStmt);
+
+        return variable;
     }
 
     @Override

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLIRGenerator.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLIRGenerator.java
@@ -283,7 +283,7 @@ public class OCLLIRGenerator extends LIRGenerator {
 
     @Override
     public Variable emitIntegerTestMove(Value left, Value right, Value trueValue, Value falseValue) {
-        Logger.traceBuildLIR(Logger.BACKEND.OpenCL, "emitIntegerTestMove");
+        Logger.traceBuildLIR(Logger.BACKEND.OpenCL, "emitIntegerTestMove: " + left + " " + "&" + right + " ? " + trueValue + " : " + falseValue);
         assert left.getPlatformKind() == right.getPlatformKind() && ((OCLKind) left.getPlatformKind()).isInteger();
 
         assert trueValue.getPlatformKind() == falseValue.getPlatformKind();

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLIRGenerator.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLIRGenerator.java
@@ -289,7 +289,7 @@ public class OCLLIRGenerator extends LIRGenerator {
         assert trueValue.getPlatformKind() == falseValue.getPlatformKind();
 
         final OCLBinary.Expr condExpr = new OCLBinary.Expr(OCLBinaryOp.BITWISE_AND, null, left, right);
-        final OCLTernary.Select selectExpr = new OCLTernary.Select(LIRKind.combine(trueValue, falseValue), condExpr, trueValue, falseValue);
+        final OCLTernary.Select selectExpr = new OCLTernary.Select(LIRKind.combine(trueValue, falseValue), condExpr, falseValue, trueValue);
 
         final Variable variable = newVariable(LIRKind.combine(trueValue, falseValue));
         final AssignStmt assignStmt = new AssignStmt(variable, selectExpr);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXLIRGenerator.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXLIRGenerator.java
@@ -322,19 +322,19 @@ public class PTXLIRGenerator extends LIRGenerator {
      */
     @Override
     public Variable emitIntegerTestMove(Value leftVal, Value right, Value trueValue, Value falseValue) {
-        Logger.traceBuildLIR(Logger.BACKEND.PTX, "emitIntegerTestMove");
+        Logger.traceBuildLIR(Logger.BACKEND.PTX, "emitIntegerTestMove: " + leftVal + " " + "&" + right + " ? " + trueValue + " : " + falseValue);
         assert leftVal.getPlatformKind() == right.getPlatformKind() && ((PTXKind) leftVal.getPlatformKind()).isInteger();
 
         assert trueValue.getPlatformKind() == falseValue.getPlatformKind();
 
         LIRKind kind = LIRKind.combine(trueValue, falseValue);
         final Variable andResult = newVariable(LIRKind.combine(leftVal, right));
-        final ConstantValue constant = new ConstantValue(andResult.getValueKind(), JavaConstant.forInt(0));
+        final ConstantValue zeroConstant = new ConstantValue(andResult.getValueKind(), JavaConstant.forInt(0));
         final Variable predicate = newVariable(LIRKind.value(PTXKind.PRED));
         final Variable result = newVariable(kind);
 
         append(new PTXLIRStmt.AssignStmt(andResult, new PTXBinary.Expr(PTXBinaryOp.BITWISE_AND, kind, leftVal, right)));
-        append(new PTXLIRStmt.AssignStmt(predicate, new PTXBinary.Expr(PTXBinaryOp.SETP_EQ, kind, andResult, constant)));
+        append(new PTXLIRStmt.AssignStmt(predicate, new PTXBinary.Expr(PTXBinaryOp.SETP_EQ, kind, andResult, zeroConstant)));
         append(new PTXLIRStmt.AssignStmt(result, new PTXTernary.Expr(PTXAssembler.PTXTernaryOp.SELP, kind, trueValue, falseValue, predicate)));
 
         return result;

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXLIRGenerator.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXLIRGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2020, 2022, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -39,7 +39,6 @@ import org.graalvm.compiler.lir.ConstantValue;
 import org.graalvm.compiler.lir.LIRFrameState;
 import org.graalvm.compiler.lir.LIRInstruction;
 import org.graalvm.compiler.lir.LabelRef;
-import org.graalvm.compiler.lir.StandardOp;
 import org.graalvm.compiler.lir.SwitchStrategy;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.LIRGenerationResult;
@@ -307,10 +306,38 @@ public class PTXLIRGenerator extends LIRGenerator {
         return null;
     }
 
+    /**
+     * It generates an IntegerTestMove operation, which moves a value to a parameter
+     * based on a bitwise and operation between two values.
+     *
+     * @param leftVal
+     *            the left value of a condition
+     * @param right
+     *            the right value of a condition
+     * @param trueValue
+     *            the true value to move in the result
+     * @param falseValue
+     *            the false value to move in the result
+     * @return Variable: reference to the variable that contains the result
+     */
     @Override
     public Variable emitIntegerTestMove(Value leftVal, Value right, Value trueValue, Value falseValue) {
-        unimplemented();
-        return null;
+        Logger.traceBuildLIR(Logger.BACKEND.PTX, "emitIntegerTestMove");
+        assert leftVal.getPlatformKind() == right.getPlatformKind() && ((PTXKind) leftVal.getPlatformKind()).isInteger();
+
+        assert trueValue.getPlatformKind() == falseValue.getPlatformKind();
+
+        LIRKind kind = LIRKind.combine(trueValue, falseValue);
+        final Variable andResult = newVariable(LIRKind.combine(leftVal, right));
+        final ConstantValue constant = new ConstantValue(andResult.getValueKind(), JavaConstant.forInt(0));
+        final Variable predicate = newVariable(LIRKind.value(PTXKind.PRED));
+        final Variable result = newVariable(kind);
+
+        append(new PTXLIRStmt.AssignStmt(andResult, new PTXBinary.Expr(PTXBinaryOp.BITWISE_AND, kind, leftVal, right)));
+        append(new PTXLIRStmt.AssignStmt(predicate, new PTXBinary.Expr(PTXBinaryOp.SETP_EQ, kind, andResult, constant)));
+        append(new PTXLIRStmt.AssignStmt(result, new PTXTernary.Expr(PTXAssembler.PTXTernaryOp.SELP, kind, trueValue, falseValue, predicate)));
+
+        return result;
     }
 
     @Override

--- a/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLIRGenerator.java
+++ b/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLIRGenerator.java
@@ -236,8 +236,9 @@ public class SPIRVLIRGenerator extends LIRGenerator {
         LIRKind kind = LIRKind.combine(trueValue, falseValue);
         final Variable result = newVariable(kind);
 
-        SPIRVBinary.IntegerTestNode ternaryInstruction = new SPIRVBinary.IntegerTestNode(SPIRVAssembler.SPIRVBinaryOp.BITWISE_AND, LIRKind.combine(leftVal, right), leftVal, right);
-        append(new SPIRVLIRStmt.AssignStmt(result, ternaryInstruction));
+        SPIRVBinary.IntegerTestNode integerTestNode = new SPIRVBinary.IntegerTestNode(SPIRVAssembler.SPIRVBinaryOp.BITWISE_AND, kind, leftVal, right);
+        SPIRVBinary.IntegerTestMoveNode moveNode = new SPIRVBinary.IntegerTestMoveNode(integerTestNode, result, kind, trueValue, falseValue);
+        append(new SPIRVLIRStmt.AssignStmt(result, moveNode));
 
         return result;
     }

--- a/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLIRGenerator.java
+++ b/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLIRGenerator.java
@@ -56,6 +56,7 @@ import uk.ac.manchester.tornado.drivers.common.logging.Logger;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVTargetDescription;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVLIRKindTool;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVStamp;
+import uk.ac.manchester.tornado.drivers.spirv.graal.asm.SPIRVAssembler;
 import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.lir.SPIRVArithmeticTool;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVBinary;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVBuiltinTool;
@@ -161,12 +162,12 @@ public class SPIRVLIRGenerator extends LIRGenerator {
 
     @Override
     public void emitMembar(int barriers) {
-
+        unimplemented();
     }
 
     @Override
     public void emitUnwind(Value operand) {
-
+        unimplemented();
     }
 
     @Override
@@ -189,12 +190,12 @@ public class SPIRVLIRGenerator extends LIRGenerator {
     @Override
     public void emitCompareBranch(PlatformKind cmpKind, Value left, Value right, Condition cond, boolean unorderedIsTrue, LabelRef trueDestination, LabelRef falseDestination,
             double trueDestinationProbability) {
-
+        unimplemented();
     }
 
     @Override
     public void emitOverflowCheckBranch(LabelRef overflow, LabelRef noOverflow, LIRKind cmpKind, double overflowProbability) {
-
+        unimplemented();
     }
 
     @Override
@@ -211,18 +212,44 @@ public class SPIRVLIRGenerator extends LIRGenerator {
         return resultConditionalMove;
     }
 
+    /**
+     * It generates an IntegerTestMove operation, which moves a value to a parameter
+     * based on a bitwise and operation between two values.
+     *
+     * @param leftVal
+     *            the left value of a condition
+     * @param right
+     *            the right value of a condition
+     * @param trueValue
+     *            the true value to move in the result
+     * @param falseValue
+     *            the false value to move in the result
+     * @return Variable: reference to the variable that contains the result
+     */
     @Override
     public Variable emitIntegerTestMove(Value leftVal, Value right, Value trueValue, Value falseValue) {
-        return null;
+        Logger.traceBuildLIR(Logger.BACKEND.SPIRV, "emitIntegerTestMove: " + leftVal + " " + "&" + right + " ? " + trueValue + " : " + falseValue);
+        assert leftVal.getPlatformKind() == right.getPlatformKind() && ((SPIRVKind) leftVal.getPlatformKind()).isInteger();
+
+        assert trueValue.getPlatformKind() == falseValue.getPlatformKind();
+
+        LIRKind kind = LIRKind.combine(trueValue, falseValue);
+        final Variable result = newVariable(kind);
+
+        SPIRVBinary.IntegerTestNode ternaryInstruction = new SPIRVBinary.IntegerTestNode(SPIRVAssembler.SPIRVBinaryOp.BITWISE_AND, LIRKind.combine(leftVal, right), leftVal, right);
+        append(new SPIRVLIRStmt.AssignStmt(result, ternaryInstruction));
+
+        return result;
     }
 
     @Override
     protected void emitForeignCallOp(ForeignCallLinkage linkage, Value targetAddress, Value result, Value[] arguments, Value[] temps, LIRFrameState info) {
-
+        unimplemented();
     }
 
     @Override
     public Variable emitByteSwap(Value operand) {
+        unimplemented();
         return null;
     }
 
@@ -233,7 +260,7 @@ public class SPIRVLIRGenerator extends LIRGenerator {
 
     @Override
     public void emitPrefetchAllocate(Value address) {
-
+        unimplemented();
     }
 
     @Override
@@ -250,7 +277,7 @@ public class SPIRVLIRGenerator extends LIRGenerator {
 
     @Override
     public void emitSpeculationFence() {
-
+        unimplemented();
     }
 
     @Override

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/branching/TestConditionals.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/branching/TestConditionals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
  * The University of Manchester.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -168,6 +168,18 @@ public class TestConditionals extends TornadoTestBase {
     public static void ternaryComplexCondition2(int[] a, int[] b) {
         for (@Parallel int i = 0; i < a.length; i++) {
             a[i] = (a[i] == 20) ? a[i] + b[i] : 5;
+        }
+    }
+
+    public static void integerTestMove(int[] output, int dimensionSize) {
+        for (@Parallel int i = 0; i < dimensionSize; i++) {
+            for (@Parallel int j = 0; j < dimensionSize; j++) {
+                if ((i % 2 == 0) & (j % 2 == 0)) {
+                    output[i + j * dimensionSize] = 10;
+                } else {
+                    output[i + j * dimensionSize] = -1;
+                }
+            }
         }
     }
 
@@ -426,6 +438,29 @@ public class TestConditionals extends TornadoTestBase {
 
         for (int value : a) {
             assertEquals(10, value);
+        }
+    }
+
+    @Test
+    public void testIntegerTestMove() {
+        final int N = 1024;
+        int[] output = new int[N * N];
+        int[] sequential = new int[N * N];
+
+        IntStream.range(0, sequential.length).sequential().forEach(i -> sequential[i] = i);
+        IntStream.range(0, output.length).sequential().forEach(i -> output[i] = i);
+
+        TaskSchedule s0 = new TaskSchedule("s0");
+
+        // @formatter:off
+        s0.task("t0", TestConditionals::integerTestMove, output, N).streamOut(output);
+        // @formatter:on
+        s0.execute();
+
+        integerTestMove(sequential, N);
+
+        for (int i = 0; i < N * N; i++) {
+            assertEquals(sequential[i], output[i]);
         }
     }
 }


### PR DESCRIPTION
#### Description

This PR implements the `IntegerTestMove` operation in the three backends; OpenCL, PTX, SPIR-V.

This operation performs a bitwise and operation between two operands and based on the outcome a value is assigned to a variable. In Java this is the test that was reproduced by issue #176:
```java
public static void integerTestMove(int[] output, int dimensionSize) {
   for (@Parallel int i = 0; i < dimensionSize; i++) {
       for (@Parallel int j = 0; j < dimensionSize; j++) {
           if ((i % 2 == 0) & (j % 2 == 0)) {
               output[i + j * dimensionSize] = 10;
           } else {
               output[i + j * dimensionSize] = -1;
           }
       }
   }
}
```

I also added the aforementioned testcase in the TornadoVM `TestConditionals` unit-tests.

Thanks to @gigiblender and @jjfumero for their assistance in some issues related to PTX and SPIR-V. The generated SPIR-V kernel passes also the validation with `spirv-val` tool.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Provide instructions about how to test the new patch. 
```bash
$ make jdk-11-plus BACKEND=opencl
$ tornado -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.branching.TestConditionals#testIntegerTestMove
$ make jdk-11-plus BACKEND=ptx
$ tornado -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.branching.TestConditionals#testIntegerTestMove
$ make jdk-11-plus BACKEND=spirv
$ tornado -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.branching.TestConditionals#testIntegerTestMove
```

----------------------------------------------------------------------------