### PR TITLE
[docs] Windows 10/11 installation updated

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -620,9 +620,9 @@ NVIDIA CUDA Toolkit.
    Downloads <https://developer.nvidia.com/cuda-downloads?target_os=Windows&target_arch=x86_64>`__.
 
 It is important to make sure that the GPU drivers are included with the CUDA Toolkit, so you may avoid downloading drivers separately. 
-The only thing to note is that GPU driver you are currently using should be of the same or higher version than the one shipped with CUDA Toolkit. 
-Thus, if you have the driver already installed, make sure that the version required by the CUDA SDK is same or higher, otherwise update GPU driver during toolkit installation. 
-Note, that NSight, BLAST libs and Visual Studio integration are irrelevant for TornadoVM builds, you need just SDK - so you may skip installing them.
+The only thing to note is that the GPU driver you are currently using should be of the same or higher version than the one shipped with CUDA Toolkit. 
+Thus, if you have the driver already installed, make sure that the version required by the CUDA SDK is same or higher, otherwise update the GPU driver during toolkit installation. 
+Note, that NSight, BLAST libs and Visual Studio integration are irrelevant for TornadoVM builds, you just need the CUDA SDK - so you may skip installing them.
 
 5. Configure the TornadoVM build: setting ENV variables
 ~~~~~~~~~~~~
@@ -658,7 +658,7 @@ There are only 2 places you should adjust:
 2. ``CUDA_PATH`` pointing to your NVIDIA GPU Computing Toolkit (CUDA) -
    this one is necessary only for builds with PTX backend.
 
-3. Compile TornadoVM
+6. Compile TornadoVM
 ~~~~~~~~~~~~
 
 Start ``<MSYS2>/mingw64.exe`` terminal, navigate to the ``<TornadoVM>``

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -619,9 +619,9 @@ NVIDIA CUDA Toolkit.
 -  Complete CUDA Toolkit from `CUDA Toolkit
    Downloads <https://developer.nvidia.com/cuda-downloads?target_os=Windows&target_arch=x86_64>`__.
 
-Note that this toolkit includes GPU drivers as well, so you may avoid downloading drivers separately. 
+It is important to make sure that the GPU drivers are included with the CUDA Toolkit, so you may avoid downloading drivers separately. 
 The only thing to note is that GPU driver you are currently using should be of the same or higher version than the one shipped with CUDA Toolkit. 
-Thus, if you have existing driver make sure that it's version is same or higher, otherwise update GPU driver during toolkit installation. 
+Thus, if you have the driver already installed, make sure that the version required by the CUDA SDK is same or higher, otherwise update GPU driver during toolkit installation. 
 Note, that NSight, BLAST libs and Visual Studio integration are irrelevant for TornadoVM builds, you need just SDK - so you may skip installing them.
 
 5. Configure the TornadoVM build: setting ENV variables

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -472,7 +472,7 @@ To run individual tests:
 TornadoVM for Windows 10/11 using GraalVM 
 ---------------------------------------------------------------
 
-**[DISCLAIMER] Please, notice that, although TornadoVM can run on Windows10, it is still experimental.**
+**[DISCLAIMER] Please, notice that, although TornadoVM can run on Windows10 via MSys2, it is still experimental.**
 
 1. Install prerequisites
 ~~~~~~~~~~~~
@@ -481,8 +481,8 @@ TornadoVM for Windows 10/11 using GraalVM
 Maven
 '''''
 
-Download Apache Maven from the `official site <https://maven.apache.org/download.cgi>`__ and extract it to any
-location on your computer. Below it's assumed that Maven's home is ``C:/Maven``.
+Download Apache Maven (at least 3.9.0) from the `official site <https://maven.apache.org/download.cgi>`__, and extract it to any
+location on your computer. Below it's assumed that Maven's home is ``C:/bin/``, but you can use any other directory. 
 
 MSys2
 '''''
@@ -565,7 +565,7 @@ Example:
 .. code:: bash
 
    #!/usr/bin/env bash
-   C:/bin/apache-maven-3.8.4-bin/apache-maven-3.8.4/bin/mvn.cmd --settings ${HOME}/.m2/settings.xml "$@"
+   C:/bin/apache-maven-3.9.1-bin/apache-maven-3.9.1/bin/mvn.cmd --settings ${HOME}/.m2/settings.xml "$@"
 
 You only need to change the path to your maven installation in Windows.
 
@@ -619,16 +619,12 @@ NVIDIA CUDA Toolkit.
 -  Complete CUDA Toolkit from `CUDA Toolkit
    Downloads <https://developer.nvidia.com/cuda-downloads?target_os=Windows&target_arch=x86_64>`__.
 
-Note that this toolkit includes GPU drivers as well, so you may avoid
-downloading drivers separately. The only thing to note is that GPU
-driver you are currently using should be of the same or higher version
-than the one shipped with CUDA Toolkit. Thus, if you have existing
-driver make sure that it’s version is same or higher, otherwise update
-GPU driver during toolkit installation. Note, that NSight, BLAST libs
-and Visual Studio integration are irrelevant for TornadoVM builds, you
-need just SDK - so you may skip installing them.
+Note that this toolkit includes GPU drivers as well, so you may avoid downloading drivers separately. 
+The only thing to note is that GPU driver you are currently using should be of the same or higher version than the one shipped with CUDA Toolkit. 
+Thus, if you have existing driver make sure that it's version is same or higher, otherwise update GPU driver during toolkit installation. 
+Note, that NSight, BLAST libs and Visual Studio integration are irrelevant for TornadoVM builds, you need just SDK - so you may skip installing them.
 
-5. Configure the build
+5. Configure the TornadoVM build: setting ENV variables
 ~~~~~~~~~~~~
 
 
@@ -639,8 +635,9 @@ the following content:
 
    #!/bin/bash
 
-   # UPDATE PATH TO ACTUAL LOCATION OF THE JDK OR GRAAL (REMEMBER OF UNIX_STYLE SLASHES AND SPACES!!!)
-   export JAVA_HOME="C:/graalvm-ce-java11-22.3.1"
+   # UPDATE PATH TO ACTUAL LOCATION OF THE JDK OR GRAAL 
+   export JAVA_HOME="C:\Users\jjfum\bin\jvms\graalvm-ce-java17-windows-amd64-22.3.1\graalvm-ce-java17-22.3.1"
+
 
    ## NEXT TWO LINES NECESSARY TO BUILD PTX (NVIDIA CUDA) BACKEND
    ## COMMENT THEM OUT OR JUST IGNORE IF YOU ARE NOT INTERESTED IN PTX BUILD
@@ -661,7 +658,7 @@ There are only 2 places you should adjust:
 2. ``CUDA_PATH`` pointing to your NVIDIA GPU Computing Toolkit (CUDA) -
    this one is necessary only for builds with PTX backend.
 
-6. Compile TornadoVM
+3. Compile TornadoVM
 ~~~~~~~~~~~~
 
 Start ``<MSYS2>/mingw64.exe`` terminal, navigate to the ``<TornadoVM>``
@@ -673,8 +670,7 @@ directory, and build TornadoVM as follows:
    source etc/sources.env
    make graal-jdk-11-plus BACKEND=ptx,opencl
 
-The ``BACKEND`` parameter has to be a comma-separated list of ``ptx``
-and ``opencl`` options. You may build ``ptx`` only when NVIDIA GPU
+The ``BACKEND`` parameter has to be a comma-separated list of ``ptx`` and ``opencl`` options. You may build ``ptx`` only when NVIDIA GPU
 Computing Toolkit (CUDA) is installed.
 
 7. Check the installation

--- a/docs/source/unsupported.rst
+++ b/docs/source/unsupported.rst
@@ -27,9 +27,8 @@ This might speed-up user code if the target device contains explicit vector unit
 3. No Dynamic Memory Allocation (*)
 '''''''''''''''''''''''''''''''''''
 
-In general, TornadoVM cannot allocate memory on demand since it must
-know the size of the buffers in advanced. However, TornadoVM performs a
-sort of partial evaluation (PE), in which the JIT compiler evaluates
+In general, TornadoVM cannot allocate memory on demand since it must know the size of the buffers in advanced. 
+However, TornadoVM performs a sort of partial evaluation (PE), in which the JIT compiler evaluates
 expressions and “materializes” values at runtime. Therefore, if the JIT
 compiler can obtain, for example, the size of an array, it will generate
 code based on the values seen at runtime.
@@ -41,26 +40,24 @@ generating the OpenCL C code.
 4. No Support for Traps/Exceptions (*)
 ''''''''''''''''''''''''''''''''''''''
 
-On GPUs there is little support for exceptions. For example, on a
-division by 0 scenario, the CPU sets a flag in one of the special
-registers. Then the Operating System can query those special registers
-and pass that value to the application runtime (in this case, the Java
-runtime). Then Java runtime handles the exception.
+On GPUs there is little support for exceptions. 
+For example, on a division by 0 scenario, the CPU sets a flag in one of the special registers. 
+Then the Operating System can query those special registers and pass that value to the application runtime (in this case, the Java runtime). 
+Then Java runtime handles the exception.
 
 However, there is no such mechanisms on GPUs
 (`link <https://docs.nvidia.com/cuda/floating-point/index.html#differences-from-x86>`__),
-which means that TornadoVM must insert extra control-flow to guarantee
-those exceptions never happen. Currently, since TornadoVM compiles at
-runtime, many of those checks can be assured at runtime. However, we
-plan to integrate exception support for TornadoVM in the future.
+which means that TornadoVM must insert extra control-flow to guarantee those exceptions never happen. 
+Currently, since TornadoVM compiles at runtime, many of those checks can be assured at runtime. 
+However, we plan to integrate exception support for TornadoVM in the future.
 
-6. No Support for static TaskGrapshs and Tasks
+6. No Support for static TaskGraphs and Tasks
 ''''''''''''''''''''''''''''''''''''''''''''
 
 TornadoVM currently does not support static ``TaskGraph`` and Tasks. For
 example, the code below is not considered valid:
 
-::
+.. code-block:: java 
 
        public static void testMethod(int[] in) {
            // ... some code ...
@@ -81,5 +78,4 @@ Note
 ~~~~
 
 Note that if a particular code segment cannot be accelerated with TornadoVM due to unsupported features, then execution falls back to the
-host JVM which will execute your code on the CPU as it would normally
-do.
+host JVM which will execute your code on the CPU as it would normally do.


### PR DESCRIPTION
This PR updates the documentation, hosted in https://tornadovm.readthedocs.io/en/latest/ with the following changes:

1. Update the installation instructions for Windows 10/11 with MSys2
2. Fixed typos on the `unsupported` page. 

The new version of the documentation will be rendered automatically with this PR. 
