### PR TITLE
[tooling] tornado script for Win11 fixed

### DIFF
--- a/assembly/src/bin/tornado
+++ b/assembly/src/bin/tornado
@@ -30,6 +30,7 @@ import shlex
 import sys
 import re
 import argparse
+import platform
 
 # ########################################################
 # FLAGS FOR TORNADOVM
@@ -90,6 +91,8 @@ class TornadoVMRunnerTool():
 
         try:
             self.java_home = os.environ["JAVA_HOME"]
+            if (platform.platform().startswith("MING")):
+                self.java_home = self.java_home.replace("\\", "/")
         except:
             print("Please ensure the JAVA_HOME environment variable is set correctly")
             sys.exit(0)


### PR DESCRIPTION
`tornado` script fixed for Windows 11. The problem was that the PATH was using the Linux directory separator (`/`) instead of the Windows separator (`\`). 

This change has been tested for Windows 11 using MSYS64 for the OpenCL and PTX backends. 

Issue related #179 
