### PR TITLE
[fix] Installer with no polyglot configuration

### DIFF
--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -311,9 +311,8 @@ class TornadoInstaller:
         backend = self.composeBackendOption(args)
 
         makeJDK = "jdk21"
-        if (args.javaHome != None and "graal" in args.javaHome) or (
-            "graal" in args.jdk
-        ):
+        polyglotOption = ""
+        if (args.javaHome != None and "graal" in args.javaHome) or ("graal" in args.jdk):
             makeJDK = "graal-jdk-21"
             polyglotOption = self.composePolyglotOption(args)
 


### PR DESCRIPTION
#### Description

This PR fixes the install script. There was an error of undeclared variable when the `polyglot` mode was not used. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
./bin/tornadovm-installer --jdk jdk21 --backend=opencl
```

