### PR TITLE
[fix] fix --profiler flag in tornado-benchmarks.py script

### DIFF
--- a/tornado-assembly/src/bin/tornado-benchmarks.py
+++ b/tornado-assembly/src/bin/tornado-benchmarks.py
@@ -231,7 +231,7 @@ def runBenchmarksFullCoverage(args):
 
 def runMediumConfiguration(args):
     jvm_options, tornado_options = composeAllOptions(args)
-    print(options)
+    print(tornado_options, jvm_options)
     for key in mediumSizes.keys():
         for size in mediumSizes[key][0]:
             numIterations = eval(mediumSizes[key][1][0])

--- a/tornado-assembly/src/bin/tornado-benchmarks.py
+++ b/tornado-assembly/src/bin/tornado-benchmarks.py
@@ -269,7 +269,8 @@ def runWithJMH(args):
 def runDefaultSizePerBenchmark(args):
     printBenchmarks()
     jvm_options, tornado_options = composeAllOptions(args)
-    print(Colors.CYAN + "[INFO] TornadoVM options: " + options + Colors.RESET)
+    print(Colors.CYAN + "[INFO] TornadoVM options: " + tornado_options +
+          jvm_options + Colors.RESET)
     for b in __BENCHMARKS__:
         command = (
             __TORNADO_COMMAND__

--- a/tornado-assembly/src/bin/tornado-benchmarks.py
+++ b/tornado-assembly/src/bin/tornado-benchmarks.py
@@ -73,7 +73,7 @@ __SKIP_SERIAL__ = " -Dtornado.benchmarks.skipserial=True "
 __SKIP_PARALLEL__ = " -Dtornado.enable=False "
 __SKIP_DEVICES__ = " -Dtornado.blacklist.devices="
 __VALIDATE__ = " -Dtornado.benchmarks.validate=True "
-__ENABLE_PROFILER_SILENT_MODE__ = " --enableProfiler silent "
+__ENABLE_PROFILER__ = " --enableProfiler "
 __DISABLE_LEVEL_ZERO_DEFAULT_SCHEDULER__ = (
     " -Dtornado.spirv.levelzero.thread.dispatcher=False "
 )
@@ -177,24 +177,25 @@ mediumSizes = {
 
 ## ========================================================================================
 def composeAllOptions(args):
-    options = __JVM_FLAGS__
+    jvm_options = __JVM_FLAGS__
+    tornado_options = ""
     if args.skip_serial:
-        options = options + __SKIP_SERIAL__
+        jvm_options = jvm_options + __SKIP_SERIAL__
     if args.skip_parallel:
-        options = options + __SKIP_PARALLEL__
+        jvm_options = jvm_options + __SKIP_PARALLEL__
     if args.validate:
-        options = options + __VALIDATE__
+        jvm_options = jvm_options + __VALIDATE__
     if args.skip_devices != None:
-        options = options + __SKIP_DEVICES__ + args.skip_devices + " "
+        jvm_options = jvm_options + __SKIP_DEVICES__ + args.skip_devices + " "
     if args.profiler:
-        options = options + __ENABLE_PROFILER_SILENT_MODE__
+        tornado_options = tornado_options + __ENABLE_PROFILER__ + args.profiler
     if args.jvmFlags != None:
-        options = options + args.jvmFlags
+        jvm_options = jvm_options + args.jvmFlags
     if args.tornadoThreadScheduler == True:
-        options = options + __DISABLE_LEVEL_ZERO_DEFAULT_SCHEDULER__
+        jvm_options = jvm_options + __DISABLE_LEVEL_ZERO_DEFAULT_SCHEDULER__
     if args.spirvOptimizer:
-        options = options + __ENABLE_SPIRV_OPTIMIZER__
-    return options
+        jvm_options = jvm_options + __ENABLE_SPIRV_OPTIMIZER__
+    return jvm_options, tornado_options
 
 
 def printBenchmarks(indent=""):
@@ -204,13 +205,14 @@ def printBenchmarks(indent=""):
 
 
 def runBenchmarksFullCoverage(args):
-    options = composeAllOptions(args)
+    jvm_options, tornado_options = composeAllOptions(args)
     for key in allSizes.keys():
         for size in allSizes[key][0]:
             command = (
                 __TORNADO_COMMAND__
+                + tornado_options
                 + ' --jvm="'
-                + options
+                + jvm_options
                 + '" '
                 + __RUNNER__
                 + ' --params="'
@@ -228,15 +230,16 @@ def runBenchmarksFullCoverage(args):
 
 
 def runMediumConfiguration(args):
-    options = composeAllOptions(args)
+    jvm_options, tornado_options = composeAllOptions(args)
     print(options)
     for key in mediumSizes.keys():
         for size in mediumSizes[key][0]:
             numIterations = eval(mediumSizes[key][1][0])
             command = (
                 __TORNADO_COMMAND__
+                + tornado_options
                 + ' --jvm="'
-                + options
+                + jvm_options
                 + '" '
                 + __RUNNER__
                 + ' --params="'
@@ -255,22 +258,24 @@ def runMediumConfiguration(args):
 
 def runWithJMH(args):
     printBenchmarks()
-    options = composeAllOptions(args)
-    print(Colors.CYAN + "[INFO] TornadoVM options: " + options + Colors.RESET)
-    command = __TORNADO_COMMAND__ + " -jar benchmarks/target/jmhbenchmarks.jar "
+    jvm_options, tornado_options = composeAllOptions(args)
+    print(Colors.CYAN + "[INFO] TornadoVM options: " + tornado_options +
+          jvm_options + Colors.RESET)
+    command = __TORNADO_COMMAND__ + tornado_options + " -jar benchmarks/target/jmhbenchmarks.jar "
     print(command)
     os.system(command)
 
 
 def runDefaultSizePerBenchmark(args):
     printBenchmarks()
-    options = composeAllOptions(args)
+    jvm_options, tornado_options = composeAllOptions(args)
     print(Colors.CYAN + "[INFO] TornadoVM options: " + options + Colors.RESET)
     for b in __BENCHMARKS__:
         command = (
             __TORNADO_COMMAND__
+            + tornado_options
             + '--jvm="'
-            + options
+            + jvm_options
             + '" '
             + __RUNNER__
             + '--params="'
@@ -344,9 +349,9 @@ def parseArguments():
     )
     parser.add_argument(
         "--profiler",
-        action="store_true",
+        action="store",
         dest="profiler",
-        default=False,
+        required=False,
         help="Run Benchmarks with the OpenCL|PTX|SPIRV profiler",
     )
     parser.add_argument(

--- a/tornado-assembly/src/bin/tornado-benchmarks.py
+++ b/tornado-assembly/src/bin/tornado-benchmarks.py
@@ -188,7 +188,7 @@ def composeAllOptions(args):
     if args.skip_devices != None:
         jvm_options = jvm_options + __SKIP_DEVICES__ + args.skip_devices + " "
     if args.profiler:
-        tornado_options = tornado_options + __ENABLE_PROFILER__ + args.profiler
+        tornado_options = tornado_options + __ENABLE_PROFILER__ + args.profiler + " "
     if args.jvmFlags != None:
         jvm_options = jvm_options + args.jvmFlags
     if args.tornadoThreadScheduler == True:


### PR DESCRIPTION
#### Description

The --profiler flag didn't work, since when enabled by the user, the flag was added to JVM options, however, it should be placed in front of the tornado command and not JVM options.

Hence, the options variable is updated to two separate variables: jvm_options and tornado_options, so every option will be placed in its right place.

#### Problem description

JVM didn't recognize the --enableProfiler flag and showed the following error:

```
tornado --jvm="-Xms24G -Xmx24G -server -Dtornado.recover.bailout=False  -Dtornado.benchmarks.skipserial=True  --enableProfiler silent "  -m tornado.benchmarks/uk.ac.manchester.tornado.benchmarks.BenchmarkRunner --p
arams="saxpy"
Unrecognized option: --enableProfiler
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
You can regenerate the error by running the following command:

```
tornado-benchmarks.py --skipSequential --profiler
```

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

You can run the tornado-benchmarks.py script just like the following example:

tornado-benchmarks.py --skipSequential --profiler console

And profiler output will be displayed on the console.

----------------------------------------------------------------------------
