### PR TITLE
[docs] YAML config file for ReadTheDocs added

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,17 +10,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-    # You can also specify other tool versions:
-    # nodejs: "19"
-    # rust: "1.64"
-    # golang: "1.19"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
- formats:
+formats:
     - pdf
 
 # Optionally declare the Python requirements required to build your docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,7 +25,6 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - build
         - docs
 
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+ formats:
+    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+    install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - build
+        - docs
+
+

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,11 +20,11 @@ formats:
     - pdf
 
 # Optionally declare the Python requirements required to build your docs
-python:
-    install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+#python:
+#    install:
+#    - method: pip
+#      path: .
+#      extra_requirements:
+#        - docs
 
 

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,6 +1,0 @@
-version: 2
-
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.11"

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"


### PR DESCRIPTION
Fix for Read The Docs. Since last week, we are getting the following exception with OpenSSL:

```bash
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/tornadovm/envs/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 280, in build_main
    args.pdb)
  File "/home/docs/checkouts/readthedocs.org/user_builds/tornadovm/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 219, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/tornadovm/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 398, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/tornadovm/envs/latest/lib/python3.7/site-packages/sphinx/registry.py", line 463, in load_extension
    err) from err
sphinx.errors.ExtensionError: Could not import extension sphinx.builders.linkcheck (exception: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168)
```
 

#### Problem description: https://github.com/readthedocs/readthedocs.org/issues/10296


#### Fix: https://github.com/urllib3/urllib3/issues/2168 

