### PR TITLE
[SPIRV] Beehive Toolkit version updated

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -191,7 +191,7 @@ def build_spirv_toolkit_and_level_zero(rebuild=False):
 
     if (rebuild or build):
         os.chdir(spirv_tool_kit)
-        subprocess.run(["git", "pull", "origin", "feat/half"])
+        subprocess.run(["git", "pull", "origin", "master"])
         subprocess.run(["mvn", "clean", "package"])
         subprocess.run(["mvn", "install"])
         os.chdir(current)

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>beehive-lab</groupId>
             <artifactId>beehive-spirv-lib</artifactId>
-            <version>0.0.2</version>
+            <version>0.0.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
#### Description

This PR updates the dependency to the Beehive SPIR-V Toolkit for the SPIR-V Code gen.
This version includes the support for the Half vector types.


#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make BACKEND=spirv
$ make tests 
```