### PR TITLE
[install] Fix the maven links

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.8.1</version>
+                        <version>3.11.0</version>
                         <configuration>
                             <forceJavacCompilerUse>true</forceJavacCompilerUse>
                             <source>11</source>
@@ -1068,7 +1068,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.8.1</version>
+                        <version>3.11.0</version>
                         <configuration>
                             <forceJavacCompilerUse>true</forceJavacCompilerUse>
                             <source>11</source>

--- a/scripts/installerConfig.py
+++ b/scripts/installerConfig.py
@@ -55,8 +55,8 @@ CMAKE = {
 ## Maven 
 MAVEN = {
     __LINUX__ : {
-        __X86_64__ : "https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz",
-        __ARM__    : "https://dlcdn.apache.org/maven/maven-3/3.9.0/binaries/apache-maven-3.9.0-bin.tar.gz",
+        __X86_64__ : "https://dlcdn.apache.org/maven/maven-3/3.9.1/binaries/apache-maven-3.9.1-bin.tar.gz",
+        __ARM__    : "https://dlcdn.apache.org/maven/maven-3/3.9.1/binaries/apache-maven-3.9.1-bin.tar.gz",
     },
     __APPLE__ : {
         __X86_64__ : None,   


### PR DESCRIPTION
#### Description

When I tried the installer on Windows 11 (WSL) the maven links were broken. The maven binaries were updated recently and we need to update the URL to the latest version.  

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$  ./scripts/tornadovm-installer --jdk graalvm-jdk-17 --backend opencl
```
