### PR TITLE
Fix aws s3 configuration usage in aws_post_processing.sh

### DIFF
--- a/tornado-assembly/src/bin/aws_post_processing.sh
+++ b/tornado-assembly/src/bin/aws_post_processing.sh
@@ -4,9 +4,9 @@ configurationFilePath=$1
 directoryBitstream=$2
 entryPoint=$3
 
-export S3_BUCKET=$(grep -w "AWS_S3_BUCKET" ${configurationFilePath} | awk -F'[[:space:]]=[[:space:]]' '{print $2}')
-export S3_DCP_KEY=$(grep -w "AWS_S3_DCP_KEY" ${configurationFilePath} | awk -F'[[:space:]]=[[:space:]]' '{print $2}')
-export S3_LOGS_KEY=$(grep -w "AWS_S3_LOGS_KEY" ${configurationFilePath} | awk -F'[[:space:]]=[[:space:]]' '{print $2}')
+export S3_BUCKET=$(grep -w "AWS_S3_BUCKET" ${configurationFilePath} | awk -F'[[:space:]]*=[[:space:]]*' '{print $2}')
+export S3_DCP_KEY=$(grep -w "AWS_S3_DCP_KEY" ${configurationFilePath} | awk -F'[[:space:]]*=[[:space:]]*' '{print $2}')
+export S3_LOGS_KEY=$(grep -w "AWS_S3_LOGS_KEY" ${configurationFilePath} | awk -F'[[:space:]]*=[[:space:]]*' '{print $2}')
 $VITIS_DIR/tools/create_vitis_afi.sh -xclbin=${directoryBitstream}/${entryPoint}.xclbin -s3_bucket="$S3_BUCKET" -s3_dcp_key="$S3_DCP_KEY" -s3_logs_key="$S3_LOGS_KEY"
 
 sudo mv ${entryPoint}.awsxclbin ${directoryBitstream}/${entryPoint}.awsxclbin

--- a/tornado-assembly/src/bin/aws_post_processing.sh
+++ b/tornado-assembly/src/bin/aws_post_processing.sh
@@ -4,9 +4,9 @@ configurationFilePath=$1
 directoryBitstream=$2
 entryPoint=$3
 
-export S3_BUCKET=$(grep -w "AWS_S3_BUCKET" ${configurationFilePath} | awk -F'=' '{print $2}')
-export S3_DCP_KEY=$(grep -w "AWS_S3_DCP_KEY" ${configurationFilePath} | awk -F'=' '{print $2}')
-export S3_LOGS_KEY=$(grep -w "AWS_S3_LOGS_KEY" ${configurationFilePath} | awk -F'=' '{print $2}')
+export S3_BUCKET=$(grep -w "AWS_S3_BUCKET" ${configurationFilePath} | awk -F'[[:space:]]=[[:space:]]' '{print $2}')
+export S3_DCP_KEY=$(grep -w "AWS_S3_DCP_KEY" ${configurationFilePath} | awk -F'[[:space:]]=[[:space:]]' '{print $2}')
+export S3_LOGS_KEY=$(grep -w "AWS_S3_LOGS_KEY" ${configurationFilePath} | awk -F'[[:space:]]=[[:space:]]' '{print $2}')
 $VITIS_DIR/tools/create_vitis_afi.sh -xclbin=${directoryBitstream}/${entryPoint}.xclbin -s3_bucket="$S3_BUCKET" -s3_dcp_key="$S3_DCP_KEY" -s3_logs_key="$S3_LOGS_KEY"
 
 sudo mv ${entryPoint}.awsxclbin ${directoryBitstream}/${entryPoint}.awsxclbin

--- a/tornado-assembly/src/bin/aws_post_processing.sh
+++ b/tornado-assembly/src/bin/aws_post_processing.sh
@@ -7,7 +7,7 @@ entryPoint=$3
 export S3_BUCKET=$(grep -w "AWS_S3_BUCKET" ${configurationFilePath} | awk -F'=' '{print $2}')
 export S3_DCP_KEY=$(grep -w "AWS_S3_DCP_KEY" ${configurationFilePath} | awk -F'=' '{print $2}')
 export S3_LOGS_KEY=$(grep -w "AWS_S3_LOGS_KEY" ${configurationFilePath} | awk -F'=' '{print $2}')
-$VITIS_DIR/tools/create_vitis_afi.sh -xclbin=${directoryBitstream}/${entryPoint}.xclbin -s3_bucket=tornadovm-fpga-bucket -s3_dcp_key=outputfolder -s3_logs_key=logfolder
+$VITIS_DIR/tools/create_vitis_afi.sh -xclbin=${directoryBitstream}/${entryPoint}.xclbin -s3_bucket=$S3_BUCKET -s3_dcp_key=$S3_DCP_KEY -s3_logs_key=$S3_LOGS_KEY
 
 sudo mv ${entryPoint}.awsxclbin ${directoryBitstream}/${entryPoint}.awsxclbin
 sudo mv to_aws ${directoryBitstream}/to_aws

--- a/tornado-assembly/src/bin/aws_post_processing.sh
+++ b/tornado-assembly/src/bin/aws_post_processing.sh
@@ -7,7 +7,7 @@ entryPoint=$3
 export S3_BUCKET=$(grep -w "AWS_S3_BUCKET" ${configurationFilePath} | awk -F'=' '{print $2}')
 export S3_DCP_KEY=$(grep -w "AWS_S3_DCP_KEY" ${configurationFilePath} | awk -F'=' '{print $2}')
 export S3_LOGS_KEY=$(grep -w "AWS_S3_LOGS_KEY" ${configurationFilePath} | awk -F'=' '{print $2}')
-$VITIS_DIR/tools/create_vitis_afi.sh -xclbin=${directoryBitstream}/${entryPoint}.xclbin -s3_bucket=$S3_BUCKET -s3_dcp_key=$S3_DCP_KEY -s3_logs_key=$S3_LOGS_KEY
+$VITIS_DIR/tools/create_vitis_afi.sh -xclbin=${directoryBitstream}/${entryPoint}.xclbin -s3_bucket="$S3_BUCKET" -s3_dcp_key="$S3_DCP_KEY" -s3_logs_key="$S3_LOGS_KEY"
 
 sudo mv ${entryPoint}.awsxclbin ${directoryBitstream}/${entryPoint}.awsxclbin
 sudo mv to_aws ${directoryBitstream}/to_aws


### PR DESCRIPTION
----------------------------------------------------------------------------

#### Description

Currently, tornado gets a configuration file for running codes on fpga.
On AWS instances, the configuration needs some metadata about S3 bucket
and related folders to upload files on S3, however, aws_post_processing.sh
is not using these metadata properly. This fix uses the defined variables
to run create_vitis_afi.sh

#### Problem description

If user has different bucket and folder names in their S3, tornado 
will fail to upload generated files to S3. So, this will prevent create_vitis_afi.sh 
script to generate AFI image for FPGA on AWS and the image will not be 
available for tornadovm to run on the FPGA device.  Also, any additional
white space after the equal sign and the value, will be propagated to the
create_vitis_afi.sh and results in errors.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [x] Yes
- [ ] No

#### How to test the new patch?

Compiling the tornadovm should generate the correct form of aws_post_processin.sh
in bin/bin and bin/sdk/bin folders. Then using any name for S3 bucket and 
dcp/logs folder keys should work properly and the AMI image should be generated.

----------------------------------------------------------------------------
