### PR TITLE
aria2c this vastly increases the network transfer lower bounds using …

### DIFF
--- a/scripts/tornadoVMInstaller.sh
+++ b/scripts/tornadoVMInstaller.sh
@@ -18,6 +18,10 @@
 
 DIRECTORY_DEPENDENCIES="etc/dependencies"
 
+aria2c -v &&function wget() {
+		aria2c -Z -c -{j,s,x}\ 15  --file-allocation=none $@  
+		}
+
 function getPlatform() {
     platform=$(uname | tr '[:upper:]' '[:lower:]')
     echo "$platform"


### PR DESCRIPTION
…threaded transfers with https://aria2.github.io/

 

## Template to be used in the PR description (remove this part when submitted the PR)

#### Description

iff a file xfer client named ariac2 is on the path and returns success for `aria2c -v` then a function in the script aliases wget to be the aria2c command for a resuming and multithreaded transfer in-place.

speaking for pacific regions and asia from experience, this is a normal enhancement to anything that touches nvidia network or openjdk.net or badly mirrored silicon valley sites.

#### Problem description

wget: 250K/Sec
aria2c as switched: 5M/sec

#### Backend/s tested

Mark the backends affected by this PR.

- [x] PTX 
- [x] OpenCL 
- [ x ] SPIRV
- [x] Github blobs  

#### OS tested

Mark the OS where this PR is tested.

- [*] Linux
- [x] OSx
- [x] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [*] No

#### How to test the new patch?

Provide instructions about how to test the new patch. 

----------------------------------------------------------------------------