### PR TITLE
[conf] Maven Local Install script fixed to 0.15-dev

### DIFF
--- a/assembly/src/bin/tornadoLocalInstallMaven
+++ b/assembly/src/bin/tornadoLocalInstallMaven
@@ -29,7 +29,7 @@
 cd $TORNADO_SDK
 cd share/java/tornado/
 
-TORNADOVM_VERSION="0.14"
+TORNADOVM_VERSION="0.15-dev"
 
 read -ra selected_backends < "${TORNADO_SDK}/etc/tornado.backend"
 


### PR DESCRIPTION
This PR fixes the TornadoVM version associated with the maven install script. 

Maven Local Install version updated to `0.15-dev`.

How to test?

```bash
$ tornado --mavenLocalInstall
```

Related issue: #189 
