### PR TITLE
[hotfix] OpenCL ThreadInfo option fixed for Automatic Reductions

### DIFF
--- a/drivers/opencl-jni/src/main/cpp/source/OCLProgram.cpp
+++ b/drivers/opencl-jni/src/main/cpp/source/OCLProgram.cpp
@@ -57,6 +57,7 @@ JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLProgram_c
     cl_int status = clBuildProgram((cl_program) program_id, (cl_uint) numDevices, (cl_device_id*) devices, options, NULL, NULL);
     LOG_OCL_AND_VALIDATE("clBuildProgram", status);
     env->ReleasePrimitiveArrayCritical(array1, devices, 0);
+    env->ReleaseStringUTFChars(str, options);
 }
 
 /*
@@ -106,6 +107,7 @@ JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_opencl_OCLProgram_
     cl_int status;
     cl_kernel kernel = clCreateKernel((cl_program) program_id, kernel_name, &status);
     LOG_OCL_AND_VALIDATE("clCreateKernel", status);
+    env->ReleaseStringUTFChars(str, kernel_name);
     return (jlong) kernel;
 }
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLKernelScheduler.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLKernelScheduler.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -39,7 +39,8 @@ public abstract class OCLKernelScheduler {
     protected double min;
     protected double max;
 
-    public static final String WARNING_FPGA_THREAD_LOCAL = "[TornadoVM OCL] Warning: TornadoVM changed the user-defined local size to: " + Arrays.toString(OCLFPGAScheduler.DEFAULT_LOCAL_WORK_SIZE) + ".";
+    public static final String WARNING_FPGA_THREAD_LOCAL = "[TornadoVM OCL] Warning: TornadoVM changed the user-defined local size to: " + Arrays.toString(OCLFPGAScheduler.DEFAULT_LOCAL_WORK_SIZE)
+            + ".";
 
     public static final String WARNING_THREAD_LOCAL = "[TornadoVM OCL] Warning: TornadoVM changed the user-defined local size to null. Now, the OpenCL driver will select the best configuration.";
 
@@ -89,7 +90,7 @@ public abstract class OCLKernelScheduler {
      * not fit, it sets the local work group to null, so the OpenCL driver chooses a
      * default value. In this case, the threads configured in the local work sizes
      * depends on each OpenCL driver.
-     * 
+     *
      * @param meta
      *            TaskMetaData.
      */

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2018, 2022, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -298,6 +298,11 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
     private int submitSequential(final TaskMetaData meta) {
         final int task;
         debugInfo(meta);
+
+        if (meta.isThreadInfoEnabled()) {
+            meta.printThreadDims();
+        }
+
         if ((meta.getGlobalWork() == null) || (meta.getGlobalWork().length == 0)) {
             // Sequential kernel execution
             task = deviceContext.enqueueNDRangeKernel(kernel, 1, null, singleThreadGlobalWorkSize, singleThreadLocalWorkSize, null);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/CUDAVersion.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/CUDAVersion.java
@@ -36,6 +36,8 @@ public class CUDAVersion {
             new CUDAVersion(10010, new CUDAComputeCapability(6, 4)), //
             new CUDAVersion(10020, new CUDAComputeCapability(6, 5)), //
             new CUDAVersion(11000, new CUDAComputeCapability(7, 0)), //
+            new CUDAVersion(11060, new CUDAComputeCapability(7, 6)), //
+            new CUDAVersion(11070, new CUDAComputeCapability(7, 6)), //
     };
 
     private final int sdkVersion;

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDevice.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDevice.java
@@ -23,11 +23,11 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx;
 
+import java.nio.ByteOrder;
+
 import uk.ac.manchester.tornado.api.TornadoTargetDevice;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.drivers.ptx.enums.PTXDeviceAttribute;
-
-import java.nio.ByteOrder;
 
 public class PTXDevice implements TornadoTargetDevice {
 
@@ -69,17 +69,17 @@ public class PTXDevice implements TornadoTargetDevice {
         maxAllocationSize = cuMemGetInfo();
     }
 
-    private native static long cuDeviceGet(int deviceId);
+    private static native long cuDeviceGet(int deviceId);
 
-    private native static String cuDeviceGetName(long cuDevice);
+    private static native String cuDeviceGetName(long cuDevice);
 
-    private native static int cuDeviceGetAttribute(long cuDevice, int attribute);
+    private static native int cuDeviceGetAttribute(long cuDevice, int attribute);
 
-    private native static long cuDeviceTotalMem(long cuDevice);
+    private static native long cuDeviceTotalMem(long cuDevice);
 
-    private native static long cuMemGetInfo();
+    private static native long cuMemGetInfo();
 
-    private native static int cuDriverGetVersion();
+    private static native int cuDriverGetVersion();
 
     @Override
     public String getDeviceName() {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXVersion.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXVersion.java
@@ -25,7 +25,8 @@ package uk.ac.manchester.tornado.drivers.ptx;
 
 public class PTXVersion {
     private enum PTX_VERSION_TO_ARCHITECTURE {
-        PTX_70(new CUDAComputeCapability(7, 0), new TargetArchitecture(8, 0)), //
+        PTX_76(new CUDAComputeCapability(7, 6), new TargetArchitecture(8, 6)), //
+        PTX_70(new CUDAComputeCapability(7, 0), new TargetArchitecture(8, 6)), //
         PTX_63(new CUDAComputeCapability(6, 3), new TargetArchitecture(7, 5)), //
         PTX_61(new CUDAComputeCapability(6, 1), new TargetArchitecture(7, 2)), //
         PTX_60(new CUDAComputeCapability(6, 0), new TargetArchitecture(7, 0)), //

--- a/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroContext.cpp
+++ b/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroContext.cpp
@@ -558,7 +558,6 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
     jfieldID buildFlagsField = env->GetFieldID(javaModuleDescClass, "pBuildFlags", "Ljava/lang/String;");
     jstring objectString = static_cast<jstring>(env->GetObjectField(javaModuleDesc, buildFlagsField));
     const char* buildFlags = env->GetStringUTFChars(objectString, 0);
-
     const char* fileName = env->GetStringUTFChars(pathToBinary, 0);
     std::string f(fileName);
 
@@ -611,6 +610,9 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
         jclass javaBuildLogClass = env->GetObjectClass(javaBuildLog);
         jfieldID fieldPtrLog = env->GetFieldID(javaBuildLogClass, "ptrZeBuildLogHandle", "J");
         env->SetLongField(javaBuildLog, fieldPtrLog, reinterpret_cast<jlong>(buildLog));
+
+        env->ReleaseStringUTFChars(objectString, buildFlags);
+        env->ReleaseStringUTFChars(pathToBinary, fileName);
 
         file.close();
         return result;

--- a/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroDescriptors.cpp
+++ b/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroDescriptors.cpp
@@ -210,6 +210,7 @@ JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_ZeR
     ulong ptrToStruct = reinterpret_cast<ulong>(descriptor);
     jfieldID fieldSelfPTr = env->GetFieldID(classDescriptor, "selfPtr", "J");
     env->SetLongField(thisObject, fieldSelfPTr, ptrToStruct);
+    env->ReleaseStringUTFChars(javaString, pKernelName);
 }
 
 /*

--- a/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroModule.cpp
+++ b/drivers/spirv-levelzero-jni/src/main/cpp/src/levelZeroModule.cpp
@@ -97,5 +97,6 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_spirv_levelzero_Lev
     env->SetLongField(javaKernelDesc, field, (jlong) kernelDesc.pNext);
     env->SetLongField(javaKernelDesc, fieldKernelDescPtr, reinterpret_cast<jlong>(&kernelDesc));
 
+    env->ReleaseStringUTFChars(javaStringName, kernelName);
     return result;
 }

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/PrebuiltTest.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/PrebuiltTest.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  *
  */
-
 package uk.ac.manchester.tornado.unittests.prebuilt;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
#### Description

Thread info was disabled for single-thread OpenCL generated programs. This PR supports debug info also for single thread kernels. This is reachable from automatic reductions in the final merge step, for example. 

This fixes issue #197

#### Backend/s tested

This PR only affects the OpenCL Backend

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make BACKEND=opencl
$ tornado --threadInfo -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.reductions.TestReductionsFloats#testComputeAverage
```

----------------------------------------------------------------------------