### PR TITLE
[fix] Dynamic reconfiguration policies

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -66,12 +66,7 @@ public class TornadoOptions {
      * Option to print TornadoVM Internal Bytecodes.
      */
     public static final boolean PRINT_BYTECODES = getBooleanValue("tornado.print.bytecodes", FALSE);
-    /**
-     * Option to debug dynamic reconfiguration policies.
-     * <p>
-     * Use `-Dtornado.dynamic.verbose=True`.
-     */
-    public static final boolean DEBUG_POLICY = getBooleanValue("tornado.dynamic.verbose", FALSE);
+
     /**
      * Option to enable experimental and new option for performing automatic full
      * reductions.
@@ -88,7 +83,7 @@ public class TornadoOptions {
     /**
      * Enable/Disable FMA Optimizations. True by default.
      */
-    public static final boolean ENABLE_FMA = getBooleanValue("tornado.enable.fma", "True");
+    public static final boolean ENABLE_FMA = getBooleanValue("tornado.enable.fma", TRUE);
     /**
      * Enable/Disable Fix Reads Optimization. True by default.
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -86,7 +86,6 @@ import uk.ac.manchester.tornado.api.enums.ProfilerMode;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoDynamicReconfigurationException;
-import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoTaskRuntimeException;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
@@ -277,7 +276,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             case 15:
                 task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5), inputObjects.get(
                         6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10), inputObjects.get(11), inputObjects.get(12), inputObjects.get(13), inputObjects.get(
-                                14));
+                        14));
                 break;
             default:
                 System.out.println(STR."COPY-IN Not supported yet: \{numObjectsCopyIn}");
@@ -629,6 +628,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                     : STR."\{((CompilableTask) task).getMethod().getDeclaringClass().getSimpleName()}.\{task.getTaskName()}";
             timeProfiler.registerMethodHandle(ProfilerType.METHOD, task.getId(), methodName);
         }
+
     }
 
     private void updateDeviceContext() {
@@ -805,7 +805,9 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     private void dumpDeoptReason(TornadoBailoutRuntimeException e) {
         if (!Tornado.DEBUG) {
             System.err.println(STR."\{RED}[Bailout] Running the sequential implementation. Enable --debug to see the reason.\{RESET}");
-        } else {
+        }else
+
+    {
             System.err.println(e.getMessage());
             for (StackTraceElement s : e.getStackTrace()) {
                 System.err.println(STR."\t\{s}");
@@ -1381,38 +1383,38 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             case 10:
                 @SuppressWarnings("rawtypes") Task10 task10 = (Task10) taskPackage.getTaskParameters()[0];
                 task10.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
-                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                                .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
                         taskPackage.getTaskParameters()[10]);
                 break;
             case 11:
                 @SuppressWarnings("rawtypes") Task11 task11 = (Task11) taskPackage.getTaskParameters()[0];
                 task11.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
-                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                                .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
                         taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11]);
                 break;
             case 12:
                 @SuppressWarnings("rawtypes") Task12 task12 = (Task12) taskPackage.getTaskParameters()[0];
                 task12.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
-                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                                .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
                         taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12]);
                 break;
             case 13:
                 @SuppressWarnings("rawtypes") Task13 task13 = (Task13) taskPackage.getTaskParameters()[0];
                 task13.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
-                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                                .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
                         taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13]);
                 break;
             case 14:
                 @SuppressWarnings("rawtypes") Task14 task14 = (Task14) taskPackage.getTaskParameters()[0];
                 task14.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
-                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                                .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
                         taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13], taskPackage
                                 .getTaskParameters()[14]);
                 break;
             case 15:
                 @SuppressWarnings("rawtypes") Task15 task15 = (Task15) taskPackage.getTaskParameters()[0];
                 task15.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
-                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                                .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
                         taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13], taskPackage
                                 .getTaskParameters()[14], taskPackage.getTaskParameters()[15]);
                 break;
@@ -1449,29 +1451,37 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         return deviceWinnerIndex;
     }
 
-    private int syncWinner(Thread[] threads) {
+    public record Tuple2(int threadWinnerIndex, Thread join) {
+    }
+
+    private Tuple2 syncWinner(Thread[] threads) {
         int winner = 0;
         boolean isAlive = true;
+        Thread join = null;
         while (isAlive) {
-
             for (int i = 0; i < threads.length; i++) {
                 isAlive = threads[i].isAlive();
                 if (!isAlive) {
-                    if (TornadoOptions.DEBUG_POLICY) {
-                        System.out.println(STR."Thread \{threads[i].getName()} finished");
+                    if (Tornado.DEBUG) {
+                        System.out.println(STR."SELECTED Thread-Device: \{threads[i].getName()} ");
                     }
                     winner = i;
-                    // kill the others
-                    for (int j = 0; j < threads.length; j++) {
-                        if (i != j) {
-                            threads[j].interrupt();
+                    join = new Thread(() -> {
+                        // kill the others
+                        for (Thread thread : threads) {
+                            if (thread.isAlive()) {
+                                try {
+                                    thread.join();
+                                } catch (InterruptedException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }
                         }
-                    }
-                    break;
+                    });
                 }
             }
         }
-        return winner;
+        return new Tuple2(winner, join);
     }
 
     private void runAllTasksJavaSequential() {
@@ -1480,19 +1490,21 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         }
     }
 
-    private void runParallelSequential(Policy policy, Thread[] threads, int indexSequential, Timer timer, long[] totalTimers) {
+    private void runThreadSequentialVersion(Policy policy, Thread[] threads, int indexSequential, Timer timer, long[] totalTimers) {
         // Last Thread runs the sequential code
         threads[indexSequential] = new Thread(() -> {
-            long start = System.currentTimeMillis();
+            Thread.currentThread().setName("Thread-sequential");
+
             if (policy == Policy.PERFORMANCE) {
-                for (int k = 0; k < PERFORMANCE_WARMUP; k++) {
+                for (int k = 0; k < 100; k++) {
                     runAllTasksJavaSequential();
                 }
-                start = timer.time();
             }
+
+            final long start = timer.time();
+            runAllTasksJavaSequential();
             final long endSequentialCode = timer.time();
-            Thread.currentThread().setName("Thread-sequential");
-            if (TornadoOptions.DEBUG_POLICY) {
+            if (Tornado.DEBUG) {
                 System.out.println(STR."Seq finished: \{Thread.currentThread().getName()}");
             }
 
@@ -1508,8 +1520,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 TaskGraph task = new TaskGraph(newTaskScheduleName);
 
                 Thread.currentThread().setName(STR."Thread-DEV: \{TornadoRuntime.getTornadoRuntime().getDriver(0).getDevice(taskScheduleNumber).getPhysicalDevice().getDeviceName()}");
-
-                long start = timer.time();
 
                 for (StreamingObject streamingObject : inputModesObjects) {
                     performStreamInObject(task, streamingObject.object, streamingObject.mode);
@@ -1531,15 +1541,15 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
                 ImmutableTaskGraph immutableTaskGraph = task.snapshot();
                 TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph);
-                executor.execute();
 
                 if (policy == Policy.PERFORMANCE) {
                     // first warm up
                     for (int k = 0; k < PERFORMANCE_WARMUP; k++) {
                         executor.execute();
                     }
-                    start = timer.time();
                 }
+
+                long start = timer.time();
                 executor.execute();
                 final long end = timer.time();
                 taskGraphIndex.put(taskScheduleNumber, task);
@@ -1551,7 +1561,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                     globalTaskGraphIndex.put(taskScheduleNumber, task);
                 }
 
-                totalTimers[taskScheduleNumber] = end - start;
+                totalTimers[taskScheduleNumber] = (end - start);
             });
         }
 
@@ -1570,7 +1580,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         long[] totalTimers = new long[numThreads];
 
         // Last Thread runs the sequential code
-        runParallelSequential(policy, threads, numDevices, timer, totalTimers);
+        runThreadSequentialVersion(policy, threads, numDevices, timer, totalTimers);
 
         // Run all task schedules in parallel
         runParallelTaskGraphs(numDevices, threads, timer, policy, totalTimers);
@@ -1582,23 +1592,25 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
         // Define the winner, based on the first thread to finish
         if (policy == Policy.LATENCY) {
-            int deviceWinnerIndex = syncWinner(threads);
-            policyTimeTable.put(policy, deviceWinnerIndex);
-        }
-
-        // JOIN
-        for (Thread t : threads) {
-            try {
-                t.join();
-            } catch (InterruptedException e) {
-                throw new TornadoDynamicReconfigurationException(e);
+            Tuple2 tuple = syncWinner(threads);
+            int deviceWinnerIndex = tuple.threadWinnerIndex;
+            tuple.join.start();
+            policyTimeTable.put(Policy.LATENCY, deviceWinnerIndex);
+        } else {
+            // JOIN for the PERFORMANCE and END_TO_END policies.
+            for (Thread t : threads) {
+                try {
+                    t.join();
+                } catch (InterruptedException e) {
+                    throw new TornadoDynamicReconfigurationException(e);
+                }
             }
         }
 
         if ((policy == Policy.PERFORMANCE || policy == Policy.END_2_END) && (masterThreadID == Thread.currentThread().getId())) {
             int deviceWinnerIndex = synchronizeWithPolicy(policy, totalTimers);
             policyTimeTable.put(policy, deviceWinnerIndex);
-            if (TornadoOptions.DEBUG_POLICY) {
+            if (Tornado.DEBUG) {
                 System.out.println(getListDevices());
                 System.out.println(STR."BEST Position: #\{deviceWinnerIndex} \{Arrays.toString(totalTimers)}");
             }
@@ -1629,7 +1641,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         for (TaskPackage taskPackage : taskPackages) {
             TornadoRuntime.setProperty(STR."\{this.getTaskGraphName()}.\{taskPackage.getId()}.device", STR."0:\{deviceWinnerIndex}");
         }
-        if (TornadoOptions.DEBUG_POLICY) {
+        if (Tornado.DEBUG) {
             System.out.println(STR."Running in parallel device: \{deviceWinnerIndex}");
         }
         TaskGraph task = taskGraphIndex.get(deviceWinnerIndex);
@@ -1707,13 +1719,12 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     private void runSequentialTaskGraph(Policy policy, Timer timer, long[] totalTimers, int indexSequential) {
-        long startSequential = timer.time();
         if (policy == Policy.PERFORMANCE) {
-            for (int k = 0; k < PERFORMANCE_WARMUP; k++) {
+            for (int k = 0; k < 100; k++) {
                 runAllTasksJavaSequential();
             }
-            startSequential = timer.time();
         }
+        long startSequential = timer.time();
         runAllTasksJavaSequential();
         final long endSequentialCode = timer.time();
         totalTimers[indexSequential] = (endSequentialCode - startSequential);
@@ -1727,7 +1738,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             String newTaskScheduleName = TASK_GRAPH_PREFIX + taskNumber;
             TaskGraph task = new TaskGraph(newTaskScheduleName);
 
-            long start = timer.time();
             for (StreamingObject streamingObject : inputModesObjects) {
                 performStreamInObject(task, streamingObject.object, streamingObject.mode);
             }
@@ -1761,16 +1771,16 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
             ImmutableTaskGraph immutableTaskGraph = task.snapshot();
             TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.execute();
 
             if (policy == Policy.PERFORMANCE) {
                 for (int k = 0; k < PERFORMANCE_WARMUP; k++) {
                     executor.execute();
                 }
-                start = timer.time();
             }
 
+            final long start = timer.time();
             executor.execute();
+            final long end = timer.time();
             taskGraphIndex.put(taskNumber, task);
 
             // TaskSchedules Global
@@ -1781,7 +1791,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 globalTaskGraphIndex.put(taskNumber, task);
             }
 
-            final long end = timer.time();
             totalTimers[taskNumber] = end - start;
         }
     }
@@ -1830,13 +1839,13 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         for (int i = 0; i < num; i++) {
             TornadoDeviceType deviceType = TornadoRuntime.getTornadoRuntime().getDriver(0).getDevice(i).getDeviceType();
             String type = switch (deviceType) {
-                case CPU -> "CPU  ";
-                case GPU -> "GPU  ";
-                case FPGA -> "FPGA  ";
+                case CPU -> "CPU";
+                case GPU -> "GPU";
+                case FPGA -> "FPGA";
                 case ACCELERATOR -> "ACCELERATOR";
                 default -> "JAVA";
             };
-            str.append(type).append(" ").append(",");
+            str.append(type).append(",").append("\t ");
         }
         str.append("JVM]");
         return str.toString();
@@ -1860,11 +1869,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
             updateHistoryTables(policy, deviceWinnerIndex);
 
-            if (TornadoOptions.DEBUG_POLICY) {
+            if (Tornado.DEBUG) {
                 System.out.println(getListDevices());
                 System.out.println(STR."BEST Position: #\{deviceWinnerIndex} \{Arrays.toString(totalTimers)}");
             }
-        }
+        } 
     }
 
     /**
@@ -1913,6 +1922,14 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     @Override
     public TornadoTaskGraphInterface scheduleWithProfileSequential(Policy policy) {
+
+        if (policy == Policy.LATENCY) {
+            if (Tornado.DEBUG) {
+                System.out.println("[WARNING]: LATENCY policy using the DRMode.SERIAL is not allowed. Changing to PERFORMANCE mode");
+            }
+            policy = Policy.PERFORMANCE;
+        }
+
         int numDevices = TornadoRuntime.getTornadoRuntime().getDriver(DEFAULT_DRIVER_INDEX).getDeviceCount();
 
         if (policyTimeTable.get(policy) == null) {
@@ -1999,7 +2016,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         }
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private void addInner(int type, Method method, ScheduleMetaData meta, String id, Object[] parameters) {
         switch (type) {
             case 0:


### PR DESCRIPTION
#### Description

This PR fixes the dynamic reconfiguration to select the correct device depending on the input policies. 

#### Problem description

The issue was that the timers were not correctly calculated, and it includes the whole performance evaluation in the case of the performance policy. This PR solves this issue and it refactors the sequential and parallel strategies. 


#### Backend/s tested

This PR has been tested with the OpenCL backend

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make
$ make tests
```

