### PR TITLE
[fix] MatrixVectorFloat4 set/get accesses fixed

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat4.java
@@ -30,7 +30,7 @@ public final class VectorFloat4 implements TornadoCollectionInterface<FloatBuffe
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
     /**
      * number of elements in the storage.
      */
@@ -44,7 +44,7 @@ public final class VectorFloat4 implements TornadoCollectionInterface<FloatBuffe
      * @param array
      *     Array to be stored
      */
-    protected VectorFloat4(int numElements, FloatArray array) {
+    private VectorFloat4(int numElements, FloatArray array) {
         this.numElements = numElements;
         this.storage = array;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte3.java
@@ -32,15 +32,15 @@ public final class ImageByte3 implements TornadoImagesInterface<ByteBuffer> {
     /**
      * backing array.
      */
-    protected final ByteArray storage;
+    private final ByteArray storage;
     /**
      * Number of rows.
      */
-    protected final int Y;
+    private final int Y;
     /**
      * Number of columns.
      */
-    protected final int X;
+    private final int X;
     /**
      * number of elements in the storage.
      */

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte4.java
@@ -33,15 +33,15 @@ public final class ImageByte4 implements TornadoImagesInterface<ByteBuffer> {
     /**
      * backing array.
      */
-    protected final ByteArray storage;
+    private final ByteArray storage;
     /**
      * Number of rows.
      */
-    protected final int Y;
+    private final int Y;
     /**
      * Number of columns.
      */
-    protected final int X;
+    private final int X;
     /**
      * number of elements in the storage.
      */

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat.java
@@ -31,15 +31,15 @@ public final class ImageFloat implements TornadoImagesInterface<FloatBuffer> {
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
     /**
      * Number of rows.
      */
-    protected final int Y;
+    private final int Y;
     /**
      * Number of columns.
      */
-    protected final int X;
+    private final int X;
     /**
      * number of elements in the storage.
      */

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat3.java
@@ -32,15 +32,15 @@ public final class ImageFloat3 implements TornadoImagesInterface<FloatBuffer> {
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
     /**
      * Number of rows.
      */
-    protected final int Y;
+    private final int Y;
     /**
      * Number of columns.
      */
-    protected final int X;
+    private final int X;
     /**
      * number of elements in the storage.
      */

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat4.java
@@ -32,15 +32,15 @@ public final class ImageFloat4 implements TornadoImagesInterface<FloatBuffer> {
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
     /**
      * Number of rows.
      */
-    protected final int Y;
+    private final int Y;
     /**
      * Number of columns.
      */
-    protected final int X;
+    private final int X;
     /**
      * number of elements in the storage.
      */

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat8.java
@@ -32,15 +32,15 @@ public final class ImageFloat8 implements TornadoImagesInterface<FloatBuffer> {
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
     /**
      * Number of rows.
      */
-    protected final int Y;
+    private final int Y;
     /**
      * Number of columns.
      */
-    protected final int X;
+    private final int X;
     /**
      * number of elements in the storage.
      */

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DDouble.java
@@ -30,7 +30,7 @@ public final class Matrix2DDouble extends Matrix2DType implements TornadoMatrixI
     /**
      * backing array.
      */
-    protected final DoubleArray storage;
+    private final DoubleArray storage;
 
     /**
      * number of elements in the storage.
@@ -103,23 +103,22 @@ public final class Matrix2DDouble extends Matrix2DType implements TornadoMatrixI
     }
 
     public VectorDouble row(int row) {
-        int index = toRowMajor(row, 0, COLUMNS);
-        int from = index;
-        int to = getFinalIndexOfRange(index);
-        int size = to - from;
+        int baseIndex = toRowMajor(row, 0, COLUMNS);
+        int to = getFinalIndexOfRange(baseIndex);
+        int size = to - baseIndex;
         DoubleArray f = new DoubleArray(size);
         int j = 0;
-        for (int i = from; i < to; i++, j++) {
+        for (int i = baseIndex; i < to; i++, j++) {
             f.set(j, storage.get(i));
         }
         return new VectorDouble(COLUMNS, f);
     }
 
     public VectorDouble column(int col) {
-        int index = StorageFormats.toRowMajor(0, col, COLUMNS);
+        int baseIndex = StorageFormats.toRowMajor(0, col, COLUMNS);
         final VectorDouble v = new VectorDouble(ROWS);
         for (int i = 0; i < ROWS; i++) {
-            v.set(i, storage.get(index + (i * COLUMNS)));
+            v.set(i, storage.get(baseIndex + (i * COLUMNS)));
         }
         return v;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat.java
@@ -31,7 +31,7 @@ public final class Matrix2DFloat extends Matrix2DType implements TornadoMatrixIn
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
 
     /**
      * number of elements in the storage.
@@ -110,13 +110,12 @@ public final class Matrix2DFloat extends Matrix2DType implements TornadoMatrixIn
     }
 
     public VectorFloat row(int row) {
-        int index = toRowMajor(row, 0, COLUMNS);
-        int from = index;
-        int to = getFinalIndexOfRange(index);
-        int size = to - from;
+        int baseIndex = toRowMajor(row, 0, COLUMNS);
+        int to = getFinalIndexOfRange(baseIndex);
+        int size = to - baseIndex;
         FloatArray f = new FloatArray(size);
         int j = 0;
-        for (int i = from; i < to; i++) {
+        for (int i = baseIndex; i < to; i++) {
             f.set(j, storage.get(i));
             j++;
         }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat4.java
@@ -37,7 +37,7 @@ public final class Matrix2DFloat4 extends Matrix2DType implements TornadoMatrixI
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
     /**
      * number of elements in the storage.
      */

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DInt.java
@@ -27,10 +27,11 @@ import uk.ac.manchester.tornado.api.types.utils.IntOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 
 public final class Matrix2DInt extends Matrix2DType implements TornadoMatrixInterface<IntBuffer> {
+
     /**
      * backing array.
      */
-    protected final IntArray storage;
+    private final IntArray storage;
 
     /**
      * number of elements in the storage.
@@ -109,13 +110,12 @@ public final class Matrix2DInt extends Matrix2DType implements TornadoMatrixInte
     }
 
     public VectorInt row(int row) {
-        int index = toRowMajor(row, 0, COLUMNS);
-        int from = index;
-        int to = getFinalIndexOfRange(index);
-        int size = to - from;
+        int baseIndex = toRowMajor(row, 0, COLUMNS);
+        int to = getFinalIndexOfRange(baseIndex);
+        int size = to - baseIndex;
         IntArray f = new IntArray(size);
         int j = 0;
-        for (int i = from; i < to; i++) {
+        for (int i = baseIndex; i < to; i++) {
             f.set(j, storage.get(i));
             j++;
         }
@@ -151,20 +151,6 @@ public final class Matrix2DInt extends Matrix2DType implements TornadoMatrixInte
                 int sum = 0;
                 for (int k = 0; k < b.getNumRows(); k++) {
                     sum += a.get(row, k) * b.get(k, col);
-                }
-                set(row, col, sum);
-            }
-        }
-    }
-
-    public void tmultiply(Matrix2DInt a, Matrix2DInt b) {
-        System.out.printf("tmult: M=%d (expect %d)\n", getNumRows(), a.getNumRows());
-        System.out.printf("tmult: N=%d (expect %d)\n", getNumColumns(), b.getNumRows());
-        for (int row = 0; row < getNumRows(); row++) {
-            for (int col = 0; col < b.getNumRows(); col++) {
-                int sum = 0;
-                for (int k = 0; k < b.getNumColumns(); k++) {
-                    sum += a.get(row, k) * b.get(col, k);
                 }
                 set(row, col, sum);
             }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DFloat.java
@@ -28,7 +28,7 @@ public final class Matrix3DFloat extends Matrix3DType implements TornadoMatrixIn
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
 
     /**
      * number of elements in the storage.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix4x4Float.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix4x4Float.java
@@ -31,11 +31,11 @@ public final class Matrix4x4Float implements TornadoMatrixInterface<FloatBuffer>
     /**
      * Number of rows.
      */
-    protected static final int ROWS = 4;
+    private static final int ROWS = 4;
     /**
      * Number of columns.
      */
-    protected static final int COLUMNS = 4;
+    private static final int COLUMNS = 4;
     /**
      * number of elements in the storage.
      */
@@ -43,7 +43,7 @@ public final class Matrix4x4Float implements TornadoMatrixInterface<FloatBuffer>
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
 
     public Matrix4x4Float() {
         this(new FloatArray(NUM_ELEMENTS));

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/utils/StorageFormats.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/utils/StorageFormats.java
@@ -38,6 +38,7 @@ public final class StorageFormats {
      *     length of a column
      * @return int
      */
+    @Deprecated
     public static int toColumnMajor(int i, int j, int ld) {
         return (j * ld) + i;
     }
@@ -49,16 +50,16 @@ public final class StorageFormats {
      *     row index
      * @param j
      *     column index
-     * @param yMax
+     * @param numColumns
      *     length of a row
      * @return int
      */
-    public static int toRowMajor(int i, int j, int yMax) {
-        return (i * yMax) + j;
+    public static int toRowMajor(int i, int j, int numColumns) {
+        return (i * numColumns) + j;
     }
 
     public static int toRowMajorVector(int i, int j, int numColumns, int vectorElements) {
-        return (i * numColumns * vectorElements) + j;
+        return ((i * numColumns) + j) * vectorElements;
     }
 
     public static int toRowMajor3D(int i, int j, int k, int zMax, int yMax) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/volumes/VolumeShort2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/volumes/VolumeShort2.java
@@ -30,19 +30,19 @@ public final class VolumeShort2 implements TornadoVolumesInterface<ShortBuffer> 
     /**
      * backing array.
      */
-    protected final ShortArray storage;
+    private final ShortArray storage;
     /**
      * Size in Y dimension.
      */
-    protected final int Y;
+    private final int Y;
     /**
      * Size in X dimension.
      */
-    protected final int X;
+    private final int X;
     /**
      * Size in Y dimension.
      */
-    protected final int Z;
+    private final int Z;
     /**
      * number of elements in the storage.
      */

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLVectorPlugins.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLVectorPlugins.java
@@ -365,7 +365,6 @@ public final class OCLVectorPlugins {
                 return true;
             }
         });
-
     }
 
     static void registerParameterPlugins(Plugins plugins) {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixVector.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixVector.java
@@ -61,10 +61,10 @@ public class MatrixVector {
     public static final int MAX_ITERATIONS = 100;
 
     private static void computeMatrixVector(Matrix2DFloat matrix, VectorFloat vector, VectorFloat output) {
-        for (@Parallel int i = 0; i < vector.size(); i++) {
+        for (@Parallel int i = 0; i < matrix.getNumRows(); i++) {
             float sum = 0.0f;
             for (int j = 0; j < matrix.getNumColumns(); j++) {
-                sum += vector.get(i) * matrix.get(i, i);
+                sum += matrix.get(i, j) * vector.get(j);
             }
             output.set(i, sum);
         }
@@ -77,7 +77,8 @@ public class MatrixVector {
             try {
                 size = Integer.parseInt(args[0]);
             } catch (NumberFormatException numberFormatException) {
-                size = 8192;
+                numberFormatException.printStackTrace();
+                throw new NullPointerException();
             }
         }
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/DFTVector.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/DFTVector.java
@@ -88,7 +88,7 @@ public class DFTVector {
             Float2 sumReal = new Float2(0, 0);
             Float2 simImag = new Float2(0, 0);
             for (int t = 0; t < n; t++) { // For each input element
-                float angle = (float) ((2 * TornadoMath.floatPI() * t * k) / n);
+                float angle = (2 * TornadoMath.floatPI() * t * k) / n;
 
                 Float2 partA = Float2.mult(inreal.get(t), TornadoMath.cos(angle));
                 Float2 partB = Float2.mult(inimag.get(t), TornadoMath.sin(angle));
@@ -138,7 +138,7 @@ public class DFTVector {
             Float8 sumReal = new Float8(0, 0, 0, 0, 0, 0, 0, 0);
             Float8 simImag = new Float8(0, 0, 0, 0, 0, 0, 0, 0);
             for (int t = 0; t < n; t++) { // For each input element
-                float angle = (float) ((2 * TornadoMath.floatPI() * t * k) / n);
+                float angle = (2 * TornadoMath.floatPI() * t * k) / n;
 
                 Float8 partA = Float8.mult(inreal.get(t), TornadoMath.cos(angle));
                 Float8 partB = Float8.mult(inimag.get(t), TornadoMath.sin(angle));
@@ -164,7 +164,7 @@ public class DFTVector {
             Float16 sumImag = new Float16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
             for (int t = 0; t < n; t++) { // For each input element
-                float angle = (float) ((2 * TornadoMath.floatPI() * t * k) / n);
+                float angle = (2 * TornadoMath.floatPI() * t * k) / n;
 
                 Float16 partA = Float16.mult(inreal.get(t), TornadoMath.cos(angle));
                 Float16 partB = Float16.mult(inimag.get(t), TornadoMath.sin(angle));

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/MatrixVector.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/MatrixVector.java
@@ -63,20 +63,20 @@ public class MatrixVector {
     public static final int ITERATIONS = 100;
 
     private static void compute(Matrix2DFloat matrix, VectorFloat vector, VectorFloat output) {
-        for (@Parallel int i = 0; i < vector.size(); i++) {
+        for (@Parallel int i = 0; i < matrix.getNumRows(); i++) {
             float sum = 0.0f;
             for (int j = 0; j < matrix.getNumColumns(); j++) {
-                sum += vector.get(i) * matrix.get(i, i);
+                sum += matrix.get(i, j) * vector.get(j);
             }
             output.set(i, sum);
         }
     }
 
-    private static void computeWithVectors(Matrix2DFloat4 matrix, VectorFloat4 vector, VectorFloat4 output) {
-        for (@Parallel int i = 0; i < vector.getLength(); i++) {
-            Float4 sum = new Float4(0, 0, 0, 0);
+    private static void computeWithVectors(Matrix2DFloat4 matrix, VectorFloat4 vector, VectorFloat output) {
+        for (@Parallel int i = 0; i < matrix.getNumRows(); i++) {
+            float sum = 0;
             for (int j = 0; j < matrix.getNumColumns(); j++) {
-                sum = Float4.add(sum, Float4.mult(vector.get(i), matrix.get(i, i)));
+                sum += Float4.sum(Float4.mult(matrix.get(i, j), vector.get(j)));
             }
             output.set(i, sum);
         }
@@ -90,7 +90,7 @@ public class MatrixVector {
         VectorFloat4 vectorFloat = new VectorFloat4(size);
 
         // Output
-        VectorFloat4 result = new VectorFloat4(size);
+        VectorFloat result = new VectorFloat(size);
 
         Random r = new Random();
         final int s = size;
@@ -186,7 +186,7 @@ public class MatrixVector {
         IntStream.range(0, size).parallel().forEach(i -> {
             float sum = 0.0f;
             for (int j = 0; j < matrix.getNumColumns(); j++) {
-                sum += vector.get(i) * matrix.get(i, i);
+                sum +=  matrix.get(i, j) * vector.get(j);
             }
             output.set(i, sum);
         });
@@ -246,7 +246,7 @@ public class MatrixVector {
             }
         }
 
-        TornadoDevice device = TornadoExecutionPlan.getDevice(0, 2);
+        TornadoDevice device = TornadoExecutionPlan.getDevice(0, 0);
 
         if (version.startsWith("vector")) {
             runWithVectorTypes(size, device);

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/VectorAddTest.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/VectorAddTest.java
@@ -243,9 +243,7 @@ public class VectorAddTest {
     }
 
     private static void computeWithStreams(final int size, FloatArray a, FloatArray b, FloatArray results) {
-        IntStream.range(0, size).parallel().forEach(i -> {
-            results.set(i, a.get(i) + b.get(i));
-        });
+        IntStream.range(0, size).parallel().forEach(i -> results.set(i, a.get(i) + b.get(i)));
     }
 
     private static void runWithJavaStreams(int size) {
@@ -295,7 +293,7 @@ public class VectorAddTest {
             }
         }
 
-        TornadoDevice device = TornadoExecutionPlan.getDevice(0, 2);
+        TornadoDevice device = TornadoExecutionPlan.getDevice(0, 0);
 
         if (version.startsWith("vector4")) {
             runWithVectorTypes4(size, device);


### PR DESCRIPTION
#### Description

This PR fixes memory accesses (get/set)  for the `Matrix2DFloat4` type.

#### Problem description

The problem was the the indexes were not correctly computed. In addition, no unit-tests was present to check this. 
This PR solves the issue and adds a test for checking the memory layout and the memory accesses of this type. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make 
$ make tests   ## pass all unit-tests
$ tornado-test --threadInfo --jvm="-Dgraph.mv.device=0:0" --printKernel -V --fast uk.ac.manchester.tornado.unittests.compute.ComputeTests#matrixVectorFloat4
```

