### PR TITLE
[compiler][flag] Fix for GraalJIT 23 and object headers.

### DIFF
--- a/tornado-assembly/src/bin/tornado
+++ b/tornado-assembly/src/bin/tornado
@@ -78,7 +78,7 @@ __OPENCL_MODULE__  = "tornado.drivers.opencl"
 # ########################################################
 __JAVA_GC_JDK11__        = "-XX:+UseParallelOldGC -XX:-UseBiasedLocking "
 __JAVA_GC_JDK16__        = "-XX:+UseParallelGC "
-__JAVA_BASE_OPTIONS__    = "-server -XX:-UseCompressedOops -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI "
+__JAVA_BASE_OPTIONS__    = "-server -XX:-UseCompressedOops -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseCompressedClassPointers "
 __TRUFFLE_BASE_OPTIONS__ = "--jvm --polyglot --vm.XX:-UseCompressedOops --vm.XX:+UnlockExperimentalVMOptions --vm.XX:+EnableJVMCI "
 
 # We do not satisfy the Graal compiler assertions because we only support a subset of the Java specification.

--- a/tornado-assembly/src/bin/tornado
+++ b/tornado-assembly/src/bin/tornado
@@ -79,7 +79,7 @@ __OPENCL_MODULE__  = "tornado.drivers.opencl"
 __JAVA_GC_JDK11__        = "-XX:+UseParallelOldGC -XX:-UseBiasedLocking "
 __JAVA_GC_JDK16__        = "-XX:+UseParallelGC "
 __JAVA_BASE_OPTIONS__    = "-server -XX:-UseCompressedOops -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseCompressedClassPointers "
-__TRUFFLE_BASE_OPTIONS__ = "--jvm --polyglot --vm.XX:-UseCompressedOops --vm.XX:+UnlockExperimentalVMOptions --vm.XX:+EnableJVMCI "
+__TRUFFLE_BASE_OPTIONS__ = "--jvm --polyglot --vm.XX:-UseCompressedOops --vm.XX:+UnlockExperimentalVMOptions --vm.XX:+EnableJVMCI -XX:-UseCompressedClassPointers "
 
 # We do not satisfy the Graal compiler assertions because we only support a subset of the Java specification.
 # This allows us to have the GraalIR in states which normally would be illegal.


### PR DESCRIPTION
#### Description

From GraalVM 23.0.1 with JDK 20, there is a header of 16 bytes when querying the JVMCI API:

`MetaAccessProvider.getArrayBaseOffset`

The TornadoVM JIT compiler reads the value from this interface to setup the bytes for the object headers on the GPU (or accelerator).

However, OpenJDK sets the value to 24 bytes, as any previous version of JDK. The issue is that, in OpenJDK, compressed oops and compressed class pointers independent from this commit:
https://github.com/openjdk/jdk/commit/382e5dc334502d9147977d50a210ed503ca9fe3e#diff-3dff3621045b158b101e55710fa74455c006ab1ec963111ebef657ff3b7abeaaR73

And when the JVMCI is enabled compressed it also enables both `CompressedOops` and `CompressedClassPointers`, as here:

https://github.com/openjdk/jdk/commit/382e5dc334502d9147977d50a210ed503ca9fe3e#diff-3dff3621045b158b101e55710fa74455c006ab1ec963111ebef657ff3b7abeaaR73

This commit explicitly disables `CompressedClassPointers` when running with JVMCI.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ tornado -version
WARNING: Using incubator modules: jdk.incubator.concurrent, jdk.incubator.vector
openjdk version "20.0.2" 2023-07-18
OpenJDK Runtime Environment GraalVM CE 20.0.2+9.1 (build 20.0.2+9-jvmci-23.0-b15)
OpenJDK 64-Bit Server VM GraalVM CE 20.0.2+9.1 (build 20.0.2+9-jvmci-23.0-b15, mixed mode)

$ tornado-test --printKernel -V --fast uk.ac.manchester.tornado.unittests.arrays.TestArrays#testVectorAdditionFloat
tornado --jvm "-Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.verbose=True -Dtornado.print.kernel=True "  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  --params "uk.ac.manchester.tornado.unittests.arrays.TestArrays#testVectorAdditionFloat"
WARNING: Using incubator modules: jdk.incubator.vector, jdk.incubator.concurrent
#pragma OPENCL EXTENSION cl_khr_fp64 : enable  
#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable  
__kernel void vectorAddFloat(__global long *_kernel_context, __constant uchar *_constant_region, __local uchar *_local_region, __global int *_atomics, __global uchar *a, __global uchar *b, __global uchar *c)
{
  long l_7, l_8, l_6; 
  float f_12, f_10, f_14; 
  ulong ul_11, ul_13, ul_1, ul_0, ul_2, ul_9; 
  int i_15, i_3, i_4, i_5; 

  // BLOCK 0
  ul_0  =  (ulong) a;
  ul_1  =  (ulong) b;
  ul_2  =  (ulong) c;
  i_3  =  get_global_size(0);
  i_4  =  get_global_id(0);
  // BLOCK 1 MERGES [0 2 ]
  i_5  =  i_4;
  for(;i_5 < 4096;)
  {
    // BLOCK 2
    l_6  =  (long) i_5;
    l_7  =  l_6 << 2;
    l_8  =  l_7 + 24L;                        // << 24 bytes instead of 16 
    ul_9  =  ul_0 + l_8;
    f_10  =  *((__global float *) ul_9);
    ul_11  =  ul_1 + l_8;
    f_12  =  *((__global float *) ul_11);
    ul_13  =  ul_2 + l_8;
    f_14  =  f_10 + f_12;
    *((__global float *) ul_13)  =  f_14;
    i_15  =  i_3 + i_5;
    i_5  =  i_15;
  }  // B2
  // BLOCK 3
  return;
}  //  kernel

Test: class uk.ac.manchester.tornado.unittests.arrays.TestArrays#testVectorAdditionFloat
	Running test: testVectorAdditionFloat    ................  [PASS] 
Test ran: 1, Failed: 0, Unsupported: 0


## Pass all tests
$ make tests
```
