### PR TITLE
[FIX][PTX] Kernel Signature and argument list fixed when running with the Kernel Context API

### DIFF
--- a/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
@@ -596,7 +596,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
             (unsigned int) gridDimX,  (unsigned int) gridDimY,  (unsigned int) gridDimZ,
             (unsigned int) blockDimX, (unsigned int) blockDimY, (unsigned int) blockDimZ,
             (unsigned int) sharedMemBytes, stream,
-            0,
+            NULL,
             arg_config);
     LOG_PTX_AND_VALIDATE("cuLaunchKernel", result);
 

--- a/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
@@ -566,7 +566,8 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
         jbyteArray stream_wrapper,
         jbyteArray args) {
 
-    CUevent beforeEvent, afterEvent;
+    CUevent beforeEvent;
+    CUevent afterEvent;
     CUmodule native_module;
     array_to_module(env, &native_module, module);
 
@@ -577,7 +578,6 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
 
     size_t arg_buffer_size = env->GetArrayLength(args);
     char arg_buffer[arg_buffer_size];
-    std::cout << "ARG SIZE: " << arg_buffer_size << std::endl;
     env->GetByteArrayRegion(args, 0, arg_buffer_size, reinterpret_cast<jbyte *>(arg_buffer));
 
     void *arg_config[] = {
@@ -596,11 +596,11 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
             (unsigned int) gridDimX,  (unsigned int) gridDimY,  (unsigned int) gridDimZ,
             (unsigned int) blockDimX, (unsigned int) blockDimY, (unsigned int) blockDimZ,
             (unsigned int) sharedMemBytes, stream,
-            NULL,
+            0,
             arg_config);
     LOG_PTX_AND_VALIDATE("cuLaunchKernel", result);
-    record_event(&afterEvent, &stream);
 
+    record_event(&afterEvent, &stream);
     env->ReleaseStringUTFChars(function_name, native_function_name);
     return wrapper_from_events(env, &beforeEvent, &afterEvent);
 }

--- a/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/PTXStream.cpp
@@ -577,6 +577,7 @@ JNIEXPORT jobjectArray JNICALL Java_uk_ac_manchester_tornado_drivers_ptx_PTXStre
 
     size_t arg_buffer_size = env->GetArrayLength(args);
     char arg_buffer[arg_buffer_size];
+    std::cout << "ARG SIZE: " << arg_buffer_size << std::endl;
     env->GetByteArrayRegion(args, 0, arg_buffer_size, reinterpret_cast<jbyte *>(arg_buffer));
 
     void *arg_config[] = {

--- a/drivers/ptx-jni/src/main/cpp/source/ptx_utils.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/ptx_utils.cpp
@@ -29,9 +29,6 @@
 CUresult record_events_create(CUevent* beforeEvent, CUevent* afterEvent) {
     CUresult result = cuEventCreate(beforeEvent, CU_EVENT_DEFAULT);
     LOG_PTX_AND_VALIDATE("cuEventCreate (beforeEvent)", result);
-    if (result == CUDA_ERROR_OUT_OF_MEMORY) {
-
-    }
     result = cuEventCreate(afterEvent, CU_EVENT_DEFAULT);
     LOG_PTX_AND_VALIDATE("cuEventCreate (afterEvent)", result);
     return result;

--- a/drivers/ptx-jni/src/main/cpp/source/ptx_utils.cpp
+++ b/drivers/ptx-jni/src/main/cpp/source/ptx_utils.cpp
@@ -28,14 +28,17 @@
 
 CUresult record_events_create(CUevent* beforeEvent, CUevent* afterEvent) {
     CUresult result = cuEventCreate(beforeEvent, CU_EVENT_DEFAULT);
-    LOG_PTX_AND_VALIDATE("cuEventCreate", result);
+    LOG_PTX_AND_VALIDATE("cuEventCreate (beforeEvent)", result);
+    if (result == CUDA_ERROR_OUT_OF_MEMORY) {
+
+    }
     result = cuEventCreate(afterEvent, CU_EVENT_DEFAULT);
-    LOG_PTX_AND_VALIDATE("cuEventCreate", result);
+    LOG_PTX_AND_VALIDATE("cuEventCreate (afterEvent)", result);
     return result;
 }
 
-CUresult record_event(CUevent* beforeEvent, CUstream* stream) {
-    CUresult result = cuEventRecord(*beforeEvent, *stream);
+CUresult record_event(CUevent* event, CUstream* stream) {
+    CUresult result = cuEventRecord(*event, *stream);
     LOG_PTX_AND_VALIDATE("cuEventRecord", result);
     return result;
 }

--- a/drivers/ptx-jni/src/main/cpp/source/ptx_utils.h
+++ b/drivers/ptx-jni/src/main/cpp/source/ptx_utils.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 CUresult record_events_create(CUevent* beforeEvent, CUevent* afterEvent);
-CUresult record_event(CUevent* beforeEvent, CUstream* stream);
+CUresult record_event(CUevent* event, CUstream* stream);
 
 #ifdef __cplusplus
 }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
@@ -30,8 +30,8 @@ import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXInstalledCode;
 import uk.ac.manchester.tornado.drivers.ptx.runtime.PTXTornadoDevice;
-import uk.ac.manchester.tornado.runtime.common.KernelArgs;
 import uk.ac.manchester.tornado.runtime.common.DeviceObjectState;
+import uk.ac.manchester.tornado.runtime.common.KernelArgs;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.tasks.GlobalObjectState;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
@@ -58,7 +58,7 @@ public class PTX {
         });
     }
 
-    private native static long cuInit();
+    private static native long cuInit();
 
     private static void initialise() {
         if (initialised) {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -244,6 +244,7 @@ public class PTXDeviceContext extends TornadoLogger implements TornadoDeviceCont
         for (int argIndex = 0; argIndex < ptxKernelArgs.getCallArguments().size(); argIndex++) {
             KernelArgs.CallArgument arg = ptxKernelArgs.getCallArguments().get(argIndex);
             if (arg.getValue() instanceof KernelArgs.KernelContextArgument) {
+                args.putLong(address);
                 continue;
             } else if (isBoxedPrimitive(arg.getValue()) || arg.getValue().getClass().isPrimitive()) {
                 args.putLong(((Number) arg.getValue()).longValue());

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXPlatform.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXPlatform.java
@@ -41,7 +41,7 @@ public class PTXPlatform extends TornadoLogger {
         }
     }
 
-    public native static int cuDeviceGetCount();
+    public static native int cuDeviceGetCount();
 
     public void cleanup() {
         for (PTXDevice device : devices) {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
@@ -50,64 +50,64 @@ public class PTXStream extends TornadoLogger {
     }
 
     //@formatter:off
-    private native static byte[][] writeArrayDtoH(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoH(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoH(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayDtoHAsync(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayDtoHAsync(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoD(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoD(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, byte[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, short[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, char[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, int[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, long[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, float[] array, long hostOffset, byte[] streamWrapper);
 
-    private native static byte[][] writeArrayHtoDAsync(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
+    private static native byte[][] writeArrayHtoDAsync(long address, long length, double[] array, long hostOffset, byte[] streamWrapper);
     //@formatter:on
 
-    private native static byte[][] cuLaunchKernel(byte[] module, String name, int gridDimX, int gridDimY, int gridDimZ, int blockDimX, int blockDimY, int blockDimZ, long sharedMemBytes, byte[] stream,
+    private static native byte[][] cuLaunchKernel(byte[] module, String name, int gridDimX, int gridDimY, int gridDimZ, int blockDimX, int blockDimY, int blockDimZ, long sharedMemBytes, byte[] stream,
             byte[] args);
 
     /**
@@ -116,13 +116,13 @@ public class PTXStream extends TornadoLogger {
      * cuStreamCreateWithPriority method will always be the greatest value returned
      * by cuCtxGetStreamPriorityRange.
      */
-    private native static byte[] cuCreateStream();
+    private static native byte[] cuCreateStream();
 
-    private native static long cuDestroyStream(byte[] streamWrapper);
+    private static native long cuDestroyStream(byte[] streamWrapper);
 
-    private native static long cuStreamSynchronize(byte[] streamWrapper);
+    private static native long cuStreamSynchronize(byte[] streamWrapper);
 
-    private native static byte[][] cuEventCreateAndRecord(boolean isProfilingEnabled, byte[] streamWrapper);
+    private static native byte[][] cuEventCreateAndRecord(boolean isProfilingEnabled, byte[] streamWrapper);
 
     private int registerEvent(EventDescriptor descriptorId) {
         return ptxEventPool.registerEvent(cuEventCreateAndRecord(TornadoOptions.isProfilerEnabled(), streamPool), descriptorId);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXArchitecture.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXArchitecture.java
@@ -74,7 +74,7 @@ public class PTXArchitecture extends Architecture {
 
         KERNEL_CONTEXT = new PTXParam(PTXAssemblerConstants.KERNEL_CONTEXT_NAME, 8, wordKind);
 
-        abiRegisters = new PTXParam[] {KERNEL_CONTEXT};
+        abiRegisters = new PTXParam[] { KERNEL_CONTEXT };
     }
 
     @Override
@@ -179,7 +179,7 @@ public class PTXArchitecture extends Architecture {
         @Override
         public String getDeclaration() {
             if (alignment != 0) {
-                return String.format(".param .align %d .%s %s", alignment, getLirKind().toString(), name);
+                return String.format(".param .%s .ptr .global .align %s %s", getLirKind().toString(), alignment, name);
             } else {
                 return String.format(".param .%s %s", getLirKind().toString(), name);
             }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssemblerConstants.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssemblerConstants.java
@@ -38,9 +38,9 @@ public class PTXAssemblerConstants {
     public static final String TEST_NOTANUMBER = "testp.notanumber";
     public static final String TEST_NORMAL = "testp.normal";
     public static final String TEST_SUBNORMAL = "testp.subnormal";
-    public static final String KERNEL_CONTEXT_NAME = "kernel_context__";
+    public static final String KERNEL_CONTEXT_NAME = "kernel_context";
 
-    public static final String KERNEL_CONTEXT_ARGUMENT_NAME = "kernel_context";
+    public static final String KERNEL_CONTEXT_ARGUMENT_NAME = "context_unused";
     public static final String GLOBAL_MEM_MODIFIER = "global";
     public static final String PARAM_MEM_MODIFIER = "param";
     public static final String SHARED_MEM_MODIFIER = "shared";

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssemblerConstants.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssemblerConstants.java
@@ -38,8 +38,19 @@ public class PTXAssemblerConstants {
     public static final String TEST_NOTANUMBER = "testp.notanumber";
     public static final String TEST_NORMAL = "testp.normal";
     public static final String TEST_SUBNORMAL = "testp.subnormal";
+
+    /**
+     * This name is used to represent the mandatory argument for the kernel context.
+     * This buffer stores the thread size information in the case of using a Grid.
+     */
     public static final String KERNEL_CONTEXT_NAME = "kernel_context";
 
+    /**
+     * This name represents the argument for the PTX kernel when developers make use
+     * of the TornadoVM {@link uk.ac.manchester.tornado.api.KernelContext} API. The
+     * name is just a symbolic representation of the parameter, and it is not
+     * intended to be used inside the kernel.
+     */
     public static final String KERNEL_CONTEXT_ARGUMENT_NAME = "context_unused";
     public static final String GLOBAL_MEM_MODIFIER = "global";
     public static final String PARAM_MEM_MODIFIER = "param";

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssemblerConstants.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssemblerConstants.java
@@ -38,7 +38,9 @@ public class PTXAssemblerConstants {
     public static final String TEST_NOTANUMBER = "testp.notanumber";
     public static final String TEST_NORMAL = "testp.normal";
     public static final String TEST_SUBNORMAL = "testp.subnormal";
-    public static final String KERNEL_CONTEXT_NAME = "kernel_context";
+    public static final String KERNEL_CONTEXT_NAME = "kernel_context__";
+
+    public static final String KERNEL_CONTEXT_ARGUMENT_NAME = "kernel_context";
     public static final String GLOBAL_MEM_MODIFIER = "global";
     public static final String PARAM_MEM_MODIFIER = "param";
     public static final String SHARED_MEM_MODIFIER = "shared";

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
@@ -266,12 +266,11 @@ public class PTXBackend extends TornadoBackend<PTXProviders> implements FrameMap
                     PTXKind kind = (PTXKind) param.getPlatformKind();
                     asm.emit(", ");
                     asm.emit(".param .align 8 .u64 %s", locals[i].getName());
-                    // asm.emit(".param .%s %s", kind.toString(), locals[i].getName());
                 } else {
                     // Skip the kernel context object
                     if (locals[i].getType().toJavaName().equals(KernelContext.class.getName())) {
                         asm.emit(", ");
-                        asm.emit(".param .u64 .ptr .global .align 8 %s", PTXAssemblerConstants.KERNEL_CONTEXT_NAME + "__");
+                        asm.emit(".param .u64 .ptr .global .align 8 %s", PTXAssemblerConstants.KERNEL_CONTEXT_ARGUMENT_NAME);
                         continue;
                     }
                     // Skip atomic integers

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
@@ -265,7 +265,8 @@ public class PTXBackend extends TornadoBackend<PTXProviders> implements FrameMap
                     final AllocatableValue param = incomingArguments.getArgument(i);
                     PTXKind kind = (PTXKind) param.getPlatformKind();
                     asm.emit(", ");
-                    asm.emit(".param .align 8 .%s %s", kind.toString(), locals[i].getName());
+                    asm.emit(".param .align 8 .u64 %s", locals[i].getName());
+                    // asm.emit(".param .%s %s", kind.toString(), locals[i].getName());
                 } else {
                     // Skip the kernel context object
                     if (locals[i].getType().toJavaName().equals(KernelContext.class.getName())) {
@@ -276,7 +277,9 @@ public class PTXBackend extends TornadoBackend<PTXProviders> implements FrameMap
                         continue;
                     }
                     asm.emit(", ");
-                    asm.emit(".param .align 8 .u64 %s", locals[i].getName());
+                    final AllocatableValue param = incomingArguments.getArgument(i);
+                    PTXKind kind = (PTXKind) param.getPlatformKind();
+                    asm.emit(".param .u64 .ptr .global .align %s %s", kind.getSizeInBytes(), locals[i].getName());
                 }
             } else {
                 final AllocatableValue param = incomingArguments.getArgument(i);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
@@ -263,7 +263,6 @@ public class PTXBackend extends TornadoBackend<PTXProviders> implements FrameMap
             if (isKernel) {
                 if (locals[i].getType().getJavaKind().isPrimitive()) {
                     final AllocatableValue param = incomingArguments.getArgument(i);
-                    PTXKind kind = (PTXKind) param.getPlatformKind();
                     asm.emit(", ");
                     asm.emit(".param .align 8 .u64 %s", locals[i].getName());
                 } else {

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
@@ -270,6 +270,8 @@ public class PTXBackend extends TornadoBackend<PTXProviders> implements FrameMap
                 } else {
                     // Skip the kernel context object
                     if (locals[i].getType().toJavaName().equals(KernelContext.class.getName())) {
+                        asm.emit(", ");
+                        asm.emit(".param .u64 .ptr .global .align 8 %s", PTXAssemblerConstants.KERNEL_CONTEXT_NAME + "__");
                         continue;
                     }
                     // Skip atomic integers

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
@@ -57,45 +57,6 @@ public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
         return callArguments;
     }
 
-    public int getArgumentsTotalSizeInBytes() {
-        int size = 0;
-        for (CallArgument argument : callArguments) {
-            if (argument.isReferenceType()) {
-                size += 8; // Reference is 8 bytes
-            } else {
-                Class<?> klass = argument.getValue().getClass();
-                if (klass == Integer.class) {
-                    size += 4;
-                } else if (klass == Float.class) {
-                    size += 4;
-                } else if (klass == Short.class) {
-                    size += 2;
-                } else if (klass == Double.class) {
-                    size += 8;
-                } else if (klass == Long.class) {
-                    size += 8;
-                } else if (klass == Byte.class) {
-                    size += 1;
-                } else if (klass == int.class) {
-                    size += 4;
-                } else if (klass == float.class) {
-                    size += 4;
-                } else if (klass == short.class) {
-                    size += 2;
-                } else if (klass == double.class) {
-                    size += 8;
-                } else if (klass == long.class) {
-                    size += 8;
-                } else if (klass == byte.class) {
-                    size += 1;
-                } else if (klass == char.class) {
-                    size += 1;
-                }
-            }
-        }
-        return size;
-    }
-
     @Override
     public void write() {
         super.write();

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
@@ -23,13 +23,12 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.mm;
 
-import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
-import uk.ac.manchester.tornado.runtime.common.KernelArgs;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.KernelArgs;
 
 public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
 
@@ -37,7 +36,7 @@ public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
     private final ArrayList<CallArgument> callArguments;
 
     public PTXKernelArgs(long address, int numArgs, PTXDeviceContext deviceContext) {
-        super(address,RESERVED_SLOTS << 3, 0, deviceContext);
+        super(address, RESERVED_SLOTS << 3, 0, deviceContext);
         this.callArguments = new ArrayList<>(numArgs);
 
         buffer.clear();
@@ -45,6 +44,9 @@ public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
 
     @Override
     public void addCallArgument(Object value, boolean isReferenceType) {
+        // inspect
+        // < argsIndex : size >
+        // < totalSize >
         callArguments.add(new CallArgument(value, isReferenceType));
     }
 
@@ -56,6 +58,45 @@ public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
     @Override
     public List<CallArgument> getCallArguments() {
         return callArguments;
+    }
+
+    public int getArgumentsTotalSizeInBytes() {
+        int size = 0;
+        for (CallArgument argument : callArguments) {
+            if (argument.isReferenceType()) {
+                size += 8; // Reference is 8 bytes
+            } else {
+                Class<?> klass = argument.getValue().getClass();
+                if (klass == Integer.class) {
+                    size += 4;
+                } else if (klass == Float.class) {
+                    size += 4;
+                } else if (klass == Short.class) {
+                    size += 2;
+                } else if (klass == Double.class) {
+                    size += 8;
+                } else if (klass == Long.class) {
+                    size += 8;
+                } else if (klass == Byte.class) {
+                    size += 1;
+                } else if (klass == int.class) {
+                    size += 4;
+                } else if (klass == float.class) {
+                    size += 4;
+                } else if (klass == short.class) {
+                    size += 2;
+                } else if (klass == double.class) {
+                    size += 8;
+                } else if (klass == long.class) {
+                    size += 8;
+                } else if (klass == byte.class) {
+                    size += 1;
+                } else if (klass == char.class) {
+                    size += 1;
+                }
+            }
+        }
+        return size;
     }
 
     @Override

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXKernelArgs.java
@@ -44,9 +44,6 @@ public class PTXKernelArgs extends PTXByteBuffer implements KernelArgs {
 
     @Override
     public void addCallArgument(Object value, boolean isReferenceType) {
-        // inspect
-        // < argsIndex : size >
-        // < totalSize >
         callArguments.add(new CallArgument(value, isReferenceType));
     }
 

--- a/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVLevelZeroInstalledCode.java
+++ b/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVLevelZeroInstalledCode.java
@@ -77,7 +77,6 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
         LevelZeroKernel levelZeroKernel = module.getKernel();
         ZeKernelHandle kernel = levelZeroKernel.getKernelHandle();
 
-
         // device's kernel context
         int result = levelZeroKernel.zeKernelSetArgumentValue(kernel.getPtrZeKernelHandle(), 0, Sizeof.LONG.getNumBytes(), callWrapper.toBuffer());
         LevelZeroUtils.errorLog("zeKernelSetArgumentValue", result);

--- a/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
+++ b/unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
@@ -3,19 +3,19 @@
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
  * The University of Manchester.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  */
 
 package uk.ac.manchester.tornado.unittests.reductions;


### PR DESCRIPTION
## Description

When running on new NVIDIA GPUs (e.g., 3070) with the latest NVIDIA Drivers (>= 510.60), TornadoVM does not generate the whole signature for the Kernel Context API. This is by design since the kernel context is always used. However, when using the new NVIDIA drivers, all kernel arguments must match in size and type with the kernel signature. 

This PR provides a fix for this scenario in which the kernel API is used. By design, we keep the first parameter as kernel context. If we have a Java parameter that represents the Kernel Context, we also add a new parameter to the PTX kernel signature using a different name.  

Related issue #195 

#### Backend/s tested

This PR only affects the PTX backend: 

- [ ] OpenCL
- [X] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make BACKEND=ptx
$ make tests

## Example

$  tornado --threadInfo --printKernel -ea -Dtornado.unittests.verbose=True -Xmx6g -Dtornado.recover.bailout=False  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsIntegersKernelContext#basic
WARNING: Using incubator modules: jdk.incubator.vector, jdk.incubator.foreign
.version 7.6 
.target sm_75 
.address_size 64 

.visible .entry s0_t0_basicAccessThreadIds_uk_ac_manchester_tornado_api_KernelContext_2101153819_int1024(.param .u64 .ptr .global .align 8 kernel_context__, .param .u64 .ptr .global .align 8 kernel_context, .param .u64 .ptr .global .align 8 a) {
	.reg .u64 rud<4>;
	.reg .s64 rsd<4>;
	.reg .u32 rui<4>;
	.reg .s32 rsi<5>;

BLOCK_0:
	ld.param.u64	rud0, [kernel_context__];
	ld.param.u64	rud1, [a];
	mov.u32	rui0, %ntid.x;
	cvt.s32.u32	rsi0, rui0;
	mov.u32	rui1, %ctaid.x;
	cvt.s32.u32	rsi1, rui1;
	mov.u32	rui2, %tid.x;
	cvt.s32.u32	rsi2, rui2;
	mad.lo.s32	rsi3, rsi0, rsi1, rsi2;
	cvt.s64.s32	rsd0, rsi3;
	shl.b64	rsd1, rsd0, 2;
	add.s64	rsd2, rsd1, 24;
	add.u64	rud2, rud1, rsd2;
	st.global.s32	[rud2], rsi3;
	ret;
}

Task info: s0.t0
	Backend           : PTX
	Device            : NVIDIA GeForce RTX 2060 with Max-Q Design GPU
	Dims              : 1
	Thread dimensions : [1024, 1, 1]
	Blocks dimensions : [256, 1, 1]
	Grids dimensions  : [4, 1, 1]

Test: class uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsIntegersKernelContext#basic
	Running test: basic                      ................  [PASS] 
Test ran: 1, Failed: 0, Unsupported: 0
```