### PR TITLE
Implement memory limit functionality per ExecutionPlan in the TornadoVM API

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -153,6 +153,10 @@ public class ImmutableTaskGraph {
         taskGraph.batch(batchSize);
     }
 
+    void withMemoryLimit(String memoryLimit) {
+
+    }
+
     TornadoDevice getDevice() {
         return taskGraph.getDevice();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -154,7 +154,7 @@ public class ImmutableTaskGraph {
     }
 
     void withMemoryLimit(String memoryLimit) {
-
+        taskGraph.memoryLimit(memoryLimit);
     }
 
     TornadoDevice getDevice() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -763,6 +763,11 @@ public class TaskGraph implements TaskGraphInterface {
         return this;
     }
 
+    TaskGraph memoryLimit(String memoryLimit) {
+        taskGraphImpl.memoryLimit(memoryLimit);
+        return this;
+    }
+
     void execute() {
         taskGraphImpl.schedule().waitOn();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -136,7 +136,6 @@ public class TornadoExecutionPlan {
     }
 
     /**
-     * @return
      */
     public TornadoExecutionPlan withConcurrentDevices() {
         tornadoExecutor.withConcurrentDevices();
@@ -259,6 +258,11 @@ public class TornadoExecutionPlan {
         return this;
     }
 
+    public TornadoExecutionPlan withMemoryLimit(String memoryLimit) {
+        tornadoExecutor.withMemoryLimit(memoryLimit);
+        return this;
+    }
+
     /**
      * Reset the execution context for the current execution plan. The TornadoVM
      * runtime system will clean the code cache and all events associated with the
@@ -311,6 +315,9 @@ public class TornadoExecutionPlan {
             immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.withBatch(batchSize));
         }
 
+        void withMemoryLimit(String memoryLimit){
+            immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.withMemoryLimit(memoryLimit));
+        }
         /**
          * For all task-graphs contained in an Executor, update the device.
          *

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -48,6 +48,7 @@ public interface TornadoTaskGraphInterface extends ProfileInterface {
 
     void batch(String batchSize);
 
+    void memoryLimit(String memoryLimit);
     void apply(Consumer<SchedulableTask> consumer);
 
     void mapAllToInner(TornadoDevice device);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
@@ -45,6 +45,15 @@ import uk.ac.manchester.tornado.runtime.graph.TornadoExecutionContext;
  * provides methods to compute chunk sizes based on the batch size and input
  * objects.
  */
+/**
+ * How to test?
+ *
+ * <p>
+ * <code>
+ *     tornado-test -V --fast uk.ac.manchester.tornado.unittests.batches.TestBatches
+ * </code>
+ * </p>
+ */
 public class BatchConfiguration {
 
     private final int totalChunks;
@@ -75,7 +84,7 @@ public class BatchConfiguration {
         HashSet<Long> inputSizes = new HashSet<>();
         LinkedHashSet<Byte> elementSizes = new LinkedHashSet<>();
 
-        for (Object o : inputObjects) {
+        for (Object o : context.getObjects()) {
             if (o.getClass().isArray()) {
                 Class<?> componentType = o.getClass().getComponentType();
                 DataTypeSize dataTypeSize = findDataTypeSize(componentType);
@@ -125,7 +134,7 @@ public class BatchConfiguration {
         return new BatchConfiguration(totalChunks, remainingChunkSize, elementSizes.getFirst());
     }
 
-    private static DataTypeSize findDataTypeSize(Class<?> dataType) {
+    public static DataTypeSize findDataTypeSize(Class<?> dataType) {
         return Arrays.stream(DataTypeSize.values()).filter(size -> size.getDataType().equals(dataType)).findFirst().orElse(null);
     }
 
@@ -141,7 +150,7 @@ public class BatchConfiguration {
         return numBytesType;
     }
 
-    private enum DataTypeSize {
+    public enum DataTypeSize {
         BYTE(byte.class, (byte) 1), //
         CHAR(char.class, (byte) 2), //
         SHORT(short.class, (byte) 2), //

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
@@ -98,11 +98,11 @@ public class BatchConfiguration {
                     case ShortArray _ -> DataTypeSize.SHORT.getSize();
                     case ByteArray _ -> DataTypeSize.BYTE.getSize();
                     case CharArray _ -> DataTypeSize.CHAR.getSize();
-                    default -> throw new TornadoRuntimeException("Unsupported array type: " + o.getClass());
+                    default -> throw new TornadoRuntimeException(STR."Unsupported array type: \{o.getClass()}");
                 };
                 elementSizes.add(elementSize);
             } else {
-                throw new TornadoRuntimeException("Unsupported type: " + o.getClass());
+                throw new TornadoRuntimeException(STR."Unsupported type: \{o.getClass()}");
             }
         }
 
@@ -118,9 +118,9 @@ public class BatchConfiguration {
         int remainingChunkSize = (int) (totalSize % batchSize);
 
         if (Tornado.DEBUG) {
-            System.out.println("Batch Size: " + batchSize);
-            System.out.println("Total chunks: " + totalChunks);
-            System.out.println("remainingChunkSize: " + remainingChunkSize);
+            System.out.println(STR."Batch Size: \{batchSize}");
+            System.out.println(STR."Total chunks: \{totalChunks}");
+            System.out.println(STR."remainingChunkSize: \{remainingChunkSize}");
         }
         return new BatchConfiguration(totalChunks, remainingChunkSize, elementSizes.getFirst());
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -231,11 +231,11 @@ public class TornadoExecutionContext {
     public void mapAllTasksToSingleDevice(TornadoDevice tornadoDevice) {
         if (tornadoDevice instanceof TornadoAcceleratorDevice tornadoAcceleratorDevice) {
             devices.clear();
-            devices.add(0, tornadoAcceleratorDevice);
+            devices.addFirst(tornadoAcceleratorDevice);
             apply(task -> task.mapTo(tornadoDevice));
             Arrays.fill(taskToDeviceMapTable, tornadoDevice);
         } else {
-            throw new TornadoRuntimeException("Device " + tornadoDevice.getClass() + " not supported yet");
+            throw new TornadoRuntimeException(STR."Device \{tornadoDevice.getClass()} not supported yet");
         }
     }
 
@@ -548,23 +548,23 @@ public class TornadoExecutionContext {
         final String ansiPurple = "\u001B[35m";
         final String ansiGreen = "\u001B[32m";
         System.out.println("-----------------------------------");
-        System.out.println(ansiCyan + "Device Table:" + ansiReset);
+        System.out.println(STR."\{ansiCyan}Device Table:\{ansiReset}");
         for (int i = 0; i < devices.size(); i++) {
             System.out.printf("[%d]: %s\n", i, devices.get(i));
         }
 
-        System.out.println(ansiYellow + "Constant Table:" + ansiReset);
+        System.out.println(STR."\{ansiYellow}Constant Table:\{ansiReset}");
         for (int i = 0; i < constants.size(); i++) {
             System.out.printf("[%d]: %s\n", i, constants.get(i));
         }
 
-        System.out.println(ansiPurple + "Object Table:" + ansiReset);
+        System.out.println(STR."\{ansiPurple}Object Table:\{ansiReset}");
         for (int i = 0; i < objects.size(); i++) {
             final Object obj = objects.get(i);
             System.out.printf("[%d]: 0x%x %s\n", i, obj.hashCode(), obj);
         }
 
-        System.out.println(ansiGreen + "Task Table:" + ansiReset);
+        System.out.println(STR."\{ansiGreen}Task Table:\{ansiReset}");
         for (int i = 0; i < tasks.size(); i++) {
             final SchedulableTask task = tasks.get(i);
             System.out.printf("[%d]: %s\n", i, task.getFullName());

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -72,6 +72,7 @@ public class TornadoExecutionContext {
     private int nextTask;
 
     private long batchSize;
+    private long executionPlanMemoryLimit;
     private Set<TornadoAcceleratorDevice> lastDevices;
 
     private boolean redeployOnDevice;
@@ -95,6 +96,7 @@ public class TornadoExecutionContext {
         Arrays.fill(taskToDeviceMapTable, null);
         nextTask = 0;
         batchSize = -1;
+        executionPlanMemoryLimit = -1;
         lastDevices = new HashSet<>();
         this.profiler = null;
         this.isDataDependencyDetected = isDataDependencyInTaskGraph();
@@ -129,6 +131,14 @@ public class TornadoExecutionContext {
 
     public void setBatchSize(long size) {
         this.batchSize = size;
+    }
+
+    public void setExecutionPlanMemoryLimit(long memoryLimitSize) {
+        this.executionPlanMemoryLimit = memoryLimitSize;
+    }
+
+    public long getExecutionPlanMemoryLimit() {
+        return executionPlanMemoryLimit;
     }
 
     public int replaceVariable(Object oldObj, Object newObj) {
@@ -255,7 +265,7 @@ public class TornadoExecutionContext {
         if (target instanceof TornadoAcceleratorDevice tornadoAcceleratorDevice) {
             accelerator = tornadoAcceleratorDevice;
         } else {
-            throw new TornadoRuntimeException("Device " + target.getClass() + " not supported yet");
+            throw new TornadoRuntimeException(STR."Device \{target.getClass()} not supported yet");
         }
 
         setDevice(accelerator);
@@ -438,7 +448,7 @@ public class TornadoExecutionContext {
     }
 
     private String canonicalizeId(String id) {
-        return id.startsWith(getId()) ? id : getId() + "." + id;
+        return id.startsWith(getId()) ? id : STR."\{getId()}.\{id}";
     }
 
     public TornadoAcceleratorDevice getDeviceForTask(String id) {
@@ -447,7 +457,7 @@ public class TornadoExecutionContext {
         if (device instanceof TornadoAcceleratorDevice) {
             tornadoDevice = (TornadoAcceleratorDevice) device;
         } else {
-            throw new RuntimeException("Device " + device.getClass() + " not supported yet");
+            throw new RuntimeException(STR."Device \{device.getClass()} not supported yet");
         }
         return getTask(id) == null ? null : tornadoDevice;
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
@@ -180,8 +180,8 @@ public class TornadoVMGraphCompiler {
                             try {
                                 tornadoVMBytecodeBuilder.emitAsyncNode(asyncNode, (dependencies[i].isEmpty()) ? -1 : depLists[i], offset, bufferBatchSize, nThreads);
                             } catch (BufferOverflowException e) {
-                                throw new TornadoRuntimeException("[ERROR] Buffer Overflow exception. Use -Dtornado.tvm.maxbytecodesize=<value> with value > " +
-                                        TornadoVMBytecodeBuilder.MAX_TORNADO_VM_BYTECODE_SIZE + " to increase the buffer code size");
+                                throw new TornadoRuntimeException(
+                                        STR."[ERROR] Buffer Overflow exception. Use -Dtornado.tvm.maxbytecodesize=<value> with value > \{TornadoVMBytecodeBuilder.MAX_TORNADO_VM_BYTECODE_SIZE} to increase the buffer code size");
                             }
                         }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -45,6 +45,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoDeviceFP64NotSupported;
 import uk.ac.manchester.tornado.api.exceptions.TornadoFailureException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
+import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.ObjectBuffer;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
@@ -245,6 +246,11 @@ public class TornadoVMInterpreter extends TornadoLogger {
     private Event execute(boolean isWarmup) {
         isWarmup = isWarmup || VIRTUAL_DEVICE_ENABLED;
         deviceForInterpreter.enableThreadSharing();
+
+        if (this.executionContext.doesExceedExecPlanLimit()) {
+            throw new TornadoMemoryException(STR."OutofMemoryException due to executionPlan.withMemoryLimit of \{executionContext.getExecutionPlanMemoryLimit()}");
+        }
+
         final long t0 = System.nanoTime();
         int lastEvent = -1;
         initWaitEventList();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -86,6 +86,7 @@ import uk.ac.manchester.tornado.api.enums.ProfilerMode;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoDynamicReconfigurationException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoTaskRuntimeException;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
@@ -413,21 +414,8 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         // The graph object is used when rewriting task-graphs (e.g., reductions)
         newTaskGraph.compilationGraph = this.compilationGraph;
 
-        if (memoryLimitSizeBytes>0 && exceedMemoryLimit()) {
 
-        }
         return newTaskGraph;
-    }
-
-//    private static volatile Instrumentation globalInstrumentation;
-
-    private boolean exceedMemoryLimit() {
-        long totalBuffer = 0l;
-
-        for (Object obj : executionContext.getObjects()) {
-            System.out.println(" Obj " + obj.getOb);
-        }
-
     }
 
     @Override
@@ -2146,6 +2134,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     @Override
     public void memoryLimit(String memoryLimit) {
        this.memoryLimitSizeBytes = parseSizeToBytes(memoryLimit);
+       executionContext.setExecutionPlanMemoryLimit(this.memoryLimitSizeBytes);
     }
 
     private long parseSizeToBytes(String sizeStr) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -413,7 +413,21 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         // The graph object is used when rewriting task-graphs (e.g., reductions)
         newTaskGraph.compilationGraph = this.compilationGraph;
 
+        if (memoryLimitSizeBytes>0 && exceedMemoryLimit()) {
+
+        }
         return newTaskGraph;
+    }
+
+//    private static volatile Instrumentation globalInstrumentation;
+
+    private boolean exceedMemoryLimit() {
+        long totalBuffer = 0l;
+
+        for (Object obj : executionContext.getObjects()) {
+            System.out.println(" Obj " + obj.getOb);
+        }
+
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -2144,6 +2144,25 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
+    public void memoryLimit(String memoryLimit) {
+        // parse value and units
+        Matcher matcher = PATTERN_BATCH.matcher(memoryLimit);
+        long value = 0;
+        String units = null;
+        if (matcher.find()) {
+            value = Long.parseLong(matcher.group(1));
+            units = matcher.group(2).toUpperCase();
+        }
+
+        // compute bytes
+        this.batchSizeBytes = switch (Objects.requireNonNull(units)) {
+            case "MB" -> value * 1_000_000;
+            case "GB" -> value * 1_000_000_000;
+            default -> throw new TornadoRuntimeException(STR."Units not supported: \{units}");
+        };
+    }
+
+    @Override
     public long getTotalTime() {
         return getProfilerTimer(ProfilerType.TOTAL_TASK_GRAPH_TIME);
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -164,7 +164,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test100MBSmall() {
 
-        long maxAllocMemory = checkMaxHeapAllocation(100, MemSize.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(100, MemSize.MB);
 
         // Fill 120MB of float array
         int size = 30000000;
@@ -197,7 +197,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test100MB() {
 
-        long maxAllocMemory = checkMaxHeapAllocation(100, MemSize.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(100, MemSize.MB);
 
         // Fill 800MB of float array
         int size = 200000000;
@@ -230,7 +230,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test300MB() {
 
-        long maxAllocMemory = checkMaxHeapAllocation(300, MemSize.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(300, MemSize.MB);
 
         // Fill 1.0GB
         int size = 250_000_000;
@@ -264,7 +264,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test512MB() {
 
-        long maxAllocMemory = checkMaxHeapAllocation(512, MemSize.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(512, MemSize.MB);
 
         // Fill 800MB
         int size = 200000000;
@@ -296,7 +296,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MB() {
 
-        long maxAllocMemory = checkMaxHeapAllocation(50, MemSize.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemSize.MB);
 
         // Fill 80MB of input Array
         int size = 20000000;
@@ -333,7 +333,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBInteger() {
 
-        long maxAllocMemory = checkMaxHeapAllocation(50, MemSize.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemSize.MB);
 
         // Fill 80MB of input Array
         int size = 20000000;
@@ -369,7 +369,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBShort() {
 
-        long maxAllocMemory = checkMaxHeapAllocation(50, MemSize.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemSize.MB);
 
         // Fill 160MB of input Array
         int size = 80000000;
@@ -406,7 +406,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBDouble() {
 
-        long maxAllocMemory = checkMaxHeapAllocation(50, MemSize.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemSize.MB);
 
         int size = 20000000;
         // or as much as we can
@@ -441,7 +441,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBLong() {
 
-        long maxAllocMemory = checkMaxHeapAllocation(50, MemSize.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemSize.MB);
 
         // Fill 160MB of input Array
         int size = 20000000;
@@ -477,7 +477,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeRestriction() {
         // total input size mismatch for IntArray
-        checkMaxHeapAllocation(5, MemSize.MB);
+        checkMaxHeapAllocationOnDevice(5, MemSize.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntArray a1 = new IntArray(3 * 1_000_000);
 
@@ -494,7 +494,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeRestrictionJavaArrays() {
         // total input size mismatch for int[]
-        checkMaxHeapAllocation(5, MemSize.MB);
+        checkMaxHeapAllocationOnDevice(5, MemSize.MB);
         int[] a0 = new int[2 * 1_000_000];
         int[] a1 = new int[3 * 1_000_000];
 
@@ -511,7 +511,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputTypeRestriction() {
         // IntArray is NOT compatible with LongArray even if the total input size is equal
-        checkMaxHeapAllocation(6, MemSize.MB);
+        checkMaxHeapAllocationOnDevice(6, MemSize.MB);
         IntArray a0 = new IntArray(4 * 1_000_000);
         LongArray a1 = new LongArray(2 * 1_000_000);
 
@@ -528,7 +528,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputTypeRestrictionJavaArrays() {
         // int[] is NOT compatible with long[] even if the total input size is equal
-        checkMaxHeapAllocation(6, MemSize.MB);
+        checkMaxHeapAllocationOnDevice(6, MemSize.MB);
         int[] a0 = new int[4 * 1_000_000];
         long[] a1 = new long[2 * 1_000_000];
 
@@ -545,7 +545,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSize() {
         // IntArray is compatible with FloatArray for the same # of elements
-        checkMaxHeapAllocation(4, MemSize.MB);
+        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
         FloatArray a1 = new FloatArray(2 * 1_000_000);
@@ -559,7 +559,7 @@ public class TestBatches extends TornadoTestBase {
         executionPlan.withBatch("1MB").execute();
 
         for (int i = 0; i < a1.getSize(); i++) {
-            Assert.assertEquals(a0.get(i), a1.get(i), 1e-20);
+            assertEquals(a0.get(i), a1.get(i), 1e-20);
         }
         executionPlan.freeDeviceMemory();
     }
@@ -567,7 +567,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeJavaArrays() {
         // int[] is compatible with float[] for the same # of elements
-        checkMaxHeapAllocation(4, MemSize.MB);
+        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
         int[] a0 = new int[2 * 1_000_000];
         IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
         float[] a1 = new float[2 * 1_000_000];
@@ -581,7 +581,7 @@ public class TestBatches extends TornadoTestBase {
         executionPlan.withBatch("1MB").execute();
 
         for (int i = 0; i < a1.length; i++) {
-            Assert.assertEquals(a0[i], a1[i], 1e-20);
+            assertEquals(a0[i], a1[i], 1e-20);
         }
         executionPlan.freeDeviceMemory();
     }
@@ -589,7 +589,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeJavaToTornado() {
         // int[] is compatible with FloatArray for the same # of elements
-        checkMaxHeapAllocation(4, MemSize.MB);
+        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
         int[] a0 = new int[2 * 1_000_000];
         IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
         FloatArray a1 = new FloatArray(2 * 1_000_000);
@@ -603,7 +603,7 @@ public class TestBatches extends TornadoTestBase {
         executionPlan.withBatch("1MB").execute();
 
         for (int i = 0; i < a1.getSize(); i++) {
-            Assert.assertEquals(a0[i], a1.get(i), 1e-20);
+            assertEquals(a0[i], a1.get(i), 1e-20);
         }
         executionPlan.freeDeviceMemory();
     }
@@ -611,7 +611,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeTornadoToJava() {
         // IntArray is compatible with float[] for the same # of elements
-        checkMaxHeapAllocation(4, MemSize.MB);
+        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
         float[] a1 = new float[2 * 1_000_000];
@@ -625,7 +625,7 @@ public class TestBatches extends TornadoTestBase {
         executionPlan.withBatch("1MB").execute();
 
         for (int i = 0; i < a1.length; i++) {
-            Assert.assertEquals(a0.get(i), a1[i], 1e-20);
+            assertEquals(a0.get(i), a1[i], 1e-20);
         }
         executionPlan.freeDeviceMemory();
     }
@@ -633,7 +633,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeJavaToTornado() {
         // int[] is compatible with IntArray for the same # of elements
-        checkMaxHeapAllocation(4, MemSize.MB);
+        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
         int[] a0 = new int[2 * 1_000_000];
         IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
         IntArray a1 = new IntArray(2 * 1_000_000);
@@ -647,7 +647,7 @@ public class TestBatches extends TornadoTestBase {
         executionPlan.withBatch("1MB").execute();
 
         for (int i = 0; i < a1.getSize(); i++) {
-            Assert.assertEquals(a0[i], a1.get(i));
+            assertEquals(a0[i], a1.get(i));
         }
         executionPlan.freeDeviceMemory();
     }
@@ -655,7 +655,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeTornadoToJava() {
         // IntArray is compatible with int[] for the same # of elements
-        checkMaxHeapAllocation(4, MemSize.MB);
+        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
         int[] a1 = new int[2 * 1_000_000];
@@ -669,28 +669,20 @@ public class TestBatches extends TornadoTestBase {
         executionPlan.withBatch("1MB").execute();
 
         for (int i = 0; i < a1.length; i++) {
-            Assert.assertEquals(a0.get(i), a1[i]);
+            assertEquals(a0.get(i), a1[i]);
         }
         executionPlan.freeDeviceMemory();
     }
 
-    private long checkMaxHeapAllocation(int size, MemSize memSize) throws UnsupportedConfigurationException {
+    private long checkMaxHeapAllocationOnDevice(int size, MemSize memSize) throws UnsupportedConfigurationException {
         long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
 
-        long memThreshold = 0;
-
-        switch (memSize) {
-            case GB:
-                memThreshold = (long) size * 1024 * 1024 * 1024;
-                break;
-            case MB:
-                memThreshold = (long) size * 1024 * 1024;
-                break;
-            case TB:
-                memThreshold = (long) size * 1024 * 1024 * 1024 * 1024;
-                break;
-
-        }
+        long memThreshold = switch (memSize) {
+            case GB -> (long) size * 1024 * 1024 * 1024;
+            case MB -> (long) size * 1024 * 1024;
+            case TB -> (long) size * 1024 * 1024 * 1024 * 1024;
+            default -> throw new IllegalStateException(STR."Unexpected value: \{memSize}");
+        };
 
         // check if there is enough memory for at least one chunk
         if (maxAllocMemory < memThreshold) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memoryplan/TestWithMemoryLimit.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memoryplan/TestWithMemoryLimit.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.memoryplan;
+
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+public class TestWithMemoryLimit extends TornadoTestBase {
+
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memoryplan/TestWithMemoryLimit.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memoryplan/TestWithMemoryLimit.java
@@ -23,6 +23,7 @@ import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.TestHello;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
@@ -30,8 +31,17 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * How to test?
+ *
+ * <p>
+ * <code>
+ *     tornado-test -V uk.ac.manchester.tornado.unittests.memoryplan.TestWithMemoryLimit
+ * </code>
+ * </p>
+ */
 public class TestWithMemoryLimit extends TornadoTestBase {
-    private static final int NUM_ELEMENTS = 16;
+    private static final int NUM_ELEMENTS = 50000000;
     private static IntArray a = new IntArray(NUM_ELEMENTS);
     private static IntArray b = new IntArray(NUM_ELEMENTS);
     private static IntArray c = new IntArray(NUM_ELEMENTS);
@@ -57,13 +67,15 @@ public class TestWithMemoryLimit extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withMemoryLimit("512MB").execute();
+        executionPlan.withMemoryLimit("1GB").execute();
 
         for (int i = 0; i < c.getSize(); i++) {
             assertEquals(a.get(i) + b.get(i), c.get(i), 0.001);
         }
+        executionPlan.freeDeviceMemory();
     }
 
+//    @Test(expected = TornadoMemoryException.class)
     @Test
     public void testWithMemoryLimitUnder() {
         TaskGraph taskGraph = new TaskGraph("s0") //
@@ -73,7 +85,7 @@ public class TestWithMemoryLimit extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withMemoryLimit("1GB").execute();
+        executionPlan.withMemoryLimit("512MB").execute();
 
         for (int i = 0; i < c.getSize(); i++) {
             assertEquals(a.get(i) + b.get(i), c.get(i), 0.001);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memoryplan/TestWithMemoryLimit.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memoryplan/TestWithMemoryLimit.java
@@ -75,8 +75,7 @@ public class TestWithMemoryLimit extends TornadoTestBase {
         executionPlan.freeDeviceMemory();
     }
 
-//    @Test(expected = TornadoMemoryException.class)
-    @Test
+    @Test(expected = TornadoMemoryException.class)
     public void testWithMemoryLimitUnder() {
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //


### PR DESCRIPTION
#### Description

This PR introduces `withMemoryLimit()` option in TornadoVM's execution plan. With this feature, the API provides the means to limit the amount of memory required in the GPU.

```
 executionPlan.withMemoryLimit("1GB").execute();
```

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?

```bash 
tornado-test -V uk.ac.manchester.tornado.unittests.memoryplan.TestWithMemoryLimit
```
----------------------------------------------------------------------------
