### PR TITLE
[fix] Fix profiler in silent mode

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -1247,7 +1247,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     private void setupProfiler() {
         if (timeProfiler == null) {
-            if (TornadoOptions.isProfilerEnabled()) {
+            if (isProfilerEnabled()) {
                 this.timeProfiler = new TimeProfiler();
             } else {
                 this.timeProfiler = new EmptyProfiler();
@@ -2265,7 +2265,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     boolean isProfilerEnabled() {
-        return timeProfiler != null;
+        return (getProfilerMode() != null || TornadoOptions.isProfilerEnabled());
     }
 
     ProfilerMode getProfilerMode() {


### PR DESCRIPTION
#### Description

This PR fixes the profiler when it is enabled in `SILENT` mode from the `TornadoExecutionPlan` API. 

#### Problem description

The issue is that the profiler was only checked from the command line argument, rather than both command line and API enabled. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make
$ tornado-test -V uk.ac.manchester.tornado.unittests.profiler.TestProfiler#testProfilerOnAndOff 
WARNING: Using incubator modules: jdk.incubator.vector

Enable Profiler
Test: class uk.ac.manchester.tornado.unittests.profiler.TestProfiler#testProfilerOnAndOff
	Running test: testProfilerOnAndOff       ................  [PASS] 
Test ran: 1, Failed: 0, Unsupported: 0
```