### PR TITLE
[runtime] Support for Mesa's rusticl

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLPlatform.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLPlatform.java
@@ -55,6 +55,8 @@ public class OCLPlatform extends TornadoLogger implements TornadoPlatform {
 
         if (isVendor("Xilinx") || isVendor("Codeplay")) {
             deviceCount = clGetDeviceCount(id, OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR.getValue());
+        } else if (isVendor("Mesa/X.org")) {
+            deviceCount = clGetDeviceCount(id, OCLDeviceType.CL_DEVICE_TYPE_GPU.getValue());
         } else {
             deviceCount = clGetDeviceCount(id, OCLDeviceType.CL_DEVICE_TYPE_ALL.getValue());
         }
@@ -62,6 +64,8 @@ public class OCLPlatform extends TornadoLogger implements TornadoPlatform {
         final long[] ids = new long[deviceCount];
         if (isVendor("Xilinx") || isVendor("Codeplay")) {
             clGetDeviceIDs(id, OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR.getValue(), ids);
+        } else if (isVendor("Mesa/X.org")) {
+            clGetDeviceIDs(id, OCLDeviceType.CL_DEVICE_TYPE_GPU.getValue(), ids);
         } else {
             clGetDeviceIDs(id, OCLDeviceType.CL_DEVICE_TYPE_ALL.getValue(), ids);
         }


### PR DESCRIPTION
Change applied on behalf of @iotamudelta for the Mesa OpenCL GPU Driver.

How to test it?

> Obtain recent Mesa with rusticl module enabled, then set RUSTICL_ENABLE=radeonsi and RUSTICL_FEATURES=fp64, and install TornadoVM with OpenCL backend. To test: tornado-benchmarks.py.

PR related: #270 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No
