### PR TITLE
[fix] Fix codegen to not generate wrong close curly bracket 

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
@@ -514,7 +514,7 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
             closeIfBlock(block, dom);
         } else if (isSwitchBlockNode(block)) {
             closeSwitchBlock(block, dom);
-        } else if (isNestedIfNode(block) && (!isStartNode(block))) {
+        } else if (isNestedIfNode(block) && (!isStartNode(block) && (!isMergeBlock(block)))) {
             closeBlock(block);
         } else if (isReturnBranchWithMerge(dom, block)) {
             closeBlock(block);


### PR DESCRIPTION
#### Description

This PR provides a fix for a corner case that was showcased in the Discussion thread #292. 

#### Problem description

The issue identified was that, for a method that does not have the `@Parallel` annotation in the indexing of the for-loops, and which has nested if-statements, an extra close curly bracket was generated incorrectly. With this PR, the code generation is fixed to only generate a close curly bracket in a nested if-statement block if it is not a merge block. 

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

