### PR TITLE
Fix GraalVM JDK21 download urls in installer_config.py

### DIFF
--- a/bin/installer_config.py
+++ b/bin/installer_config.py
@@ -77,12 +77,12 @@ JDK = {
     },
     __GRAALVM21__: {
         __LINUX__: {
-            __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-x64_bin.tar.gz",
-            __ARM__: "https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-aarch64_bin.tar.gz",
+            __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-x64_bin.tar.gz",
+            __ARM__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-aarch64_bin.tar.gz",
         },
         __APPLE__: {
-            __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-21.0.1/graalvm-community-jdk-21.0.1_macos-x64_bin.tar.gz",
-            __ARM__: "https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-21.0.1/graalvm-community-jdk-21.0.1_macos-aarch64_bin.tar.gz",
+            __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_macos-x64_bin.tar.gz",
+            __ARM__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_macos-aarch64_bin.tar.gz",
         },
     },
     __CORRETTO21__: {


### PR DESCRIPTION
#### Description

Fixed the download link for GraalVM21 in the install scripts, `./bin/installer_config.py`
#### Problem description

The original download link is redirected to [the release page](https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-21.0.1). This is an HTML resource rather than gzip, and will throw an exception when the script tries to decompress it
```
Checking dependency: graalvm-community-jdk-21.0.1_macos-aarch64_bin.tar.gz
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/tarfile.py", line 1682, in gzopen
    t = cls.taropen(name, mode, fileobj, **kwargs)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/tarfile.py", line 1659, in taropen
    return cls(name, mode, fileobj, **kwargs)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/tarfile.py", line 1522, in __init__
    self.firstmember = self.next()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/tarfile.py", line 2327, in next
    tarinfo = self.tarinfo.fromtarfile(self)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/tarfile.py", line 1112, in fromtarfile
    buf = tarfile.fileobj.read(BLOCKSIZE)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/gzip.py", line 300, in read
    return self._buffer.read(size)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/_compression.py", line 68, in readinto
    data = self.read(len(byte_view))
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/gzip.py", line 487, in read
    if not self._read_gzip_header():
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/gzip.py", line 435, in _read_gzip_header
    raise BadGzipFile('Not a gzipped file (%r)' % magic)
gzip.BadGzipFile: Not a gzipped file (b'\n\n')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/tais/Coding/TornadoVM/./bin/tornadovm-installer", line 413, in <module>
    installer.install(args)
  File "/Users/tais/Coding/TornadoVM/./bin/tornadovm-installer", line 323, in install
    self.downloadJDK(args.jdk)
  File "/Users/tais/Coding/TornadoVM/./bin/tornadovm-installer", line 201, in downloadJDK
    tar = tarfile.open(fullPath, "r:gz")
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/tarfile.py", line 1629, in open
    return func(name, filemode, fileobj, **kwargs)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/tarfile.py", line 1686, in gzopen
    raise ReadError("not a gzip file")
tarfile.ReadError: not a gzip file
```


#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No
