### PR TITLE
[fix] Runtime Name Check for Grid Schedulers

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/GridScheduler.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/GridScheduler.java
@@ -17,6 +17,7 @@
  */
 package uk.ac.manchester.tornado.api;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class GridScheduler {
@@ -42,5 +43,9 @@ public class GridScheduler {
 
     public boolean contains(String taskScheduleName, String taskName) {
         return gridTaskMap.containsKey(taskScheduleName + "." + taskName);
+    }
+
+    public Set<String> keySet() {
+        return gridTaskMap.keySet();
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import uk.ac.manchester.tornado.api.common.Access;
+import uk.ac.manchester.tornado.api.common.PrebuiltTaskPackage;
 import uk.ac.manchester.tornado.api.common.TaskPackage;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task;
@@ -630,7 +631,8 @@ public class TaskGraph implements TaskGraphInterface {
     @Override
     public TaskGraph prebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
         checkTaskName(id);
-        taskGraphImpl.addPrebuiltTask(id, entryPoint, filename, args, accesses, device, dimensions);
+        TaskPackage prebuiltTask = TaskPackage.createPrebuiltTask(id, entryPoint, filename, args, accesses, device, dimensions);
+        taskGraphImpl.addPrebuiltTask(prebuiltTask);
         return this;
     }
 
@@ -659,7 +661,9 @@ public class TaskGraph implements TaskGraphInterface {
     @Override
     public TaskGraph prebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions, int[] atomics) {
         checkTaskName(id);
-        taskGraphImpl.addPrebuiltTask(id, entryPoint, filename, args, accesses, device, dimensions, atomics);
+        PrebuiltTaskPackage prebuiltTask = TaskPackage.createPrebuiltTask(id, entryPoint, filename, args, accesses, device, dimensions);
+        prebuiltTask.withAtomics(atomics);
+        taskGraphImpl.addPrebuiltTask(prebuiltTask);
         return this;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.common.TaskPackage;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
@@ -89,15 +88,9 @@ public interface TornadoTaskGraphInterface extends ProfileInterface {
 
     void addTask(TaskPackage taskPackage);
 
-    void addPrebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions);
-
-    void addPrebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions, int[] atomics);
-
-    void addScalaTask(String id, Object function, Object[] args);
+    void addPrebuiltTask(TaskPackage taskPackage);
 
     String getTaskGraphName();
-
-    void replaceParameter(Object oldParameter, Object newParameter);
 
     void useDefaultThreadScheduler(boolean use);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/PrebuiltTaskPackage.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/PrebuiltTaskPackage.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.common;
+
+public class PrebuiltTaskPackage extends TaskPackage {
+
+    private final String entryPoint;
+    private final String filename;
+    private final Object[] args;
+    private final Access[] accesses;
+    private final TornadoDevice device;
+    private final int[] dimensions;
+    private int[] atomics;
+
+    public PrebuiltTaskPackage(String id, String entryPoint, String fileName, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
+        super(id, null);
+        this.entryPoint = entryPoint;
+        this.filename = fileName;
+        this.args = args;
+        this.accesses = accesses;
+        this.device = device;
+        this.dimensions = dimensions;
+    }
+
+    public PrebuiltTaskPackage withAtomics(int[] atomics) {
+        this.atomics = atomics;
+        return this;
+    }
+
+    public String getEntryPoint() {
+        return entryPoint;
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+
+    public Object[] getArgs() {
+        return args;
+    }
+
+    public Access[] getAccesses() {
+        return accesses;
+    }
+
+    public TornadoDevice getDevice() {
+        return device;
+    }
+
+    public int[] getDimensions() {
+        return dimensions;
+    }
+
+    @Override
+    public boolean isPrebuiltTask() {
+        return true;
+    }
+
+    public int[] getAtomics() {
+        return atomics;
+    }
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TaskPackage.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TaskPackage.java
@@ -41,6 +41,8 @@ public class TaskPackage {
     private final Object[] taskParameters;
     private long numThreadsToRun;
 
+    private boolean isPrebuiltTask;
+
     public TaskPackage(String id, Task code) {
         this.id = id;
         this.taskType = 0;
@@ -110,29 +112,29 @@ public class TaskPackage {
         this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10 };
     }
 
-    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> TaskPackage(String id, TornadoFunctions.Task11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
-            T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11) {
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> TaskPackage(String id, Task11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6,
+            T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11) {
         this.id = id;
         this.taskType = 11;
         this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11 };
     }
 
-    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> TaskPackage(String id, TornadoFunctions.Task12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> code, T1 arg1, T2 arg2, T3 arg3,
-            T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12) {
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> TaskPackage(String id, Task12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
+            T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12) {
         this.id = id;
         this.taskType = 12;
         this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12 };
     }
 
-    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> TaskPackage(String id, TornadoFunctions.Task13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> code, T1 arg1, T2 arg2,
-            T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13) {
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> TaskPackage(String id, Task13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+            T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13) {
         this.id = id;
         this.taskType = 13;
         this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13 };
     }
 
-    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> TaskPackage(String id, TornadoFunctions.Task14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> code, T1 arg1,
-            T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14) {
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> TaskPackage(String id, Task14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> code, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14) {
         this.id = id;
         this.taskType = 14;
         this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14 };
@@ -217,6 +219,10 @@ public class TaskPackage {
         return new TaskPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
     }
 
+    public static PrebuiltTaskPackage createPrebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
+        return new PrebuiltTaskPackage(id, entryPoint, filename, args, accesses, device, dimensions);
+    }
+
     public String getId() {
         return id;
     }
@@ -234,12 +240,16 @@ public class TaskPackage {
     }
 
     /**
-     * Get all parameters to the lambda expression. First parameter is reserved to
-     * the input code.
+     * Get all parameters to the lambda expression. First parameter is reserved to the input code.
      *
      * @return an object array with all parameters.
      */
     public Object[] getTaskParameters() {
         return taskParameters;
     }
+
+    public boolean isPrebuiltTask() {
+        return isPrebuiltTask;
+    }
+
 }

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -79,6 +79,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGrid"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGridScheduler"),
+    TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.Grids"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestCombinedTaskGraph"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestVectorAdditionKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.KernelContextWorkGroupTests"),

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/ReduceCodeAnalysis.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/ReduceCodeAnalysis.java
@@ -58,6 +58,7 @@ import org.graalvm.compiler.nodes.java.MethodCallTargetNode;
 import org.graalvm.compiler.nodes.java.StoreIndexedNode;
 
 import uk.ac.manchester.tornado.api.annotations.Reduce;
+import uk.ac.manchester.tornado.api.common.PrebuiltTaskPackage;
 import uk.ac.manchester.tornado.api.common.TaskPackage;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
@@ -389,6 +390,11 @@ public class ReduceCodeAnalysis {
         HashMap<Integer, MetaReduceTasks> tableMetaDataReduce = new HashMap<>();
 
         for (TaskPackage taskMetadata : taskPackages) {
+
+            if (taskMetadata instanceof PrebuiltTaskPackage) {
+                // We skip analysis of pre-built tasks
+                continue;
+            }
 
             Object taskCode = taskMetadata.getTaskParameters()[0];
             StructuredGraph graph = CodeAnalysis.buildHighLevelGraalGraph(taskCode);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -307,28 +307,21 @@ public class TaskUtils {
 
     }
 
-    public static PrebuiltTask createTask(ScheduleMetaData meta, PrebuiltTaskPackage prebuiltTaskPackage) {
-        DomainTree domain = buildDomainTree(prebuiltTaskPackage.getDimensions());
+    public static PrebuiltTask createTask(ScheduleMetaData meta, PrebuiltTaskPackage taskPackage) {
+        DomainTree domain = buildDomainTree(taskPackage.getDimensions());
         PrebuiltTask prebuiltTask = new PrebuiltTask(meta, //
-                prebuiltTaskPackage.getId(), //
-                prebuiltTaskPackage.getEntryPoint(), //
-                prebuiltTaskPackage.getFilename(), //
-                prebuiltTaskPackage.getArgs(),  //
-                prebuiltTaskPackage.getAccesses(), //
-                prebuiltTaskPackage.getDevice(), //
+                taskPackage.getId(), //
+                taskPackage.getEntryPoint(), //
+                taskPackage.getFilename(), //
+                taskPackage.getArgs(),  //
+                taskPackage.getAccesses(), //
+                taskPackage.getDevice(), //
                 domain);
-        if (prebuiltTaskPackage.getAtomics() != null) {
-            prebuiltTask.withAtomics(prebuiltTaskPackage.getAtomics());
+        if (taskPackage.getAtomics() != null) {
+            prebuiltTask.withAtomics(taskPackage.getAtomics());
         }
         return prebuiltTask;
     }
-
-    //    public static PrebuiltTask createTask(ScheduleMetaData meta, PrebuiltTaskPackage prebuiltTaskPackage) {
-    //        DomainTree domain = buildDomainTree(prebuiltTaskPackage.getDimensions());
-    //        PrebuiltTask prebuiltTask = new PrebuiltTask(meta, id, entryPoint, filename, args, accesses, device, domain);
-    //        prebuiltTask.withAtomics(atomics);
-    //        return prebuiltTask;
-    //    }
 
     private static CompilableTask createTask(ScheduleMetaData meta, String id, Method method, Object code, boolean extractCVs, Object... args) {
         final int numArgs;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/compiler/TornadoCompilerIdentifier.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/compiler/TornadoCompilerIdentifier.java
@@ -37,5 +37,4 @@ public class TornadoCompilerIdentifier implements CompilationIdentifier {
     public String toString(Verbosity verbosity) {
         return STR."\{name}-\{id}";
     }
-
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
@@ -68,9 +68,9 @@ public class PrebuiltTask implements SchedulableTask {
 
     }
 
-    public PrebuiltTask(ScheduleMetaData scheduleMeta, String id, String entryPoint, String filename, Object[] args, Access[] access, TornadoDevice device, DomainTree domain, int[] atomics) {
-        this(scheduleMeta, id, entryPoint, filename, args, access, device, domain);
+    public PrebuiltTask withAtomics(int[] atomics) {
         this.atomics = atomics;
+        return this;
     }
 
     @Override
@@ -115,7 +115,7 @@ public class PrebuiltTask implements SchedulableTask {
 
     @Override
     public String getFullName() {
-        return "task - " + meta.getId() + "[" + entryPoint + "]";
+        return STR."task - \{meta.getId()}[\{entryPoint}]";
     }
 
     @Override
@@ -138,11 +138,9 @@ public class PrebuiltTask implements SchedulableTask {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof CompilableTask) {
-            CompilableTask other = (CompilableTask) obj;
+        if (obj instanceof CompilableTask other) {
             return getId().equals(other.getId());
         }
-
         return false;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -60,8 +60,8 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoDriver;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoTaskGraphInterface;
-import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.Event;
+import uk.ac.manchester.tornado.api.common.PrebuiltTaskPackage;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.common.TaskPackage;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
@@ -364,43 +364,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         }
         argumentsLookUp.remove(oldRef);
         argumentsLookUp.add(newRef);
-    }
-
-    @Override
-    public void replaceParameter(Object oldParameter, Object newParameter) {
-        // 1. Update from the streamIn list of objects
-        updateReference(oldParameter, newParameter, streamInObjects);
-
-        // 2. Update from the stream out list of objects
-        updateReference(oldParameter, newParameter, streamOutObjects);
-
-        // 3. Update from graphContext and replace the object state.
-        // Otherwise, if the object is copied in (via COPY_IN), we might think the
-        // object is already on the device heap.
-        executionContext.replaceObjectState(oldParameter, newParameter);
-
-        // 4. Update the global states array in the vm.
-        if (vm != null) {
-            vm.fetchGlobalStates();
-        }
-
-        // 5. Set the update data flag to true in order to create a new call wrapper
-        // on the device.
-        updateData = true;
-
-        // 6. Update task-parameters
-        // Force to recompile the task-sketcher
-        for (TaskPackage tp : taskPackages) {
-            Object[] params = tp.getTaskParameters();
-            for (int k = 1; k < params.length; k++) {
-                if (params[k].equals(oldParameter)) {
-                    params[k] = newParameter;
-                }
-            }
-        }
-        if (this.gridScheduler == null) {
-            triggerRecompile();
-        }
     }
 
     @Override
@@ -1296,7 +1259,29 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     @Override
     public TornadoTaskGraphInterface schedule(GridScheduler gridScheduler) {
         this.gridScheduler = gridScheduler;
+        // check schedule names
+        checkGridSchedulerNames();
+        // Schedule the task-graph
         return schedule();
+    }
+
+    private boolean isTaskNamePresent(String taskName) {
+        for (TaskPackage taskPackage : taskPackages) {
+            if (taskName.equals(STR."\{taskGraphName}.\{taskPackage.getId()}")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void checkGridSchedulerNames() {
+        Set<String> gridTaskNames = gridScheduler.keySet();
+        for (String gridName : gridTaskNames) {
+            if (!isTaskNamePresent(gridName)) {
+                throw new TornadoRuntimeException(STR."[ERROR] Grid scheduler with name \{gridName} not found in the Task-Graph");
+            }
+        }
+
     }
 
     @SuppressWarnings("unchecked")
@@ -2100,18 +2085,10 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
-    public void addPrebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
-        addInner(TaskUtils.createTask(meta(), id, entryPoint, filename, args, accesses, device, dimensions));
-    }
-
-    @Override
-    public void addPrebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions, int[] atomics) {
-        addInner(TaskUtils.createTask(meta(), id, entryPoint, filename, args, accesses, device, dimensions, atomics));
-    }
-
-    @Override
-    public void addScalaTask(String id, Object function, Object[] args) {
-        addInner(TaskUtils.scalaTask(id, function, args));
+    public void addPrebuiltTask(TaskPackage taskPackage) {
+        taskPackages.add(taskPackage);
+        PrebuiltTaskPackage prebuiltTaskPackage = (PrebuiltTaskPackage) taskPackage;
+        addInner(TaskUtils.createTask(meta(), prebuiltTaskPackage));
     }
 
     @Override

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGridScheduler.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGridScheduler.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -30,15 +30,15 @@ import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
  * <p>
  * How to run?
  * </p>
  * <code>
- *      tornado-test -V --debug uk.ac.manchester.tornado.unittests.grid.TestGridScheduler
+ * tornado-test -V --debug uk.ac.manchester.tornado.unittests.grid.TestGridScheduler
  * </code>
  *
  */
@@ -49,7 +49,7 @@ public class TestGridScheduler {
         vectorAddFloat(a, b, c);
 
         for (int i = 0; i < c.getSize(); i++) {
-       // for (float v : c) {
+            // for (float v : c) {
             acc += c.get(i);
         }
         return acc;
@@ -138,8 +138,7 @@ public class TestGridScheduler {
 
         ImmutableTaskGraph immutableTaskGraph1 = s1.snapshot();
         TornadoExecutionPlan executionPlan1 = new TornadoExecutionPlan(immutableTaskGraph1);
-        executionPlan1.withGridScheduler(gridScheduler) //
-                .execute();
+        executionPlan1.execute();
 
         // Final SUM
         float finalSum = tornadoC.get(0);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/Grids.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/Grids.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.kernelcontext.api;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * How to run?
+ *
+ * <p>
+ * <code>
+ * tornado-test --threadInfo --printKernel uk.ac.manchester.tornado.unittests.kernelcontext.api.Grids
+ * </code>
+ * </p>
+ */
+public class Grids extends TornadoTestBase {
+
+    private static void psKernel(KernelContext kc, FloatArray tArray, FloatArray vArray, FloatArray results) {
+        int idx = kc.localIdx;
+
+        results.set(5 * idx + 0, kc.globalIdx);
+        results.set(5 * idx + 1, kc.globalGroupSizeX);
+        results.set(5 * idx + 2, kc.localGroupSizeX);
+        results.set(5 * idx + 3, kc.localIdx);
+        results.set(5 * idx + 4, 9999);
+    }
+
+    @Test
+    public void testWithCorrectNames() {
+        final int gridSize = 32;
+
+        final int size = 100000;
+
+        // Prepare : convert the arrays to Tornado Native off-heap arrays
+        FloatArray timesArray = new FloatArray(size);
+        FloatArray obsArray = new FloatArray(size);
+
+        FloatArray resArray = new FloatArray(100000);
+        resArray.init(0.0f);
+
+        // We need the worker & grid to be able to allocate shared memory on the device
+        WorkerGrid worker = new WorkerGrid1D(gridSize);
+        GridScheduler gridScheduler = new GridScheduler("PeriodSearchTaskGraph.t0", worker);
+        KernelContext context = new KernelContext();
+        worker.setLocalWork(gridSize, 1, 1);
+
+        TaskGraph taskGraph = new TaskGraph("PeriodSearchTaskGraph");
+
+        taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, timesArray, obsArray) //
+                .task("t0", Grids::psKernel, context, timesArray, obsArray, resArray) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, resArray);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+
+        executionPlan.withGridScheduler(gridScheduler) //
+                .execute();
+
+    }
+
+    @Test(expected = TornadoRuntimeException.class)
+    public void testWithIncorrectGraphName() {
+        final int gridSize = 32;
+
+        final int size = 100000;
+
+        // Prepare : convert the arrays to Tornado Native off-heap arrays
+        FloatArray timesArray = new FloatArray(size);
+        FloatArray obsArray = new FloatArray(size);
+
+        FloatArray resArray = new FloatArray(100000);
+        resArray.init(0.0f);
+
+        // We need the worker & grid to be able to allocate shared memory on the device
+        WorkerGrid worker = new WorkerGrid1D(gridSize);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+        worker.setLocalWork(gridSize, 1, 1);
+
+        TaskGraph taskGraph = new TaskGraph("PeriodSearchTaskGraph");
+
+        taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, timesArray, obsArray) //
+                .task("t0", Grids::psKernel, context, timesArray, obsArray, resArray) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, resArray);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+
+        executionPlan.withGridScheduler(gridScheduler) //
+                .execute();
+
+    }
+
+    @Test(expected = TornadoRuntimeException.class)
+    public void testWithIncorrectGraphAndTaskName() {
+        final int gridSize = 32;
+
+        final int size = 100000;
+
+        // Prepare : convert the arrays to Tornado Native off-heap arrays
+        FloatArray timesArray = new FloatArray(size);
+        FloatArray obsArray = new FloatArray(size);
+
+        FloatArray resArray = new FloatArray(100000);
+        resArray.init(0.0f);
+
+        // We need the worker & grid to be able to allocate shared memory on the device
+        WorkerGrid worker = new WorkerGrid1D(gridSize);
+        GridScheduler gridScheduler = new GridScheduler("foo.bar", worker);
+        KernelContext context = new KernelContext();
+        worker.setLocalWork(gridSize, 1, 1);
+
+        TaskGraph taskGraph = new TaskGraph("PeriodSearchTaskGraph");
+
+        taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, timesArray, obsArray) //
+                .task("t0", Grids::psKernel, context, timesArray, obsArray, resArray) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, resArray);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+
+        executionPlan.withGridScheduler(gridScheduler) //
+                .execute();
+
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/Grids.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/Grids.java
@@ -42,6 +42,9 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  */
 public class Grids extends TornadoTestBase {
 
+    final int gridSize = 32;
+    final int size = 100000;
+
     private static void psKernel(KernelContext kc, FloatArray tArray, FloatArray vArray, FloatArray results) {
         int idx = kc.localIdx;
 
@@ -54,27 +57,22 @@ public class Grids extends TornadoTestBase {
 
     @Test
     public void testWithCorrectNames() {
-        final int gridSize = 32;
 
-        final int size = 100000;
-
-        // Prepare : convert the arrays to Tornado Native off-heap arrays
         FloatArray timesArray = new FloatArray(size);
         FloatArray obsArray = new FloatArray(size);
 
         FloatArray resArray = new FloatArray(100000);
         resArray.init(0.0f);
 
-        // We need the worker & grid to be able to allocate shared memory on the device
         WorkerGrid worker = new WorkerGrid1D(gridSize);
-        GridScheduler gridScheduler = new GridScheduler("PeriodSearchTaskGraph.t0", worker);
+        GridScheduler gridScheduler = new GridScheduler("foo.bar", worker);
         KernelContext context = new KernelContext();
         worker.setLocalWork(gridSize, 1, 1);
 
-        TaskGraph taskGraph = new TaskGraph("PeriodSearchTaskGraph");
+        TaskGraph taskGraph = new TaskGraph("foo");
 
         taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, timesArray, obsArray) //
-                .task("t0", Grids::psKernel, context, timesArray, obsArray, resArray) //
+                .task("bar", Grids::psKernel, context, timesArray, obsArray, resArray) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, resArray);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
@@ -87,24 +85,18 @@ public class Grids extends TornadoTestBase {
 
     @Test(expected = TornadoRuntimeException.class)
     public void testWithIncorrectGraphName() {
-        final int gridSize = 32;
-
-        final int size = 100000;
-
-        // Prepare : convert the arrays to Tornado Native off-heap arrays
         FloatArray timesArray = new FloatArray(size);
         FloatArray obsArray = new FloatArray(size);
 
         FloatArray resArray = new FloatArray(100000);
         resArray.init(0.0f);
 
-        // We need the worker & grid to be able to allocate shared memory on the device
         WorkerGrid worker = new WorkerGrid1D(gridSize);
         GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
         worker.setLocalWork(gridSize, 1, 1);
 
-        TaskGraph taskGraph = new TaskGraph("PeriodSearchTaskGraph");
+        TaskGraph taskGraph = new TaskGraph("foo");
 
         taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, timesArray, obsArray) //
                 .task("t0", Grids::psKernel, context, timesArray, obsArray, resArray) //
@@ -120,24 +112,18 @@ public class Grids extends TornadoTestBase {
 
     @Test(expected = TornadoRuntimeException.class)
     public void testWithIncorrectGraphAndTaskName() {
-        final int gridSize = 32;
-
-        final int size = 100000;
-
-        // Prepare : convert the arrays to Tornado Native off-heap arrays
         FloatArray timesArray = new FloatArray(size);
         FloatArray obsArray = new FloatArray(size);
 
         FloatArray resArray = new FloatArray(100000);
         resArray.init(0.0f);
 
-        // We need the worker & grid to be able to allocate shared memory on the device
         WorkerGrid worker = new WorkerGrid1D(gridSize);
         GridScheduler gridScheduler = new GridScheduler("foo.bar", worker);
         KernelContext context = new KernelContext();
         worker.setLocalWork(gridSize, 1, 1);
 
-        TaskGraph taskGraph = new TaskGraph("PeriodSearchTaskGraph");
+        TaskGraph taskGraph = new TaskGraph("t0");
 
         taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, timesArray, obsArray) //
                 .task("t0", Grids::psKernel, context, timesArray, obsArray, resArray) //


### PR DESCRIPTION
#### Description
Grid Schedulers contain the name of an existing task graph and a task name. However, it could be possible that, due to a programmer's error, the grid name does not match with any existing tasks within the assigned task-graph. This PR adds this check and it refactors the PrebuilTask API to use the same style as the Compilable Task API.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make 
$ tornado-test -V --threadInfo --printKernel uk.ac.manchester.tornado.unittests.kernelcontext.api.Grids
```

Pass also all unit-tests

```bash
$ make tests
```
