### PR TITLE
[fix] benchmark classpath with JMH option

### DIFF
--- a/tornado-assembly/src/bin/tornado-benchmarks.py
+++ b/tornado-assembly/src/bin/tornado-benchmarks.py
@@ -261,7 +261,7 @@ def runWithJMH(args):
     jvm_options, tornado_options = composeAllOptions(args)
     print(Colors.CYAN + "[INFO] TornadoVM options: " + tornado_options +
           jvm_options + Colors.RESET)
-    command = __TORNADO_COMMAND__ + tornado_options + " -jar benchmarks/target/jmhbenchmarks.jar "
+    command = __TORNADO_COMMAND__ + tornado_options + " -jar tornado-benchmarks/target/jmhbenchmarks.jar "
     print(command)
     os.system(command)
 


### PR DESCRIPTION
#### Description

This PR fixes the old classpath of TornadoVM when running the benchmarks with the JMH option. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make
$ tornado-benchmarks.py --jmh
```


