### PR TITLE
CUDA PTX Header Fixed

### DIFF
--- a/drivers/opencl-jni/src/main/cpp/source/OCLProgram.cpp
+++ b/drivers/opencl-jni/src/main/cpp/source/OCLProgram.cpp
@@ -57,6 +57,7 @@ JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLProgram_c
     cl_int status = clBuildProgram((cl_program) program_id, (cl_uint) numDevices, (cl_device_id*) devices, options, NULL, NULL);
     LOG_OCL_AND_VALIDATE("clBuildProgram", status);
     env->ReleasePrimitiveArrayCritical(array1, devices, 0);
+    env->ReleaseStringUTFChars(str, options);
 }
 
 /*
@@ -106,6 +107,7 @@ JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLProgram_
     cl_int status;
     cl_kernel kernel = clCreateKernel((cl_program) program_id, kernel_name, &status);
     LOG_OCL_AND_VALIDATE("clCreateKernel", status);
+    env->ReleaseStringUTFChars(str, kernel_name);
     return (jlong) kernel;
 }
 

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/CUDAVersion.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/CUDAVersion.java
@@ -36,6 +36,8 @@ public class CUDAVersion {
             new CUDAVersion(10010, new CUDAComputeCapability(6, 4)), //
             new CUDAVersion(10020, new CUDAComputeCapability(6, 5)), //
             new CUDAVersion(11000, new CUDAComputeCapability(7, 0)), //
+            new CUDAVersion(11060, new CUDAComputeCapability(7, 6)), //
+            new CUDAVersion(11070, new CUDAComputeCapability(7, 6)), //
     };
 
     private final int sdkVersion;

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDevice.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDevice.java
@@ -23,11 +23,11 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx;
 
+import java.nio.ByteOrder;
+
 import uk.ac.manchester.tornado.api.TornadoTargetDevice;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.drivers.ptx.enums.PTXDeviceAttribute;
-
-import java.nio.ByteOrder;
 
 public class PTXDevice implements TornadoTargetDevice {
 
@@ -69,17 +69,17 @@ public class PTXDevice implements TornadoTargetDevice {
         maxAllocationSize = cuMemGetInfo();
     }
 
-    private native static long cuDeviceGet(int deviceId);
+    private static native long cuDeviceGet(int deviceId);
 
-    private native static String cuDeviceGetName(long cuDevice);
+    private static native String cuDeviceGetName(long cuDevice);
 
-    private native static int cuDeviceGetAttribute(long cuDevice, int attribute);
+    private static native int cuDeviceGetAttribute(long cuDevice, int attribute);
 
-    private native static long cuDeviceTotalMem(long cuDevice);
+    private static native long cuDeviceTotalMem(long cuDevice);
 
-    private native static long cuMemGetInfo();
+    private static native long cuMemGetInfo();
 
-    private native static int cuDriverGetVersion();
+    private static native int cuDriverGetVersion();
 
     @Override
     public String getDeviceName() {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXVersion.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXVersion.java
@@ -25,7 +25,8 @@ package uk.ac.manchester.tornado.drivers.ptx;
 
 public class PTXVersion {
     private enum PTX_VERSION_TO_ARCHITECTURE {
-        PTX_70(new CUDAComputeCapability(7, 0), new TargetArchitecture(8, 0)), //
+        PTX_76(new CUDAComputeCapability(7, 6), new TargetArchitecture(8, 6)), //
+        PTX_70(new CUDAComputeCapability(7, 0), new TargetArchitecture(8, 6)), //
         PTX_63(new CUDAComputeCapability(6, 3), new TargetArchitecture(7, 5)), //
         PTX_61(new CUDAComputeCapability(6, 1), new TargetArchitecture(7, 2)), //
         PTX_60(new CUDAComputeCapability(6, 0), new TargetArchitecture(7, 0)), //

--- a/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroContext.cpp
+++ b/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroContext.cpp
@@ -558,7 +558,6 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
     jfieldID buildFlagsField = env->GetFieldID(javaModuleDescClass, "pBuildFlags", "Ljava/lang/String;");
     jstring objectString = static_cast<jstring>(env->GetObjectField(javaModuleDesc, buildFlagsField));
     const char* buildFlags = env->GetStringUTFChars(objectString, 0);
-
     const char* fileName = env->GetStringUTFChars(pathToBinary, 0);
     std::string f(fileName);
 
@@ -611,6 +610,9 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
         jclass javaBuildLogClass = env->GetObjectClass(javaBuildLog);
         jfieldID fieldPtrLog = env->GetFieldID(javaBuildLogClass, "ptrZeBuildLogHandle", "J");
         env->SetLongField(javaBuildLog, fieldPtrLog, reinterpret_cast<jlong>(buildLog));
+
+        env->ReleaseStringUTFChars(objectString, buildFlags);
+        env->ReleaseStringUTFChars(pathToBinary, fileName);
 
         file.close();
         return result;

--- a/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroDescriptors.cpp
+++ b/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroDescriptors.cpp
@@ -210,6 +210,7 @@ JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_ZeR
     ulong ptrToStruct = reinterpret_cast<ulong>(descriptor);
     jfieldID fieldSelfPTr = env->GetFieldID(classDescriptor, "selfPtr", "J");
     env->SetLongField(thisObject, fieldSelfPTr, ptrToStruct);
+    env->ReleaseStringUTFChars(javaString, pKernelName);
 }
 
 /*

--- a/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroModule.cpp
+++ b/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroModule.cpp
@@ -97,5 +97,6 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
     env->SetLongField(javaKernelDesc, field, (jlong) kernelDesc.pNext);
     env->SetLongField(javaKernelDesc, fieldKernelDescPtr, reinterpret_cast<jlong>(&kernelDesc));
 
+    env->ReleaseStringUTFChars(javaStringName, kernelName);
     return result;
 }

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/PrebuiltTest.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/PrebuiltTest.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  *
  */
-
 package uk.ac.manchester.tornado.unittests.prebuilt;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
#### Description

This PR extends/fixes the PTX header for newer GPUs with Compute Capability >= 7.5. This PR has been tested for 2060, 1050 and 3070 GPUs. 

Note that, due to an error in the Kernel Launch when using the NVIDIA GPU driver >= 510.60, some of the kernels do not work. However, this PR updates the header for the assembly PTX code for running on modern GPUs. 

Additionally, this PR fixes the JNI code of Level Zero and the SPIR-V backend., 

#### Backend/s tested

This PR affects to the PTX and SPIR-V backends.

- [ ] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make BACKEND=ptx
$ tornado --threadInfo --printKernel -Ds0.t0.device=0:0 -m tornado.examples/uk.ac.manchester.tornado.examples.compute.MatrixMultiplication2D

.version 7.6            ## VERSION UPDATED
.target sm_75        ## SM INFO UPDATED
.address_size 64 

.visible .entry ... 
```
For the SPIR-V : 

```bash
$ make BACKEND=spirv
$ make tests
```
