### PR TITLE
Enable Under Demand Data Transfers from Device to Host

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/DataConfig.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/DataConfig.java
@@ -1,0 +1,105 @@
+package uk.ac.manchester.tornado.api;
+
+import java.lang.foreign.ValueLayout;
+import java.lang.reflect.Array;
+
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
+
+public class DataConfig {
+
+    private long offset;
+
+    private long offsetMaterialized;
+    private long partialSize;
+
+    private long partialSizeMaterialized;
+
+    private ValueLayout layout;
+
+    private boolean isMaterialized;
+
+    private long totalSizeInBytes;
+
+    private int elementSize;
+
+    public DataConfig(Object object, ValueLayout layout) {
+        this.layout = layout;
+        computeElementSize();
+        computeTotalSizeOfObject(object);
+    }
+
+    private void computeElementSize() {
+        // layout is mandatory
+        elementSize = switch (layout) {
+            case ValueLayout.OfFloat _, ValueLayout.OfInt _ -> 4;
+            case ValueLayout.OfDouble _, ValueLayout.OfLong _ -> 8;
+            case ValueLayout.OfShort _, ValueLayout.OfChar _ -> 2;
+            case ValueLayout.OfByte _ -> 1;
+            case null, default -> throw new TornadoRuntimeException("[error] Data type not supported");
+        };
+    }
+
+    private void computeTotalSizeOfObject(Object object) {
+        if (object instanceof TornadoNativeArray array) {
+            totalSizeInBytes = array.getNumBytesWithoutHeader();
+        } else if (object.getClass().isArray()) {
+            totalSizeInBytes = (long) Array.getLength(object) * elementSize;
+        } else {
+            throw new TornadoRuntimeException("[error] Data type not supported");
+        }
+    }
+
+    public DataConfig withOffset(long offset) {
+        this.offset = offset;
+        return this;
+    }
+
+    public DataConfig withSize(long size) {
+        this.partialSize = size;
+        return this;
+    }
+
+    public long getOffset() {
+        if (isMaterialized) {
+            return this.offsetMaterialized;
+        } else {
+            throw new TornadoRuntimeException("[error] Invoke materialize() before any getter");
+        }
+    }
+
+    public long getPartialSize() {
+        if (isMaterialized) {
+            return this.partialSizeMaterialized;
+        } else {
+            throw new TornadoRuntimeException("[error] Invoke materialize() before any getter");
+        }
+    }
+
+    public ValueLayout getLayout() {
+        return this.layout;
+    }
+
+    /**
+     * Compute offset and size based on the information we have.
+     */
+    public void materialize() {
+        // compute offset and size based on the information we have
+
+        long arrayHeader = TornadoNativeArray.ARRAY_HEADER;
+        if (partialSize == 0) {
+            // copy from offset to the end of the array
+            partialSizeMaterialized = totalSizeInBytes;
+        } else {
+            partialSizeMaterialized = partialSize * elementSize;
+        }
+
+        if (offset == 0) {
+            // copy from the beginning
+            offsetMaterialized = arrayHeader;
+        } else {
+            offsetMaterialized = arrayHeader + (offset * elementSize);
+        }
+        isMaterialized = true;
+    }
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/DataRange.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/DataRange.java
@@ -1,10 +1,31 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package uk.ac.manchester.tornado.api;
-
-import java.lang.foreign.ValueLayout;
 
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 
+/**
+ * Data Range Class provides a set of utilities to perform partial copies between
+ * the accelerator (e.g., a GPU) and the CPU.
+ *
+ * @since 1.0.1
+ */
 public class DataRange {
 
     private final TornadoNativeArray tornadoNativeArray;
@@ -15,13 +36,11 @@ public class DataRange {
 
     private long partialSizeMaterialized;
 
-    private ValueLayout layout;
-
     private boolean isMaterialized;
 
-    private long totalSizeInBytes;
+    private final long totalSizeInBytes;
 
-    private int elementSize;
+    private final int elementSize;
 
     public DataRange(TornadoNativeArray tornadoNativeArray) {
         this.tornadoNativeArray = tornadoNativeArray;
@@ -53,10 +72,6 @@ public class DataRange {
         } else {
             throw new TornadoRuntimeException("[error] Invoke materialize() before any getter");
         }
-    }
-
-    public ValueLayout getLayout() {
-        return this.layout;
     }
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/DataRange.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/DataRange.java
@@ -94,6 +94,11 @@ public class DataRange {
         } else {
             offsetMaterialized = arrayHeader + (offset * elementSize);
         }
+
+        if ((partialSizeMaterialized + offsetMaterialized) > (totalSizeInBytes + arrayHeader)) {
+            throw new TornadoRuntimeException("[Error] Partial Copy size is larger than the array size. Check the value passed to the `withSize` method");
+        }
+
         isMaterialized = true;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -77,6 +77,10 @@ public class ImmutableTaskGraph {
         taskGraph.syncRuntimeTransferToHost(objects);
     }
 
+    void transferToHost(Object object, long offset, long partialCopySize) {
+        taskGraph.syncRuntimeTransferToHost(object, offset, partialCopySize);
+    }
+
     long getTotalTime() {
         return taskGraph.getTotalTime();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -711,7 +711,7 @@ public class TaskGraph implements TaskGraphInterface {
      * </p>
      *
      * </p>
-     * {@link uk.ac.manchester.tornado.api.enums.DataTransferMode#USER_DEFINED}: it
+     * {@link uk.ac.manchester.tornado.api.enums.DataTransferMode#UNDER_DEMAND}: it
      * transfers data only under demand. Data are not transferred unless the
      * execution-plan, an {@link TornadoExecutionPlan} object, invokes the
      * `transferToHost` function. This is used for optimization of data transfers.
@@ -793,6 +793,10 @@ public class TaskGraph implements TaskGraphInterface {
 
     void syncRuntimeTransferToHost(Object... objects) {
         taskGraphImpl.syncRuntimeTransferToHost(objects);
+    }
+
+    void syncRuntimeTransferToHost(Object object, long offset, long partialCopySize) {
+        taskGraphImpl.syncRuntimeTransferToHost(object, offset, partialCopySize);
     }
 
     TornadoDevice getDevice() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
@@ -559,7 +559,7 @@ public interface TaskGraphInterface {
      * </p>
      *
      * </p>
-     * {@link uk.ac.manchester.tornado.api.enums.DataTransferMode#USER_DEFINED}: it
+     * {@link uk.ac.manchester.tornado.api.enums.DataTransferMode#UNDER_DEMAND}: it
      * transfers data only under demand. Data are not transferred unless the
      * execution-plan, an {@link TornadoExecutionPlan} object, invokes the
      * `transferToHost` function. This is used for optimization of data transfers.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -312,10 +312,10 @@ public class TornadoExecutionPlan {
             immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(objects));
         }
 
-        void partialTransferToHost(Object object, DataConfig dataConfig) {
+        void partialTransferToHost(DataRange dataRange) {
             // At this point we compute the offsets and the total size in bytes.
-            dataConfig.materialize();
-            immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(object, dataConfig.getOffset(), dataConfig.getPartialSize()));
+            dataRange.materialize();
+            immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(dataRange.getArray(), dataRange.getOffset(), dataRange.getPartialSize()));
         }
 
         boolean isFinished() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -312,6 +312,12 @@ public class TornadoExecutionPlan {
             immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(objects));
         }
 
+        void partialTransferToHost(Object object, DataConfig dataConfig) {
+            // At this point we compute the offsets and the total size in bytes.
+            dataConfig.materialize();
+            immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(object, dataConfig.getOffset(), dataConfig.getPartialSize()));
+        }
+
         boolean isFinished() {
             boolean result = true;
             for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionResult.java
@@ -49,7 +49,7 @@ public class TornadoExecutionResult {
      * Transfer data from device to host. This is applied for all immutable
      * task-graphs within an executor. This method is used when a task-graph defines
      * transferToHost using the
-     * {@link uk.ac.manchester.tornado.api.enums.DataTransferMode#USER_DEFINED}.
+     * {@link uk.ac.manchester.tornado.api.enums.DataTransferMode#UNDER_DEMAND}.
      * This indicates the runtime to not to copy-out the data en every iteration and
      * transfer the data under demand.
      *
@@ -60,6 +60,11 @@ public class TornadoExecutionResult {
      */
     public TornadoExecutionResult transferToHost(Object... objects) {
         tornadoProfilerResult.getExecutor().transferToHost(objects);
+        return this;
+    }
+
+    public TornadoExecutionResult transferToHost(Object object, DataConfig dataConfig) {
+        tornadoProfilerResult.getExecutor().partialTransferToHost(object, dataConfig);
         return this;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2024, APT Group, Department of Computer Science,
  * The University of Manchester.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,11 +24,11 @@ package uk.ac.manchester.tornado.api;
  * profiler information (e.g., read/write time, kernel time, etc.) through the
  * {@link TornadoProfilerResult} object.
  *
- * @since TornadoVM-0.15
+ * @since 0.15.0
  */
 public class TornadoExecutionResult {
 
-    private TornadoProfilerResult tornadoProfilerResult;
+    private final TornadoProfilerResult tornadoProfilerResult;
 
     TornadoExecutionResult(TornadoProfilerResult profilerResult) {
         this.tornadoProfilerResult = profilerResult;
@@ -40,6 +40,8 @@ public class TornadoExecutionResult {
      * the execution plan enables the profiler.
      *
      * @return {@link TornadoProfilerResult}
+     *
+     * @since 0.15.0
      */
     public TornadoProfilerResult getProfilerResult() {
         return tornadoProfilerResult;
@@ -57,12 +59,26 @@ public class TornadoExecutionResult {
      *     Host objects to transfer the data to.
      *
      * @return {@link TornadoExecutionResult}
+     *
+     * @since 0.15.0
      */
     public TornadoExecutionResult transferToHost(Object... objects) {
         tornadoProfilerResult.getExecutor().transferToHost(objects);
         return this;
     }
 
+    /**
+     * Partial data transfer from the device to the host. This is applied for all immutable
+     * task-graphs within an executor. This indicates the runtime to not to copy-out the data
+     * en every iteration and transfer the data under demand. The sub-region to be copied is
+     * specified in the data range.
+     *
+     * @param dataRange
+     *     Range of type: {@link DataRange}
+     * @return {@link TornadoExecutionResult}
+     *
+     * @since v1.0.1
+     */
     public TornadoExecutionResult transferToHost(DataRange dataRange) {
         tornadoProfilerResult.getExecutor().partialTransferToHost(dataRange);
         return this;
@@ -73,6 +89,8 @@ public class TornadoExecutionResult {
      * execution.
      *
      * @return boolean
+     *
+     * @since 0.15.0
      */
     public boolean isReady() {
         return tornadoProfilerResult.getExecutor().isFinished();

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionResult.java
@@ -63,8 +63,8 @@ public class TornadoExecutionResult {
         return this;
     }
 
-    public TornadoExecutionResult transferToHost(Object object, DataConfig dataConfig) {
-        tornadoProfilerResult.getExecutor().partialTransferToHost(object, dataConfig);
+    public TornadoExecutionResult transferToHost(DataRange dataRange) {
+        tornadoProfilerResult.getExecutor().partialTransferToHost(dataRange);
         return this;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -73,6 +73,8 @@ public interface TornadoTaskGraphInterface extends ProfileInterface {
 
     void syncRuntimeTransferToHost(Object... objects);
 
+    void syncRuntimeTransferToHost(Object objects, long offset, long partialCopySize);
+
     String getId();
 
     TaskMetaDataInterface meta();

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/enums/DataTransferMode.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/enums/DataTransferMode.java
@@ -44,5 +44,5 @@ public class DataTransferMode {
      * {@link uk.ac.manchester.tornado.api.TornadoExecutionResult#transferToHost(Object...)}
      * method.
      */
-    public static final int USER_DEFINED = 2;
+    public static final int UNDER_DEMAND = 2;
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/ObjectBuffer.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/ObjectBuffer.java
@@ -42,7 +42,7 @@ public interface ObjectBuffer {
 
     void read(Object reference);
 
-    int read(Object reference, long hostOffset, int[] events, boolean useDeps);
+    int read(Object reference, long hostOffset, long partialReadSize, int[] events, boolean useDeps);
 
     void write(Object reference);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/TornadoDeviceObjectState.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/TornadoDeviceObjectState.java
@@ -34,4 +34,9 @@ public interface TornadoDeviceObjectState {
     boolean hasContents();
 
     void setContents(boolean value);
+
+    void setPartialCopySize(long partialCopySize);
+
+    long getPartialCopySize();
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -45,7 +45,9 @@ public final class ByteArray extends TornadoNativeArray {
 
     /**
      * Constructs a new instance of the {@code ByteArray} that will store a user-specified number of elements.
-     * @param numberOfElements The number of elements in the array.
+     *
+     * @param numberOfElements
+     *     The number of elements in the array.
      */
     public ByteArray(int numberOfElements) {
         this.numberOfElements = numberOfElements;
@@ -60,7 +62,9 @@ public final class ByteArray extends TornadoNativeArray {
 
     /**
      * Internal method used to create a new instance of the {@code ByteArray} from on-heap data.
-     * @param values The on-heap byte array to create the instance from.
+     *
+     * @param values
+     *     The on-heap byte array to create the instance from.
      * @return A new {@code ByteArray} instance, initialized with values of the on-heap byte array.
      */
     private static ByteArray createSegment(byte[] values) {
@@ -73,7 +77,9 @@ public final class ByteArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code ByteArray} class from an on-heap byte array.
-     * @param values The on-heap byte array to create the instance from.
+     *
+     * @param values
+     *     The on-heap byte array to create the instance from.
      * @return A new {@code ByteArray} instance, initialized with values of the on-heap byte array.
      */
     public static ByteArray fromArray(byte[] values) {
@@ -82,7 +88,9 @@ public final class ByteArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code ByteArray} class from a set of byte values.
-     * @param values The byte values to initialize the array with.
+     *
+     * @param values
+     *     The byte values to initialize the array with.
      * @return A new {@code ByteArray} instance, initialized with the given values.
      */
     public static ByteArray fromElements(byte... values) {
@@ -91,7 +99,9 @@ public final class ByteArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code ByteArray} class from a {@link MemorySegment}.
-     * @param segment The {@link MemorySegment} containing the off-heap byte data.
+     *
+     * @param segment
+     *     The {@link MemorySegment} containing the off-heap byte data.
      * @return A new {@code ByteArray} instance, initialized with the segment data.
      */
     public static ByteArray fromSegment(MemorySegment segment) {
@@ -105,6 +115,7 @@ public final class ByteArray extends TornadoNativeArray {
     /**
      * Converts the byte data from off-heap to on-heap, by copying the values of a {@code ByteArray}
      * instance into a new on-heap array.
+     *
      * @return A new on-heap byte array, initialized with the values stored in the {@code ByteArray} instance.
      */
     public byte[] toHeapArray() {
@@ -117,8 +128,11 @@ public final class ByteArray extends TornadoNativeArray {
 
     /**
      * Sets the byte value at a specified index of the {@code ByteArray} instance.
-     * @param index The index at which to set the byte value.
-     * @param value The byte value to store at the specified index.
+     *
+     * @param index
+     *     The index at which to set the byte value.
+     * @param value
+     *     The byte value to store at the specified index.
      */
     public void set(int index, byte value) {
         segment.setAtIndex(JAVA_BYTE, baseIndex + index, value);
@@ -126,8 +140,10 @@ public final class ByteArray extends TornadoNativeArray {
 
     /**
      * Gets the byte value stored at the specified index of the {@code ByteArray} instance.
-     * @param index The index of which to retrieve the byte value.
-     * @return
+     *
+     * @param index
+     *     The index of which to retrieve the byte value.
+     * @return en element byte of the off-heap array
      */
     public byte get(int index) {
         return segment.getAtIndex(JAVA_BYTE, baseIndex + index);
@@ -141,9 +157,16 @@ public final class ByteArray extends TornadoNativeArray {
         init((byte) 0);
     }
 
+    @Override
+    public int getElementSize() {
+        return BYTE_BYTES;
+    }
+
     /**
      * Initializes all the elements of the {@code ByteArray} instance with a specified value.
-     * @param value The byte value to initialize the {@code ByteArray} instance with.
+     *
+     * @param value
+     *     The byte value to initialize the {@code ByteArray} instance with.
      */
     public void init(byte value) {
         for (int i = 0; i < getSize(); i++) {
@@ -152,8 +175,8 @@ public final class ByteArray extends TornadoNativeArray {
     }
 
     /**
-     * Returns the number of byte elements stored in the {@code ByteArray} instance.
-     * @return
+     * @return Returns the number of byte elements stored in the {@code ByteArray} instance.
+     *
      */
     @Override
     public int getSize() {
@@ -162,6 +185,7 @@ public final class ByteArray extends TornadoNativeArray {
 
     /**
      * Returns the underlying {@link MemorySegment} of the {@code ByteArray} instance.
+     *
      * @return The {@link MemorySegment} associated with the {@code ByteArray} instance.
      */
     @Override
@@ -171,6 +195,7 @@ public final class ByteArray extends TornadoNativeArray {
 
     /**
      * Returns the total number of bytes that the {@link MemorySegment}, associated with the {@code ByteArray} instance, occupies.
+     *
      * @return The total number of bytes of the {@link MemorySegment}.
      */
     @Override
@@ -181,6 +206,7 @@ public final class ByteArray extends TornadoNativeArray {
     /**
      * Returns the number of bytes of the {@link MemorySegment} that is associated with the {@code ByteArray} instance,
      * excluding the header bytes.
+     *
      * @return The number of bytes of the raw data in the {@link MemorySegment}.
      */
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -44,7 +44,9 @@ public final class CharArray extends TornadoNativeArray {
 
     /**
      * Constructs a new instance of the {@code CharArray} that will store a user-specified number of elements.
-     * @param numberOfElements The number of elements in the array.
+     *
+     * @param numberOfElements
+     *     The number of elements in the array.
      */
     public CharArray(int numberOfElements) {
         this.numberOfElements = numberOfElements;
@@ -64,9 +66,16 @@ public final class CharArray extends TornadoNativeArray {
         init('\u0000');
     }
 
+    @Override
+    public int getElementSize() {
+        return CHAR_BYTES;
+    }
+
     /**
      * Internal method used to create a new instance of the {@code CharArray} from on-heap data.
-     * @param values The on-heap char array to create the instance from.
+     *
+     * @param values
+     *     The on-heap char array to create the instance from.
      * @return A new {@code CharArray} instance, initialized with values of the on-heap char array.
      */
     private static CharArray createSegment(char[] values) {
@@ -79,7 +88,9 @@ public final class CharArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code CharArray} class from an on-heap char array.
-     * @param values The on-heap char array to create the instance from.
+     *
+     * @param values
+     *     The on-heap char array to create the instance from.
      * @return A new {@code CharArray} instance, initialized with values of the on-heap char array.
      */
     public static CharArray fromArray(char[] values) {
@@ -88,7 +99,9 @@ public final class CharArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code CharArray} class from a set of char values.
-     * @param values The char values to initialize the array with.
+     *
+     * @param values
+     *     The char values to initialize the array with.
      * @return A new {@code CharArray} instance, initialized with the given values.
      */
     public static CharArray fromElements(char... values) {
@@ -97,7 +110,9 @@ public final class CharArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code CharArray} class from a {@link MemorySegment}.
-     * @param segment The {@link MemorySegment} containing the off-heap char data.
+     *
+     * @param segment
+     *     The {@link MemorySegment} containing the off-heap char data.
      * @return A new {@code CharArray} instance, initialized with the segment data.
      */
     public static CharArray fromSegment(MemorySegment segment) {
@@ -111,6 +126,7 @@ public final class CharArray extends TornadoNativeArray {
     /**
      * Converts the char data from off-heap to on-heap, by copying the values of a {@code CharArray}
      * instance into a new on-heap array.
+     *
      * @return A new on-heap char array, initialized with the values stored in the {@code CharArray} instance.
      */
     public char[] toHeapArray() {
@@ -123,8 +139,11 @@ public final class CharArray extends TornadoNativeArray {
 
     /**
      * Sets the char value at a specified index of the {@code CharArray} instance.
-     * @param index The index at which to set the char value.
-     * @param value The char value to store at the specified index.
+     *
+     * @param index
+     *     The index at which to set the char value.
+     * @param value
+     *     The char value to store at the specified index.
      */
     public void set(int index, char value) {
         segment.setAtIndex(JAVA_CHAR, baseIndex + index, value);
@@ -132,7 +151,9 @@ public final class CharArray extends TornadoNativeArray {
 
     /**
      * Gets the char value stored at the specified index of the {@code CharArray} instance.
-     * @param index The index of which to retrieve the char value.
+     *
+     * @param index
+     *     The index of which to retrieve the char value.
      * @return
      */
     public char get(int index) {
@@ -141,7 +162,9 @@ public final class CharArray extends TornadoNativeArray {
 
     /**
      * Initializes all the elements of the {@code CharArray} instance with a specified value.
-     * @param value The char value to initialize the {@code ByteArray} instance with.
+     *
+     * @param value
+     *     The char value to initialize the {@code ByteArray} instance with.
      */
     public void init(char value) {
         for (int i = 0; i < getSize(); i++) {
@@ -151,6 +174,7 @@ public final class CharArray extends TornadoNativeArray {
 
     /**
      * Returns the number of char elements stored in the {@code CharArray} instance.
+     *
      * @return
      */
     @Override
@@ -160,6 +184,7 @@ public final class CharArray extends TornadoNativeArray {
 
     /**
      * Returns the underlying {@link MemorySegment} of the {@code CharArray} instance.
+     *
      * @return The {@link MemorySegment} associated with the {@code CharArray} instance.
      */
     @Override
@@ -169,6 +194,7 @@ public final class CharArray extends TornadoNativeArray {
 
     /**
      * Returns the total number of bytes that the {@link MemorySegment}, associated with the {@code CharArray} instance, occupies.
+     *
      * @return The total number of bytes of the {@link MemorySegment}.
      */
     @Override
@@ -179,6 +205,7 @@ public final class CharArray extends TornadoNativeArray {
     /**
      * Returns the number of bytes of the {@link MemorySegment} that is associated with the {@code CharArray} instance,
      * excluding the header bytes.
+     *
      * @return The number of bytes of the raw data in the {@link MemorySegment}.
      */
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -45,7 +45,9 @@ public final class DoubleArray extends TornadoNativeArray {
 
     /**
      * Constructs a new instance of the {@code DoubleArray} that will store a user-specified number of elements.
-     * @param numberOfElements The number of elements in the array.
+     *
+     * @param numberOfElements
+     *     The number of elements in the array.
      */
     public DoubleArray(int numberOfElements) {
         this.numberOfElements = numberOfElements;
@@ -60,7 +62,9 @@ public final class DoubleArray extends TornadoNativeArray {
 
     /**
      * Internal method used to create a new instance of the {@code DoubleArray} from on-heap data.
-     * @param values The on-heap double array to create the instance from.
+     *
+     * @param values
+     *     The on-heap double array to create the instance from.
      * @return A new {@code DoubleArray} instance, initialized with values of the on-heap double array.
      */
     private static DoubleArray createSegment(double[] values) {
@@ -73,7 +77,9 @@ public final class DoubleArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code DoubleArray} class from an on-heap double array.
-     * @param values The on-heap double array to create the instance from.
+     *
+     * @param values
+     *     The on-heap double array to create the instance from.
      * @return A new {@code DoubleArray} instance, initialized with values of the on-heap double array.
      */
     public static DoubleArray fromArray(double[] values) {
@@ -82,7 +88,9 @@ public final class DoubleArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code DoubleArray} class from a set of double values.
-     * @param values The double values to initialize the array with.
+     *
+     * @param values
+     *     The double values to initialize the array with.
      * @return A new {@code DoubleArray} instance, initialized with the given values.
      */
     public static DoubleArray fromElements(double... values) {
@@ -91,7 +99,9 @@ public final class DoubleArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code DoubleArray} class from a {@link MemorySegment}.
-     * @param segment The {@link MemorySegment} containing the off-heap double data.
+     *
+     * @param segment
+     *     The {@link MemorySegment} containing the off-heap double data.
      * @return A new {@code DoubleArray} instance, initialized with the segment data.
      */
     public static DoubleArray fromSegment(MemorySegment segment) {
@@ -105,6 +115,7 @@ public final class DoubleArray extends TornadoNativeArray {
     /**
      * Converts the double data from off-heap to on-heap, by copying the values of a {@code DoubleArray}
      * instance into a new on-heap array.
+     *
      * @return A new on-heap double array, initialized with the values stored in the {@code DoubleArray} instance.
      */
     public double[] toHeapArray() {
@@ -117,8 +128,11 @@ public final class DoubleArray extends TornadoNativeArray {
 
     /**
      * Sets the double value at a specified index of the {@code DoubleArray} instance.
-     * @param index The index at which to set the double value.
-     * @param value The double value to store at the specified index.
+     *
+     * @param index
+     *     The index at which to set the double value.
+     * @param value
+     *     The double value to store at the specified index.
      */
     public void set(int index, double value) {
         segment.setAtIndex(JAVA_DOUBLE, baseIndex + index, value);
@@ -126,7 +140,9 @@ public final class DoubleArray extends TornadoNativeArray {
 
     /**
      * Gets the double value stored at the specified index of the {@code DoubleArray} instance.
-     * @param index The index of which to retrieve the double value.
+     *
+     * @param index
+     *     The index of which to retrieve the double value.
      * @return
      */
     public double get(int index) {
@@ -141,9 +157,16 @@ public final class DoubleArray extends TornadoNativeArray {
         init(0.0);
     }
 
+    @Override
+    public int getElementSize() {
+        return DOUBLE_BYTES;
+    }
+
     /**
      * Initializes all the elements of the {@code DoubleArray} instance with a specified value.
-     * @param value The double value to initialize the {@code DoubleArray} instance with.
+     *
+     * @param value
+     *     The double value to initialize the {@code DoubleArray} instance with.
      */
     public void init(double value) {
         for (int i = 0; i < getSize(); i++) {
@@ -153,6 +176,7 @@ public final class DoubleArray extends TornadoNativeArray {
 
     /**
      * Returns the number of double elements stored in the {@code DoubleArray} instance.
+     *
      * @return
      */
     @Override
@@ -162,6 +186,7 @@ public final class DoubleArray extends TornadoNativeArray {
 
     /**
      * Returns the underlying {@link MemorySegment} of the {@code DoubleArray} instance.
+     *
      * @return The {@link MemorySegment} associated with the {@code DoubleArray} instance.
      */
     @Override
@@ -171,6 +196,7 @@ public final class DoubleArray extends TornadoNativeArray {
 
     /**
      * Returns the total number of bytes that the {@link MemorySegment}, associated with the {@code DoubleArray} instance, occupies.
+     *
      * @return The total number of bytes of the {@link MemorySegment}.
      */
     @Override
@@ -181,6 +207,7 @@ public final class DoubleArray extends TornadoNativeArray {
     /**
      * Returns the number of bytes of the {@link MemorySegment} that is associated with the {@code DoubleArray} instance,
      * excluding the header bytes.
+     *
      * @return The number of bytes of the raw data in the {@link MemorySegment}.
      */
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -46,7 +46,9 @@ public final class FloatArray extends TornadoNativeArray {
 
     /**
      * Constructs a new instance of the {@code FloatArray} that will store a user-specified number of elements.
-     * @param numberOfElements The number of elements in the array.
+     *
+     * @param numberOfElements
+     *     The number of elements in the array.
      */
     public FloatArray(int numberOfElements) {
         this.numberOfElements = numberOfElements;
@@ -60,7 +62,9 @@ public final class FloatArray extends TornadoNativeArray {
 
     /**
      * Internal method used to create a new instance of the {@code FloatArray} from on-heap data.
-     * @param values The on-heap float array to create the instance from.
+     *
+     * @param values
+     *     The on-heap float array to create the instance from.
      * @return A new {@code FloatArray} instance, initialized with values of the on-heap float array.
      */
     private static FloatArray createSegment(float[] values) {
@@ -73,7 +77,9 @@ public final class FloatArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code FloatArray} class from an on-heap float array.
-     * @param values The on-heap float array to create the instance from.
+     *
+     * @param values
+     *     The on-heap float array to create the instance from.
      * @return A new {@code FloatArray} instance, initialized with values of the on-heap float array.
      */
     public static FloatArray fromArray(float[] values) {
@@ -82,7 +88,9 @@ public final class FloatArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code FloatArray} class from a set of float values.
-     * @param values The float values to initialize the array with.
+     *
+     * @param values
+     *     The float values to initialize the array with.
      * @return A new {@code FloatArray} instance, initialized with the given values.
      */
     public static FloatArray fromElements(float... values) {
@@ -91,7 +99,9 @@ public final class FloatArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code FloatArray} class from a {@link MemorySegment}.
-     * @param segment The {@link MemorySegment} containing the off-heap float data.
+     *
+     * @param segment
+     *     The {@link MemorySegment} containing the off-heap float data.
      * @return A new {@code FloatArray} instance, initialized with the segment data.
      */
     public static FloatArray fromSegment(MemorySegment segment) {
@@ -105,6 +115,7 @@ public final class FloatArray extends TornadoNativeArray {
     /**
      * Converts the float data from off-heap to on-heap, by copying the values of a {@code FloatArray}
      * instance into a new on-heap array.
+     *
      * @return A new on-heap float array, initialized with the values stored in the {@code FloatArray} instance.
      */
     public float[] toHeapArray() {
@@ -117,8 +128,11 @@ public final class FloatArray extends TornadoNativeArray {
 
     /**
      * Sets the float value at a specified index of the {@code FloatArray} instance.
-     * @param index The index at which to set the float value.
-     * @param value The float value to store at the specified index.
+     *
+     * @param index
+     *     The index at which to set the float value.
+     * @param value
+     *     The float value to store at the specified index.
      */
     public void set(int index, float value) {
         segment.setAtIndex(JAVA_FLOAT, baseIndex + index, value);
@@ -126,7 +140,9 @@ public final class FloatArray extends TornadoNativeArray {
 
     /**
      * Gets the float value stored at the specified index of the {@code FloatArray} instance.
-     * @param index The index of which to retrieve the float value.
+     *
+     * @param index
+     *     The index of which to retrieve the float value.
      * @return
      */
     public float get(int index) {
@@ -141,9 +157,16 @@ public final class FloatArray extends TornadoNativeArray {
         init(0.0f);
     }
 
+    @Override
+    public int getElementSize() {
+        return FLOAT_BYTES;
+    }
+
     /**
      * Initializes all the elements of the {@code FloatArray} instance with a specified value.
-     * @param value The float value to initialize the {@code FloatArray} instance with.
+     *
+     * @param value
+     *     The float value to initialize the {@code FloatArray} instance with.
      */
     public void init(float value) {
         for (int i = 0; i < getSize(); i++) {
@@ -153,6 +176,7 @@ public final class FloatArray extends TornadoNativeArray {
 
     /**
      * Returns the number of float elements stored in the {@code FloatArray} instance.
+     *
      * @return
      */
     @Override
@@ -162,6 +186,7 @@ public final class FloatArray extends TornadoNativeArray {
 
     /**
      * Returns the underlying {@link MemorySegment} of the {@code FloatArray} instance.
+     *
      * @return The {@link MemorySegment} associated with the {@code FloatArray} instance.
      */
     @Override
@@ -171,6 +196,7 @@ public final class FloatArray extends TornadoNativeArray {
 
     /**
      * Returns the total number of bytes that the {@link MemorySegment}, associated with the {@code FloatArray} instance, occupies.
+     *
      * @return The total number of bytes of the {@link MemorySegment}.
      */
     @Override
@@ -181,6 +207,7 @@ public final class FloatArray extends TornadoNativeArray {
     /**
      * Returns the number of bytes of the {@link MemorySegment} that is associated with the {@code FloatArray} instance,
      * excluding the header bytes.
+     *
      * @return The number of bytes of the raw data in the {@link MemorySegment}.
      */
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -43,7 +43,9 @@ public final class IntArray extends TornadoNativeArray {
 
     /**
      * Constructs a new instance of the {@code IntArray} that will store a user-specified number of elements.
-     * @param numberOfElements The number of elements in the array.
+     *
+     * @param numberOfElements
+     *     The number of elements in the array.
      */
     public IntArray(int numberOfElements) {
         this.numberOfElements = numberOfElements;
@@ -57,7 +59,9 @@ public final class IntArray extends TornadoNativeArray {
 
     /**
      * Internal method used to create a new instance of the {@code IntArray} from on-heap data.
-     * @param values The on-heap int array to create the instance from.
+     *
+     * @param values
+     *     The on-heap int array to create the instance from.
      * @return A new {@code IntArray} instance, initialized with values of the on-heap int array.
      */
     private static IntArray createSegment(int[] values) {
@@ -70,7 +74,9 @@ public final class IntArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code IntArray} class from an on-heap int array.
-     * @param values The on-heap int array to create the instance from.
+     *
+     * @param values
+     *     The on-heap int array to create the instance from.
      * @return A new {@code IntArray} instance, initialized with values of the on-heap int array.
      */
     public static IntArray fromArray(int[] values) {
@@ -79,7 +85,9 @@ public final class IntArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code IntArray} class from a set of int values.
-     * @param values The int values to initialize the array with.
+     *
+     * @param values
+     *     The int values to initialize the array with.
      * @return A new {@code IntArray} instance, initialized with the given values.
      */
     public static IntArray fromElements(int... values) {
@@ -88,7 +96,9 @@ public final class IntArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code IntArray} class from a {@link MemorySegment}.
-     * @param segment The {@link MemorySegment} containing the off-heap int data.
+     *
+     * @param segment
+     *     The {@link MemorySegment} containing the off-heap int data.
      * @return A new {@code IntArray} instance, initialized with the segment data.
      */
     public static IntArray fromSegment(MemorySegment segment) {
@@ -102,6 +112,7 @@ public final class IntArray extends TornadoNativeArray {
     /**
      * Converts the int data from off-heap to on-heap, by copying the values of a {@code IntArray}
      * instance into a new on-heap array.
+     *
      * @return A new on-heap int array, initialized with the values stored in the {@code IntArray} instance.
      */
     public int[] toHeapArray() {
@@ -114,8 +125,11 @@ public final class IntArray extends TornadoNativeArray {
 
     /**
      * Sets the int value at a specified index of the {@code IntArray} instance.
-     * @param index The index at which to set the int value.
-     * @param value The int value to store at the specified index.
+     *
+     * @param index
+     *     The index at which to set the int value.
+     * @param value
+     *     The int value to store at the specified index.
      */
     public void set(int index, int value) {
         segment.setAtIndex(JAVA_INT, baseIndex + index, value);
@@ -123,7 +137,9 @@ public final class IntArray extends TornadoNativeArray {
 
     /**
      * Gets the int value stored at the specified index of the {@code IntArray} instance.
-     * @param index The index of which to retrieve the int value.
+     *
+     * @param index
+     *     The index of which to retrieve the int value.
      * @return
      */
     public int get(int index) {
@@ -138,9 +154,16 @@ public final class IntArray extends TornadoNativeArray {
         init(0);
     }
 
+    @Override
+    public int getElementSize() {
+        return INT_BYTES;
+    }
+
     /**
      * Initializes all the elements of the {@code IntArray} instance with a specified value.
-     * @param value The int value to initialize the {@code IntArray} instance with.
+     *
+     * @param value
+     *     The int value to initialize the {@code IntArray} instance with.
      */
     public void init(int value) {
         for (int i = 0; i < getSize(); i++) {
@@ -150,6 +173,7 @@ public final class IntArray extends TornadoNativeArray {
 
     /**
      * Returns the number of int elements stored in the {@code IntArray} instance.
+     *
      * @return
      */
     @Override
@@ -159,6 +183,7 @@ public final class IntArray extends TornadoNativeArray {
 
     /**
      * Returns the total number of bytes that the {@link MemorySegment}, associated with the {@code IntArray} instance, occupies.
+     *
      * @return The total number of bytes of the {@link MemorySegment}.
      */
     @Override
@@ -169,6 +194,7 @@ public final class IntArray extends TornadoNativeArray {
     /**
      * Returns the number of bytes of the {@link MemorySegment} that is associated with the {@code IntArray} instance,
      * excluding the header bytes.
+     *
      * @return The number of bytes of the raw data in the {@link MemorySegment}.
      */
     @Override
@@ -178,6 +204,7 @@ public final class IntArray extends TornadoNativeArray {
 
     /**
      * Returns the underlying {@link MemorySegment} of the {@code IntArray} instance.
+     *
      * @return The {@link MemorySegment} associated with the {@code IntArray} instance.
      */
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -44,7 +44,9 @@ public final class LongArray extends TornadoNativeArray {
 
     /**
      * Constructs a new instance of the {@code LongArray} that will store a user-specified number of elements.
-     * @param numberOfElements The number of elements in the array.
+     *
+     * @param numberOfElements
+     *     The number of elements in the array.
      */
     public LongArray(int numberOfElements) {
         this.numberOfElements = numberOfElements;
@@ -58,7 +60,9 @@ public final class LongArray extends TornadoNativeArray {
 
     /**
      * Internal method used to create a new instance of the {@code LongArray} from on-heap data.
-     * @param values The on-heap long array to create the instance from.
+     *
+     * @param values
+     *     The on-heap long array to create the instance from.
      * @return A new {@code LongArray} instance, initialized with values of the on-heap long array.
      */
     private static LongArray createSegment(long[] values) {
@@ -71,7 +75,9 @@ public final class LongArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code LongArray} class from an on-heap long array.
-     * @param values The on-heap long array to create the instance from.
+     *
+     * @param values
+     *     The on-heap long array to create the instance from.
      * @return A new {@code LongArray} instance, initialized with values of the on-heap long array.
      */
     public static LongArray fromArray(long[] values) {
@@ -80,7 +86,9 @@ public final class LongArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code LongArray} class from a set of long values.
-     * @param values The long values to initialize the array with.
+     *
+     * @param values
+     *     The long values to initialize the array with.
      * @return A new {@code LongArray} instance, initialized with the given values.
      */
     public static LongArray fromElements(long... values) {
@@ -89,7 +97,9 @@ public final class LongArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code LongArray} class from a {@link MemorySegment}.
-     * @param segment The {@link MemorySegment} containing the off-heap long data.
+     *
+     * @param segment
+     *     The {@link MemorySegment} containing the off-heap long data.
      * @return A new {@code LongArray} instance, initialized with the segment data.
      */
     public static LongArray fromSegment(MemorySegment segment) {
@@ -103,6 +113,7 @@ public final class LongArray extends TornadoNativeArray {
     /**
      * Converts the long data from off-heap to on-heap, by copying the values of a {@code LongArray}
      * instance into a new on-heap array.
+     *
      * @return A new on-heap long array, initialized with the values stored in the {@code LongArray} instance.
      */
     public long[] toHeapArray() {
@@ -115,8 +126,11 @@ public final class LongArray extends TornadoNativeArray {
 
     /**
      * Sets the long value at a specified index of the {@code LongArray} instance.
-     * @param index The index at which to set the long value.
-     * @param value The long value to store at the specified index.
+     *
+     * @param index
+     *     The index at which to set the long value.
+     * @param value
+     *     The long value to store at the specified index.
      */
     public void set(int index, long value) {
         segment.setAtIndex(JAVA_LONG, baseIndex + index, value);
@@ -124,7 +138,9 @@ public final class LongArray extends TornadoNativeArray {
 
     /**
      * Gets the long value stored at the specified index of the {@code LongArray} instance.
-     * @param index The index of which to retrieve the long value.
+     *
+     * @param index
+     *     The index of which to retrieve the long value.
      * @return
      */
     public long get(int index) {
@@ -139,9 +155,16 @@ public final class LongArray extends TornadoNativeArray {
         init(0);
     }
 
+    @Override
+    public int getElementSize() {
+        return LONG_BYTES;
+    }
+
     /**
      * Initializes all the elements of the {@code LongArray} instance with a specified value.
-     * @param value The long value to initialize the {@code LongArray} instance with.
+     *
+     * @param value
+     *     The long value to initialize the {@code LongArray} instance with.
      */
     public void init(long value) {
         for (int i = 0; i < getSize(); i++) {
@@ -151,6 +174,7 @@ public final class LongArray extends TornadoNativeArray {
 
     /**
      * Returns the number of long elements stored in the {@code LongArray} instance.
+     *
      * @return
      */
     @Override
@@ -160,6 +184,7 @@ public final class LongArray extends TornadoNativeArray {
 
     /**
      * Returns the underlying {@link MemorySegment} of the {@code LongArray} instance.
+     *
      * @return The {@link MemorySegment} associated with the {@code LongArray} instance.
      */
     @Override
@@ -169,6 +194,7 @@ public final class LongArray extends TornadoNativeArray {
 
     /**
      * Returns the total number of bytes that the {@link MemorySegment}, associated with the {@code LongArray} instance, occupies.
+     *
      * @return The total number of bytes of the {@link MemorySegment}.
      */
     @Override
@@ -179,6 +205,7 @@ public final class LongArray extends TornadoNativeArray {
     /**
      * Returns the number of bytes of the {@link MemorySegment} that is associated with the {@code LongArray} instance,
      * excluding the header bytes.
+     *
      * @return The number of bytes of the raw data in the {@link MemorySegment}.
      */
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -44,7 +44,9 @@ public final class ShortArray extends TornadoNativeArray {
 
     /**
      * Constructs a new instance of the {@code ShortArray} that will store a user-specified number of elements.
-     * @param numberOfElements The number of elements in the array.
+     *
+     * @param numberOfElements
+     *     The number of elements in the array.
      */
     public ShortArray(int numberOfElements) {
         this.numberOfElements = numberOfElements;
@@ -59,7 +61,9 @@ public final class ShortArray extends TornadoNativeArray {
 
     /**
      * Internal method used to create a new instance of the {@code ShortArray} from on-heap data.
-     * @param values The on-heap short array to create the instance from.
+     *
+     * @param values
+     *     The on-heap short array to create the instance from.
      * @return A new {@code ShortArray} instance, initialized with values of the on-heap short array.
      */
     private static ShortArray createSegment(short[] values) {
@@ -72,7 +76,9 @@ public final class ShortArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code ShortArray} class from an on-heap short array.
-     * @param values The on-heap short array to create the instance from.
+     *
+     * @param values
+     *     The on-heap short array to create the instance from.
      * @return A new {@code ShortArray} instance, initialized with values of the on-heap short array.
      */
     public static ShortArray fromArray(short[] values) {
@@ -81,7 +87,9 @@ public final class ShortArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code ShortArray} class from a set of short values.
-     * @param values The short values to initialize the array with.
+     *
+     * @param values
+     *     The short values to initialize the array with.
      * @return A new {@code ShortArray} instance, initialized with the given values.
      */
     public static ShortArray fromElements(short... values) {
@@ -90,7 +98,9 @@ public final class ShortArray extends TornadoNativeArray {
 
     /**
      * Creates a new instance of the {@code ShortArray} class from a {@link MemorySegment}.
-     * @param segment The {@link MemorySegment} containing the off-heap short data.
+     *
+     * @param segment
+     *     The {@link MemorySegment} containing the off-heap short data.
      * @return A new {@code ShortArray} instance, initialized with the segment data.
      */
     public static ShortArray fromSegment(MemorySegment segment) {
@@ -104,6 +114,7 @@ public final class ShortArray extends TornadoNativeArray {
     /**
      * Converts the short data from off-heap to on-heap, by copying the values of a {@code ShortArray}
      * instance into a new on-heap array.
+     *
      * @return A new on-heap short array, initialized with the values stored in the {@code ShortArray} instance.
      */
     public short[] toHeapArray() {
@@ -116,8 +127,11 @@ public final class ShortArray extends TornadoNativeArray {
 
     /**
      * Sets the short value at a specified index of the {@code ShortArray} instance.
-     * @param index The index at which to set the short value.
-     * @param value The short value to store at the specified index.
+     *
+     * @param index
+     *     The index at which to set the short value.
+     * @param value
+     *     The short value to store at the specified index.
      */
     public void set(int index, short value) {
         segment.setAtIndex(JAVA_SHORT, baseIndex + index, value);
@@ -125,7 +139,9 @@ public final class ShortArray extends TornadoNativeArray {
 
     /**
      * Gets the short value stored at the specified index of the {@code ShortArray} instance.
-     * @param index The index of which to retrieve the short value.
+     *
+     * @param index
+     *     The index of which to retrieve the short value.
      * @return
      */
     public short get(int index) {
@@ -140,9 +156,16 @@ public final class ShortArray extends TornadoNativeArray {
         init((short) 0);
     }
 
+    @Override
+    public int getElementSize() {
+        return SHORT_BYTES;
+    }
+
     /**
      * Initializes all the elements of the {@code ShortArray} instance with a specified value.
-     * @param value The short value to initialize the {@code ShortArray} instance with.
+     *
+     * @param value
+     *     The short value to initialize the {@code ShortArray} instance with.
      */
     public void init(short value) {
         for (int i = 0; i < getSize(); i++) {
@@ -152,6 +175,7 @@ public final class ShortArray extends TornadoNativeArray {
 
     /**
      * Returns the number of short elements stored in the {@code ShortArray} instance.
+     *
      * @return
      */
     @Override
@@ -161,6 +185,7 @@ public final class ShortArray extends TornadoNativeArray {
 
     /**
      * Returns the underlying {@link MemorySegment} of the {@code ShortArray} instance.
+     *
      * @return The {@link MemorySegment} associated with the {@code ShortArray} instance.
      */
     @Override
@@ -170,6 +195,7 @@ public final class ShortArray extends TornadoNativeArray {
 
     /**
      * Returns the total number of bytes that the {@link MemorySegment}, associated with the {@code ShortArray} instance, occupies.
+     *
      * @return The total number of bytes of the {@link MemorySegment}.
      */
     @Override
@@ -180,6 +206,7 @@ public final class ShortArray extends TornadoNativeArray {
     /**
      * Returns the number of bytes of the {@link MemorySegment} that is associated with the {@code ShortArray} instance,
      * excluding the header bytes.
+     *
      * @return The number of bytes of the raw data in the {@link MemorySegment}.
      */
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/TornadoNativeArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/TornadoNativeArray.java
@@ -45,24 +45,28 @@ public abstract sealed class TornadoNativeArray permits //
 
     /**
      * Returns the number of elements stored in the native array.
+     *
      * @return The number of elements of the native data array.
      */
     public abstract int getSize();
 
     /**
      * Returns the underlying {@link MemorySegment} of the native array.
+     *
      * @return The {@link MemorySegment} associated with the native array instance.
      */
     public abstract MemorySegment getSegment();
 
     /**
      * Returns the total number of bytes that the {@link MemorySegment} occupies, including the header bytes.
+     *
      * @return The total number of bytes of the {@link MemorySegment}.
      */
     public abstract long getNumBytesOfSegment();
 
     /**
      * Returns the number of bytes of the {@link MemorySegment}, excluding the header bytes.
+     *
      * @return The number of bytes of the raw data in the {@link MemorySegment}.
      */
     public abstract long getNumBytesWithoutHeader();
@@ -71,5 +75,7 @@ public abstract sealed class TornadoNativeArray permits //
      * Clears the contents of the native array.
      */
     protected abstract void clear();
+
+    public abstract int getElementSize();
 
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyTornado.java
@@ -128,7 +128,7 @@ public class NBodyTornado extends BenchmarkDriver {
         }
         taskGraph = new TaskGraph("benchmark");
         taskGraph.task("t0", ComputeKernels::nBody, numBodies, posSeq, velSeq, delT, espSqr);
-        taskGraph.transferToHost(DataTransferMode.USER_DEFINED, posSeq, velSeq);
+        taskGraph.transferToHost(DataTransferMode.UNDER_DEMAND, posSeq, velSeq);
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/AtomicsBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/AtomicsBuffer.java
@@ -66,7 +66,7 @@ public class AtomicsBuffer implements ObjectBuffer {
     }
 
     @Override
-    public int read(Object reference, long hostOffset, int[] events, boolean useDeps) {
+    public int read(Object reference, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         throw new TornadoRuntimeException("Not implemented");
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
@@ -77,7 +77,7 @@ public class FieldBuffer {
             debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: reading with offset != 0
-        int event = objectBuffer.read(getFieldValue(ref), 0, events, useDeps);
+        int event = objectBuffer.read(getFieldValue(ref), 0, 0, events, useDeps);
         return event;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
@@ -239,7 +239,7 @@ public abstract class OCLArrayWrapper<T> implements ObjectBuffer {
     @Override
     public void read(final Object value) {
         // TODO: reading with offset != 0
-        read(value, 0, null, false);
+        read(value, 0, 0, null, false);
     }
 
     /**
@@ -257,7 +257,7 @@ public abstract class OCLArrayWrapper<T> implements ObjectBuffer {
      *     operation.
      */
     @Override
-    public int read(final Object value, long hostOffset, int[] events, boolean useDeps) {
+    public int read(final Object value, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         final T array = cast(value);
         if (array == null) {
             throw new TornadoRuntimeException("[ERROR] output data is NULL");

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
@@ -28,6 +28,18 @@ import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
 
+import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
+import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
+import uk.ac.manchester.tornado.api.memory.ObjectBuffer;
+import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
+import uk.ac.manchester.tornado.api.types.arrays.CharArray;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.arrays.LongArray;
+import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
+import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.api.types.collections.VectorDouble2;
 import uk.ac.manchester.tornado.api.types.collections.VectorDouble3;
 import uk.ac.manchester.tornado.api.types.collections.VectorDouble4;
@@ -40,18 +52,6 @@ import uk.ac.manchester.tornado.api.types.collections.VectorInt2;
 import uk.ac.manchester.tornado.api.types.collections.VectorInt3;
 import uk.ac.manchester.tornado.api.types.collections.VectorInt4;
 import uk.ac.manchester.tornado.api.types.collections.VectorInt8;
-import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
-import uk.ac.manchester.tornado.api.types.arrays.CharArray;
-import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.arrays.LongArray;
-import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
-import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
-import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
-import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
-import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
-import uk.ac.manchester.tornado.api.memory.ObjectBuffer;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.exceptions.TornadoUnsupportedError;
@@ -106,7 +106,7 @@ public class OCLMemorySegmentWrapper implements ObjectBuffer {
 
     @Override
     public void read(final Object reference) {
-        read(reference, 0, null, false);
+        read(reference, 0, 0, null, false);
     }
 
     private MemorySegment getSegment(final Object reference) {
@@ -135,15 +135,19 @@ public class OCLMemorySegmentWrapper implements ObjectBuffer {
     }
 
     @Override
-    public int read(final Object reference, long hostOffset, int[] events, boolean useDeps) {
+    public int read(final Object reference, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         MemorySegment segment;
         segment = getSegment(reference);
-
         final int returnEvent;
         final long numBytes = getSizeSubRegionSize() > 0 ? getSizeSubRegionSize() : bufferSize;
-        if (batchSize <= 0) {
+        if (partialReadSize != 0) {
+            // Partial Copy Out due to a under demand copy by the user
+            returnEvent = deviceContext.readBuffer(toBuffer(), TornadoNativeArray.ARRAY_HEADER, partialReadSize, segment.address(), hostOffset, (useDeps) ? events : null);
+        } else if (batchSize <= 0) {
+            // Partial Copy Out due to batch processing
             returnEvent = deviceContext.readBuffer(toBuffer(), bufferOffset, numBytes, segment.address(), hostOffset, (useDeps) ? events : null);
         } else {
+            // Full copy out (default)
             returnEvent = deviceContext.readBuffer(toBuffer(), TornadoNativeArray.ARRAY_HEADER, numBytes, segment.address(), hostOffset + TornadoNativeArray.ARRAY_HEADER, (useDeps) ? events : null);
         }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLObjectWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLObjectWrapper.java
@@ -329,11 +329,11 @@ public class OCLObjectWrapper implements ObjectBuffer {
     @Override
     public void read(Object object) {
         // XXX: offset 0
-        read(object, 0, null, false);
+        read(object, 0, 0, null, false);
     }
 
     @Override
-    public int read(Object object, long hostOffset, int[] events, boolean useDeps) {
+    public int read(Object object, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         buffer.position(buffer.capacity());
         int event = deviceContext.readBuffer(toBuffer(), bufferOffset, getObjectSize(), buffer.array(), hostOffset, (useDeps) ? events : null);
         for (int i = 0; i < fields.length; i++) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
@@ -216,11 +216,11 @@ public class OCLVectorWrapper implements ObjectBuffer {
     @Override
     public void read(final Object value) {
         // TODO: reading with offset != 0
-        read(value, 0, null, false);
+        read(value, 0, 0, null, false);
     }
 
     @Override
-    public int read(final Object value, long hostOffset, int[] events, boolean useDeps) {
+    public int read(final Object value, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         TornadoInternalError.guarantee(value instanceof PrimitiveStorage, "Expecting a PrimitiveStorage type");
         final Object array = TornadoUtils.getAnnotatedObjectFromField(value, Payload.class);
         if (array == null) {
@@ -341,7 +341,7 @@ public class OCLVectorWrapper implements ObjectBuffer {
             }
         } else if (type == FloatArray.class || type == IntArray.class || type == DoubleArray.class || type == LongArray.class || type == ShortArray.class || type == CharArray.class || type == ByteArray.class) {
             return JavaKind.Object;
-        }  else {
+        } else {
             TornadoInternalError.shouldNotReachHere("The type should be an array, but found: " + type);
         }
         return null;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -627,6 +627,7 @@ public class OCLTornadoDevice implements TornadoAcceleratorDevice {
 
     @Override
     public int streamOutBlocking(Object object, long hostOffset, TornadoDeviceObjectState state, int[] events) {
+        long partialCopySize = state.getPartialCopySize();
         if (state.isAtomicRegionPresent()) {
             int eventID = state.getObjectBuffer().enqueueRead(null, 0, null, false);
             if (object instanceof AtomicInteger) {
@@ -637,7 +638,7 @@ public class OCLTornadoDevice implements TornadoAcceleratorDevice {
             return eventID;
         } else {
             TornadoInternalError.guarantee(state.hasObjectBuffer(), "invalid variable");
-            return state.getObjectBuffer().read(object, hostOffset, events, events == null);
+            return state.getObjectBuffer().read(object, hostOffset, partialCopySize, events, events == null);
         }
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/FieldBuffer.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/FieldBuffer.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -90,7 +90,7 @@ public class FieldBuffer {
             debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: reading with offset != 0
-        return objectBuffer.read(getFieldValue(ref), 0, events, useDeps);
+        return objectBuffer.read(getFieldValue(ref), 0, 0, events, useDeps);
     }
 
     public long toBuffer() {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
@@ -90,11 +90,11 @@ public abstract class PTXArrayWrapper<T> implements ObjectBuffer {
 
     @Override
     public void read(Object reference) {
-        read(reference, 0, null, false);
+        read(reference, 0, 0, null, false);
     }
 
     @Override
-    public int read(Object reference, long hostOffset, int[] events, boolean useDeps) {
+    public int read(Object reference, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         T array = cast(reference);
         if (array == null) {
             throw new TornadoRuntimeException("[ERROR] output data is NULL");

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
@@ -314,12 +314,12 @@ public class PTXObjectWrapper implements ObjectBuffer {
 
     @Override
     public void read(Object object) {
-        // XXX: offset 0
-        read(object, 0, null, false);
+        // XXX: offset and partial size set to 0
+        read(object, 0, 0, null, false);
     }
 
     @Override
-    public int read(Object object, long hostOffset, int[] events, boolean useDeps) {
+    public int read(Object object, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         int event = -1;
         buffer.position(buffer.capacity());
         event = deviceContext.readBuffer(toBuffer(), getObjectSize(), buffer.array(), hostOffset, (useDeps) ? events : null);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
@@ -193,11 +193,11 @@ public class PTXVectorWrapper implements ObjectBuffer {
     @Override
     public void read(final Object value) {
         // TODO: reading with offset != 0
-        read(value, 0, null, false);
+        read(value, 0, 0, null, false);
     }
 
     @Override
-    public int read(final Object value, long hostOffset, int[] events, boolean useDeps) {
+    public int read(final Object value, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         TornadoInternalError.guarantee(value instanceof PrimitiveStorage, "Expecting a PrimitiveStorage type");
         final Object array = TornadoUtils.getAnnotatedObjectFromField(value, Payload.class);
         if (array == null) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -466,7 +466,7 @@ public class PTXTornadoDevice implements TornadoAcceleratorDevice {
     @Override
     public int streamOutBlocking(Object object, long hostOffset, TornadoDeviceObjectState objectState, int[] events) {
         TornadoInternalError.guarantee(objectState.hasObjectBuffer(), "invalid variable");
-        return objectState.getObjectBuffer().read(object, hostOffset, events, events != null);
+        return objectState.getObjectBuffer().read(object, hostOffset, objectState.getPartialCopySize(), events, events != null);
     }
 
     /**

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/FieldBuffer.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/FieldBuffer.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -79,7 +79,7 @@ public class FieldBuffer {
             debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: reading with offset != 0
-        return objectBuffer.read(getFieldValue(ref), 0, events, useDeps);
+        return objectBuffer.read(getFieldValue(ref), 0, 0, events, useDeps);
     }
 
     public void write(final Object ref) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
@@ -113,7 +113,7 @@ public abstract class SPIRVArrayWrapper<T> implements ObjectBuffer {
 
     @Override
     public void read(Object object) {
-        read(object, 0, null, false);
+        read(object, 0, 0, null, false);
     }
 
     /*
@@ -144,7 +144,7 @@ public abstract class SPIRVArrayWrapper<T> implements ObjectBuffer {
     }
 
     @Override
-    public int read(Object reference, long hostOffset, int[] events, boolean useDeps) {
+    public int read(Object reference, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         final T array = cast(reference);
         if (array == null) {
             throw new TornadoRuntimeException("[ERROR] output data is NULL");

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMultiDimArrayWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMultiDimArrayWrapper.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -95,7 +95,7 @@ public class SPIRVMultiDimArrayWrapper<T, E> extends SPIRVArrayWrapper<T> {
         final E[] elements = innerCast(values);
         // XXX: Offset is 0
         for (int i = 0; i < elements.length; i++) {
-            wrappers[i].read(elements[i], 0, null, false);
+            wrappers[i].read(elements[i], 0, 0, null, false);
         }
         deviceContext.enqueueBarrier(deviceContext.getDeviceIndex());
         return 0;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
@@ -337,11 +337,11 @@ public class SPIRVObjectWrapper implements ObjectBuffer {
     @Override
     public void read(Object object) {
         // XXX: offset 0
-        read(object, 0, null, false);
+        read(object, 0, 0, null, false);
     }
 
     @Override
-    public int read(Object object, long hostOffset, int[] events, boolean useDeps) {
+    public int read(Object object, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         buffer.position(buffer.capacity());
         int event = deviceContext.readBuffer(toBuffer(), bufferOffset, getObjectSize(), buffer.array(), hostOffset, (useDeps) ? events : null);
         for (int i = 0; i < fields.length; i++) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
@@ -227,11 +227,11 @@ public class SPIRVVectorWrapper implements ObjectBuffer {
     @Override
     public void read(final Object value) {
         // TODO: reading with offset != 0
-        read(value, 0, null, false);
+        read(value, 0, 0, null, false);
     }
 
     @Override
-    public int read(final Object value, long hostOffset, int[] events, boolean useDeps) {
+    public int read(final Object value, long hostOffset, long partialReadSize, int[] events, boolean useDeps) {
         TornadoInternalError.guarantee(value instanceof PrimitiveStorage, "Expecting a PrimitiveStorage type");
         final Object array = TornadoUtils.getAnnotatedObjectFromField(value, Payload.class);
         if (array == null) {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/NBody.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/NBody.java
@@ -151,7 +151,7 @@ public class NBody {
         final TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, posTornadoVM, velTornadoVM) //
                 .task("t0", NBody::nBody, numBodies, posTornadoVM, velTornadoVM, delT, espSqr) //
-                .transferToHost(DataTransferMode.USER_DEFINED, posTornadoVM, velTornadoVM);
+                .transferToHost(DataTransferMode.UNDER_DEMAND, posTornadoVM, velTornadoVM);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph).withWarmUp();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/DeviceObjectState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/DeviceObjectState.java
@@ -35,12 +35,14 @@ public class DeviceObjectState implements TornadoDeviceObjectState {
 
     private boolean contents;
     private boolean lockBuffer;
+    private long partialSize;
 
     public DeviceObjectState() {
         objectBuffer = null;
         atomicRegionPresent = false;
         contents = false;
         lockBuffer = false;
+        partialSize = 0;
     }
 
     public void setObjectBuffer(ObjectBuffer value) {
@@ -96,5 +98,15 @@ public class DeviceObjectState implements TornadoDeviceObjectState {
     @Override
     public void setAtomicRegion() {
         this.atomicRegionPresent = true;
+    }
+
+    @Override
+    public void setPartialCopySize(long partialCopySize) {
+        this.partialSize = partialCopySize;
+    }
+
+    @Override
+    public long getPartialCopySize() {
+        return this.partialSize;
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
@@ -28,7 +28,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
-import uk.ac.manchester.tornado.api.DataConfig;
+import uk.ac.manchester.tornado.api.DataRange;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
@@ -279,9 +279,11 @@ public class TestAPI extends TornadoTestBase {
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
         TornadoExecutionResult executionResult = executionPlan.execute();
 
-        DataConfig dataConfig = new DataConfig(data, ValueLayout.JAVA_INT);
-        executionResult.transferToHost(data, dataConfig.withSize(N / 2));
-        executionResult.transferToHost(data, dataConfig.withOffset(N / 2).withSize(N / 2));
+        DataRange dataRange = new DataRange(data);
+
+        executionResult.transferToHost(dataRange.withSize(N / 2));
+
+        executionResult.transferToHost(dataRange.withOffset(N / 2).withSize(N / 2));
 
         // Mark all device memory buffers as free, thus the TornadoVM runtime can reuse
         // device buffers for other execution plans.

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
@@ -28,6 +28,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
+import uk.ac.manchester.tornado.api.DataConfig;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
@@ -188,6 +189,9 @@ public class TestAPI extends TornadoTestBase {
         }
     }
 
+    /**
+     * Perform the copy out under demand. It performs a copy from the device to the host of the entire array via the execution result.
+     */
     @Test
     public void testLazyCopyOut() {
         final int N = 1024;
@@ -201,7 +205,7 @@ public class TestAPI extends TornadoTestBase {
 
         taskGraph.transferToDevice(DataTransferMode.FIRST_EXECUTION, data) //
                 .task("t0", TestArrays::addAccumulator, data, 1) //
-                .transferToHost(DataTransferMode.USER_DEFINED, data);
+                .transferToHost(DataTransferMode.UNDER_DEMAND, data);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
@@ -219,6 +223,10 @@ public class TestAPI extends TornadoTestBase {
         }
     }
 
+    /**
+     * Perform the copy out under demand. It performs a copy from the device to the host of the entire array via the execution result.
+     * In this test, input and output use the same array.
+     */
     @Test
     public void testLazyCopyOut2() {
         final int N = 128;
@@ -233,7 +241,7 @@ public class TestAPI extends TornadoTestBase {
 
         taskGraph.transferToDevice(DataTransferMode.FIRST_EXECUTION, data);
         taskGraph.task("t0", TestArrays::addAccumulator, data, 1);
-        taskGraph.transferToHost(DataTransferMode.USER_DEFINED, data);
+        taskGraph.transferToHost(DataTransferMode.UNDER_DEMAND, data);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlanPlan = new TornadoExecutionPlan(immutableTaskGraph);
@@ -243,6 +251,41 @@ public class TestAPI extends TornadoTestBase {
         executionResult.transferToHost(data);
 
         executionPlanPlan.freeDeviceMemory();
+
+        for (int i = 0; i < N; i++) {
+            assertEquals(21, data.get(i));
+        }
+    }
+
+    /**
+     * Perform the copy out under demand. It performs a copy of a subset of the output array.
+     */
+    @Test
+    public void testLazyPartialCopyOut() {
+        final int N = 1024;
+        int size = 20;
+        IntArray data = new IntArray(N);
+
+        IntStream.range(0, N).parallel().forEach(idx -> data.set(idx, size));
+
+        TaskGraph taskGraph = new TaskGraph("s0");
+        assertNotNull(taskGraph);
+
+        taskGraph.transferToDevice(DataTransferMode.FIRST_EXECUTION, data) //
+                .task("t0", TestArrays::addAccumulator, data, 1) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, data);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+        TornadoExecutionResult executionResult = executionPlan.execute();
+
+        DataConfig dataConfig = new DataConfig(data, ValueLayout.JAVA_INT);
+        executionResult.transferToHost(data, dataConfig.withSize(N / 2));
+        executionResult.transferToHost(data, dataConfig.withOffset(N / 2).withSize(N / 2));
+
+        // Mark all device memory buffers as free, thus the TornadoVM runtime can reuse
+        // device buffers for other execution plans.
+        executionPlan.freeDeviceMemory();
 
         for (int i = 0; i < N; i++) {
             assertEquals(21, data.get(i));


### PR DESCRIPTION
#### Description

This PR enables under-demand sub-copies from the device to the host. 
This is useful for iterative algorithms in which we do not have to copy all data back and forth between
iterations. Rather. we can keep the data on the device, and perform the transfer under demand. 

This functionality was already available since version 0.15 of TornadoVM. This PR extends this functionality by allowing developers to copy sub-regions under demand. 

There is a new method in the TornadoExecutionResult to perform partial copies.
The following code snippet shows an example:

```java
// Build a Task Graph and declare the copy out (transfer to host) as a UNDER_DEMAND copy
taskGraph.transferToDevice(DataTransferMode.FIRST_EXECUTION, data) //
                .task("t0", TestArrays::addAccumulator, data, 1) //
                .transferToHost(DataTransferMode.UNDER_DEMAND, data);

// Create an immutable task graph
ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();

// Create an execution plan
TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);

// Run the execution plan and obtain the execution result.
TornadoExecutionResult executionResult = executionPlan.execute();

// From the Execution Result, we can build a DataRange and specify the range to copy out
DataRange dataRange = new DataRange(data);


// Copy under demand from offset 0 (0 is the default is not specified) until size = N/2.
executionResult.transferToHost(dataRange.withSize(N / 2));

// Perform a second copy from offset = N/2 with size = N/2. 
executionResult.transferToHost(dataRange.withOffset(N / 2).withSize(N / 2));
```

Using the data range, developers specify the offset and the size to copy. 
Both of these parameters are optional (`withOffset(x)` and `withSize(y)`).

- If the offset is not specified, the TornadoVM Runtime selects offset 0
- If the size if not specified, the TornadoVM runtime copies from the selected (or default) offset until the end of the array. 


#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make
$ tornado-test -V uk.ac.manchester.tornado.unittests.api.TestAPI#testLazyPartialCopyOut
```
