### PR TITLE
[fix/180] Fix offset for vector instructions that operate in private memory space

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLArithmeticTool.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLArithmeticTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2018, 2020, 2022, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -28,6 +28,7 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.RSQRT;
 
+import jdk.vm.ci.meta.JavaConstant;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.calc.FloatConvert;
 import org.graalvm.compiler.lir.ConstantValue;
@@ -62,6 +63,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.VectorLoadSt
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.VectorStoreStmt;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLUnary.MemoryAccess;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLUnary.OCLAddressCast;
+import uk.ac.manchester.tornado.drivers.opencl.graal.meta.OCLMemorySpace;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.vector.VectorUtil;
 
 public class OCLArithmeticTool extends ArithmeticLIRGenerator {
@@ -332,7 +334,7 @@ public class OCLArithmeticTool extends ArithmeticLIRGenerator {
         if (oclKind.isVector()) {
             OCLBinaryIntrinsic intrinsic = VectorUtil.resolveLoadIntrinsic(oclKind);
             OCLAddressCast cast = new OCLAddressCast(base, LIRKind.value(oclKind.getElementKind()));
-            emitVectorLoad(result, intrinsic, new ConstantValue(LIRKind.value(OCLKind.INT), PrimitiveConstant.INT_0), cast, (MemoryAccess) address);
+            emitVectorLoad(result, intrinsic, getOffsetValue(oclKind, (MemoryAccess) address), cast, (MemoryAccess) address);
         } else {
             OCLAddressCast cast = new OCLAddressCast(base, lirKind);
             emitLoad(result, cast, (MemoryAccess) address);
@@ -364,7 +366,7 @@ public class OCLArithmeticTool extends ArithmeticLIRGenerator {
         if (oclKind.isVector()) {
             OCLTernaryIntrinsic intrinsic = VectorUtil.resolveStoreIntrinsic(oclKind);
             OCLAddressCast cast = new OCLAddressCast(memAccess.getBase(), LIRKind.value(oclKind.getElementKind()));
-            getGen().append(new VectorStoreStmt(intrinsic, new ConstantValue(LIRKind.value(OCLKind.INT), PrimitiveConstant.INT_0), cast, memAccess, input));
+            getGen().append(new VectorStoreStmt(intrinsic, getOffsetValue(oclKind, memAccess), cast, memAccess, input));
         } else {
 
             /**
@@ -472,6 +474,38 @@ public class OCLArithmeticTool extends ArithmeticLIRGenerator {
     public Value emitMathCopySign(Value magnitude, Value sign) {
         unimplemented();
         return null;
+    }
+
+    /**
+     * It calculates and returns the offset for vstore/vload operations as a Value
+     * object.
+     *
+     * @param oclKind
+     *            the kind for getting the size of the element type in a vector
+     * @param memoryAccess
+     *            the object that holds the index of an element in a vector
+     * @return
+     */
+    private Value getPrivateOffsetValue(OCLKind oclKind, MemoryAccess memoryAccess) {
+        Value privateOffsetValue = null;
+        if (memoryAccess == null) {
+            return null;
+        }
+        if (memoryAccess.getIndex() instanceof ConstantValue) {
+            ConstantValue constantValue = (ConstantValue) memoryAccess.getIndex();
+            int parsedIntegerIndex = Integer.parseInt(constantValue.getConstant().toValueString());
+            int s = parsedIntegerIndex / oclKind.getVectorLength();
+            privateOffsetValue = new ConstantValue(LIRKind.value(OCLKind.INT), JavaConstant.forInt(s));
+        }
+        return privateOffsetValue;
+    }
+
+    private Value getOffsetValue(OCLKind oclKind, MemoryAccess memoryAccess) {
+        if (memoryAccess.getBase().memorySpace == OCLMemorySpace.GLOBAL.getBase().memorySpace) {
+            return new ConstantValue(LIRKind.value(OCLKind.INT), PrimitiveConstant.INT_0);
+        } else {
+            return getPrivateOffsetValue(oclKind, memoryAccess);
+        }
     }
 
     public Value emitFMAInstruction(Value op1, Value op2, Value op3) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorDouble.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework: 
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -248,6 +248,10 @@ public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
 
     @Override
     public int size() {
+        return numElements;
+    }
+
+    public int getLength() {
         return numElements;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorFloat.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework: 
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -243,6 +243,10 @@ public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
 
     @Override
     public int size() {
+        return numElements;
+    }
+
+    public int getLength() {
         return numElements;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/collections/types/VectorInt.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework: 
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -252,6 +252,10 @@ public class VectorInt implements PrimitiveStorage<IntBuffer> {
 
     @Override
     public int size() {
+        return numElements;
+    }
+
+    public int getLength() {
         return numElements;
     }
 }

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestDoubles.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestDoubles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
  * The University of Manchester.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +34,7 @@ import uk.ac.manchester.tornado.api.collections.types.VectorDouble;
 import uk.ac.manchester.tornado.api.collections.types.VectorDouble2;
 import uk.ac.manchester.tornado.api.collections.types.VectorDouble3;
 import uk.ac.manchester.tornado.api.collections.types.VectorDouble4;
+import uk.ac.manchester.tornado.api.collections.types.VectorDouble8;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 public class TestDoubles extends TornadoTestBase {
@@ -315,6 +316,122 @@ public class TestDoubles extends TornadoTestBase {
             assertEquals(sequential.getY(), output.get(i).getY(), 0.001);
             assertEquals(sequential.getZ(), output.get(i).getZ(), 0.001);
             assertEquals(sequential.getW(), output.get(i).getW(), 0.001);
+        }
+    }
+
+    public static void testPrivateVectorDouble2(VectorDouble2 output) {
+        VectorDouble2 vectorDouble2 = new VectorDouble2(output.getLength());
+
+        for (int i = 0; i < vectorDouble2.getLength(); i++) {
+            vectorDouble2.set(i, new Double2(i, i));
+        }
+
+        Double2 sum = new Double2(0, 0);
+
+        for (int i = 0; i < vectorDouble2.getLength(); i++) {
+            Double2 f = vectorDouble2.get(i);
+            sum = Double2.add(f, sum);
+        }
+
+        output.set(0, sum);
+    }
+
+    @Test
+    public void privateVectorDouble2() {
+        int size = 16;
+        VectorDouble2 sequentialOutput = new VectorDouble2(size);
+        VectorDouble2 tornadoOutput = new VectorDouble2(size);
+
+        TaskSchedule ts = new TaskSchedule("s0");
+        ts.task("t0", TestDoubles::testPrivateVectorDouble2, tornadoOutput);
+        ts.streamOut(tornadoOutput);
+        ts.execute();
+
+        testPrivateVectorDouble2(sequentialOutput);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(sequentialOutput.get(i).getX(), tornadoOutput.get(i).getX(), 0.001);
+            assertEquals(sequentialOutput.get(i).getY(), tornadoOutput.get(i).getY(), 0.001);
+        }
+    }
+
+    public static void testPrivateVectorDouble4(VectorDouble4 output) {
+        VectorDouble4 vectorDouble4 = new VectorDouble4(output.getLength());
+
+        for (int i = 0; i < vectorDouble4.getLength(); i++) {
+            vectorDouble4.set(i, new Double4(i, i, i, i));
+        }
+
+        Double4 sum = new Double4(0, 0, 0, 0);
+
+        for (int i = 0; i < vectorDouble4.getLength(); i++) {
+            Double4 f = vectorDouble4.get(i);
+            sum = Double4.add(f, sum);
+        }
+
+        output.set(0, sum);
+    }
+
+    @Test
+    public void privateVectorDouble4() {
+        int size = 16;
+        VectorDouble4 sequentialOutput = new VectorDouble4(size);
+        VectorDouble4 tornadoOutput = new VectorDouble4(size);
+
+        TaskSchedule ts = new TaskSchedule("s0");
+        ts.task("t0", TestDoubles::testPrivateVectorDouble4, tornadoOutput);
+        ts.streamOut(tornadoOutput);
+        ts.execute();
+
+        testPrivateVectorDouble4(sequentialOutput);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(sequentialOutput.get(i).getX(), tornadoOutput.get(i).getX(), 0.001);
+            assertEquals(sequentialOutput.get(i).getY(), tornadoOutput.get(i).getY(), 0.001);
+            assertEquals(sequentialOutput.get(i).getZ(), tornadoOutput.get(i).getZ(), 0.001);
+            assertEquals(sequentialOutput.get(i).getW(), tornadoOutput.get(i).getW(), 0.001);
+        }
+    }
+
+    public static void testPrivateVectorDouble8(VectorDouble8 output) {
+        VectorDouble8 vectorDouble8 = new VectorDouble8(output.getLength());
+
+        for (int i = 0; i < vectorDouble8.getLength(); i++) {
+            vectorDouble8.set(i, new Double8(i, i, i, i, i, i, i, i));
+        }
+
+        Double8 sum = new Double8(0, 0, 0, 0, 0, 0, 0, 0);
+
+        for (int i = 0; i < vectorDouble8.getLength(); i++) {
+            Double8 f = vectorDouble8.get(i);
+            sum = Double8.add(f, sum);
+        }
+
+        output.set(0, sum);
+    }
+
+    @Test
+    public void privateVectorDouble8() {
+        int size = 16;
+        VectorDouble8 sequentialOutput = new VectorDouble8(16);
+        VectorDouble8 tornadoOutput = new VectorDouble8(16);
+
+        TaskSchedule ts = new TaskSchedule("s0");
+        ts.task("t0", TestDoubles::testPrivateVectorDouble8, tornadoOutput);
+        ts.streamOut(tornadoOutput);
+        ts.execute();
+
+        testPrivateVectorDouble8(sequentialOutput);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(sequentialOutput.get(i).getS0(), tornadoOutput.get(i).getS0(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS1(), tornadoOutput.get(i).getS1(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS2(), tornadoOutput.get(i).getS2(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS3(), tornadoOutput.get(i).getS3(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS4(), tornadoOutput.get(i).getS4(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS5(), tornadoOutput.get(i).getS5(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS6(), tornadoOutput.get(i).getS6(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS7(), tornadoOutput.get(i).getS7(), 0.001);
         }
     }
 

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
  * The University of Manchester.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -559,6 +559,122 @@ public class TestFloats extends TornadoTestBase {
         assertEquals(8.0f, output.get(0).getS1(), 0.001);
         assertEquals(8.0f, output.get(0).getS2(), 0.001);
 
+    }
+
+    public static void testPrivateVectorFloat2(VectorFloat2 output) {
+        VectorFloat2 vectorFloat2 = new VectorFloat2(output.getLength());
+
+        for (int i = 0; i < vectorFloat2.getLength(); i++) {
+            vectorFloat2.set(i, new Float2(i, i));
+        }
+
+        Float2 sum = new Float2(0, 0);
+
+        for (int i = 0; i < vectorFloat2.getLength(); i++) {
+            Float2 f = vectorFloat2.get(i);
+            sum = Float2.add(f, sum);
+        }
+
+        output.set(0, sum);
+    }
+
+    @Test
+    public void privateVectorFloat2() {
+        int size = 16;
+        VectorFloat2 sequentialOutput = new VectorFloat2(size);
+        VectorFloat2 tornadoOutput = new VectorFloat2(size);
+
+        TaskSchedule ts = new TaskSchedule("s0");
+        ts.task("t0", TestFloats::testPrivateVectorFloat2, tornadoOutput);
+        ts.streamOut(tornadoOutput);
+        ts.execute();
+
+        testPrivateVectorFloat2(sequentialOutput);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(sequentialOutput.get(i).getX(), tornadoOutput.get(i).getX(), 0.001);
+            assertEquals(sequentialOutput.get(i).getY(), tornadoOutput.get(i).getY(), 0.001);
+        }
+    }
+
+    public static void testPrivateVectorFloat4(VectorFloat4 output) {
+        VectorFloat4 vectorFloat4 = new VectorFloat4(output.getLength());
+
+        for (int i = 0; i < vectorFloat4.getLength(); i++) {
+            vectorFloat4.set(i, new Float4(i, i, i, i));
+        }
+
+        Float4 sum = new Float4(0, 0, 0, 0);
+
+        for (int i = 0; i < vectorFloat4.getLength(); i++) {
+            Float4 f = vectorFloat4.get(i);
+            sum = Float4.add(f, sum);
+        }
+
+        output.set(0, sum);
+    }
+
+    @Test
+    public void privateVectorFloat4() {
+        int size = 16;
+        VectorFloat4 sequentialOutput = new VectorFloat4(size);
+        VectorFloat4 tornadoOutput = new VectorFloat4(size);
+
+        TaskSchedule ts = new TaskSchedule("s0");
+        ts.task("t0", TestFloats::testPrivateVectorFloat4, tornadoOutput);
+        ts.streamOut(tornadoOutput);
+        ts.execute();
+
+        testPrivateVectorFloat4(sequentialOutput);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(sequentialOutput.get(i).getX(), tornadoOutput.get(i).getX(), 0.001);
+            assertEquals(sequentialOutput.get(i).getY(), tornadoOutput.get(i).getY(), 0.001);
+            assertEquals(sequentialOutput.get(i).getZ(), tornadoOutput.get(i).getZ(), 0.001);
+            assertEquals(sequentialOutput.get(i).getW(), tornadoOutput.get(i).getW(), 0.001);
+        }
+    }
+
+    public static void testPrivateVectorFloat8(VectorFloat8 output) {
+        VectorFloat8 vectorFloat8 = new VectorFloat8(output.getLength());
+
+        for (int i = 0; i < vectorFloat8.getLength(); i++) {
+            vectorFloat8.set(i, new Float8(i, i, i, i, i, i, i, i));
+        }
+
+        Float8 sum = new Float8(0, 0, 0, 0, 0, 0, 0, 0);
+
+        for (int i = 0; i < vectorFloat8.getLength(); i++) {
+            Float8 f = vectorFloat8.get(i);
+            sum = Float8.add(f, sum);
+        }
+
+        output.set(0, sum);
+    }
+
+    @Test
+    public void privateVectorFloat8() {
+        int size = 16;
+        VectorFloat8 sequentialOutput = new VectorFloat8(16);
+        VectorFloat8 tornadoOutput = new VectorFloat8(16);
+
+        TaskSchedule ts = new TaskSchedule("s0");
+        ts.task("t0", TestFloats::testPrivateVectorFloat8, tornadoOutput);
+        ts.streamOut(tornadoOutput);
+        ts.execute();
+
+        testPrivateVectorFloat8(sequentialOutput);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(sequentialOutput.get(i).getS0(), tornadoOutput.get(i).getS0(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS1(), tornadoOutput.get(i).getS1(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS2(), tornadoOutput.get(i).getS2(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS3(), tornadoOutput.get(i).getS3(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS4(), tornadoOutput.get(i).getS4(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS5(), tornadoOutput.get(i).getS5(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS6(), tornadoOutput.get(i).getS6(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS7(), tornadoOutput.get(i).getS7(), 0.001);
+        }
     }
 
 }

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestInts.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestInts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
  * The University of Manchester.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -638,6 +638,122 @@ public class TestInts extends TornadoTestBase {
             assertEquals(sequential.getS5(), output.get(i).getS5(), 0.01);
             assertEquals(sequential.getS6(), output.get(i).getS6(), 0.01);
             assertEquals(sequential.getS7(), output.get(i).getS7(), 0.01);
+        }
+    }
+
+    public static void testPrivateVectorInt2(VectorInt2 output) {
+        VectorInt2 vectorInt2 = new VectorInt2(output.getLength());
+
+        for (int i = 0; i < vectorInt2.getLength(); i++) {
+            vectorInt2.set(i, new Int2(i, i));
+        }
+
+        Int2 sum = new Int2(0, 0);
+
+        for (int i = 0; i < vectorInt2.getLength(); i++) {
+            Int2 f = vectorInt2.get(i);
+            sum = Int2.add(f, sum);
+        }
+
+        output.set(0, sum);
+    }
+
+    @Test
+    public void privateVectorInt2() {
+        int size = 16;
+        VectorInt2 sequentialOutput = new VectorInt2(size);
+        VectorInt2 tornadoOutput = new VectorInt2(size);
+
+        TaskSchedule ts = new TaskSchedule("s0");
+        ts.task("t0", TestInts::testPrivateVectorInt2, tornadoOutput);
+        ts.streamOut(tornadoOutput);
+        ts.execute();
+
+        testPrivateVectorInt2(sequentialOutput);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(sequentialOutput.get(i).getX(), tornadoOutput.get(i).getX(), 0.001);
+            assertEquals(sequentialOutput.get(i).getY(), tornadoOutput.get(i).getY(), 0.001);
+        }
+    }
+
+    public static void testPrivateVectorInt4(VectorInt4 output) {
+        VectorInt4 vectorInt4 = new VectorInt4(output.getLength());
+
+        for (int i = 0; i < vectorInt4.getLength(); i++) {
+            vectorInt4.set(i, new Int4(i, i, i, i));
+        }
+
+        Int4 sum = new Int4(0, 0, 0, 0);
+
+        for (int i = 0; i < vectorInt4.getLength(); i++) {
+            Int4 f = vectorInt4.get(i);
+            sum = Int4.add(f, sum);
+        }
+
+        output.set(0, sum);
+    }
+
+    @Test
+    public void privateVectorInt4() {
+        int size = 16;
+        VectorInt4 sequentialOutput = new VectorInt4(size);
+        VectorInt4 tornadoOutput = new VectorInt4(size);
+
+        TaskSchedule ts = new TaskSchedule("s0");
+        ts.task("t0", TestInts::testPrivateVectorInt4, tornadoOutput);
+        ts.streamOut(tornadoOutput);
+        ts.execute();
+
+        testPrivateVectorInt4(sequentialOutput);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(sequentialOutput.get(i).getX(), tornadoOutput.get(i).getX(), 0.001);
+            assertEquals(sequentialOutput.get(i).getY(), tornadoOutput.get(i).getY(), 0.001);
+            assertEquals(sequentialOutput.get(i).getZ(), tornadoOutput.get(i).getZ(), 0.001);
+            assertEquals(sequentialOutput.get(i).getW(), tornadoOutput.get(i).getW(), 0.001);
+        }
+    }
+
+    public static void testPrivateVectorInt8(VectorInt8 output) {
+        VectorInt8 vectorInt8 = new VectorInt8(output.getLength());
+
+        for (int i = 0; i < vectorInt8.getLength(); i++) {
+            vectorInt8.set(i, new Int8(i, i, i, i, i, i, i, i));
+        }
+
+        Int8 sum = new Int8(0, 0, 0, 0, 0, 0, 0, 0);
+
+        for (int i = 0; i < vectorInt8.getLength(); i++) {
+            Int8 f = vectorInt8.get(i);
+            sum = Int8.add(f, sum);
+        }
+
+        output.set(0, sum);
+    }
+
+    @Test
+    public void privateVectorInt8() {
+        int size = 16;
+        VectorInt8 sequentialOutput = new VectorInt8(16);
+        VectorInt8 tornadoOutput = new VectorInt8(16);
+
+        TaskSchedule ts = new TaskSchedule("s0");
+        ts.task("t0", TestInts::testPrivateVectorInt8, tornadoOutput);
+        ts.streamOut(tornadoOutput);
+        ts.execute();
+
+        testPrivateVectorInt8(sequentialOutput);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(sequentialOutput.get(i).getS0(), tornadoOutput.get(i).getS0(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS1(), tornadoOutput.get(i).getS1(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS2(), tornadoOutput.get(i).getS2(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS3(), tornadoOutput.get(i).getS3(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS4(), tornadoOutput.get(i).getS4(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS5(), tornadoOutput.get(i).getS5(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS6(), tornadoOutput.get(i).getS6(), 0.001);
+            assertEquals(sequentialOutput.get(i).getS7(), tornadoOutput.get(i).getS7(), 0.001);
         }
     }
 


### PR DESCRIPTION
This PR addresses the issue described in #180. The problem is that the compiler was generating the same offset for accessing all the elements within a vector.
For example, if a vector of type `VectorFloat2` has four `Float2` elements, this should result in the emission of four consecutive `vload` and `vstore` operations (one per element). In this case the compiler would overwrite and load the data of the first element.

This PR resolves this issue by providing a method to calculate the offset and use it when the memory space corresponds to private memory.

In a nutshell, it includes:
- fix of the problem in `OCLArithmeticTool` class.
- addition of unit-tests to cover all supported vector types
- addition of `getLength` method for `VectorFloat`, `VectorInt`, `VectorDouble` types, in order to be consistent with other vector types.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
tornado-test.py --verbose --printKernel uk.ac.manchester.tornado.unittests.vectortypes.TestDoubles#privateVectorDouble2
tornado-test.py --verbose --printKernel uk.ac.manchester.tornado.unittests.vectortypes.TestDoubles#privateVectorDouble4
tornado-test.py --verbose --printKernel uk.ac.manchester.tornado.unittests.vectortypes.TestDoubles#privateVectorDouble8
tornado-test.py --verbose --printKernel uk.ac.manchester.tornado.unittests.vectortypes.TestInts#privateVectorInt2
tornado-test.py --verbose --printKernel uk.ac.manchester.tornado.unittests.vectortypes.TestInts#privateVectorInt4
tornado-test.py --verbose --printKernel uk.ac.manchester.tornado.unittests.vectortypes.TestInts#privateVectorInt8
tornado-test.py --verbose --printKernel uk.ac.manchester.tornado.unittests.vectortypes.TestFloats#privateVectorFloat2
tornado-test.py --verbose --printKernel uk.ac.manchester.tornado.unittests.vectortypes.TestFloats#privateVectorFloat4
tornado-test.py --verbose --printKernel uk.ac.manchester.tornado.unittests.vectortypes.TestFloats#privateVectorFloat8
```

This functionality is currently not supported in SPIR-V. We will open a separate PR for this.

----------------------------------------------------------------------------