### PR TITLE
Fix duplicate printing of thread info when debug is enabled

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -298,7 +298,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
         final int task;
         debugInfo(meta);
 
-        if (meta.isThreadInfoEnabled()) {
+        if (meta.isThreadInfoEnabled() && !meta.isDebug()) {
             meta.printThreadDims();
         }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -288,17 +288,10 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
         deviceContext.enqueueNDRangeKernel(kernel, 1, null, singleThreadGlobalWorkSize, singleThreadLocalWorkSize, null);
     }
 
-    private void debugInfo(final TaskMetaData meta) {
-        if (meta.isDebug()) {
-            meta.printThreadDims();
-        }
-    }
-
     private int submitSequential(final TaskMetaData meta) {
         final int task;
-        debugInfo(meta);
 
-        if (meta.isThreadInfoEnabled() && !meta.isDebug()) {
+        if (meta.isThreadInfoEnabled()) {
             meta.printThreadDims();
         }
 


### PR DESCRIPTION
#### Description

This PR fixes the duplicate printing of thread information. When both the flags for debugging (`--debug`) and thread info (`--threadInfo`) were enabled, the thread information was printed twice. In this PR, the thread information is printed only if the debug flag is not also enabled. 

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No
