### PR TITLE
[fix] memory limit checks

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -257,6 +257,7 @@ public class TornadoExecutionPlan {
         this.disableProfiler = true;
         return this;
     }
+
     /**
      * Prevents the TornadoExecutionPlan to execute if the I/O buffers exceed the provided limit.
      *
@@ -320,9 +321,10 @@ public class TornadoExecutionPlan {
             immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.withBatch(batchSize));
         }
 
-        void withMemoryLimit(String memoryLimit){
+        void withMemoryLimit(String memoryLimit) {
             immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.withMemoryLimit(memoryLimit));
         }
+
         /**
          * For all task-graphs contained in an Executor, update the device.
          *

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/TornadoCollectionInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/TornadoCollectionInterface.java
@@ -26,4 +26,5 @@ public sealed interface TornadoCollectionInterface<T extends Buffer> //
         permits VectorDouble, VectorDouble2, VectorDouble3, VectorDouble4, VectorDouble8, VectorDouble16, //
         VectorFloat, VectorFloat2, VectorFloat3, VectorFloat4, VectorFloat8, VectorFloat16, //
         VectorInt, VectorInt2, VectorInt3, VectorInt4, VectorInt8, VectorInt16 {
+    long getNumBytes();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble.java
@@ -238,4 +238,9 @@ public final class VectorDouble implements TornadoCollectionInterface<DoubleBuff
     public void clear() {
         storage.clear();
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble16.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble16.java
@@ -27,10 +27,12 @@ public final class VectorDouble16 implements TornadoCollectionInterface<DoubleBu
     public static final Class<VectorDouble16> TYPE = VectorDouble16.class;
 
     private static final int ELEMENT_SIZE = 16;
+
     /**
      * backing array.
      */
-    protected final DoubleArray storage;
+    private final DoubleArray storage;
+
     /**
      * number of elements in the storage.
      */
@@ -42,7 +44,7 @@ public final class VectorDouble16 implements TornadoCollectionInterface<DoubleBu
      * @param numElements
      * @param array
      */
-    protected VectorDouble16(int numElements, DoubleArray array) {
+    VectorDouble16(int numElements, DoubleArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -209,6 +211,11 @@ public final class VectorDouble16 implements TornadoCollectionInterface<DoubleBu
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble2.java
@@ -28,10 +28,12 @@ public final class VectorDouble2 implements TornadoCollectionInterface<DoubleBuf
 
     public static final Class<VectorDouble2> TYPE = VectorDouble2.class;
     private static final int ELEMENT_SIZE = 2;
+
     /**
      * backing array.
      */
-    protected final DoubleArray storage;
+    private final DoubleArray storage;
+
     /**
      * number of elements in the storage.
      */
@@ -43,7 +45,7 @@ public final class VectorDouble2 implements TornadoCollectionInterface<DoubleBuf
      * @param numElements
      * @param array
      */
-    protected VectorDouble2(int numElements, DoubleArray array) {
+    VectorDouble2(int numElements, DoubleArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -208,6 +210,11 @@ public final class VectorDouble2 implements TornadoCollectionInterface<DoubleBuf
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble3.java
@@ -32,7 +32,7 @@ public final class VectorDouble3 implements TornadoCollectionInterface<DoubleBuf
     /**
      * backing array.
      */
-    protected final DoubleArray storage;
+    private final DoubleArray storage;
     /**
      * number of elements in the storage.
      */
@@ -44,7 +44,7 @@ public final class VectorDouble3 implements TornadoCollectionInterface<DoubleBuf
      * @param numElements
      * @param array
      */
-    protected VectorDouble3(int numElements, DoubleArray array) {
+    VectorDouble3(int numElements, DoubleArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -211,6 +211,11 @@ public final class VectorDouble3 implements TornadoCollectionInterface<DoubleBuf
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble4.java
@@ -29,10 +29,11 @@ public final class VectorDouble4 implements TornadoCollectionInterface<DoubleBuf
     public static final Class<VectorDouble4> TYPE = VectorDouble4.class;
 
     private static final int ELEMENT_SIZE = 4;
+
     /**
      * backing array.
      */
-    protected final DoubleArray storage;
+    private final DoubleArray storage;
     /**
      * number of elements in the storage.
      */
@@ -44,7 +45,7 @@ public final class VectorDouble4 implements TornadoCollectionInterface<DoubleBuf
      * @param numElements
      * @param array
      */
-    protected VectorDouble4(int numElements, DoubleArray array) {
+    VectorDouble4(int numElements, DoubleArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -213,6 +214,11 @@ public final class VectorDouble4 implements TornadoCollectionInterface<DoubleBuf
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorDouble8.java
@@ -29,10 +29,11 @@ public final class VectorDouble8 implements TornadoCollectionInterface<DoubleBuf
     public static final Class<VectorDouble8> TYPE = VectorDouble8.class;
 
     private static final int ELEMENT_SIZE = 8;
+
     /**
      * backing array.
      */
-    protected final DoubleArray storage;
+    private final DoubleArray storage;
     /**
      * number of elements in the storage.
      */
@@ -44,7 +45,7 @@ public final class VectorDouble8 implements TornadoCollectionInterface<DoubleBuf
      * @param numElements
      * @param array
      */
-    protected VectorDouble8(int numElements, DoubleArray array) {
+    VectorDouble8(int numElements, DoubleArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -211,6 +212,11 @@ public final class VectorDouble8 implements TornadoCollectionInterface<DoubleBuf
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat.java
@@ -228,4 +228,9 @@ public final class VectorFloat implements TornadoCollectionInterface<FloatBuffer
     public void clear() {
         storage.clear();
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat16.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat16.java
@@ -27,10 +27,10 @@ public final class VectorFloat16 implements TornadoCollectionInterface<FloatBuff
     public static final Class<VectorFloat16> TYPE = VectorFloat16.class;
 
     private static final int ELEMENT_SIZE = 16;
-    protected final FloatArray storage;
+    private final FloatArray storage;
     private final int numElements;
 
-    protected VectorFloat16(int numElements, FloatArray array) {
+    VectorFloat16(int numElements, FloatArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -158,5 +158,10 @@ public final class VectorFloat16 implements TornadoCollectionInterface<FloatBuff
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat2.java
@@ -32,7 +32,7 @@ public final class VectorFloat2 implements TornadoCollectionInterface<FloatBuffe
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
 
     /**
      * number of elements in the storage.
@@ -45,7 +45,7 @@ public final class VectorFloat2 implements TornadoCollectionInterface<FloatBuffe
      * @param numElements
      * @param array
      */
-    protected VectorFloat2(int numElements, FloatArray array) {
+    VectorFloat2(int numElements, FloatArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -206,5 +206,10 @@ public final class VectorFloat2 implements TornadoCollectionInterface<FloatBuffe
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat3.java
@@ -27,10 +27,12 @@ public final class VectorFloat3 implements TornadoCollectionInterface<FloatBuffe
     public static final Class<VectorFloat3> TYPE = VectorFloat3.class;
 
     private static final int ELEMENT_SIZE = 3;
+
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
+
     /**
      * number of elements in the storage.
      */
@@ -44,7 +46,7 @@ public final class VectorFloat3 implements TornadoCollectionInterface<FloatBuffe
      * @param array
      *     array to be copied
      */
-    protected VectorFloat3(int numElements, FloatArray array) {
+    VectorFloat3(int numElements, FloatArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -215,4 +217,8 @@ public final class VectorFloat3 implements TornadoCollectionInterface<FloatBuffe
         storage.clear();
     }
 
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat4.java
@@ -215,4 +215,8 @@ public final class VectorFloat4 implements TornadoCollectionInterface<FloatBuffe
         storage.clear();
     }
 
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorFloat8.java
@@ -32,7 +32,7 @@ public final class VectorFloat8 implements TornadoCollectionInterface<FloatBuffe
     /**
      * backing array.
      */
-    protected final FloatArray storage;
+    private final FloatArray storage;
     /**
      * number of elements in the storage.
      */
@@ -44,7 +44,7 @@ public final class VectorFloat8 implements TornadoCollectionInterface<FloatBuffe
      * @param numElements
      * @param array
      */
-    protected VectorFloat8(int numElements, FloatArray array) {
+    VectorFloat8(int numElements, FloatArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -214,5 +214,10 @@ public final class VectorFloat8 implements TornadoCollectionInterface<FloatBuffe
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt.java
@@ -243,4 +243,9 @@ public final class VectorInt implements TornadoCollectionInterface<IntBuffer> {
     public void clear() {
         storage.clear();
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt16.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt16.java
@@ -29,10 +29,11 @@ public final class VectorInt16 implements TornadoCollectionInterface<IntBuffer> 
     public static final Class<VectorInt16> TYPE = VectorInt16.class;
 
     private static final int ELEMENT_SIZE = 16;
+
     /**
      * backing array.
      */
-    protected final IntArray storage;
+    private final IntArray storage;
     /**
      * number of elements in the storage.
      */
@@ -44,7 +45,7 @@ public final class VectorInt16 implements TornadoCollectionInterface<IntBuffer> 
      * @param numElements
      * @param array
      */
-    protected VectorInt16(int numElements, IntArray array) {
+    VectorInt16(int numElements, IntArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -210,4 +211,8 @@ public final class VectorInt16 implements TornadoCollectionInterface<IntBuffer> 
         storage.clear();
     }
 
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt2.java
@@ -32,7 +32,7 @@ public final class VectorInt2 implements TornadoCollectionInterface<IntBuffer> {
     /**
      * backing array.
      */
-    protected final IntArray storage;
+    private final IntArray storage;
     /**
      * number of elements in the storage.
      */
@@ -44,7 +44,7 @@ public final class VectorInt2 implements TornadoCollectionInterface<IntBuffer> {
      * @param numElements
      * @param array
      */
-    protected VectorInt2(int numElements, IntArray array) {
+    VectorInt2(int numElements, IntArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -206,6 +206,11 @@ public final class VectorInt2 implements TornadoCollectionInterface<IntBuffer> {
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt3.java
@@ -44,7 +44,7 @@ public final class VectorInt3 implements TornadoCollectionInterface<IntBuffer> {
      * @param numElements
      * @param array
      */
-    protected VectorInt3(int numElements, IntArray array) {
+    VectorInt3(int numElements, IntArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -208,6 +208,11 @@ public final class VectorInt3 implements TornadoCollectionInterface<IntBuffer> {
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt4.java
@@ -29,10 +29,11 @@ public final class VectorInt4 implements TornadoCollectionInterface<IntBuffer> {
     public static final Class<VectorInt4> TYPE = VectorInt4.class;
 
     private static final int ELEMENT_SIZE = 4;
+
     /**
      * backing array.
      */
-    protected final IntArray storage;
+    private final IntArray storage;
     /**
      * number of elements in the storage.
      */
@@ -44,7 +45,7 @@ public final class VectorInt4 implements TornadoCollectionInterface<IntBuffer> {
      * @param numElements
      * @param array
      */
-    protected VectorInt4(int numElements, IntArray array) {
+    VectorInt4(int numElements, IntArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -214,6 +215,11 @@ public final class VectorInt4 implements TornadoCollectionInterface<IntBuffer> {
 
     public void clear() {
         storage.clear();
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/collections/VectorInt8.java
@@ -29,10 +29,12 @@ public final class VectorInt8 implements TornadoCollectionInterface<IntBuffer> {
     public static final Class<VectorInt8> TYPE = VectorInt8.class;
 
     private static final int ELEMENT_SIZE = 8;
+
     /**
      * backing array.
      */
-    protected final IntArray storage;
+    private final IntArray storage;
+
     /**
      * number of elements in the storage.
      */
@@ -44,7 +46,7 @@ public final class VectorInt8 implements TornadoCollectionInterface<IntBuffer> {
      * @param numElements
      * @param array
      */
-    protected VectorInt8(int numElements, IntArray array) {
+    VectorInt8(int numElements, IntArray array) {
         this.numElements = numElements;
         this.storage = array;
     }
@@ -210,4 +212,8 @@ public final class VectorInt8 implements TornadoCollectionInterface<IntBuffer> {
         storage.clear();
     }
 
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte3.java
@@ -180,4 +180,8 @@ public final class ImageByte3 implements TornadoImagesInterface<ByteBuffer> {
         storage.clear();
     }
 
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageByte4.java
@@ -260,4 +260,9 @@ public final class ImageByte4 implements TornadoImagesInterface<ByteBuffer> {
     public void clear() {
         storage.clear();
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat.java
@@ -255,4 +255,9 @@ public final class ImageFloat implements TornadoImagesInterface<FloatBuffer> {
     public void clear() {
         storage.clear();
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat3.java
@@ -271,4 +271,9 @@ public final class ImageFloat3 implements TornadoImagesInterface<FloatBuffer> {
         storage.clear();
     }
 
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat4.java
@@ -233,4 +233,9 @@ public final class ImageFloat4 implements TornadoImagesInterface<FloatBuffer> {
         storage.clear();
     }
 
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/ImageFloat8.java
@@ -267,4 +267,9 @@ public final class ImageFloat8 implements TornadoImagesInterface<FloatBuffer> {
     public void clear() {
         storage.clear();
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/TornadoImagesInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/images/TornadoImagesInterface.java
@@ -25,4 +25,6 @@ public sealed interface TornadoImagesInterface<T extends Buffer> //
         extends PrimitiveStorage<T> //
         permits ImageByte3, ImageByte4, //
         ImageFloat, ImageFloat3, ImageFloat4, ImageFloat8 {
+
+    long getNumBytes();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DDouble.java
@@ -195,4 +195,9 @@ public final class Matrix2DDouble extends Matrix2DType implements TornadoMatrixI
     public int size() {
         return numElements;
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat.java
@@ -201,4 +201,9 @@ public final class Matrix2DFloat extends Matrix2DType implements TornadoMatrixIn
     public int size() {
         return numElements;
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DFloat4.java
@@ -226,4 +226,9 @@ public final class Matrix2DFloat4 extends Matrix2DType implements TornadoMatrixI
     public int size() {
         return numElements;
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DInt.java
@@ -205,4 +205,9 @@ public final class Matrix2DInt extends Matrix2DType implements TornadoMatrixInte
         return numElements;
     }
 
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DType.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix2DType.java
@@ -55,4 +55,5 @@ abstract class Matrix2DType {
 
     public abstract void clear();
 
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DFloat.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DFloat.java
@@ -138,4 +138,9 @@ public final class Matrix3DFloat extends Matrix3DType implements TornadoMatrixIn
     public int size() {
         return numElements;
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DFloat4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DFloat4.java
@@ -161,4 +161,9 @@ public final class Matrix3DFloat4 extends Matrix3DType implements TornadoMatrixI
     public int size() {
         return numElements;
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix4x4Float.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix4x4Float.java
@@ -229,4 +229,9 @@ public final class Matrix4x4Float implements TornadoMatrixInterface<FloatBuffer>
     public void clear() {
         storage.clear();
     }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/TornadoMatrixInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/TornadoMatrixInterface.java
@@ -24,4 +24,6 @@ import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 public sealed interface TornadoMatrixInterface<T extends Buffer> extends PrimitiveStorage<T> //
         permits Matrix2DDouble, Matrix2DFloat, Matrix2DFloat4, Matrix2DInt, //
         Matrix3DFloat, Matrix3DFloat4, Matrix4x4Float  {
+
+    long getNumBytes();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Byte3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Byte3.java
@@ -199,4 +199,9 @@ public final class Byte3 implements TornadoVectorsInterface<ByteBuffer> {
         return storage;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Byte4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Byte4.java
@@ -220,4 +220,9 @@ public final class Byte4 implements TornadoVectorsInterface<ByteBuffer> {
         return storage;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double16.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double16.java
@@ -374,4 +374,9 @@ public final class Double16 implements TornadoVectorsInterface<DoubleBuffer> {
     public double[] toArray() {
         return storage;
     }
+
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 8;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double2.java
@@ -279,4 +279,9 @@ public final class Double2 implements TornadoVectorsInterface<DoubleBuffer> {
         return storage;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 8;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double3.java
@@ -285,4 +285,9 @@ public final class Double3 implements TornadoVectorsInterface<DoubleBuffer> {
         return storage;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 8;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double4.java
@@ -291,4 +291,9 @@ public final class Double4 implements TornadoVectorsInterface<DoubleBuffer> {
     public double[] toArray() {
         return storage;
     }
+
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 8;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Double8.java
@@ -301,4 +301,9 @@ public final class Double8 implements TornadoVectorsInterface<DoubleBuffer> {
     public double[] toArray() {
         return storage;
     }
+
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 8;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float16.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float16.java
@@ -333,4 +333,9 @@ public final class Float16 implements TornadoVectorsInterface<FloatBuffer> {
     public float[] toArray() {
         return storage;
     }
+
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float2.java
@@ -269,4 +269,8 @@ public final class Float2 implements TornadoVectorsInterface<FloatBuffer> {
         return storage;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float3.java
@@ -296,4 +296,9 @@ public final class Float3 implements TornadoVectorsInterface<FloatBuffer> {
         return storage;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float4.java
@@ -297,4 +297,9 @@ public final class Float4 implements TornadoVectorsInterface<FloatBuffer> {
         return storage;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float8.java
@@ -307,4 +307,9 @@ public final class Float8 implements TornadoVectorsInterface<FloatBuffer> {
         return storage;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int16.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int16.java
@@ -369,4 +369,9 @@ public final class Int16 implements TornadoVectorsInterface<IntBuffer> {
     public int size() {
         return NUM_ELEMENTS;
     }
+
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int2.java
@@ -218,4 +218,9 @@ public final class Int2 implements TornadoVectorsInterface<IntBuffer> {
         return NUM_ELEMENTS;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int3.java
@@ -214,4 +214,9 @@ public final class Int3 implements TornadoVectorsInterface<IntBuffer> {
         return NUM_ELEMENTS;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int4.java
@@ -229,4 +229,9 @@ public final class Int4 implements TornadoVectorsInterface<IntBuffer> {
         return NUM_ELEMENTS;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Int8.java
@@ -303,4 +303,9 @@ public final class Int8 implements TornadoVectorsInterface<IntBuffer> {
         return NUM_ELEMENTS;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 4;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Short2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Short2.java
@@ -198,4 +198,9 @@ public final class Short2 implements TornadoVectorsInterface<ShortBuffer> {
         return storage;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 2;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Short3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Short3.java
@@ -206,4 +206,9 @@ public final class Short3 implements TornadoVectorsInterface<ShortBuffer> {
         return storage;
     }
 
+    @Override
+    public long getNumBytes() {
+        return NUM_ELEMENTS * 2;
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/TornadoVectorsInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/TornadoVectorsInterface.java
@@ -28,4 +28,5 @@ public sealed interface TornadoVectorsInterface<T extends Buffer> //
         Float2, Float3, Float4, Float8, Float16, //
         Int2, Int3, Int4, Int8, Int16, //
         Short2, Short3 {
+    long getNumBytes();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/volumes/TornadoVolumesInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/volumes/TornadoVolumesInterface.java
@@ -23,4 +23,6 @@ import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 public sealed interface TornadoVolumesInterface<T extends Buffer> //
         extends PrimitiveStorage<T> permits VolumeShort2 {
+
+    long getNumBytes();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/volumes/VolumeShort2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/volumes/VolumeShort2.java
@@ -164,4 +164,8 @@ public final class VolumeShort2 implements TornadoVolumesInterface<ShortBuffer> 
         storage.clear();
     }
 
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesWithoutHeader();
+    }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -38,8 +38,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.Event;
@@ -56,7 +58,12 @@ import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.arrays.LongArray;
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
-import uk.ac.manchester.tornado.runtime.common.BatchConfiguration;
+import uk.ac.manchester.tornado.api.types.collections.TornadoCollectionInterface;
+import uk.ac.manchester.tornado.api.types.images.TornadoImagesInterface;
+import uk.ac.manchester.tornado.api.types.matrix.TornadoMatrixInterface;
+import uk.ac.manchester.tornado.api.types.vectors.Float2;
+import uk.ac.manchester.tornado.api.types.vectors.TornadoVectorsInterface;
+import uk.ac.manchester.tornado.api.types.volumes.TornadoVolumesInterface;
 import uk.ac.manchester.tornado.runtime.common.DeviceObjectState;
 import uk.ac.manchester.tornado.runtime.common.KernelArgs;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
@@ -94,6 +101,8 @@ public class TornadoExecutionContext {
 
     private TornadoProfiler profiler;
 
+    private static int INIT_VALUE = -1;
+
     public TornadoExecutionContext(String id) {
         name = id;
         meta = new ScheduleMetaData(name);
@@ -108,7 +117,7 @@ public class TornadoExecutionContext {
         Arrays.fill(taskToDeviceMapTable, null);
         nextTask = 0;
         batchSize = -1;
-        executionPlanMemoryLimit = -1;
+        executionPlanMemoryLimit = INIT_VALUE;
         lastDevices = new HashSet<>();
         this.profiler = null;
         this.isDataDependencyDetected = isDataDependencyInTaskGraph();
@@ -153,43 +162,41 @@ public class TornadoExecutionContext {
         return executionPlanMemoryLimit;
     }
 
-    public boolean doesExceedExecPlanLimit() {
+    public boolean isMemoryLimited() {
+        return getExecutionPlanMemoryLimit() != INIT_VALUE;
+    }
+
+    public boolean doesExceedExecutionPlanLimit() {
         long totalSize = 0;
 
-        HashSet<Long> inputSizes = new HashSet<>();
-        LinkedHashSet<Byte> elementSizes = new LinkedHashSet<>();
-
-        for (Object o : getObjects()) {
-            if (o.getClass().isArray()) {
-                Class<?> componentType = o.getClass().getComponentType();
+        for (Object parameter : getObjects()) {
+            if (parameter.getClass().isArray()) {
+                Class<?> componentType = parameter.getClass().getComponentType();
                 DataTypeSize dataTypeSize = DataTypeSize.findDataTypeSize(componentType);
                 if (dataTypeSize == null) {
                     throw new TornadoRuntimeException("[UNSUPPORTED] Data type not supported for processing in batches");
                 }
-                long size = Array.getLength(o);
+                long size = Array.getLength(parameter);
                 totalSize += size * dataTypeSize.getSize();
-
-                elementSizes.add(dataTypeSize.getSize());
-                inputSizes.add(totalSize);
-            } else if (o instanceof TornadoNativeArray tornadoNativeArray) {
+            } else if (parameter instanceof TornadoNativeArray tornadoNativeArray) {
                 totalSize += tornadoNativeArray.getNumBytesWithoutHeader();
-                inputSizes.add(totalSize);
-                byte elementSize = switch (tornadoNativeArray) {
-                    case IntArray _ -> DataTypeSize.INT.getSize();
-                    case FloatArray _ -> DataTypeSize.FLOAT.getSize();
-                    case DoubleArray _ -> DataTypeSize.DOUBLE.getSize();
-                    case LongArray _ -> DataTypeSize.LONG.getSize();
-                    case ShortArray _ -> DataTypeSize.SHORT.getSize();
-                    case ByteArray _ -> DataTypeSize.BYTE.getSize();
-                    case CharArray _ -> DataTypeSize.CHAR.getSize();
-                    default -> throw new TornadoRuntimeException(STR."Unsupported array type: \{o.getClass()}");
-                };
-                elementSizes.add(elementSize);
+            } else if (parameter instanceof TornadoVectorsInterface<?> tornadoVector) {
+                totalSize += tornadoVector.getNumBytes();
+            } else if (parameter instanceof TornadoCollectionInterface<?> collection) {
+                totalSize += collection.getNumBytes();
+            } else if (parameter instanceof TornadoVolumesInterface<?> tornadoVolume) {
+                totalSize += tornadoVolume.getNumBytes();
+            } else if (parameter instanceof TornadoMatrixInterface<?> tornadoMatrix) {
+                totalSize += tornadoMatrix.getNumBytes();
+            } else if (parameter instanceof TornadoImagesInterface<?> tornadoImage) {
+                totalSize += tornadoImage.getNumBytes();
+            } else if (parameter instanceof KernelContext || parameter instanceof AtomicInteger) {
+                // ignore
             } else {
-                throw new TornadoRuntimeException(STR."Unsupported type: \{o.getClass()}");
+                throw new TornadoRuntimeException(STR."Unsupported type: \{parameter.getClass()}");
             }
         }
-        return getExecutionPlanMemoryLimit() != -1 && totalSize > getExecutionPlanMemoryLimit();
+        return totalSize > getExecutionPlanMemoryLimit();
     }
 
     public int replaceVariable(Object oldObj, Object newObj) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,18 +49,10 @@ import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
-import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
-import uk.ac.manchester.tornado.api.types.arrays.CharArray;
-import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.arrays.LongArray;
-import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.api.types.collections.TornadoCollectionInterface;
 import uk.ac.manchester.tornado.api.types.images.TornadoImagesInterface;
 import uk.ac.manchester.tornado.api.types.matrix.TornadoMatrixInterface;
-import uk.ac.manchester.tornado.api.types.vectors.Float2;
 import uk.ac.manchester.tornado.api.types.vectors.TornadoVectorsInterface;
 import uk.ac.manchester.tornado.api.types.volumes.TornadoVolumesInterface;
 import uk.ac.manchester.tornado.runtime.common.DeviceObjectState;
@@ -168,7 +159,7 @@ public class TornadoExecutionContext {
 
     public boolean doesExceedExecutionPlanLimit() {
         long totalSize = 0;
-
+        
         for (Object parameter : getObjects()) {
             if (parameter.getClass().isArray()) {
                 Class<?> componentType = parameter.getClass().getComponentType();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -243,11 +243,15 @@ public class TornadoVMInterpreter extends TornadoLogger {
         finishedWarmup = true;
     }
 
+    private boolean isMemoryLimitEnabled() {
+        return executionContext.isMemoryLimited();
+    }
+
     private Event execute(boolean isWarmup) {
         isWarmup = isWarmup || VIRTUAL_DEVICE_ENABLED;
         deviceForInterpreter.enableThreadSharing();
 
-        if (this.executionContext.doesExceedExecPlanLimit()) {
+        if (isMemoryLimitEnabled() && executionContext.doesExceedExecutionPlanLimit()) {
             throw new TornadoMemoryException(STR."OutofMemoryException due to executionPlan.withMemoryLimit of \{executionContext.getExecutionPlanMemoryLimit()}");
         }
 


### PR DESCRIPTION
#### Description

This PR fixes the checks for the memory limit and adds the supported off-heap types.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make
$ make tests
$ tornado-test -V uk.ac.manchester.tornado.unittests.vectortypes.TestFloats
```
