### PR TITLE
[install] Temurin binary configuration added

### DIFF
--- a/bin/installer_config.py
+++ b/bin/installer_config.py
@@ -33,6 +33,7 @@ __MANDREL21__ = "mandrel-jdk-21"
 __CORRETTO21__ = "corretto-jdk-21"
 __MICROSOFT20__ = "microsoft-jdk-20"
 __ZULU21__ = "zulu-jdk-21"
+__TEMURIN21__ = "temurin-jdk-21"
 
 ## cmake
 CMAKE = {
@@ -117,6 +118,16 @@ JDK = {
         __APPLE__: {
             __X86_64__: "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-macosx_x64.tar.gz",
             __ARM__: "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-macosx_aarch64.tar.gz",
+        },
+    },
+    __TEMURIN21__: {
+        __LINUX__: {
+            __X86_64__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz",
+            __ARM__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz",
+        },
+        __APPLE__: {
+            __X86_64__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz",
+            __ARM__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.1_12.tar.gz",
         },
     },
 }

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -31,7 +31,7 @@ import wget
 import installer_config as config
 
 __DIRECTORY_DEPENDENCIES__ = "etc/dependencies"
-__VERSION__ = "v0.16-dev"
+__VERSION__ = "v1.0.1-dev"
 
 __SUPPORTED_JDKS__ = [
     config.__JDK21__,
@@ -40,6 +40,7 @@ __SUPPORTED_JDKS__ = [
     config.__MICROSOFT20__,
     config.__MANDREL21__,
     config.__ZULU21__,
+    config.__TEMURIN21__,
 ]
 
 __SUPPORTED_BACKENDS__ = ["opencl", "spirv", "ptx"]
@@ -191,7 +192,15 @@ class TornadoInstaller:
         fullPath = self.workDirName + "/" + fileName
 
         if not os.path.exists(fullPath):
-            wget.download(url, fullPath)
+            try:
+                wget.download(url, fullPath)
+            except:
+                import urllib3
+                http = urllib3.PoolManager()
+                response = http.request('GET', url)
+                jdkImage = response.data
+                with open(fullPath, 'wb') as file:
+                    file.write(jdkImage)
 
         tar = tarfile.open(fullPath, "r:gz")
         extractedDirectory = self.getJDKDirectoryName(tar)
@@ -336,11 +345,12 @@ def listSupportedJDKs():
         """
     TornadoVM Installer - Select a JDK implementation to install with TornadoVM:
 
-    jdk21            : Install TornadoVM with OpenJDK 21 (Oracle OpenJDK)"
-    graalvm-jdk-21   : Install TornadoVM with GraalVM and JDK 21 (GraalVM 23.1.0)"
-    mandrel-jdk-21   : Install TornadoVM with Mandrel and JDK 21 (GraalVM 23.1.0)"
-    corretto-jdk-21  : Install TornadoVM with Corretto JDK 21"
-    zulu-jdk-21     : Install TornadoVM with Azul Zulu JDK 21"
+    jdk21            : Install TornadoVM with OpenJDK 21 (Oracle OpenJDK)
+    graalvm-jdk-21   : Install TornadoVM with GraalVM and JDK 21 (GraalVM 23.1.0)
+    mandrel-jdk-21   : Install TornadoVM with Mandrel and JDK 21 (GraalVM 23.1.0)
+    corretto-jdk-21  : Install TornadoVM with Corretto JDK 21
+    zulu-jdk-21      : Install TornadoVM with Azul Zulu JDK 21
+    temurin-jdk-21   : Install TornadoVM with Eclipse Temurin JDK 21
 
     Usage:
      $ ./bin/tornadovm-installer  --jdk <JDK_VERSION> --backend <BACKEND>


### PR DESCRIPTION
#### Description

This PR adds the Eclipse Temurin configuration as an option to install using the TornadoVM installer.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [X] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ ./bin/tornadovm-installer --jdk temurin-jdk-21 --backend=opencl
$ source setvars.sh
$ tornado -version
openjdk version "21.0.1" 2023-10-17 LTS
OpenJDK Runtime Environment Temurin-21.0.1+12 (build 21.0.1+12-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.1+12 (build 21.0.1+12-LTS, mixed mode)

$ make tests
```

I also tested the script on Mac OSx with Apple M2. 
