### PR TITLE
[Fix] PTX Thread Block for 1D Reductions

### DIFF
--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
@@ -56,7 +56,7 @@ public class OCLDevice implements OCLTargetDevice {
     private long localMemorySize;
     private int maxWorkItemDimensions;
     private long[] maxWorkItemSizes;
-    private long maxWorkGroupSize;
+    private int maxWorkGroupSize;
     private long maxConstantBufferSize;
     private long doubleFPConfig;
     private long singleFPConfig;
@@ -336,9 +336,9 @@ public class OCLDevice implements OCLTargetDevice {
         return maxWorkItemSizes;
     }
 
-    private long getDeviceMaxWorkGroupSize_0() {
+    private int getDeviceMaxWorkGroupSize_0() {
         queryOpenCLAPI(OCLDeviceInfo.CL_DEVICE_MAX_WORK_GROUP_SIZE.getValue());
-        maxWorkGroupSize = buffer.getLong();
+        maxWorkGroupSize = buffer.getInt();
         return maxWorkGroupSize;
     }
 
@@ -352,7 +352,7 @@ public class OCLDevice implements OCLTargetDevice {
     }
 
     @Override
-    public long getMaxThreadsPerBlock() {
+    public int getMaxThreadsPerBlock() {
         return maxWorkGroupSize;
     }
 

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2020-2022, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
@@ -40,10 +40,6 @@ import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceInfo;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLLocalMemType;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-
-import static uk.ac.manchester.tornado.drivers.opencl.OpenCL.CL_TRUE;
-import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableFreq;
 
 public class OCLDevice implements OCLTargetDevice {
 
@@ -130,6 +126,7 @@ public class OCLDevice implements OCLTargetDevice {
         getDeviceSingleFPConfig();
         getDeviceMemoryBaseAlignment();
         getDeviceMaxWorkItemSizes();
+        getDeviceMaxWorkGroupSize();
         getDeviceName();
         getDeviceVersion();
         getDeviceType();
@@ -143,7 +140,7 @@ public class OCLDevice implements OCLTargetDevice {
         getDeviceVendorId();
     }
 
-    native static void clGetDeviceInfo(long id, int info, byte[] buffer);
+    static native void clGetDeviceInfo(long id, int info, byte[] buffer);
 
     public long getId() {
         return id;
@@ -341,7 +338,8 @@ public class OCLDevice implements OCLTargetDevice {
 
     private long getDeviceMaxWorkGroupSize_0() {
         queryOpenCLAPI(OCLDeviceInfo.CL_DEVICE_MAX_WORK_GROUP_SIZE.getValue());
-        return buffer.getLong();
+        maxWorkGroupSize = buffer.getLong();
+        return maxWorkGroupSize;
     }
 
     @Override
@@ -351,6 +349,11 @@ public class OCLDevice implements OCLTargetDevice {
         }
         maxWorkGroupSize = getDeviceMaxWorkGroupSize_0();
         return new long[] { maxWorkGroupSize };
+    }
+
+    @Override
+    public long getMaxThreadsPerBlock() {
+        return maxWorkGroupSize;
     }
 
     @Override

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDevice.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDevice.java
@@ -158,8 +158,8 @@ public class VirtualOCLDevice extends TornadoLogger implements OCLTargetDevice {
     }
 
     @Override
-    public long getMaxThreadsPerBlock() {
-        return maxWorkGroupSize[0];
+    public int getMaxThreadsPerBlock() {
+        return (int) maxWorkGroupSize[0];
     }
 
     @Override

--- a/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDevice.java
+++ b/drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDevice.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2020-2022 APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -155,6 +155,11 @@ public class VirtualOCLDevice extends TornadoLogger implements OCLTargetDevice {
 
     public long[] getDeviceMaxWorkGroupSize() {
         return maxWorkGroupSize;
+    }
+
+    @Override
+    public long getMaxThreadsPerBlock() {
+        return maxWorkGroupSize[0];
     }
 
     @Override

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDevice.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDevice.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2020-2022 APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -47,6 +47,7 @@ public class PTXDevice implements TornadoTargetDevice {
     private final long totalDeviceMemory;
     private final long constantBufferSize;
     private final long maxAllocationSize;
+    private long maxThreadsPerBlock;
 
     public PTXDevice(int deviceIndex) {
         this.deviceIndex = deviceIndex;
@@ -59,6 +60,7 @@ public class PTXDevice implements TornadoTargetDevice {
         maxFrequency = cuDeviceGetAttribute(cuDevice, PTXDeviceAttribute.CLOCK_RATE.value());
         maxWorkItemSizes = initMaxWorkItemSizes();
         maxGridSizes = initMaxGridSizes();
+        maxThreadsPerBlock = cuDeviceGetAttribute(cuDevice, PTXDeviceAttribute.MAX_THREADS_PER_BLOCK.value());
         ptxVersion = CUDAVersion.getMaxPTXVersion(cuDriverGetVersion());
         computeCapability = initComputeCapability();
         targetArchitecture = ptxVersion.getArchitecture(computeCapability);
@@ -135,6 +137,11 @@ public class PTXDevice implements TornadoTargetDevice {
     @Override
     public long[] getDeviceMaxWorkGroupSize() {
         return maxGridSizes;
+    }
+
+    @Override
+    public long getMaxThreadsPerBlock() {
+        return maxThreadsPerBlock;
     }
 
     @Override

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDevice.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDevice.java
@@ -47,7 +47,7 @@ public class PTXDevice implements TornadoTargetDevice {
     private final long totalDeviceMemory;
     private final long constantBufferSize;
     private final long maxAllocationSize;
-    private long maxThreadsPerBlock;
+    private int maxThreadsPerBlock;
 
     public PTXDevice(int deviceIndex) {
         this.deviceIndex = deviceIndex;
@@ -140,7 +140,7 @@ public class PTXDevice implements TornadoTargetDevice {
     }
 
     @Override
-    public long getMaxThreadsPerBlock() {
+    public int getMaxThreadsPerBlock() {
         return maxThreadsPerBlock;
     }
 

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2020-2022 APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -204,17 +204,17 @@ public class PTXDeviceContext extends TornadoLogger implements TornadoDeviceCont
         if (taskMeta.isWorkerGridAvailable()) {
             WorkerGrid grid = taskMeta.getWorkerGrid(taskMeta.getId());
             int[] global = Arrays.stream(grid.getGlobalWork()).mapToInt(l -> (int) l).toArray();
-
             if (grid.getLocalWork() != null) {
                 blockDimension = Arrays.stream(grid.getLocalWork()).mapToInt(l -> (int) l).toArray();
             } else {
-                blockDimension = scheduler.calculateBlockDimension(grid.getGlobalWork(), module.getMaxThreadBlocks(), grid.dimension(), module.javaName);
+
+                blockDimension = scheduler.calculateBlockDimension(grid.getGlobalWork(), module.getPotentialBlockSizeMaxOccupancy(), grid.dimension(), module.javaName);
             }
 
             PTXGridInfo gridInfo = new PTXGridInfo(module, Arrays.stream(blockDimension).mapToLong(i -> i).toArray());
             boolean checkedDimensions = gridInfo.checkGridDimensions();
             if (!checkedDimensions) {
-                blockDimension = scheduler.calculateBlockDimension(grid.getGlobalWork(), module.getMaxThreadBlocks(), grid.dimension(), module.javaName);
+                blockDimension = scheduler.calculateBlockDimension(grid.getGlobalWork(), module.getPotentialBlockSizeMaxOccupancy(), grid.dimension(), module.javaName);
                 System.out.println("Warning: TornadoVM changed the user-defined local size to the following: [" + blockDimension[0] + ", " + blockDimension[1] + ", " + blockDimension[2] + "].");
             }
             gridDimension = scheduler.calculateGridDimension(module.javaName, grid.dimension(), global, blockDimension);

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXGridInfo.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXGridInfo.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * Copyright (c) 2021-2022 APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -24,9 +24,9 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx;
 
-import uk.ac.manchester.tornado.drivers.common.GridInfo;
-
 import java.util.Arrays;
+
+import uk.ac.manchester.tornado.drivers.common.GridInfo;
 
 public class PTXGridInfo implements GridInfo {
     public final PTXModule ptxModule;
@@ -39,9 +39,8 @@ public class PTXGridInfo implements GridInfo {
 
     @Override
     public final boolean checkGridDimensions() {
-        int maxWorkGroupSize = ptxModule.getMaxThreadBlocks();
+        long maxWorkGroupSize = ptxModule.getPotentialBlockSizeMaxOccupancy();
         long totalThreads = Arrays.stream(localWork).reduce(1, (a, b) -> a * b);
-
         return totalThreads <= maxWorkGroupSize;
     }
 }

--- a/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXModule.java
+++ b/drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXModule.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2020-2022 APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,13 +38,13 @@ public class PTXModule {
         javaName = name;
     }
 
-    private native static byte[] cuModuleLoadData(byte[] source);
+    private static native byte[] cuModuleLoadData(byte[] source);
 
-    private native static long cuModuleUnload(byte[] module);
+    private static native long cuModuleUnload(byte[] module);
 
-    private native static int cuOccupancyMaxPotentialBlockSize(byte[] module, String funcName);
+    private static native int cuOccupancyMaxPotentialBlockSize(byte[] module, String funcName);
 
-    public int getMaxThreadBlocks() {
+    public int getPotentialBlockSizeMaxOccupancy() {
         if (maxBlockSize < 0) {
             maxBlockSize = cuOccupancyMaxPotentialBlockSize(moduleWrapper, kernelFunctionName);
         }

--- a/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroDevice.java
+++ b/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroDevice.java
@@ -181,8 +181,8 @@ public class SPIRVLevelZeroDevice extends SPIRVDevice {
     }
 
     @Override
-    public long getMaxThreadsPerBlock() {
-        return getDeviceMaxWorkGroupSize()[0];
+    public int getMaxThreadsPerBlock() {
+        return (int) getDeviceMaxWorkGroupSize()[0];
     }
 
     @Override

--- a/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroDevice.java
+++ b/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroDevice.java
@@ -181,6 +181,11 @@ public class SPIRVLevelZeroDevice extends SPIRVDevice {
     }
 
     @Override
+    public long getMaxThreadsPerBlock() {
+        return getDeviceMaxWorkGroupSize()[0];
+    }
+
+    @Override
     public int getDeviceMaxClockFrequency() {
         return deviceProperties.getCoreClockRate();
     }

--- a/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLDevice.java
+++ b/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLDevice.java
@@ -97,7 +97,7 @@ public class SPIRVOCLDevice extends SPIRVDevice {
     }
 
     @Override
-    public long getMaxThreadsPerBlock() {
+    public int getMaxThreadsPerBlock() {
         return device.getMaxThreadsPerBlock();
     }
 

--- a/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLDevice.java
+++ b/drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLDevice.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * Copyright (c) 2021-2022 APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -94,6 +94,11 @@ public class SPIRVOCLDevice extends SPIRVDevice {
     @Override
     public long[] getDeviceMaxWorkGroupSize() {
         return device.getDeviceMaxWorkGroupSize();
+    }
+
+    @Override
+    public long getMaxThreadsPerBlock() {
+        return device.getMaxThreadsPerBlock();
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTargetDevice.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTargetDevice.java
@@ -55,7 +55,7 @@ public interface TornadoTargetDevice {
 
     long[] getDeviceMaxWorkGroupSize();
 
-    long getMaxThreadsPerBlock();
+    int getMaxThreadsPerBlock();
 
     int getDeviceMaxClockFrequency();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTargetDevice.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTargetDevice.java
@@ -1,8 +1,8 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2013-2021, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -10,12 +10,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2, or (at your option)
  * any later version.
- * 
+ *
  * GNU Classpath is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with GNU Classpath; see the file COPYING.  If not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
@@ -25,7 +25,7 @@
  * making a combined work based on this library.  Thus, the terms and
  * conditions of the GNU General Public License cover the whole
  * combination.
- * 
+ *
  * As a special exception, the copyright holders of this library give you
  * permission to link this library with independent modules to produce an
  * executable, regardless of the license terms of these independent
@@ -54,6 +54,8 @@ public interface TornadoTargetDevice {
     long[] getDeviceMaxWorkItemSizes();
 
     long[] getDeviceMaxWorkGroupSize();
+
+    long getMaxThreadsPerBlock();
 
     int getDeviceMaxClockFrequency();
 


### PR DESCRIPTION
#### Description

When running TornadoVM using the PTX backend on 30XX GPUs, the thread block was not calculated correctly. For 1D we what to maximize the occupancy but the runtime was obtaining a lower number of threads compared to th JIT compiler during the partial evaluation.

This patch provides a fix for this by using the `maxThreadBlock` instead of the max occupancy in the case of 1D kernels.

Related issue #194 

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [X] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [X] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

This affects the reductions and the PTX backend:

```bash
make BACKEND=ptx
tornado-test --threadInfo -V uk.ac.manchester.tornado.unittests.reductions.TestReductionsFloats
```
