### PR TITLE
[spirv][fix] emit Vector16 Capability for 16-width vectors

### DIFF
--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVPrimitiveTypes.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVPrimitiveTypes.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * Copyright (c) 2021, 2024 APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -70,8 +70,8 @@ public class SPIRVPrimitiveTypes {
 
     private SPIRVId getVectorType(SPIRVKind vectorType, SPIRVId typeID) {
         SPIRVId intPrimitiveId = getTypePrimitive(vectorType.getElementKind());
-        if (vectorType.getVectorLength() == 8 && !vector16Capability) {
-            // Having 8 components for TypeVector requires the Vector16 capability
+        if ((vectorType.getVectorLength() == 8 || vectorType.getVectorLength() == 16) && !vector16Capability) {
+            // Having 8 or 16 components for TypeVector requires the Vector16 capability
             module.add(new SPIRVOpCapability(SPIRVCapability.Vector16()));
             vector16Capability = true;
         }


### PR DESCRIPTION
#### Description

This PR fixes the warning for SPIR-V Kernels generating vector-16 instructions (e.g., Float16).

#### Problem description

The issue is that the `spirv-val` was emitting an error due to a missing SPIR-V capability in the generated SPIR-V kernels. 
This PR adds the capability when it is required. 

#### Backend/s tested

This PR only affects the SPIR-V backend,

- [ ] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make BACKEND=spirv
$ tornado-test --printKernel --debug -V uk.ac.manchester.tornado.unittests.vectortypes.TestFloats#testSimpleDotProductFloat16
.... 
[SPIRV-Runtime] SPIRV Registering VM Intrinsics Plugins - pending
SPIRV-File : /tmp/tornadoVM-spirv/11047078642496-s0.t0dotMethodFloat16.spv     <<< Kernel File
[SPIRV-Runtime] Set SPIR-V entry point: dotMethodFloat16

$ spirv-val /tmp/tornadoVM-spirv/11047078642496-s0.t0dotMethodFloat16.spv    <<< Note that the kernel file is different per execution
```
If nothing is emitted in the last instruction, then the kernel is correct.
 
