### PR TITLE
Move input sizes check to also check for tornado arrays

### DIFF
--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -596,7 +596,8 @@ Current Limitations of Batch Processing
 
 There is a set of limitations with the current implementation of batch processing.
 
-1. All arrays passed to the input methods to be compiled to the target device have to have the same data type and size.
+1. All arrays passed to the input methods to be compiled to the target device have to have the total size and element size
+(e.g. combining FloatArray and IntArray is possible).
 2. We only support arrays of primitives that are passed as arguments. This means that scope arrays in batches are not currently supported.
 3. All bytecodes make use of the same OpenCL command queue / CUDA stream.
 4. Matrix or non-regular batch distributions. (E.g., MxM would need to be split by rows in matrix-A and columns in matrix-B).

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
@@ -26,6 +26,7 @@ package uk.ac.manchester.tornado.runtime.common;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
@@ -36,6 +37,7 @@ import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.arrays.LongArray;
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.runtime.graph.TornadoExecutionContext;
 
 /**
@@ -69,56 +71,38 @@ public class BatchConfiguration {
         // Get the size of the batch
         List<Object> inputObjects = context.getObjects();
         long totalSize = 0;
-        DataTypeSize dataTypeSize = null;
 
-        HashSet<Class<?>> classObjects = new HashSet<>();
         HashSet<Long> inputSizes = new HashSet<>();
+        LinkedHashSet<Byte> elementSizes = new LinkedHashSet<>();
 
         for (Object o : inputObjects) {
             if (o.getClass().isArray()) {
                 Class<?> componentType = o.getClass().getComponentType();
-                dataTypeSize = findDataTypeSize(componentType);
+                DataTypeSize dataTypeSize = findDataTypeSize(componentType);
                 if (dataTypeSize == null) {
                     throw new TornadoRuntimeException("[UNSUPPORTED] Data type not supported for processing in batches");
                 }
                 long size = Array.getLength(o);
                 totalSize = size * dataTypeSize.getSize();
 
-                classObjects.add(componentType);
+                elementSizes.add(dataTypeSize.getSize());
                 inputSizes.add(totalSize);
-                if (classObjects.size() > 1) {
-                    throw new TornadoRuntimeException("[UNSUPPORTED] Input objects with different data types not currently supported");
-                }
-            } else if (o instanceof IntArray) {
-                totalSize = ((IntArray) o).getNumBytesWithoutHeader();
+            } else if (o instanceof TornadoNativeArray tornadoNativeArray) {
+                totalSize = tornadoNativeArray.getNumBytesWithoutHeader();
                 inputSizes.add(totalSize);
-                dataTypeSize = findDataTypeSize(int.class);
-            } else if (o instanceof FloatArray) {
-                totalSize = ((FloatArray) o).getNumBytesWithoutHeader();
-                inputSizes.add(totalSize);
-                dataTypeSize = findDataTypeSize(float.class);
-            } else if (o instanceof DoubleArray) {
-                totalSize = ((DoubleArray) o).getNumBytesWithoutHeader();
-                inputSizes.add(totalSize);
-                dataTypeSize = findDataTypeSize(double.class);
-            } else if (o instanceof LongArray) {
-                totalSize = ((LongArray) o).getNumBytesWithoutHeader();
-                inputSizes.add(totalSize);
-                dataTypeSize = findDataTypeSize(long.class);
-            } else if (o instanceof ShortArray) {
-                totalSize = ((ShortArray) o).getNumBytesWithoutHeader();
-                inputSizes.add(totalSize);
-                dataTypeSize = findDataTypeSize(short.class);
-            } else if (o instanceof ByteArray) {
-                totalSize = ((ByteArray) o).getNumBytesWithoutHeader();
-                inputSizes.add(totalSize);
-                dataTypeSize = findDataTypeSize(byte.class);
-            } else if (o instanceof CharArray) {
-                totalSize = ((CharArray) o).getNumBytesWithoutHeader();
-                inputSizes.add(totalSize);
-                dataTypeSize = findDataTypeSize(char.class);
+                byte elementSize = switch (tornadoNativeArray) {
+                    case IntArray _ -> DataTypeSize.INT.getSize();
+                    case FloatArray _ -> DataTypeSize.FLOAT.getSize();
+                    case DoubleArray _ -> DataTypeSize.DOUBLE.getSize();
+                    case LongArray _ -> DataTypeSize.LONG.getSize();
+                    case ShortArray _ -> DataTypeSize.SHORT.getSize();
+                    case ByteArray _ -> DataTypeSize.BYTE.getSize();
+                    case CharArray _ -> DataTypeSize.CHAR.getSize();
+                    default -> throw new TornadoRuntimeException("Unsupported array type: " + o.getClass());
+                };
+                elementSizes.add(elementSize);
             } else {
-                throw new TornadoRuntimeException("Unsupported type: ");
+                throw new TornadoRuntimeException("Unsupported type: " + o.getClass());
             }
         }
 
@@ -126,7 +110,9 @@ public class BatchConfiguration {
             throw new TornadoRuntimeException("[UNSUPPORTED] Input objects with different sizes not currently supported");
         }
 
-        assert dataTypeSize != null;
+        if (elementSizes.size() > 1) {
+            throw new TornadoRuntimeException("[UNSUPPORTED] Input objects with different element sizes not currently supported");
+        }
 
         int totalChunks = (int) (totalSize / batchSize);
         int remainingChunkSize = (int) (totalSize % batchSize);
@@ -136,7 +122,7 @@ public class BatchConfiguration {
             System.out.println("Total chunks: " + totalChunks);
             System.out.println("remainingChunkSize: " + remainingChunkSize);
         }
-        return new BatchConfiguration(totalChunks, remainingChunkSize, dataTypeSize.getSize());
+        return new BatchConfiguration(totalChunks, remainingChunkSize, elementSizes.getFirst());
     }
 
     private static DataTypeSize findDataTypeSize(Class<?> dataType) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
@@ -89,9 +89,6 @@ public class BatchConfiguration {
                 if (classObjects.size() > 1) {
                     throw new TornadoRuntimeException("[UNSUPPORTED] Input objects with different data types not currently supported");
                 }
-                if (inputSizes.size() > 1) {
-                    throw new TornadoRuntimeException("[UNSUPPORTED] Input objects with different sizes not currently supported");
-                }
             } else if (o instanceof IntArray) {
                 totalSize = ((IntArray) o).getNumBytesWithoutHeader();
                 inputSizes.add(totalSize);
@@ -123,6 +120,10 @@ public class BatchConfiguration {
             } else {
                 throw new TornadoRuntimeException("Unsupported type: ");
             }
+        }
+
+        if (inputSizes.size() > 1) {
+            throw new TornadoRuntimeException("[UNSUPPORTED] Input objects with different sizes not currently supported");
         }
 
         assert dataTypeSize != null;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -107,9 +107,57 @@ public class TestBatches extends TornadoTestBase {
         }
     }
 
+    static void compute(IntArray in, LongArray out) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, in.get(i));
+        }
+    }
+
     static void compute(int[] in, int[] out) {
         for (@Parallel int i = 0; i < in.length; i++) {
             out[i] = in[i];
+        }
+    }
+
+    static void compute(int[] in, long[] out) {
+        for (@Parallel int i = 0; i < out.length; i++) {
+            out[i] = in[i];
+        }
+    }
+
+    static void compute(int[] in, IntArray out) {
+        for (@Parallel int i = 0; i < in.length; i++) {
+            out.set(i, in[i]);
+        }
+    }
+
+    static void compute(IntArray out, int[] in) {
+        for (@Parallel int i = 0; i < in.length; i++) {
+            out.set(i, in[i]);
+        }
+    }
+
+    static void compute(int[] in, float[] out) {
+        for (@Parallel int i = 0; i < in.length; i++) {
+            out[i] = in[i];
+        }
+    }
+
+    static void compute(IntArray in, FloatArray out) {
+        for (@Parallel int i = 0; i < in.getSize(); i++) {
+            out.set(i, in.get(i));
+        }
+    }
+
+    static void compute(int[] in, FloatArray out) {
+        for (@Parallel int i = 0; i < in.length; i++) {
+            out.set(i, in[i]);
+        }
+    }
+
+    static void compute(IntArray in, float[] out) {
+        for (@Parallel int i = 0; i < in.getSize(); i++) {
+            out[i] = in.get(i);
         }
     }
 
@@ -427,8 +475,8 @@ public class TestBatches extends TornadoTestBase {
     }
 
     @Test
-    public void testSameInputSizeRestriction() {
-        // This test checks that the BatchConfiguration restrictions for different input sizes is met
+    public void testSameInputSizeAndTypeRestriction() {
+        // total input size mismatch for IntArray
         checkMaxHeapAllocation(5, MemSize.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntArray a1 = new IntArray(3 * 1_000_000);
@@ -444,8 +492,8 @@ public class TestBatches extends TornadoTestBase {
     }
 
     @Test
-    public void testSameInputSizeRestrictionJavaArrays() {
-        // This test checks that the BatchConfiguration restrictions for different input sizes is met
+    public void testSameInputSizeAndTypeRestrictionJavaArrays() {
+        // total input size mismatch for int[]
         checkMaxHeapAllocation(5, MemSize.MB);
         int[] a0 = new int[2 * 1_000_000];
         int[] a1 = new int[3 * 1_000_000];
@@ -457,6 +505,172 @@ public class TestBatches extends TornadoTestBase {
         ImmutableTaskGraph snapshot = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
         Assert.assertThrows(TornadoRuntimeException.class, () -> executionPlan.withBatch("1MB").execute());
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void testSameInputTypeRestriction() {
+        // IntArray is NOT compatible with LongArray even if the total input size is equal
+        checkMaxHeapAllocation(6, MemSize.MB);
+        IntArray a0 = new IntArray(4 * 1_000_000);
+        LongArray a1 = new LongArray(2 * 1_000_000);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
+                .task("t0", TestBatches::compute, a0, a1) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
+        ImmutableTaskGraph snapshot = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
+        Assert.assertThrows(TornadoRuntimeException.class, () -> executionPlan.withBatch("1MB").execute());
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void testSameInputTypeRestrictionJavaArrays() {
+        // int[] is NOT compatible with long[] even if the total input size is equal
+        checkMaxHeapAllocation(6, MemSize.MB);
+        int[] a0 = new int[4 * 1_000_000];
+        long[] a1 = new long[2 * 1_000_000];
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
+                .task("t0", TestBatches::compute, a0, a1) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
+        ImmutableTaskGraph snapshot = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
+        Assert.assertThrows(TornadoRuntimeException.class, () -> executionPlan.withBatch("1MB").execute());
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void testSameInputSize() {
+        // IntArray is compatible with FloatArray for the same # of elements
+        checkMaxHeapAllocation(4, MemSize.MB);
+        IntArray a0 = new IntArray(2 * 1_000_000);
+        IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
+        FloatArray a1 = new FloatArray(2 * 1_000_000);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
+                .task("t0", TestBatches::compute, a0, a1) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
+        ImmutableTaskGraph snapshot = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
+        executionPlan.withBatch("1MB").execute();
+
+        for (int i = 0; i < a1.getSize(); i++) {
+            Assert.assertEquals(a0.get(i), a1.get(i), 1e-20);
+        }
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void testSameInputSizeJavaArrays() {
+        // int[] is compatible with float[] for the same # of elements
+        checkMaxHeapAllocation(4, MemSize.MB);
+        int[] a0 = new int[2 * 1_000_000];
+        IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
+        float[] a1 = new float[2 * 1_000_000];
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
+                .task("t0", TestBatches::compute, a0, a1) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
+        ImmutableTaskGraph snapshot = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
+        executionPlan.withBatch("1MB").execute();
+
+        for (int i = 0; i < a1.length; i++) {
+            Assert.assertEquals(a0[i], a1[i], 1e-20);
+        }
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void testSameInputSizeJavaToTornado() {
+        // int[] is compatible with FloatArray for the same # of elements
+        checkMaxHeapAllocation(4, MemSize.MB);
+        int[] a0 = new int[2 * 1_000_000];
+        IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
+        FloatArray a1 = new FloatArray(2 * 1_000_000);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
+                .task("t0", TestBatches::compute, a0, a1) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
+        ImmutableTaskGraph snapshot = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
+        executionPlan.withBatch("1MB").execute();
+
+        for (int i = 0; i < a1.getSize(); i++) {
+            Assert.assertEquals(a0[i], a1.get(i), 1e-20);
+        }
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void testSameInputSizeTornadoToJava() {
+        // IntArray is compatible with float[] for the same # of elements
+        checkMaxHeapAllocation(4, MemSize.MB);
+        IntArray a0 = new IntArray(2 * 1_000_000);
+        IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
+        float[] a1 = new float[2 * 1_000_000];
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
+                .task("t0", TestBatches::compute, a0, a1) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
+        ImmutableTaskGraph snapshot = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
+        executionPlan.withBatch("1MB").execute();
+
+        for (int i = 0; i < a1.length; i++) {
+            Assert.assertEquals(a0.get(i), a1[i], 1e-20);
+        }
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void testSameInputSizeAndTypeJavaToTornado() {
+        // int[] is compatible with IntArray for the same # of elements
+        checkMaxHeapAllocation(4, MemSize.MB);
+        int[] a0 = new int[2 * 1_000_000];
+        IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
+        IntArray a1 = new IntArray(2 * 1_000_000);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
+                .task("t0", TestBatches::compute, a0, a1) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
+        ImmutableTaskGraph snapshot = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
+        executionPlan.withBatch("1MB").execute();
+
+        for (int i = 0; i < a1.getSize(); i++) {
+            Assert.assertEquals(a0[i], a1.get(i));
+        }
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void testSameInputSizeAndTypeTornadoToJava() {
+        // IntArray is compatible with int[] for the same # of elements
+        checkMaxHeapAllocation(4, MemSize.MB);
+        IntArray a0 = new IntArray(2 * 1_000_000);
+        IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
+        int[] a1 = new int[2 * 1_000_000];
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
+                .task("t0", TestBatches::compute, a0, a1) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
+        ImmutableTaskGraph snapshot = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
+        executionPlan.withBatch("1MB").execute();
+
+        for (int i = 0; i < a1.length; i++) {
+            Assert.assertEquals(a0.get(i), a1[i]);
+        }
         executionPlan.freeDeviceMemory();
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -131,9 +131,9 @@ public class TestBatches extends TornadoTestBase {
         }
     }
 
-    static void compute(IntArray out, int[] in) {
-        for (@Parallel int i = 0; i < in.length; i++) {
-            out.set(i, in[i]);
+    static void compute(IntArray in, int[] out) {
+        for (@Parallel int i = 0; i < in.getSize(); i++) {
+            out[i] = in.get(i);
         }
     }
 


### PR DESCRIPTION
#### Description

TornadoVM currently requires all inputs to have the same size when using batching.
However, the BatchConfiguration only checked that for java arrays before. That seems unintended.

The patch moves the check until after the loop to also cover TornadoVM array types.

I ran the tests locally and saw some failures, but from inspecting them, none of the failing tests uses batching, so the failures are likely unrelated.

#### Problem description

From reading the code, I noticed that the check only covers Java arrays. I wrote a test that ensures that mismatching sizes are discovered early instead of crashing the JVM.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Run the added tests (potentially with the changes to BatchConfiguration reverted).
