### PR TITLE
Support Mesa's rusticl.

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLPlatform.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLPlatform.java
@@ -55,6 +55,8 @@ public class OCLPlatform extends TornadoLogger implements TornadoPlatform {
 
         if (isVendor("Xilinx") || isVendor("Codeplay")) {
             deviceCount = clGetDeviceCount(id, OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR.getValue());
+        } else if (isVendor("Mesa/X.org")) {
+            deviceCount = clGetDeviceCount(id, OCLDeviceType.CL_DEVICE_TYPE_GPU.getValue());
         } else {
             deviceCount = clGetDeviceCount(id, OCLDeviceType.CL_DEVICE_TYPE_ALL.getValue());
         }
@@ -62,6 +64,8 @@ public class OCLPlatform extends TornadoLogger implements TornadoPlatform {
         final long[] ids = new long[deviceCount];
         if (isVendor("Xilinx") || isVendor("Codeplay")) {
             clGetDeviceIDs(id, OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR.getValue(), ids);
+        } else if (isVendor("Mesa/X.org")) {
+            clGetDeviceIDs(id, OCLDeviceType.CL_DEVICE_TYPE_GPU.getValue(), ids);
         } else {
             clGetDeviceIDs(id, OCLDeviceType.CL_DEVICE_TYPE_ALL.getValue(), ids);
         }


### PR DESCRIPTION
#### Description

In order to obtain a correct clDeviceCount and correct clGetDeviceIDs from Mesa's rusticl implementation, CL_DEVICE_TYPE_GPU must be explicitly set in the API. Follow the example for Xilinx and Codeplay to do so for Mesa/X.org.

Thank you for contributing to TornadoVM. This template provides checkpoints before opening PR, and a template to be filled when submitting a PR on GitHub.

#### Problem description

Without the patch on Mesa's rusticl, clDeviceCount returns an error code and hence Tornado is not functional.

#### Backend/s tested

Mark the backends affected by this PR.

- [ X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

Obtain recent Mesa with rusticl module enabled, set RUSTICL_ENABLE=radeonsi and RUSTICL_FEATURES=fp64 , install TornadoVM with OpenCL backend, run tornado-benchmarks.py.

This was tested on AMD Radeon Vega Frontier Edition (vega10, LLVM 15.0.7, DRM 3.54, 6.5.1-060501-generic) with tip of tree Mesa@f1bc58cb. A few benchmarks fail in amdgpu CS (unrelated to Tornado).

----------------------------------------------------------------------------
