### PR TITLE
Fix Typo in Installer Script

### DIFF
--- a/scripts/tornadovm-installer
+++ b/scripts/tornadovm-installer
@@ -271,7 +271,7 @@ class TornadoInstaller():
         backend = self.composeBackendOption(args)
 
         makeJDK = "jdk-11-plus"
-        if ((args.javaHome != None and args.javaHome.startswith("graal")) or args.jdk.startswith("graal")):
+        if ((args.javaHome != None and args.javaHome.startswith("graal")) or (args.jdk != None and args.jdk.startswith("graal"))):
             makeJDK = "graal-jdk-11-plus"
         
         if (args.javaHome != None):

--- a/scripts/tornadovm-installer
+++ b/scripts/tornadovm-installer
@@ -271,7 +271,7 @@ class TornadoInstaller():
         backend = self.composeBackendOption(args)
 
         makeJDK = "jdk-11-plus"
-        if ((args.javaHome != None and args.javaHome.startswith("graal")) or (args.jdk != None and args.jdk.startswith("graal"))):
+        if ((args.javaHome != None and args.javaHome.find("graal") != -1) or (args.jdk != None and args.jdk.startswith("graal"))):
             makeJDK = "graal-jdk-11-plus"
         
         if (args.javaHome != None):


### PR DESCRIPTION
#### Description

Fixes a typo in a condition in the installer script preventing the installation with a custom OpenJDK whose path does not start with `"graal"`

#### Problem description

Running `./scripts/tornadovm-installer --help` states:
```
If you want to select another version of OpenJDK, you can use --javaHome="<pathToJavaHome>" and install as follows:
      $ ./scripts/tornadovm-installer --backend <BACKEND> --javaHome=<pathToJavaHome> 
```

Enter a `<pathToJavaHome>` that does not start with `"graal"` and the script tries to access `args.jdk.startswith` which throws an error because it is `None`.

#### Backend/s tested

Does not apply, just a line in a python script

#### How to test the new patch?

```
/scripts/tornadovm-installer --backend <BACKEND> --javaHome=<pathToJavaHome> 
```
with a `<pathToJavaHome>` that does not start with `"graal"`. 

----------------------------------------------------------------------------