### PR TITLE
[checkstyle] Add exception handling to checkstyle configuration to support STR templates

### DIFF
--- a/tornado-assembly/src/etc/checkstyle.xml
+++ b/tornado-assembly/src/etc/checkstyle.xml
@@ -19,6 +19,11 @@
         <property name="offCommentFormat" value="CHECKSTYLE.OFF"/>
         <property name="onCommentFormat" value="CHECKSTYLE.ON"/>
     </module>
+    <property name="haltOnException" value="false"/>
+    <!-- This a temporary workaround until they add proper support for String Templates-->
+    <module name="SuppressionSingleFilter">
+        <property name="message" value=".*IllegalStateException occurred while parsing file.*"/>
+    </module>
     <module name="TreeWalker">
         <module name="AvoidStarImport">
             <property name="allowClassImports" value="false"/>


### PR DESCRIPTION
#### Description

Using String Templates caused checkstyle to fail due to unsupported rules. 

There is an open PR, so it is going to be officially supported soon. https://github.com/checkstyle/checkstyle/issues/13830#issuecomment-1892787426

However, they provided the following temporary workaround to suppress errors regarding String Templates  
https://github.com/checkstyle/checkstyle/issues/12542#issuecomment-1362261537.
#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [x] Windows

#### How to test the new patch?

```bash
make checkstyle
```
----------------------------------------------------------------------------
