### PR TITLE
[math] ceil function added 

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/math/TornadoMath.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/math/TornadoMath.java
@@ -404,4 +404,12 @@ public class TornadoMath {
         return new Float3(dot(m.row(0).asFloat3(), x), dot(m.row(1).asFloat3(), x), dot(m.row(2).asFloat3(), x));
     }
 
+    public static float ceil(float value) {
+        return (float) Math.ceil(value);
+    }
+
+    public static double ceil(double value) {
+        return Math.ceil(value);
+    }
+
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/asm/OCLAssembler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/asm/OCLAssembler.java
@@ -706,6 +706,8 @@ public final class OCLAssembler extends Assembler {
         public static final OCLUnaryIntrinsic WRITE_MEM_FENCE = new OCLUnaryIntrinsic("write_mem_fence");
 
         public static final OCLUnaryIntrinsic ABS = new OCLUnaryIntrinsic("abs");
+
+        public static final OCLUnaryIntrinsic CEIL = new OCLUnaryIntrinsic("ceil");
         public static final OCLUnaryIntrinsic EXP = new OCLUnaryIntrinsic("exp");
         public static final OCLUnaryIntrinsic SQRT = new OCLUnaryIntrinsic("sqrt");
         public static final OCLUnaryIntrinsic LOG = new OCLUnaryIntrinsic("log");

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLMathPlugins.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLMathPlugins.java
@@ -30,6 +30,7 @@ import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPBinaryInt
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.ACOS;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.ASIN;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.ATAN;
+import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.CEIL;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.COS;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.COSPI;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.EXP;
@@ -129,6 +130,14 @@ public class OCLMathPlugins {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
                 b.push(kind, b.append(OCLFPUnaryIntrinsicNode.create(value, LOG, kind)));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("ceil", type) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(kind, b.append(OCLFPUnaryIntrinsicNode.create(value, CEIL, kind)));
                 return true;
             }
         });

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLBuiltinTool.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLBuiltinTool.java
@@ -37,6 +37,7 @@ import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCL
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.ACOS;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.ASIN;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.ATAN;
+import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.CEIL;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.COS;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.COSPI;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.EXP;
@@ -118,8 +119,8 @@ public class OCLBuiltinTool {
     }
 
     public Value genFloatCeil(Value input) {
-        unimplemented();
-        return null;
+        Logger.traceBuildLIR(Logger.BACKEND.OpenCL, "genCeil: ceil(%s)", input);
+        return new OCLUnary.Intrinsic(CEIL, LIRKind.value(input.getPlatformKind()), input);
     }
 
     public Value genFloatCos(Value input) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFPUnaryIntrinsicNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFPUnaryIntrinsicNode.java
@@ -141,6 +141,7 @@ public class OCLFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
             case ASIN -> gen.genFloatASin(input);
             case ACOS -> gen.genFloatACos(input);
             case ATAN -> gen.genFloatATan(input);
+            case CEIL -> gen.genFloatCeil(input);
             case COS -> gen.genFloatCos(input);
             case FABS -> gen.genFloatAbs(input);
             case EXP -> gen.genFloatExp(input);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssembler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssembler.java
@@ -32,6 +32,7 @@ import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssemblerConstan
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssemblerConstants.MOVE;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssemblerConstants.ROUND_NEAREST_EVEN;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssemblerConstants.ROUND_NEGATIVE_INFINITY_INTEGER;
+import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssemblerConstants.ROUND_POSITIVE_INFINITY_INTEGER;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssemblerConstants.ROUND_TOWARD_ZERO_INTEGER;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssemblerConstants.SPACE;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssemblerConstants.STMT_DELIMITER;
@@ -559,6 +560,8 @@ public class PTXAssembler extends Assembler {
         public static final PTXUnaryIntrinsic ABS = new PTXUnaryIntrinsic("abs", null);
         public static final PTXUnaryIntrinsic EXP2 = new PTXUnaryIntrinsic("ex2.approx", null);
         public static final PTXUnaryIntrinsic SQRT = new PTXUnaryIntrinsic("sqrt");
+
+        public static final PTXUnaryIntrinsic CEIL = new PTXUnaryIntrinsic("cvt", ROUND_POSITIVE_INFINITY_INTEGER);
         public static final PTXUnaryIntrinsic LOG2 = new PTXUnaryIntrinsic("lg2.approx", null);
         public static final PTXUnaryIntrinsic SIN = new PTXUnaryIntrinsic("sin.approx", null);
         public static final PTXUnaryIntrinsic COS = new PTXUnaryIntrinsic("cos.approx", null);
@@ -571,13 +574,12 @@ public class PTXAssembler extends Assembler {
             public void emit(PTXCompilationResultBuilder crb, Value x, Variable dest) {
                 final PTXAssembler asm = crb.getAssembler();
                 emitOpcode(asm);
-                PTXKind destType = (PTXKind) dest.getPlatformKind();
 
                 PTXKind instructionKind = PTXKind.B32;
                 if (((PTXKind) x.getPlatformKind()).is64Bit()) {
                     instructionKind = PTXKind.B64;
                 }
-                asm.emit("." + instructionKind);
+                asm.emit(STR.".\{instructionKind}" );
 
                 asm.emitSymbol(TAB);
                 asm.emitValues(new Value[] { dest, x });

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssemblerConstants.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssemblerConstants.java
@@ -69,6 +69,8 @@ public class PTXAssemblerConstants {
     public static final String ROUND_TOWARD_ZERO_INTEGER = "rzi";
     public static final String ROUND_NEGATIVE_INFINITY_INTEGER = "rmi";
 
+    public static final String ROUND_POSITIVE_INFINITY_INTEGER = "rpi";
+
     public static final String TAB = "\t";
     public static final String COMMA = ",";
     public static final String STMT_DELIMITER = ";";

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXMathPlugins.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXMathPlugins.java
@@ -27,6 +27,7 @@ import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrin
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrinsicNode.Operation.FMIN;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrinsicNode.Operation.POW;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.ATAN;
+import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.CEIL;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.COS;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.COSPI;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.EXP;
@@ -191,6 +192,15 @@ public class PTXMathPlugins {
                 return true;
             }
         });
+
+        r.register(new InvocationPlugin("ceil", type) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(kind, b.append(PTXFPUnaryIntrinsicNode.create(value, CEIL, kind)));
+                return true;
+            }
+        });
+
     }
 
     private static void registerFloatMath2Plugins(Registration r, Class<?> type, JavaKind kind) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXBuiltinTool.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXBuiltinTool.java
@@ -9,7 +9,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -28,6 +28,7 @@ import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXBin
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXBinaryIntrinsic.INT_MIN;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXBinaryIntrinsic.RADIANS;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXUnaryIntrinsic.ABS;
+import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXUnaryIntrinsic.CEIL;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXUnaryIntrinsic.COS;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXUnaryIntrinsic.EXP2;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXUnaryIntrinsic.FLOAT_FLOOR;
@@ -99,8 +100,8 @@ public class PTXBuiltinTool {
     }
 
     public Value genFloatCeil(Value input) {
-        unimplemented();
-        return null;
+        Logger.traceBuildLIR(Logger.BACKEND.PTX, "genCeil: ceil(%s)", input);
+        return new PTXUnary.Intrinsic(CEIL, LIRKind.value(input.getPlatformKind()), input);
     }
 
     public Value genFloatCos(Value input) {
@@ -157,9 +158,9 @@ public class PTXBuiltinTool {
      * while the second argument that corresponds to the degrees is value y.
      *
      * @param x
-     *            the constant value of (pi/180)
+     *     the constant value of (pi/180)
      * @param y
-     *            the angle value measured in degrees
+     *     the angle value measured in degrees
      * @return Value: the approximately equivalent angle measured in radians
      */
     public Value genFloatRadians(Value x, Value y) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXFPUnaryIntrinsicNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXFPUnaryIntrinsicNode.java
@@ -157,6 +157,9 @@ public class PTXFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
             case ATAN:
                 result = gen.genFloatATan(auxValue);
                 break;
+            case CEIL:
+                result = gen.genFloatCeil(auxValue);
+                break;
             case COS:
                 result = gen.genFloatCos(auxValue);
                 break;
@@ -370,6 +373,7 @@ public class PTXFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
     // @formatter:off
     public enum Operation {
         ATAN,
+        CEIL,
         COS,
         EXP,
         FABS,

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVMathPlugins.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVMathPlugins.java
@@ -112,6 +112,14 @@ public class SPIRVMathPlugins {
                 return true;
             }
         });
+
+        r.register(new InvocationPlugin("ceil", type) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(kind, b.append(SPIRVFPUnaryIntrinsicNode.create(value, SPIRVUnaryOperation.CEIL, kind)));
+                return true;
+            }
+        });
     }
 
     private static void registerTrigonometric1Plugins(InvocationPlugins.Registration r, Class<?> type, JavaKind kind) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SPIRVFPUnaryIntrinsicNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SPIRVFPUnaryIntrinsicNode.java
@@ -146,6 +146,7 @@ public class SPIRVFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLI
         Value result = switch (operation()) {
             case ASIN -> gen.genFloatASin(input);
             case ACOS -> gen.genFloatACos(input);
+            case CEIL -> gen.genFloatCeil(input);
             case FABS -> gen.genFloatAbs(input);
             case EXP -> gen.genFloatExp(input);
             case SIGN -> gen.generateSign(input);


### PR DESCRIPTION
#### Description

This PR adds support for the `Math.ceil` and `TornadoMath.ceil` functions for all the backends. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Test for each of the backends
```bash
$ make BACKEND=opencl
$ tornado-test --printKernel -V --fast uk.ac.manchester.tornado.unittests.math.TestMath#testMathCeil

$ make BACKEND=spirv
$ tornado-test --printKernel -V --fast uk.ac.manchester.tornado.unittests.math.TestMath#testMathCeil

$ make BACKEND=ptx
$ tornado-test --printKernel -V --fast uk.ac.manchester.tornado.unittests.math.TestMath#testMathCeil
```


