### PR TITLE
[tests] half-type (fp16) tests added in the whitelist

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -191,6 +191,13 @@ __TORNADO_TESTS_WHITE_LIST__ = [
     "uk.ac.manchester.tornado.unittests.vm.concurrency.TestConcurrentBackends#testThreeBackendsSerial",
     "uk.ac.manchester.tornado.unittests.vm.concurrency.TestConcurrentBackends#testThreeBackendsConcurrent",
 
+
+    ## Half-float
+    'uk.ac.manchester.tornado.unittests.arrays.TestArrays#testVectorAdditionHalfFloat',
+    'uk.ac.manchester.tornado.unittests.arrays.TestArrays#testVectorSubtractionHalfFloat',
+    'uk.ac.manchester.tornado.unittests.arrays.TestArrays#testVectorMultiplicationHalfFloat',
+    'uk.ac.manchester.tornado.unittests.arrays.TestArrays#testVectorDivisionHalfFloat',
+
 ]
 
 # ################################################################################################################


### PR DESCRIPTION
#### Description

This PR adds the FP16 for the OpenCL tests in the white list. The reason is that, for some devices, even though the half types are not supported, it is possible to perform FP16 computations. Thus, the TornadoVM runtime cannot throw an exception just by looking at the OpenCL properties of the device. Rather, it continues the execution of the kernel and the driver will launch an error code is the kernel is not supported. 

This does not mean that the kernel is not correct. For this reason, we add these FP16 to the white list of unit-tests. 

#### Backend/s tested

This PR only affects the OpenCL backend. 

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make 
tornado -ea  --jvm "-Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.verbose=True "  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  --params "uk.ac.manchester.tornado.unittests.arrays.TestArrays"
```
