### PR TITLE
[api][design] Make TornadoVM API interfaces sealed

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -50,7 +50,7 @@ import java.lang.foreign.MemorySegment;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
 
 @SegmentElementSize(size = 1)
-public class ByteArray extends TornadoNativeArray {
+public final class ByteArray extends TornadoNativeArray {
     private static final int BYTE_BYTES = 1;
     private MemorySegment segment;
     private int numberOfElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -50,7 +50,7 @@ import java.lang.foreign.MemorySegment;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
 
 @SegmentElementSize(size = 2)
-public class CharArray extends TornadoNativeArray {
+public final class CharArray extends TornadoNativeArray {
     private static final int CHAR_BYTES = 2;
     private MemorySegment segment;
     private int numberOfElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -50,7 +50,7 @@ import java.lang.foreign.MemorySegment;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
 
 @SegmentElementSize(size = 8)
-public class DoubleArray extends TornadoNativeArray {
+public final class DoubleArray extends TornadoNativeArray {
     private static final int DOUBLE_BYTES = 8;
     private MemorySegment segment;
     private int numberOfElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -50,7 +50,7 @@ import java.lang.foreign.MemorySegment;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
 
 @SegmentElementSize(size = 4)
-public class FloatArray extends TornadoNativeArray {
+public final class FloatArray extends TornadoNativeArray {
     private static final int FLOAT_BYTES = 4;
     private MemorySegment segment;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -49,7 +49,7 @@ import java.lang.foreign.MemorySegment;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
 
 @SegmentElementSize(size = 4)
-public class IntArray extends TornadoNativeArray {
+public final class IntArray extends TornadoNativeArray {
     private static final int INT_BYTES = 4;
     private int numberOfElements;
     private MemorySegment segment;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -50,7 +50,7 @@ import java.lang.foreign.MemorySegment;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
 
 @SegmentElementSize(size = 8)
-public class LongArray extends TornadoNativeArray {
+public final class LongArray extends TornadoNativeArray {
     private static final int LONG_BYTES = 8;
     private MemorySegment segment;
     private int numberOfElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -50,7 +50,7 @@ import java.lang.foreign.MemorySegment;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
 
 @SegmentElementSize(size = 2)
-public class ShortArray extends TornadoNativeArray {
+public final class ShortArray extends TornadoNativeArray {
     private static final int SHORT_BYTES = 2;
     private MemorySegment segment;
     private int numberOfElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/TornadoNativeArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/TornadoNativeArray.java
@@ -43,7 +43,16 @@ package uk.ac.manchester.tornado.api.types.arrays;
 
 import java.lang.foreign.MemorySegment;
 
-public abstract class TornadoNativeArray {
+import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorByte;
+import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorDouble;
+import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorFloat;
+import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorInt;
+import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorShort;
+
+public abstract sealed class TornadoNativeArray permits //
+        IntArray, FloatArray, DoubleArray, LongArray, ShortArray, //
+        ByteArray, CharArray, NativeVectorByte, NativeVectorDouble, //
+        NativeVectorShort, NativeVectorFloat, NativeVectorInt {
     public static final long ARRAY_HEADER = Long.parseLong(System.getProperty("tornado.panama.objectHeader", "24"));
 
     public abstract int getSize();
@@ -53,7 +62,6 @@ public abstract class TornadoNativeArray {
     public abstract long getNumBytesOfSegment();
 
     public abstract long getNumBytesWithoutHeader();
-
 
     protected abstract void clear();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeByte3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeByte3.java
@@ -48,10 +48,9 @@ import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public final class NativeByte3 implements PrimitiveStorage<ByteBuffer> {
+public final class NativeByte3 implements TornadoNativeCollectionsInterface<ByteBuffer> {
 
     public static final Class<NativeByte3> TYPE = NativeByte3.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeByte4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeByte4.java
@@ -47,10 +47,9 @@ import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public final class NativeByte4 implements PrimitiveStorage<ByteBuffer> {
+public final class NativeByte4 implements TornadoNativeCollectionsInterface<ByteBuffer> {
 
     public static final Class<NativeByte4> TYPE = NativeByte4.class;
     private static final String NUMBER_FORMAT = "{ x=%-7d, y=%-7d, z=%-7d, w=%-7d }";

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeFloat2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeFloat2.java
@@ -49,11 +49,10 @@ import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 
 @Vector
-public final class NativeFloat2 implements PrimitiveStorage<FloatBuffer> {
+public final class NativeFloat2 implements TornadoNativeCollectionsInterface<FloatBuffer> {
 
     public static final Class<NativeFloat2> TYPE = NativeFloat2.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeFloat3.java
@@ -48,13 +48,12 @@ import java.nio.FloatBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.vectors.Float2;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.vectors.Float2;
 
 @Vector
-public final class NativeFloat3 implements PrimitiveStorage<FloatBuffer> {
+public final class NativeFloat3 implements TornadoNativeCollectionsInterface<FloatBuffer> {
 
     public static final Class<NativeFloat3> TYPE = NativeFloat3.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeFloat4.java
@@ -48,14 +48,13 @@ import java.nio.FloatBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.api.types.vectors.Float2;
 import uk.ac.manchester.tornado.api.types.vectors.Float3;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
-import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 
 @Vector
-public final class NativeFloat4 implements PrimitiveStorage<FloatBuffer> {
+public final class NativeFloat4 implements TornadoNativeCollectionsInterface<FloatBuffer> {
 
     public static final Class<NativeFloat4> TYPE = NativeFloat4.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeFloat8.java
@@ -48,13 +48,12 @@ import java.nio.FloatBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.vectors.Float4;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 @Vector
-public final class NativeFloat8 implements PrimitiveStorage<FloatBuffer> {
+public final class NativeFloat8 implements TornadoNativeCollectionsInterface<FloatBuffer> {
 
     public static final Class<NativeFloat8> TYPE = NativeFloat8.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeInt2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeInt2.java
@@ -47,10 +47,9 @@ import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public class NativeInt2 implements PrimitiveStorage<IntBuffer> {
+public final class NativeInt2 implements TornadoNativeCollectionsInterface<IntBuffer> {
 
     public static final Class<NativeInt2> TYPE = NativeInt2.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeInt3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeInt3.java
@@ -46,12 +46,11 @@ import java.nio.IntBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.vectors.Int2;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
+import uk.ac.manchester.tornado.api.types.vectors.Int2;
 
 @Vector
-public class NativeInt3 implements PrimitiveStorage<IntBuffer> {
+public final class NativeInt3 implements TornadoNativeCollectionsInterface<IntBuffer> {
     public static final Class<NativeInt3> TYPE = NativeInt3.class;
 
     private static final String NUMBER_FORMAT = "{ x=%-7d, y=%-7d, z=%-7d }";

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeInt4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeInt4.java
@@ -46,13 +46,12 @@ import java.nio.IntBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.vectors.Int2;
 import uk.ac.manchester.tornado.api.types.vectors.Int3;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public class NativeInt4 implements PrimitiveStorage<IntBuffer> {
+public final class NativeInt4 implements TornadoNativeCollectionsInterface<IntBuffer> {
     public static final Class<NativeInt4> TYPE = NativeInt4.class;
 
     private static final String NUMBER_FORMAT = "{ x=%-7d, y=%-7d, z=%-7d, w=%-7d }";

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeInt8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeInt8.java
@@ -47,13 +47,12 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.vectors.Int4;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.IntOps;
+import uk.ac.manchester.tornado.api.types.vectors.Int4;
 
 @Vector
-public class NativeInt8 implements PrimitiveStorage<IntBuffer> {
+public final class NativeInt8 implements TornadoNativeCollectionsInterface<IntBuffer> {
     public static final Class<NativeInt8> TYPE = NativeInt8.class;
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeShort2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeShort2.java
@@ -48,11 +48,10 @@ import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.ShortOps;
 
 @Vector
-public final class NativeShort2 implements PrimitiveStorage<ShortBuffer> {
+public final class NativeShort2 implements TornadoNativeCollectionsInterface<ShortBuffer> {
 
     public static final Class<NativeShort2> TYPE = NativeShort2.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeShort3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeShort3.java
@@ -47,10 +47,9 @@ import java.nio.ShortBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public final class NativeShort3 implements PrimitiveStorage<ShortBuffer> {
+public final class NativeShort3 implements TornadoNativeCollectionsInterface<ShortBuffer> {
 
     public static final Class<NativeShort3> TYPE = NativeShort3.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeVectorByte.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeVectorByte.java
@@ -48,7 +48,7 @@ import java.lang.foreign.MemorySegment;
 
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 
-public class NativeVectorByte extends TornadoNativeArray {
+public final class NativeVectorByte extends TornadoNativeArray {
     private final int BYTE_BYTES = 1;
     private MemorySegment segment;
     private int numberOfElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeVectorDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeVectorDouble.java
@@ -48,7 +48,7 @@ import java.lang.foreign.MemorySegment;
 
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 
-public class NativeVectorDouble extends TornadoNativeArray {
+public final class NativeVectorDouble extends TornadoNativeArray {
     private final int DOUBLE_BYTES = 8;
     private MemorySegment segment;
     private int numberOfElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeVectorFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeVectorFloat.java
@@ -48,7 +48,7 @@ import java.lang.foreign.MemorySegment;
 
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 
-public class NativeVectorFloat extends TornadoNativeArray {
+public final class NativeVectorFloat extends TornadoNativeArray {
     private final int FLOAT_BYTES = 4;
     private MemorySegment segment;
     private int numberOfElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeVectorInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/NativeVectorInt.java
@@ -48,7 +48,7 @@ import java.lang.foreign.MemorySegment;
 
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 
-public class NativeVectorInt extends TornadoNativeArray {
+public final class NativeVectorInt extends TornadoNativeArray {
     private final int INT_BYTES = 4;
     private int numberOfElements;
     private MemorySegment segment;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/TornadoNativeCollectionsInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/natives/TornadoNativeCollectionsInterface.java
@@ -41,64 +41,14 @@
  */
 package uk.ac.manchester.tornado.api.types.arrays.natives;
 
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import java.nio.Buffer;
 
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
+import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
-import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
-
-public final class NativeVectorShort extends TornadoNativeArray {
-    private final int SHORT_BYTES = 2;
-    private MemorySegment segment;
-    private int numberOfElements;
-    private long segmentByteSize;
-
-    public NativeVectorShort(int numberOfElements) {
-        this.numberOfElements = numberOfElements;
-        segmentByteSize = numberOfElements * SHORT_BYTES;
-
-        segment = Arena.ofAuto().allocate(segmentByteSize, 1);
-        segment.setAtIndex(JAVA_INT, 0, numberOfElements);
-    }
-
-    public void set(int index, short value) {
-        segment.setAtIndex(JAVA_SHORT, index, value);
-    }
-
-    public short get(int index) {
-        return segment.getAtIndex(JAVA_SHORT, index);
-    }
-
-    public void init(short value) {
-        for (int i = 0; i < getSize(); i++) {
-            segment.setAtIndex(JAVA_SHORT, i, value);
-        }
-    }
-
-    @Override
-    public int getSize() {
-        return numberOfElements;
-    }
-
-    @Override
-    public MemorySegment getSegment() {
-        return segment;
-    }
-
-    @Override
-    public long getNumBytesOfSegment() {
-        return segmentByteSize;
-    }
-
-    @Override
-    public long getNumBytesWithoutHeader() {
-        return segmentByteSize;
-    }
-
-    @Override
-    protected void clear() {
-        init((short) 0);
-    }
+public sealed interface TornadoNativeCollectionsInterface<T extends Buffer> //
+        extends PrimitiveStorage<T> //
+        permits NativeByte3, NativeByte4, //
+        NativeFloat2, NativeFloat3, NativeFloat4, NativeFloat8, //
+        NativeInt2, NativeInt3, NativeInt4, NativeInt8, //
+        NativeShort2, NativeShort3 {
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/TornadoCollectionInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/TornadoCollectionInterface.java
@@ -39,66 +39,15 @@
  * exception statement from your version.
  *
  */
-package uk.ac.manchester.tornado.api.types.arrays.natives;
+package uk.ac.manchester.tornado.api.types.collections;
 
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import java.nio.Buffer;
 
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
+import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
-import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
-
-public final class NativeVectorShort extends TornadoNativeArray {
-    private final int SHORT_BYTES = 2;
-    private MemorySegment segment;
-    private int numberOfElements;
-    private long segmentByteSize;
-
-    public NativeVectorShort(int numberOfElements) {
-        this.numberOfElements = numberOfElements;
-        segmentByteSize = numberOfElements * SHORT_BYTES;
-
-        segment = Arena.ofAuto().allocate(segmentByteSize, 1);
-        segment.setAtIndex(JAVA_INT, 0, numberOfElements);
-    }
-
-    public void set(int index, short value) {
-        segment.setAtIndex(JAVA_SHORT, index, value);
-    }
-
-    public short get(int index) {
-        return segment.getAtIndex(JAVA_SHORT, index);
-    }
-
-    public void init(short value) {
-        for (int i = 0; i < getSize(); i++) {
-            segment.setAtIndex(JAVA_SHORT, i, value);
-        }
-    }
-
-    @Override
-    public int getSize() {
-        return numberOfElements;
-    }
-
-    @Override
-    public MemorySegment getSegment() {
-        return segment;
-    }
-
-    @Override
-    public long getNumBytesOfSegment() {
-        return segmentByteSize;
-    }
-
-    @Override
-    public long getNumBytesWithoutHeader() {
-        return segmentByteSize;
-    }
-
-    @Override
-    protected void clear() {
-        init((short) 0);
-    }
+public sealed interface TornadoCollectionInterface<T extends Buffer> //
+        extends PrimitiveStorage<T>  //
+        permits VectorDouble, VectorDouble2, VectorDouble3, VectorDouble4, VectorDouble8, //
+        VectorFloat, VectorFloat2, VectorFloat3, VectorFloat4, VectorFloat8, //
+        VectorInt, VectorInt2, VectorInt3, VectorInt4, VectorInt8 {
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble.java
@@ -45,10 +45,9 @@ import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 
-public class VectorDouble implements PrimitiveStorage<DoubleBuffer> {
+public final class VectorDouble implements TornadoCollectionInterface<DoubleBuffer> {
 
     private static final int ELEMENT_SIZE = 1;
     private final int numElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble2.java
@@ -43,10 +43,9 @@ import static uk.ac.manchester.tornado.api.types.vectors.Double2.add;
 import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Double2;
 
-public class VectorDouble2 implements PrimitiveStorage<DoubleBuffer> {
+public final class VectorDouble2 implements TornadoCollectionInterface<DoubleBuffer> {
 
     public static final Class<VectorDouble2> TYPE = VectorDouble2.class;
     private static final int ELEMENT_SIZE = 2;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble3.java
@@ -43,10 +43,9 @@ import static uk.ac.manchester.tornado.api.types.vectors.Double3.add;
 import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Double3;
 
-public class VectorDouble3 implements PrimitiveStorage<DoubleBuffer> {
+public final class VectorDouble3 implements TornadoCollectionInterface<DoubleBuffer> {
 
     public static final Class<VectorDouble3> TYPE = VectorDouble3.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble4.java
@@ -43,10 +43,9 @@ import static uk.ac.manchester.tornado.api.types.vectors.Double4.add;
 import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Double4;
 
-public class VectorDouble4 implements PrimitiveStorage<DoubleBuffer> {
+public final class VectorDouble4 implements TornadoCollectionInterface<DoubleBuffer> {
 
     public static final Class<VectorDouble4> TYPE = VectorDouble4.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble8.java
@@ -43,10 +43,9 @@ import static uk.ac.manchester.tornado.api.types.vectors.Double8.add;
 import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Double8;
 
-public class VectorDouble8 implements PrimitiveStorage<DoubleBuffer> {
+public final class VectorDouble8 implements TornadoCollectionInterface<DoubleBuffer> {
 
     public static final Class<VectorDouble8> TYPE = VectorDouble8.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat.java
@@ -45,10 +45,9 @@ import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 
-public class VectorFloat implements PrimitiveStorage<FloatBuffer> {
+public final class VectorFloat implements TornadoCollectionInterface<FloatBuffer> {
 
     private static final int ELEMENT_SIZE = 1;
     private final int numElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat2.java
@@ -43,10 +43,9 @@ import static uk.ac.manchester.tornado.api.types.vectors.Float2.add;
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Float2;
 
-public class VectorFloat2 implements PrimitiveStorage<FloatBuffer> {
+public final class VectorFloat2 implements TornadoCollectionInterface<FloatBuffer> {
 
     public static final Class<VectorFloat2> TYPE = VectorFloat2.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat3.java
@@ -44,10 +44,9 @@ package uk.ac.manchester.tornado.api.types.collections;
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Float3;
 
-public class VectorFloat3 implements PrimitiveStorage<FloatBuffer> {
+public final class VectorFloat3 implements TornadoCollectionInterface<FloatBuffer> {
 
     public static final Class<VectorFloat3> TYPE = VectorFloat3.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat4.java
@@ -44,10 +44,9 @@ package uk.ac.manchester.tornado.api.types.collections;
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
-public class VectorFloat4 implements PrimitiveStorage<FloatBuffer> {
+public final class VectorFloat4 implements TornadoCollectionInterface<FloatBuffer> {
 
     public static final Class<VectorFloat4> TYPE = VectorFloat4.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat8.java
@@ -46,10 +46,9 @@ import static uk.ac.manchester.tornado.api.types.vectors.Float8.add;
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Float8;
 
-public class VectorFloat8 implements PrimitiveStorage<FloatBuffer> {
+public final class VectorFloat8 implements TornadoCollectionInterface<FloatBuffer> {
 
     public static final Class<VectorFloat8> TYPE = VectorFloat8.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt.java
@@ -45,10 +45,9 @@ import java.nio.IntBuffer;
 
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.IntOps;
 
-public class VectorInt implements PrimitiveStorage<IntBuffer> {
+public final class VectorInt implements TornadoCollectionInterface<IntBuffer> {
 
     private static final int ELEMENT_SIZE = 1;
     private final int numElements;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt2.java
@@ -43,10 +43,9 @@ import static uk.ac.manchester.tornado.api.types.vectors.Int2.add;
 import java.nio.IntBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Int2;
 
-public class VectorInt2 implements PrimitiveStorage<IntBuffer> {
+public final class VectorInt2 implements TornadoCollectionInterface<IntBuffer> {
 
     public static final Class<VectorInt2> TYPE = VectorInt2.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt3.java
@@ -43,10 +43,9 @@ import static uk.ac.manchester.tornado.api.types.vectors.Int3.add;
 import java.nio.IntBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Int3;
 
-public class VectorInt3 implements PrimitiveStorage<IntBuffer> {
+public final class VectorInt3 implements TornadoCollectionInterface<IntBuffer> {
 
     public static final Class<VectorInt3> TYPE = VectorInt3.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt4.java
@@ -43,10 +43,9 @@ import static uk.ac.manchester.tornado.api.types.vectors.Int4.add;
 import java.nio.IntBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Int4;
 
-public class VectorInt4 implements PrimitiveStorage<IntBuffer> {
+public final class VectorInt4 implements TornadoCollectionInterface<IntBuffer> {
 
     public static final Class<VectorInt4> TYPE = VectorInt4.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt8.java
@@ -43,10 +43,9 @@ import static uk.ac.manchester.tornado.api.types.vectors.Int8.add;
 import java.nio.IntBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Int8;
 
-public class VectorInt8 implements PrimitiveStorage<IntBuffer> {
+public final class VectorInt8 implements TornadoCollectionInterface<IntBuffer> {
 
     public static final Class<VectorInt8> TYPE = VectorInt8.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/common/PrimitiveStorage.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/common/PrimitiveStorage.java
@@ -44,7 +44,20 @@ package uk.ac.manchester.tornado.api.types.common;
 import java.io.Serializable;
 import java.nio.Buffer;
 
-public interface PrimitiveStorage<T extends Buffer> extends Serializable {
+import uk.ac.manchester.tornado.api.types.arrays.natives.TornadoNativeCollectionsInterface;
+import uk.ac.manchester.tornado.api.types.collections.TornadoCollectionInterface;
+import uk.ac.manchester.tornado.api.types.images.TornadoImagesInterface;
+import uk.ac.manchester.tornado.api.types.matrix.TornadoMatrixInterface;
+import uk.ac.manchester.tornado.api.types.vectors.TornadoVectorsInterface;
+import uk.ac.manchester.tornado.api.types.volumes.TornadoVolumesInterface;
+
+public sealed interface PrimitiveStorage<T extends Buffer> extends Serializable //
+        permits TornadoNativeCollectionsInterface, //
+        TornadoCollectionInterface, //
+        TornadoImagesInterface, //
+        TornadoMatrixInterface, //
+        TornadoVectorsInterface, //
+        TornadoVolumesInterface {
 
     void loadFromBuffer(T buffer);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte3.java
@@ -44,12 +44,11 @@ package uk.ac.manchester.tornado.api.types.images;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.ByteOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 import uk.ac.manchester.tornado.api.types.vectors.Byte3;
 
-public class ImageByte3 implements PrimitiveStorage<ByteBuffer> {
+public final class ImageByte3 implements TornadoImagesInterface<ByteBuffer> {
 
     public static final Class<ImageByte3> TYPE = ImageByte3.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte4.java
@@ -44,13 +44,12 @@ package uk.ac.manchester.tornado.api.types.images;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.ByteOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 import uk.ac.manchester.tornado.api.types.vectors.Byte4;
 import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
-public class ImageByte4 implements PrimitiveStorage<ByteBuffer> {
+public final class ImageByte4 implements TornadoImagesInterface<ByteBuffer> {
 
     public static final Class<ImageByte4> TYPE = ImageByte4.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat.java
@@ -46,12 +46,11 @@ import java.nio.FloatBuffer;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.api.types.utils.FloatingPointError;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 
-public class ImageFloat implements PrimitiveStorage<FloatBuffer> {
+public final class ImageFloat implements TornadoImagesInterface<FloatBuffer> {
 
     /**
      * backing array.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat3.java
@@ -44,12 +44,11 @@ package uk.ac.manchester.tornado.api.types.images;
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.api.types.utils.FloatingPointError;
 import uk.ac.manchester.tornado.api.types.vectors.Float3;
 
-public class ImageFloat3 implements PrimitiveStorage<FloatBuffer> {
+public final class ImageFloat3 implements TornadoImagesInterface<FloatBuffer> {
 
     public static final Class<ImageFloat3> TYPE = ImageFloat3.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat4.java
@@ -44,12 +44,11 @@ package uk.ac.manchester.tornado.api.types.images;
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
-public class ImageFloat4 implements PrimitiveStorage<FloatBuffer> {
+public final class ImageFloat4 implements TornadoImagesInterface<FloatBuffer> {
 
     public static final Class<ImageFloat4> TYPE = ImageFloat4.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat8.java
@@ -44,12 +44,11 @@ package uk.ac.manchester.tornado.api.types.images;
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.api.types.utils.FloatingPointError;
 import uk.ac.manchester.tornado.api.types.vectors.Float8;
 
-public class ImageFloat8 implements PrimitiveStorage<FloatBuffer> {
+public final class ImageFloat8 implements TornadoImagesInterface<FloatBuffer> {
 
     public static final Class<ImageFloat8> TYPE = ImageFloat8.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/TornadoImagesInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/TornadoImagesInterface.java
@@ -39,66 +39,12 @@
  * exception statement from your version.
  *
  */
-package uk.ac.manchester.tornado.api.types.arrays.natives;
+package uk.ac.manchester.tornado.api.types.images;
 
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import java.nio.Buffer;
 
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
+import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
-import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
-
-public final class NativeVectorShort extends TornadoNativeArray {
-    private final int SHORT_BYTES = 2;
-    private MemorySegment segment;
-    private int numberOfElements;
-    private long segmentByteSize;
-
-    public NativeVectorShort(int numberOfElements) {
-        this.numberOfElements = numberOfElements;
-        segmentByteSize = numberOfElements * SHORT_BYTES;
-
-        segment = Arena.ofAuto().allocate(segmentByteSize, 1);
-        segment.setAtIndex(JAVA_INT, 0, numberOfElements);
-    }
-
-    public void set(int index, short value) {
-        segment.setAtIndex(JAVA_SHORT, index, value);
-    }
-
-    public short get(int index) {
-        return segment.getAtIndex(JAVA_SHORT, index);
-    }
-
-    public void init(short value) {
-        for (int i = 0; i < getSize(); i++) {
-            segment.setAtIndex(JAVA_SHORT, i, value);
-        }
-    }
-
-    @Override
-    public int getSize() {
-        return numberOfElements;
-    }
-
-    @Override
-    public MemorySegment getSegment() {
-        return segment;
-    }
-
-    @Override
-    public long getNumBytesOfSegment() {
-        return segmentByteSize;
-    }
-
-    @Override
-    public long getNumBytesWithoutHeader() {
-        return segmentByteSize;
-    }
-
-    @Override
-    protected void clear() {
-        init((short) 0);
-    }
+public sealed interface TornadoImagesInterface<T extends Buffer> //
+        extends PrimitiveStorage<T> permits ImageByte3, ImageByte4, ImageFloat, ImageFloat3, ImageFloat4, ImageFloat8 {
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DDouble.java
@@ -47,11 +47,10 @@ import java.nio.DoubleBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.collections.VectorDouble;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 
-public class Matrix2DDouble extends Matrix2DType implements PrimitiveStorage<DoubleBuffer> {
+public final class Matrix2DDouble extends Matrix2DType implements TornadoMatrixInterface<DoubleBuffer> {
     /**
      * backing array.
      */

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat.java
@@ -48,10 +48,9 @@ import static uk.ac.manchester.tornado.api.types.utils.StorageFormats.toRowMajor
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
 
-public class Matrix2DFloat extends Matrix2DType implements PrimitiveStorage<FloatBuffer> {
+public final class Matrix2DFloat extends Matrix2DType implements TornadoMatrixInterface<FloatBuffer> {
 
     /**
      * backing array.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat4.java
@@ -46,12 +46,11 @@ import java.nio.FloatBuffer;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
-public class Matrix2DFloat4 extends Matrix2DType implements PrimitiveStorage<FloatBuffer> {
+public final class Matrix2DFloat4 extends Matrix2DType implements TornadoMatrixInterface<FloatBuffer> {
 
     public static final Class<Matrix2DFloat4> TYPE = Matrix2DFloat4.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DInt.java
@@ -47,11 +47,10 @@ import java.nio.IntBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.collections.VectorInt;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.IntOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 
-public class Matrix2DInt extends Matrix2DType implements PrimitiveStorage<IntBuffer> {
+public final class Matrix2DInt extends Matrix2DType implements TornadoMatrixInterface<IntBuffer> {
     /**
      * backing array.
      */

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DFloat.java
@@ -44,11 +44,10 @@ package uk.ac.manchester.tornado.api.types.matrix;
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 
-public class Matrix3DFloat extends Matrix3DType implements PrimitiveStorage<FloatBuffer> {
+public final class Matrix3DFloat extends Matrix3DType implements TornadoMatrixInterface<FloatBuffer> {
 
     /**
      * backing array.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DFloat4.java
@@ -44,12 +44,11 @@ package uk.ac.manchester.tornado.api.types.matrix;
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
-public class Matrix3DFloat4 extends Matrix3DType implements PrimitiveStorage<FloatBuffer> {
+public final class Matrix3DFloat4 extends Matrix3DType implements TornadoMatrixInterface<FloatBuffer> {
 
     public static final Class<Matrix3DFloat4> TYPE = Matrix3DFloat4.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix4x4Float.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix4x4Float.java
@@ -44,12 +44,11 @@ package uk.ac.manchester.tornado.api.types.matrix;
 import java.nio.FloatBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.api.types.utils.FloatingPointError;
 import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
-public class Matrix4x4Float implements PrimitiveStorage<FloatBuffer> {
+public final class Matrix4x4Float implements TornadoMatrixInterface<FloatBuffer> {
 
     public static final Class<Matrix4x4Float> TYPE = Matrix4x4Float.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/NativeDouble2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/NativeDouble2.java
@@ -44,17 +44,16 @@ package uk.ac.manchester.tornado.api.types.matrix;
 import java.lang.foreign.ValueLayout;
 import java.nio.DoubleBuffer;
 
-import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorDouble;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.vectors.Double2;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
+import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorDouble;
 import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
+import uk.ac.manchester.tornado.api.types.vectors.Double2;
 
 @Vector
-public class NativeDouble2 implements PrimitiveStorage<DoubleBuffer> {
+public final class NativeDouble2 implements TornadoMatrixInterface<DoubleBuffer> {
 
     public static final Class<NativeDouble2> TYPE = NativeDouble2.class;
     public static final Class<NativeVectorDouble> FIELD_CLASS = NativeVectorDouble.class;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/NativeDouble3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/NativeDouble3.java
@@ -44,18 +44,17 @@ package uk.ac.manchester.tornado.api.types.matrix;
 import java.lang.foreign.ValueLayout;
 import java.nio.DoubleBuffer;
 
-import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorDouble;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorDouble;
+import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 import uk.ac.manchester.tornado.api.types.vectors.Double2;
 import uk.ac.manchester.tornado.api.types.vectors.Double3;
-import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
-import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 
 @Vector
-public class NativeDouble3 implements PrimitiveStorage<DoubleBuffer> {
+public final class NativeDouble3 implements TornadoMatrixInterface<DoubleBuffer> {
 
     public static final Class<NativeDouble3> TYPE = NativeDouble3.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/NativeDouble4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/NativeDouble4.java
@@ -44,19 +44,18 @@ package uk.ac.manchester.tornado.api.types.matrix;
 import java.lang.foreign.ValueLayout;
 import java.nio.DoubleBuffer;
 
-import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorDouble;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorDouble;
+import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 import uk.ac.manchester.tornado.api.types.vectors.Double2;
 import uk.ac.manchester.tornado.api.types.vectors.Double3;
 import uk.ac.manchester.tornado.api.types.vectors.Double4;
-import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
-import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 
 @Vector
-public class NativeDouble4 implements PrimitiveStorage<DoubleBuffer> {
+public final class NativeDouble4 implements TornadoMatrixInterface<DoubleBuffer> {
 
     public static final Class<NativeDouble4> TYPE = NativeDouble4.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/NativeDouble8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/NativeDouble8.java
@@ -44,18 +44,17 @@ package uk.ac.manchester.tornado.api.types.matrix;
 import java.lang.foreign.ValueLayout;
 import java.nio.DoubleBuffer;
 
-import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorDouble;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorDouble;
+import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 import uk.ac.manchester.tornado.api.types.vectors.Double4;
 import uk.ac.manchester.tornado.api.types.vectors.Double8;
-import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
-import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 
 @Vector
-public class NativeDouble8 implements PrimitiveStorage<DoubleBuffer> {
+public final class NativeDouble8 implements TornadoMatrixInterface<DoubleBuffer> {
 
     public static final Class<NativeDouble8> TYPE = NativeDouble8.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/TornadoMatrixInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/TornadoMatrixInterface.java
@@ -39,66 +39,14 @@
  * exception statement from your version.
  *
  */
-package uk.ac.manchester.tornado.api.types.arrays.natives;
+package uk.ac.manchester.tornado.api.types.matrix;
 
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import java.nio.Buffer;
 
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
+import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
-import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
-
-public final class NativeVectorShort extends TornadoNativeArray {
-    private final int SHORT_BYTES = 2;
-    private MemorySegment segment;
-    private int numberOfElements;
-    private long segmentByteSize;
-
-    public NativeVectorShort(int numberOfElements) {
-        this.numberOfElements = numberOfElements;
-        segmentByteSize = numberOfElements * SHORT_BYTES;
-
-        segment = Arena.ofAuto().allocate(segmentByteSize, 1);
-        segment.setAtIndex(JAVA_INT, 0, numberOfElements);
-    }
-
-    public void set(int index, short value) {
-        segment.setAtIndex(JAVA_SHORT, index, value);
-    }
-
-    public short get(int index) {
-        return segment.getAtIndex(JAVA_SHORT, index);
-    }
-
-    public void init(short value) {
-        for (int i = 0; i < getSize(); i++) {
-            segment.setAtIndex(JAVA_SHORT, i, value);
-        }
-    }
-
-    @Override
-    public int getSize() {
-        return numberOfElements;
-    }
-
-    @Override
-    public MemorySegment getSegment() {
-        return segment;
-    }
-
-    @Override
-    public long getNumBytesOfSegment() {
-        return segmentByteSize;
-    }
-
-    @Override
-    public long getNumBytesWithoutHeader() {
-        return segmentByteSize;
-    }
-
-    @Override
-    protected void clear() {
-        init((short) 0);
-    }
+public sealed interface TornadoMatrixInterface<T extends Buffer> extends PrimitiveStorage<T> //
+        permits Matrix2DDouble, Matrix2DFloat, Matrix2DFloat4, Matrix2DInt, //
+        Matrix3DFloat, Matrix3DFloat4, Matrix4x4Float, NativeDouble2, //
+        NativeDouble3, NativeDouble4, NativeDouble8 {
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Byte3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Byte3.java
@@ -46,10 +46,9 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public final class Byte3 implements PrimitiveStorage<ByteBuffer> {
+public final class Byte3 implements TornadoVectorsInterface<ByteBuffer> {
 
     public static final Class<Byte3> TYPE = Byte3.class;
     private static final String NUMBER_FORMAT = "{ x=%-7d, y=%-7d, z=%-7d }";

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Byte4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Byte4.java
@@ -46,10 +46,9 @@ import java.nio.ByteBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public final class Byte4 implements PrimitiveStorage<ByteBuffer> {
+public final class Byte4 implements TornadoVectorsInterface<ByteBuffer> {
 
     public static final Class<Byte4> TYPE = Byte4.class;
     private static final String NUMBER_FORMAT = "{ x=%-7d, y=%-7d, z=%-7d, w=%-7d }";

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double2.java
@@ -46,11 +46,10 @@ import java.nio.DoubleBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 
 @Vector
-public final class Double2 implements PrimitiveStorage<DoubleBuffer> {
+public final class Double2 implements TornadoVectorsInterface<DoubleBuffer> {
 
     public static final Class<Double2> TYPE = Double2.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double3.java
@@ -46,11 +46,10 @@ import java.nio.DoubleBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 
 @Vector
-public final class Double3 implements PrimitiveStorage<DoubleBuffer> {
+public final class Double3 implements TornadoVectorsInterface<DoubleBuffer> {
 
     public static final Class<Double3> TYPE = Double3.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double4.java
@@ -47,11 +47,10 @@ import java.util.Arrays;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 
 @Vector
-public final class Double4 implements PrimitiveStorage<DoubleBuffer> {
+public final class Double4 implements TornadoVectorsInterface<DoubleBuffer> {
 
     public static final Class<Double4> TYPE = Double4.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double8.java
@@ -46,11 +46,10 @@ import java.nio.DoubleBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 
 @Vector
-public final class Double8 implements PrimitiveStorage<DoubleBuffer> {
+public final class Double8 implements TornadoVectorsInterface<DoubleBuffer> {
 
     public static final Class<Double8> TYPE = Double8.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float2.java
@@ -46,11 +46,10 @@ import java.nio.FloatBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 
 @Vector
-public final class Float2 implements PrimitiveStorage<FloatBuffer> {
+public final class Float2 implements TornadoVectorsInterface<FloatBuffer> {
 
     public static final Class<Float2> TYPE = Float2.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float3.java
@@ -46,11 +46,10 @@ import java.nio.FloatBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 
 @Vector
-public final class Float3 implements PrimitiveStorage<FloatBuffer> {
+public final class Float3 implements TornadoVectorsInterface<FloatBuffer> {
 
     public static final Class<Float3> TYPE = Float3.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float4.java
@@ -47,11 +47,10 @@ import java.util.Arrays;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 
 @Vector
-public final class Float4 implements PrimitiveStorage<FloatBuffer> {
+public final class Float4 implements TornadoVectorsInterface<FloatBuffer> {
 
     public static final Class<Float4> TYPE = Float4.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float8.java
@@ -46,11 +46,10 @@ import java.nio.FloatBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 
 @Vector
-public final class Float8 implements PrimitiveStorage<FloatBuffer> {
+public final class Float8 implements TornadoVectorsInterface<FloatBuffer> {
 
     public static final Class<Float8> TYPE = Float8.class;
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int2.java
@@ -47,10 +47,9 @@ import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.natives.NativeVectorInt;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public final class Int2 implements PrimitiveStorage<IntBuffer> {
+public final class Int2 implements TornadoVectorsInterface<IntBuffer> {
 
     public static final Class<Int2> TYPE = Int2.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int3.java
@@ -46,10 +46,9 @@ import java.nio.IntBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public final class Int3 implements PrimitiveStorage<IntBuffer> {
+public final class Int3 implements TornadoVectorsInterface<IntBuffer> {
 
     public static final Class<Int3> TYPE = Int3.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int4.java
@@ -46,10 +46,9 @@ import java.nio.IntBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public final class Int4 implements PrimitiveStorage<IntBuffer> {
+public final class Int4 implements TornadoVectorsInterface<IntBuffer> {
 
     public static final Class<Int4> TYPE = Int4.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int8.java
@@ -47,11 +47,10 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.IntOps;
 
 @Vector
-public final class Int8 implements PrimitiveStorage<IntBuffer> {
+public final class Int8 implements TornadoVectorsInterface<IntBuffer> {
 
     public static final Class<Int8> TYPE = Int8.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Short2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Short2.java
@@ -46,11 +46,10 @@ import java.nio.ShortBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.utils.ShortOps;
 
 @Vector
-public final class Short2 implements PrimitiveStorage<ShortBuffer> {
+public final class Short2 implements TornadoVectorsInterface<ShortBuffer> {
 
     public static final Class<Short2> TYPE = Short2.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Short3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Short3.java
@@ -46,10 +46,9 @@ import java.nio.ShortBuffer;
 import uk.ac.manchester.tornado.api.internal.annotations.Payload;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 @Vector
-public final class Short3 implements PrimitiveStorage<ShortBuffer> {
+public final class Short3 implements TornadoVectorsInterface<ShortBuffer> {
 
     public static final Class<Short3> TYPE = Short3.class;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/TornadoVectorsInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/TornadoVectorsInterface.java
@@ -39,66 +39,17 @@
  * exception statement from your version.
  *
  */
-package uk.ac.manchester.tornado.api.types.arrays.natives;
+package uk.ac.manchester.tornado.api.types.vectors;
 
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import java.nio.Buffer;
 
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
+import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
-import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
-
-public final class NativeVectorShort extends TornadoNativeArray {
-    private final int SHORT_BYTES = 2;
-    private MemorySegment segment;
-    private int numberOfElements;
-    private long segmentByteSize;
-
-    public NativeVectorShort(int numberOfElements) {
-        this.numberOfElements = numberOfElements;
-        segmentByteSize = numberOfElements * SHORT_BYTES;
-
-        segment = Arena.ofAuto().allocate(segmentByteSize, 1);
-        segment.setAtIndex(JAVA_INT, 0, numberOfElements);
-    }
-
-    public void set(int index, short value) {
-        segment.setAtIndex(JAVA_SHORT, index, value);
-    }
-
-    public short get(int index) {
-        return segment.getAtIndex(JAVA_SHORT, index);
-    }
-
-    public void init(short value) {
-        for (int i = 0; i < getSize(); i++) {
-            segment.setAtIndex(JAVA_SHORT, i, value);
-        }
-    }
-
-    @Override
-    public int getSize() {
-        return numberOfElements;
-    }
-
-    @Override
-    public MemorySegment getSegment() {
-        return segment;
-    }
-
-    @Override
-    public long getNumBytesOfSegment() {
-        return segmentByteSize;
-    }
-
-    @Override
-    public long getNumBytesWithoutHeader() {
-        return segmentByteSize;
-    }
-
-    @Override
-    protected void clear() {
-        init((short) 0);
-    }
+public sealed interface TornadoVectorsInterface<T extends Buffer> //
+        extends PrimitiveStorage<T> //
+        permits Byte3, Byte4, //
+        Double2, Double3, Double4, Double8, //
+        Float2, Float3, Float4, Float8, //
+        Int2, Int3, Int4, Int8, //
+        Short2, Short3 {
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/volumes/TornadoVolumesInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/volumes/TornadoVolumesInterface.java
@@ -39,66 +39,12 @@
  * exception statement from your version.
  *
  */
-package uk.ac.manchester.tornado.api.types.arrays.natives;
+package uk.ac.manchester.tornado.api.types.volumes;
 
-import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_SHORT;
+import java.nio.Buffer;
 
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemorySegment;
+import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
-import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
-
-public final class NativeVectorShort extends TornadoNativeArray {
-    private final int SHORT_BYTES = 2;
-    private MemorySegment segment;
-    private int numberOfElements;
-    private long segmentByteSize;
-
-    public NativeVectorShort(int numberOfElements) {
-        this.numberOfElements = numberOfElements;
-        segmentByteSize = numberOfElements * SHORT_BYTES;
-
-        segment = Arena.ofAuto().allocate(segmentByteSize, 1);
-        segment.setAtIndex(JAVA_INT, 0, numberOfElements);
-    }
-
-    public void set(int index, short value) {
-        segment.setAtIndex(JAVA_SHORT, index, value);
-    }
-
-    public short get(int index) {
-        return segment.getAtIndex(JAVA_SHORT, index);
-    }
-
-    public void init(short value) {
-        for (int i = 0; i < getSize(); i++) {
-            segment.setAtIndex(JAVA_SHORT, i, value);
-        }
-    }
-
-    @Override
-    public int getSize() {
-        return numberOfElements;
-    }
-
-    @Override
-    public MemorySegment getSegment() {
-        return segment;
-    }
-
-    @Override
-    public long getNumBytesOfSegment() {
-        return segmentByteSize;
-    }
-
-    @Override
-    public long getNumBytesWithoutHeader() {
-        return segmentByteSize;
-    }
-
-    @Override
-    protected void clear() {
-        init((short) 0);
-    }
+public sealed interface TornadoVolumesInterface<T extends Buffer> //
+        extends PrimitiveStorage<T> permits VolumeShort2 {
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/volumes/VolumeShort2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/volumes/VolumeShort2.java
@@ -44,10 +44,9 @@ package uk.ac.manchester.tornado.api.types.volumes;
 import java.nio.ShortBuffer;
 
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
-import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.api.types.vectors.Short2;
 
-public class VolumeShort2 implements PrimitiveStorage<ShortBuffer> {
+public final class VolumeShort2 implements TornadoVolumesInterface<ShortBuffer> {
 
     public static final Class<VolumeShort2> TYPE = VolumeShort2.class;
 


### PR DESCRIPTION
#### Description

Expanding on the suggestion of @SirYwell (a TornadoVM committer), this PR adds sealed classes for the main collections and types interfaces of TornadoVM.
This has a few benefits:
- Since main classes./interfaces are sealed, developers cannot create custom data types outside of the control of the TornadoVM JIT compiler and the runtime. 
- It simplifies internal checks (runtime) 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

This PR updates the design of the APIs. It does not change behaviour. To check everything runs as expected:

```bash
// OpenCL Backend
$ make 
$ make tests

// SPIR-V Backend
$ make BACKEND=spirv
$ make tests

// PTX Backend
$ make BACKEND=ptx
$ make tests
```