### PR TITLE
[PTX] Fix #195: PTX Kernel Signature match with arguments size during kernel launch

### DIFF
--- a/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
@@ -596,7 +596,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
             (unsigned int) gridDimX,  (unsigned int) gridDimY,  (unsigned int) gridDimZ,
             (unsigned int) blockDimX, (unsigned int) blockDimY, (unsigned int) blockDimZ,
             (unsigned int) sharedMemBytes, stream,
-            0,
+            NULL,
             arg_config);
     LOG_PTX_AND_VALIDATE("cuLaunchKernel", result);
 

--- a/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
@@ -566,7 +566,8 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
         jbyteArray stream_wrapper,
         jbyteArray args) {
 
-    CUevent beforeEvent, afterEvent;
+    CUevent beforeEvent;
+    CUevent afterEvent;
     CUmodule native_module;
     array_to_module(env, &native_module, module);
 
@@ -577,7 +578,6 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
 
     size_t arg_buffer_size = env->GetArrayLength(args);
     char arg_buffer[arg_buffer_size];
-    std::cout << "ARG SIZE: " << arg_buffer_size << std::endl;
     env->GetByteArrayRegion(args, 0, arg_buffer_size, reinterpret_cast<jbyte *>(arg_buffer));
 
     void *arg_config[] = {
@@ -596,11 +596,11 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
             (unsigned int) gridDimX,  (unsigned int) gridDimY,  (unsigned int) gridDimZ,
             (unsigned int) blockDimX, (unsigned int) blockDimY, (unsigned int) blockDimZ,
             (unsigned int) sharedMemBytes, stream,
-            NULL,
+            0,
             arg_config);
     LOG_PTX_AND_VALIDATE("cuLaunchKernel", result);
-    record_event(&afterEvent, &stream);
 
+    record_event(&afterEvent, &stream);
     env->ReleaseStringUTFChars(function_name, native_function_name);
     return wrapper_from_events(env, &beforeEvent, &afterEvent);
 }

--- a/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
@@ -577,6 +577,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
 
     size_t arg_buffer_size = env->GetArrayLength(args);
     char arg_buffer[arg_buffer_size];
+    std::cout << "ARG SIZE: " << arg_buffer_size << std::endl;
     env->GetByteArrayRegion(args, 0, arg_buffer_size, reinterpret_cast<jbyte *>(arg_buffer));
 
     void *arg_config[] = {

--- a/drivers/ptx-jni/src/main/cpp/source/ptx_utils.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/ptx_utils.cpp
@@ -29,9 +29,6 @@
 CUresult record_events_create(CUevent* beforeEvent, CUevent* afterEvent) {
     CUresult result = cuEventCreate(beforeEvent, CU_EVENT_DEFAULT);
     LOG_PTX_AND_VALIDATE("cuEventCreate (beforeEvent)", result);
-    if (result == CUDA_ERROR_OUT_OF_MEMORY) {
-
-    }
     result = cuEventCreate(afterEvent, CU_EVENT_DEFAULT);
     LOG_PTX_AND_VALIDATE("cuEventCreate (afterEvent)", result);
     return result;

--- a/drivers/ptx-jni/src/main/cpp/source/ptx_utils.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/ptx_utils.cpp
@@ -28,14 +28,17 @@
 
 CUresult record_events_create(CUevent* beforeEvent, CUevent* afterEvent) {
     CUresult result = cuEventCreate(beforeEvent, CU_EVENT_DEFAULT);
-    LOG_PTX_AND_VALIDATE("cuEventCreate", result);
+    LOG_PTX_AND_VALIDATE("cuEventCreate (beforeEvent)", result);
+    if (result == CUDA_ERROR_OUT_OF_MEMORY) {
+
+    }
     result = cuEventCreate(afterEvent, CU_EVENT_DEFAULT);
-    LOG_PTX_AND_VALIDATE("cuEventCreate", result);
+    LOG_PTX_AND_VALIDATE("cuEventCreate (afterEvent)", result);
     return result;
 }
 
-CUresult record_event(CUevent* beforeEvent, CUstream* stream) {
-    CUresult result = cuEventRecord(*beforeEvent, *stream);
+CUresult record_event(CUevent* event, CUstream* stream) {
+    CUresult result = cuEventRecord(*event, *stream);
     LOG_PTX_AND_VALIDATE("cuEventRecord", result);
     return result;
 }

--- a/drivers/ptx-jni/src/main/cpp/source/ptx_utils.h
+++ b/drivers/ptx-jni/src/main/cpp/source/ptx_utils.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 CUresult record_events_create(CUevent* beforeEvent, CUevent* afterEvent);
-CUresult record_event(CUevent* beforeEvent, CUstream* stream);
+CUresult record_event(CUevent* event, CUstream* stream);
 
 #ifdef __cplusplus
 }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
@@ -30,8 +30,8 @@ import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXInstalledCode;
 import uk.ac.manchester.tornado.drivers.ptx.runtime.PTXTornadoDevice;
-import uk.ac.manchester.tornado.runtime.common.KernelArgs;
 import uk.ac.manchester.tornado.runtime.common.DeviceObjectState;
+import uk.ac.manchester.tornado.runtime.common.KernelArgs;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.tasks.GlobalObjectState;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
@@ -58,7 +58,7 @@ public class PTX {
         });
     }
 
-    private native static long cuInit();
+    private static native long cuInit();
 
     private static void initialise() {
         if (initialised) {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXPlatform.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXPlatform.java
@@ -41,7 +41,7 @@ public class PTXPlatform extends TornadoLogger {
         }
     }
 
-    public native static int cuDeviceGetCount();
+    public static native int cuDeviceGetCount();
 
     public void cleanup() {
         for (PTXDevice device : devices) {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
@@ -50,64 +50,64 @@ public class PTXStream extends TornadoLogger {
     }
 
     //@formatter:off
-    private native static byte[][] writeArrayDtoH(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
     //@formatter:on
 
-    private native static byte[][] cuLaunchKernel(byte[] module, String name, int gridDimX, int gridDimY, int gridDimZ, int blockDimX, int blockDimY, int blockDimZ, long sharedMemBytes, byte[] stream,
+    private static native byte[][] cuLaunchKernel(byte[] module, String name, int gridDimX, int gridDimY, int gridDimZ, int blockDimX, int blockDimY, int blockDimZ, long sharedMemBytes, byte[] stream,
             byte[] args);
 
     /**
@@ -116,13 +116,13 @@ public class PTXStream extends TornadoLogger {
      * cuStreamCreateWithPriority method will always be the greatest value returned
      * by cuCtxGetStreamPriorityRange.
      */
-    private native static byte[] cuCreateStream();
+    private static native byte[] cuCreateStream();
 
-    private native static long cuDestroyStream(byte[] streamWrapper);
+    private static native long cuDestroyStream(byte[] streamWrapper);
 
-    private native static long cuStreamSynchronize(byte[] streamWrapper);
+    private static native long cuStreamSynchronize(byte[] streamWrapper);
 
-    private native static byte[][] cuEventCreateAndRecord(boolean isProfilingEnabled, byte[] streamWrapper);
+    private static native byte[][] cuEventCreateAndRecord(boolean isProfilingEnabled, byte[] streamWrapper);
 
     private int registerEvent(EventDescriptor descriptorId) {
         return ptxEventPool.registerEvent(cuEventCreateAndRecord(TornadoOptions.isProfilerEnabled(), streamPool), descriptorId);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXArchitecture.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXArchitecture.java
@@ -74,7 +74,7 @@ public class PTXArchitecture extends Architecture {
 
         KERNEL_CONTEXT = new PTXParam(PTXAssemblerConstants.KERNEL_CONTEXT_NAME, 8, wordKind);
 
-        abiRegisters = new PTXParam[] {KERNEL_CONTEXT};
+        abiRegisters = new PTXParam[] { KERNEL_CONTEXT };
     }
 
     @Override
@@ -179,7 +179,7 @@ public class PTXArchitecture extends Architecture {
         @Override
         public String getDeclaration() {
             if (alignment != 0) {
-                return String.format(".param .align %d .%s %s", alignment, getLirKind().toString(), name);
+                return String.format(".param .%s .ptr .global .align %s %s", getLirKind().toString(), alignment, name);
             } else {
                 return String.format(".param .%s %s", getLirKind().toString(), name);
             }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
@@ -265,7 +265,8 @@ public class PTXBackend extends TornadoBackend<PTXProviders> implements FrameMap
                     final AllocatableValue param = incomingArguments.getArgument(i);
                     PTXKind kind = (PTXKind) param.getPlatformKind();
                     asm.emit(", ");
-                    asm.emit(".param .align 8 .%s %s", kind.toString(), locals[i].getName());
+                    asm.emit(".param .align 8 .u64 %s", locals[i].getName());
+                    // asm.emit(".param .%s %s", kind.toString(), locals[i].getName());
                 } else {
                     // Skip the kernel context object
                     if (locals[i].getType().toJavaName().equals(KernelContext.class.getName())) {
@@ -276,7 +277,9 @@ public class PTXBackend extends TornadoBackend<PTXProviders> implements FrameMap
                         continue;
                     }
                     asm.emit(", ");
-                    asm.emit(".param .align 8 .u64 %s", locals[i].getName());
+                    final AllocatableValue param = incomingArguments.getArgument(i);
+                    PTXKind kind = (PTXKind) param.getPlatformKind();
+                    asm.emit(".param .u64 .ptr .global .align %s %s", kind.getSizeInBytes(), locals[i].getName());
                 }
             } else {
                 final AllocatableValue param = incomingArguments.getArgument(i);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
@@ -57,45 +57,6 @@ public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
         return callArguments;
     }
 
-    public int getArgumentsTotalSizeInBytes() {
-        int size = 0;
-        for (CallArgument argument : callArguments) {
-            if (argument.isReferenceType()) {
-                size += 8; // Reference is 8 bytes
-            } else {
-                Class<?> klass = argument.getValue().getClass();
-                if (klass == Integer.class) {
-                    size += 4;
-                } else if (klass == Float.class) {
-                    size += 4;
-                } else if (klass == Short.class) {
-                    size += 2;
-                } else if (klass == Double.class) {
-                    size += 8;
-                } else if (klass == Long.class) {
-                    size += 8;
-                } else if (klass == Byte.class) {
-                    size += 1;
-                } else if (klass == int.class) {
-                    size += 4;
-                } else if (klass == float.class) {
-                    size += 4;
-                } else if (klass == short.class) {
-                    size += 2;
-                } else if (klass == double.class) {
-                    size += 8;
-                } else if (klass == long.class) {
-                    size += 8;
-                } else if (klass == byte.class) {
-                    size += 1;
-                } else if (klass == char.class) {
-                    size += 1;
-                }
-            }
-        }
-        return size;
-    }
-
     @Override
     public void write() {
         super.write();

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
@@ -23,13 +23,12 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.mm;
 
-import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
-import uk.ac.manchester.tornado.runtime.common.KernelArgs;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.KernelArgs;
 
 public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
 
@@ -37,7 +36,7 @@ public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
     private final ArrayList<CallArgument> callArguments;
 
     public PTXKernelArgs(long address, int numArgs, PTXDeviceContext deviceContext) {
-        super(address,RESERVED_SLOTS << 3, 0, deviceContext);
+        super(address, RESERVED_SLOTS << 3, 0, deviceContext);
         this.callArguments = new ArrayList<>(numArgs);
 
         buffer.clear();
@@ -45,6 +44,9 @@ public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
 
     @Override
     public void addCallArgument(Object value, boolean isReferenceType) {
+        // inspect
+        // < argsIndex : size >
+        // < totalSize >
         callArguments.add(new CallArgument(value, isReferenceType));
     }
 
@@ -56,6 +58,45 @@ public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
     @Override
     public List<CallArgument> getCallArguments() {
         return callArguments;
+    }
+
+    public int getArgumentsTotalSizeInBytes() {
+        int size = 0;
+        for (CallArgument argument : callArguments) {
+            if (argument.isReferenceType()) {
+                size += 8; // Reference is 8 bytes
+            } else {
+                Class<?> klass = argument.getValue().getClass();
+                if (klass == Integer.class) {
+                    size += 4;
+                } else if (klass == Float.class) {
+                    size += 4;
+                } else if (klass == Short.class) {
+                    size += 2;
+                } else if (klass == Double.class) {
+                    size += 8;
+                } else if (klass == Long.class) {
+                    size += 8;
+                } else if (klass == Byte.class) {
+                    size += 1;
+                } else if (klass == int.class) {
+                    size += 4;
+                } else if (klass == float.class) {
+                    size += 4;
+                } else if (klass == short.class) {
+                    size += 2;
+                } else if (klass == double.class) {
+                    size += 8;
+                } else if (klass == long.class) {
+                    size += 8;
+                } else if (klass == byte.class) {
+                    size += 1;
+                } else if (klass == char.class) {
+                    size += 1;
+                }
+            }
+        }
+        return size;
     }
 
     @Override

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
@@ -44,9 +44,6 @@ public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
 
     @Override
     public void addCallArgument(Object value, boolean isReferenceType) {
-        // inspect
-        // < argsIndex : size >
-        // < totalSize >
         callArguments.add(new CallArgument(value, isReferenceType));
     }
 

--- a/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVLevelZeroInstalledCode.java
+++ b/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVLevelZeroInstalledCode.java
@@ -77,7 +77,6 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
         LevelZeroKernel levelZeroKernel = module.getKernel();
         ZeKernelHandle kernel = levelZeroKernel.getKernelHandle();
 
-
         // device's kernel context
         int result = levelZeroKernel.zeKernelSetArgumentValue(kernel.getPtrZeKernelHandle(), 0, Sizeof.LONG.getNumBytes(), callWrapper.toBuffer());
         LevelZeroUtils.errorLog("zeKernelSetArgumentValue", result);

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
@@ -3,19 +3,19 @@
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
  * The University of Manchester.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 
 package uk.ac.manchester.tornado.unittests.reductions;


### PR DESCRIPTION
#### Description

This PR provides a fix for #195. The issue is that, from the NVIDIA Driver 510.60, the driver checks for the argument size of each parameter passed to the kernel. This was, in fact, a bug in the TornadoVM runtime. This patch provides a fix by using all buffers of the same size, and then padding when necessary. 


With this patch, TornadoVM can run many unittests, including Matrix Multiplication benchmarks. However, there are still some errors during the kernel launch only when using the TornadoVM Kernel API. The fix for this part will be provided in a separate PR. Additionally, some of the reductions produce not-correct results (only from 30XX GPUs with NVIDIA driver >= 510.60). 
This will be also patched in a separated PR. 

The TornadoVM backend for GPUs using NVIDIA Drivers <= 510.54 is still working as normal. 

#### Backend/s tested

This PR only affects the PTX-backed, 

- [ ] OpenCL
- [X] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make BACKEND=ptx
$ tornado -Ds0.t0.device=0:0 -m tornado.examples/uk.ac.manchester.tornado.examples.compute.MatrixMultiplication2D
$ tornado --threadInfo --printKernel -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.reductions.TestReductionsFloats#testComputeAverage
```


----------------------------------------------------------------------------