### PR TITLE
[fix][install] Python module deps fixed. SPIR-V installer improved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ BACKENDS := --backends $(BACKEND)
 build jdk21:
 	bin/compile --jdk jdk21 $(BACKENDS)
 
+rebuild-deps-jdk21:
+	bin/compile --jdk jdk21 --rebuild $(BACKENDS)
+
 graal-jdk-21:
 	bin/compile --jdk graal-jdk-21 $(BACKENDS)
 
@@ -19,9 +22,6 @@ ptx:
 
 spirv:
 	bin/compile --jdk jdk21 --backends spirv,ptx,opencl
-
-offline:
-	bin/compile --jdk jdk21 $(BACKENDS) --offline
 
 # Variable passed for the preparation of the Xilinx FPGA emulated target device. The default device is `xilinx_u50_gen3x16_xdma_201920_3`.
 # make xilinx_emulation FPGA_PLATFORM=<platform_name> NUM_OF_FPGA_DEVICES=<number_of_devices>

--- a/bin/compile
+++ b/bin/compile
@@ -131,7 +131,7 @@ def clone_opencl_headers():
         os.chdir(current)
         shutil.rmtree(tmpDirectory)
 
-def build_levelzero_jni_lib():
+def build_levelzero_jni_lib(rebuild=False):
     """
     Pulls and Builds the Level Zero JNI library
     """
@@ -146,27 +146,32 @@ def build_levelzero_jni_lib():
                 "https://github.com/beehive-lab/levelzero-jni",
             ],
         )
+        rebuild=True
 
-    os.chdir(levelzeroLib)
+    if (rebuild):
+        os.chdir(levelzeroLib)
 
-    ## Always pull for the latest changes
-    subprocess.run(["git", "pull", "origin", "master"])
-    subprocess.run(["mvn", "clean", "install"])
+        ## Always pull for the latest changes
+        subprocess.run(["git", "pull", "origin", "master"])
+        subprocess.run(["mvn", "clean", "install"])
 
-    ## Build native library
-    os.chdir("levelZeroLib")
-    levelzero_build_directory_cpp = "build"
-    if not os.path.exists(levelzero_build_directory_cpp):
-        os.mkdir(levelzero_build_directory_cpp)
+        ## Build native library
+        os.chdir("levelZeroLib")
+        levelzero_build_directory_cpp = "build"
+        if not os.path.exists(levelzero_build_directory_cpp):
+            os.mkdir(levelzero_build_directory_cpp)
+            os.chdir(levelzero_build_directory_cpp)
+        else:
+            os.chdir(levelzero_build_directory_cpp)
+            subprocess.run(["make", "clean", ],)
 
-    os.chdir(levelzero_build_directory_cpp)
-    subprocess.run(["cmake", "..", ],)
-    subprocess.run(["make", "-j", "8"],)
+        subprocess.run(["cmake", "..", ],)
+        subprocess.run(["make", "-j", "8"],)
 
-    os.chdir(current)
+        os.chdir(current)
 
 
-def build_spirv_toolkit_and_level_zero():
+def build_spirv_toolkit_and_level_zero(rebuild=False):
     """
     Builds the SPIR-V Toolkit and Level Zero libraries.
     """
@@ -181,23 +186,25 @@ def build_spirv_toolkit_and_level_zero():
                 "https://github.com/beehive-lab/beehive-spirv-toolkit.git",
             ],
         )
+        rebuild = True
 
-    os.chdir(spirv_tool_kit)
-    subprocess.run(["git", "pull", "origin", "master"])
-    subprocess.run(["mvn", "clean", "package"])
-    subprocess.run(["mvn", "install"])
-    os.chdir(current)
-
-    level_zero_lib = "level-zero"
-
-    if not os.path.exists(level_zero_lib):
-        subprocess.run(["git", "clone", "https://github.com/oneapi-src/level-zero"])
-        os.chdir(level_zero_lib)
-        os.mkdir("build")
-        os.chdir("build")
-        subprocess.run(["cmake", ".."])
-        subprocess.run(["cmake", "--build", ".", "--config", "Release"])
+    if (rebuild):
+        os.chdir(spirv_tool_kit)
+        subprocess.run(["git", "pull", "origin", "master"])
+        subprocess.run(["mvn", "clean", "package"])
+        subprocess.run(["mvn", "install"])
         os.chdir(current)
+
+        level_zero_lib = "level-zero"
+
+        if not os.path.exists(level_zero_lib):
+            subprocess.run(["git", "clone", "https://github.com/oneapi-src/level-zero"])
+            os.chdir(level_zero_lib)
+            os.mkdir("build")
+            os.chdir("build")
+            subprocess.run(["cmake", ".."])
+            subprocess.run(["cmake", "--build", ".", "--config", "Release"])
+            os.chdir(current)
 
     os.environ["ZE_SHARED_LOADER"] = os.path.join(
         current, "level-zero/build/lib/libze_loader.so"
@@ -330,6 +337,13 @@ def parse_args():
         default=False,
         help="To enable interoperability with Truffle Programming Languages."
     )
+    parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        dest="rebuild",
+        default=False,
+        help="Enable pull and rebuild of the external dependencies."
+    )
 
     args = parser.parse_args()
     return args
@@ -351,11 +365,10 @@ def main():
 
     if "spirv" in args.backends:
         # 1) Build the SPIR-V Toolkit
-        build_spirv_toolkit_and_level_zero()
+        build_spirv_toolkit_and_level_zero(args.rebuild)
 
         # 2) Build the Level Zero JNI library
-        build_levelzero_jni_lib()
-
+        build_levelzero_jni_lib(args.rebuild)
 
     mvn_build_result = build_tornadovm(args, backend_profiles)
 

--- a/bin/compile
+++ b/bin/compile
@@ -233,7 +233,7 @@ def build_tornadovm(args, backend_profiles):
     Builds TornadoVM with the specified JDK and backend options.
 
     Args:
-        args (object): The arguments passed by the user. The JDK version as well as other options (e.g., offline (bool) and polyglot (bool) are used.
+        args (object): The arguments passed by the user. The JDK version as well as other options (e.g., if polyglot is used).
         backend_profiles (str): The processed backend options.
 
     Returns:
@@ -243,8 +243,6 @@ def build_tornadovm(args, backend_profiles):
         options = f"-T1.5C -Dcmake.root.dir=$CMAKE_ROOT -P{args.jdk},{backend_profiles},graalvm-polyglot "
     else:
         options = f"-T1.5C -Dcmake.root.dir=$CMAKE_ROOT -P{args.jdk},{backend_profiles} "
-    if args.offline:
-        options = "-o " + options
 
     print(f"mvn {options} install")
     try:
@@ -324,13 +322,6 @@ def parse_args():
         "--jdk", help="JDK version (e.g., jdk21, graal-jdk-21)"
     )
     parser.add_argument("--backends", help="e.g., opencl,ptx,spirv")
-    parser.add_argument(
-        "--offline",
-        action="store_true",
-        dest="offline",
-        default=False,
-        help="Optional flag: OFFLINE",
-    )
     parser.add_argument(
         "--polyglot",
         action="store_true",

--- a/bin/compile
+++ b/bin/compile
@@ -137,6 +137,7 @@ def build_levelzero_jni_lib(rebuild=False):
     """
     current = os.getcwd()
     levelzeroLib = "levelzero-jni"
+    build=False
     if not os.path.exists(levelzeroLib):
         ## clone only if directory does not exist
         subprocess.run(
@@ -146,9 +147,9 @@ def build_levelzero_jni_lib(rebuild=False):
                 "https://github.com/beehive-lab/levelzero-jni",
             ],
         )
-        rebuild=True
+        build=True
 
-    if (rebuild):
+    if (rebuild or build):
         os.chdir(levelzeroLib)
 
         ## Always pull for the latest changes
@@ -177,7 +178,7 @@ def build_spirv_toolkit_and_level_zero(rebuild=False):
     """
     current = os.getcwd()
     spirv_tool_kit = "beehive-spirv-toolkit"
-
+    build=True
     if not os.path.exists(spirv_tool_kit):
         subprocess.run(
             [
@@ -186,9 +187,9 @@ def build_spirv_toolkit_and_level_zero(rebuild=False):
                 "https://github.com/beehive-lab/beehive-spirv-toolkit.git",
             ],
         )
-        rebuild = True
+        build = True
 
-    if (rebuild):
+    if (rebuild or build):
         os.chdir(spirv_tool_kit)
         subprocess.run(["git", "pull", "origin", "master"])
         subprocess.run(["mvn", "clean", "package"])

--- a/bin/softwareDevDependencies.txt
+++ b/bin/softwareDevDependencies.txt
@@ -1,7 +1,7 @@
-Requests>=2.31.0
-tqdm>=4.66.1
-urllib3>=1.26.5
-wget>=3.2
-black>=22.1.0
-rstcheck>=6.2.0
-pre-commit>=3.4.0
+Requests
+tqdm
+urllib3
+wget
+black
+rstcheck
+pre-commit

--- a/bin/tornadoDepModules.txt
+++ b/bin/tornadoDepModules.txt
@@ -1,6 +1,6 @@
-Requests==2.31.0
-tqdm==4.66.1
-urllib3==1.26.5
-wget==3.2
-black==22.1.0
+Requests
+tqdm
+urllib3
+wget
+black
 sphinx_rtd_theme


### PR DESCRIPTION
#### Description

This PR improves the installation process for all backends and includes a cache compilation of all SPIR-V package/module dependencies. 
We do not need to pull and rebuild all SPIR-V dependencies with every TornadoVM build. 
We can force to rebuild the dependencies by running:

```bash
make rebuild-deps-jdk21 BACKEND=spirv
```

Otherwise, if the depdenceis are not present, it will only download and build the first time.
This speeds up the TornadoVM build process for SPIR-V. 

#### Problem description

Related issue #299 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
## remove the dependencies to trigger the automatic download and build
$ rm -Rf levelzero-jni/ level-zero/ spirv-beehive-toolkit/
$ make BACKEND=spirv
```

To force rebuild all dependencies:

```bash
$ make rebuild-deps-jdk21 BACKEND=spirv
```
