### PR TITLE
Batch Processing with Multiple tasks in a task-graph

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -759,7 +759,7 @@ public class TaskGraph implements TaskGraphInterface {
     }
 
     TaskGraph batch(String batchSize) {
-        taskGraphImpl.batch(batchSize);
+        taskGraphImpl.withBatch(batchSize);
         return this;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -46,7 +46,7 @@ public interface TornadoTaskGraphInterface extends ProfileInterface {
 
     void scheduleInner();
 
-    void batch(String batchSize);
+    void withBatch(String batchSize);
 
     void withMemoryLimit(String memoryLimit);
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -176,10 +176,6 @@ public class TornadoVM extends TornadoLogger {
         executeActionOnInterpreters(TornadoVMInterpreter::clearInstalledCode);
     }
 
-    public void setCompileUpdate() {
-        executeActionOnInterpreters(TornadoVMInterpreter::setCompileUpdate);
-    }
-
     public void dumpProfiles() {
         executeActionOnInterpreters(TornadoVMInterpreter::dumpProfiles);
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
@@ -79,7 +79,6 @@ public class BatchConfiguration {
 
     public static BatchConfiguration computeChunkSizes(TornadoExecutionContext context, long batchSize) {
         // Get the size of the batch
-        List<Object> inputObjects = context.getObjects();
         long totalSize = 0;
 
         HashSet<Long> inputSizes = new HashSet<>();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -107,7 +107,7 @@ public class TornadoExecutionContext {
         taskToDeviceMapTable = new TornadoAcceleratorDevice[MAX_TASKS];
         Arrays.fill(taskToDeviceMapTable, null);
         nextTask = 0;
-        batchSize = -1;
+        batchSize = INIT_VALUE;
         executionPlanMemoryLimit = INIT_VALUE;
         lastDevices = new HashSet<>();
         this.profiler = null;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -153,7 +153,7 @@ public class TornadoVMBytecodeBuilder {
          * It constructs a new {@link TornadoVMBytecodeAssembler} instance.
          *
          * @param code
-         *            The byte array to hold the assembled bytecode.
+         *     The byte array to hold the assembled bytecode.
          */
         TornadoVMBytecodeAssembler(byte[] code) {
             buffer = ByteBuffer.wrap(code);
@@ -262,8 +262,8 @@ public class TornadoVMBytecodeBuilder {
          */
         public void dump() {
             final int width = 16;
-            System.out.printf("code  : capacity = %s, in use = %s   \n", RuntimeUtilities.humanReadableByteCount(buffer.capacity(), true),
-                    RuntimeUtilities.humanReadableByteCount(buffer.position(), true));
+            System.out.printf("code  : capacity = %s, in use = %s   \n", RuntimeUtilities.humanReadableByteCount(buffer.capacity(), true), RuntimeUtilities.humanReadableByteCount(buffer.position(),
+                    true));
             for (int i = 0; i < buffer.position(); i += width) {
                 System.out.printf("[0x%04x]: ", i);
                 for (int j = 0; j < Math.min(buffer.capacity() - i, width); j++) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -234,10 +234,6 @@ public class TornadoVMInterpreter extends TornadoLogger {
         }
     }
 
-    public void setCompileUpdate() {
-        this.doUpdate = true;
-    }
-
     public void warmup() {
         execute(true);
         finishedWarmup = true;
@@ -605,8 +601,8 @@ public class TornadoVMInterpreter extends TornadoLogger {
 
         // Check if a different batch size was used for the same kernel. If true, then
         // the kernel needs to be recompiled.
-
         if (!shouldCompile(installedCodes[globalToLocalTaskIndex(taskIndex)]) && task.getBatchThreads() != 0 && task.getBatchThreads() != batchThreads) {
+            task.forceCompilation();
             installedCodes[globalToLocalTaskIndex(taskIndex)].invalidate();
         }
         // Set the batch size in the task information
@@ -622,7 +618,7 @@ public class TornadoVMInterpreter extends TornadoLogger {
             task.mapTo(deviceForInterpreter);
             try {
                 task.attachProfiler(timeProfiler);
-                if (taskIndex == (tasks.size() - 1) || doUpdate) {
+                if (taskIndex == (tasks.size() - 1)) {
                     // If it is the last task within the task-schedule or doUpdate is true -> we
                     // force compilation. This is useful when compiling code for Xilinx/Altera
                     // FPGAs, that has to be a single source.
@@ -630,7 +626,6 @@ public class TornadoVMInterpreter extends TornadoLogger {
                 }
                 installedCodes[globalToLocalTaskIndex(taskIndex)] = deviceForInterpreter.installCode(task);
                 profilerUpdateForPreCompiledTask(task);
-                doUpdate = false;
             } catch (TornadoBailoutRuntimeException e) {
                 throw new TornadoBailoutRuntimeException("Unable to compile " + task.getFullName() + "\n" + "The internal error is: " + e.getMessage() + "\n" + "Stacktrace: " + Arrays.toString(e
                         .getStackTrace()), e);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -542,22 +542,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     }
 
-    private void triggerRecompile() {
-        // 1. Force to recompile the task-sketcher
-        int i = 0;
-        for (TaskPackage tp : taskPackages) {
-            updateTask(tp, i);
-            i++;
-        }
-
-        // 2. Clear the code caches in every instance of a TornadoVMInterpreter that
-        // TornadoVM instantiated
-        if (vm != null) {
-            vm.clearInstalledCode();
-            vm.setCompileUpdate();
-        }
-    }
-
     @Override
     public TornadoAcceleratorDevice getDeviceForTask(String id) {
         return executionContext.getDeviceForTask(id);
@@ -2141,7 +2125,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
-    public void batch(String batchSize) {
+    public void withBatch(String batchSize) {
         this.batchSizeBytes = parseSizeToBytes(batchSize);
         executionContext.setBatchSize(this.batchSizeBytes);
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -690,7 +690,9 @@ public class TestBatches extends TornadoTestBase {
 
     @Test
     public void testBatchNotEven() {
-        // Allocate ~1GB 
+        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
+
+        // Allocate ~1GB
         FloatArray array = new FloatArray(1024 * 1024 * 256);
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.EVERY_EXECUTION, array) //
@@ -706,7 +708,6 @@ public class TestBatches extends TornadoTestBase {
             assertEquals(i * i, array.get(i), 0.001f);
         }
         executionPlan.freeDeviceMemory();
-
     }
 
     private long checkMaxHeapAllocationOnDevice(int size, MemoryUnit memoryUnit) throws UnsupportedConfigurationException {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -165,7 +165,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test100MBSmall() {
 
-        long maxAllocMemory = getMaxHeapAllocationOnDevice(100, MemoryUnit.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(100, MemoryUnit.MB);
 
         // Fill 120MB of float array
         int size = 30000000;
@@ -198,7 +198,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test100MB() {
 
-        long maxAllocMemory = getMaxHeapAllocationOnDevice(100, MemoryUnit.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(100, MemoryUnit.MB);
 
         // Fill 800MB of float array
         int size = 200000000;
@@ -231,7 +231,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test300MB() {
 
-        long maxAllocMemory = getMaxHeapAllocationOnDevice(300, MemoryUnit.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(300, MemoryUnit.MB);
 
         // Fill 1.0GB
         int size = 250_000_000;
@@ -265,7 +265,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test512MB() {
 
-        long maxAllocMemory = getMaxHeapAllocationOnDevice(512, MemoryUnit.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(512, MemoryUnit.MB);
 
         // Fill 800MB
         int size = 200000000;
@@ -297,7 +297,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MB() {
 
-        long maxAllocMemory = getMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
 
         // Fill 80MB of input Array
         int size = 20000000;
@@ -334,7 +334,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBInteger() {
 
-        long maxAllocMemory = getMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
 
         // Fill 80MB of input Array
         int size = 20000000;
@@ -370,7 +370,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBShort() {
 
-        long maxAllocMemory = getMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
 
         // Fill 160MB of input Array
         int size = 80000000;
@@ -407,7 +407,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBDouble() {
 
-        long maxAllocMemory = getMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
 
         int size = 20000000;
         // or as much as we can
@@ -442,7 +442,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBLong() {
 
-        long maxAllocMemory = getMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
 
         // Fill 160MB of input Array
         int size = 20000000;
@@ -478,7 +478,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeRestriction() {
         // total input size mismatch for IntArray
-        getMaxHeapAllocationOnDevice(5, MemoryUnit.MB);
+        checkMaxHeapAllocationOnDevice(5, MemoryUnit.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntArray a1 = new IntArray(3 * 1_000_000);
 
@@ -495,7 +495,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeRestrictionJavaArrays() {
         // total input size mismatch for int[]
-        getMaxHeapAllocationOnDevice(5, MemoryUnit.MB);
+        checkMaxHeapAllocationOnDevice(5, MemoryUnit.MB);
         int[] a0 = new int[2 * 1_000_000];
         int[] a1 = new int[3 * 1_000_000];
 
@@ -512,7 +512,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputTypeRestriction() {
         // IntArray is NOT compatible with LongArray even if the total input size is equal
-        getMaxHeapAllocationOnDevice(6, MemoryUnit.MB);
+        checkMaxHeapAllocationOnDevice(6, MemoryUnit.MB);
         IntArray a0 = new IntArray(4 * 1_000_000);
         LongArray a1 = new LongArray(2 * 1_000_000);
 
@@ -529,7 +529,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputTypeRestrictionJavaArrays() {
         // int[] is NOT compatible with long[] even if the total input size is equal
-        getMaxHeapAllocationOnDevice(6, MemoryUnit.MB);
+        checkMaxHeapAllocationOnDevice(6, MemoryUnit.MB);
         int[] a0 = new int[4 * 1_000_000];
         long[] a1 = new long[2 * 1_000_000];
 
@@ -546,7 +546,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSize() {
         // IntArray is compatible with FloatArray for the same # of elements
-        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
+        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
         FloatArray a1 = new FloatArray(2 * 1_000_000);
@@ -568,7 +568,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeJavaArrays() {
         // int[] is compatible with float[] for the same # of elements
-        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
+        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         int[] a0 = new int[2 * 1_000_000];
         IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
         float[] a1 = new float[2 * 1_000_000];
@@ -590,7 +590,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeJavaToTornado() {
         // int[] is compatible with FloatArray for the same # of elements
-        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
+        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         int[] a0 = new int[2 * 1_000_000];
         IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
         FloatArray a1 = new FloatArray(2 * 1_000_000);
@@ -612,7 +612,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeTornadoToJava() {
         // IntArray is compatible with float[] for the same # of elements
-        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
+        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
         float[] a1 = new float[2 * 1_000_000];
@@ -634,7 +634,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeJavaToTornado() {
         // int[] is compatible with IntArray for the same # of elements
-        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
+        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         int[] a0 = new int[2 * 1_000_000];
         IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
         IntArray a1 = new IntArray(2 * 1_000_000);
@@ -656,7 +656,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeTornadoToJava() {
         // IntArray is compatible with int[] for the same # of elements
-        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
+        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
         int[] a1 = new int[2 * 1_000_000];
@@ -709,7 +709,7 @@ public class TestBatches extends TornadoTestBase {
 
     }
 
-    private long getMaxHeapAllocationOnDevice(int size, MemoryUnit memoryUnit) throws UnsupportedConfigurationException {
+    private long checkMaxHeapAllocationOnDevice(int size, MemoryUnit memoryUnit) throws UnsupportedConfigurationException {
         long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
 
         long memThreshold = switch (memoryUnit) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -29,9 +29,7 @@ import org.junit.Test;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
-import uk.ac.manchester.tornado.api.TornadoExecutionResult;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
@@ -167,7 +165,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test100MBSmall() {
 
-        long maxAllocMemory = checkMaxHeapAllocationOnDevice(100, MemSize.MB);
+        long maxAllocMemory = getMaxHeapAllocationOnDevice(100, MemoryUnit.MB);
 
         // Fill 120MB of float array
         int size = 30000000;
@@ -200,7 +198,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test100MB() {
 
-        long maxAllocMemory = checkMaxHeapAllocationOnDevice(100, MemSize.MB);
+        long maxAllocMemory = getMaxHeapAllocationOnDevice(100, MemoryUnit.MB);
 
         // Fill 800MB of float array
         int size = 200000000;
@@ -233,7 +231,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test300MB() {
 
-        long maxAllocMemory = checkMaxHeapAllocationOnDevice(300, MemSize.MB);
+        long maxAllocMemory = getMaxHeapAllocationOnDevice(300, MemoryUnit.MB);
 
         // Fill 1.0GB
         int size = 250_000_000;
@@ -267,7 +265,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test512MB() {
 
-        long maxAllocMemory = checkMaxHeapAllocationOnDevice(512, MemSize.MB);
+        long maxAllocMemory = getMaxHeapAllocationOnDevice(512, MemoryUnit.MB);
 
         // Fill 800MB
         int size = 200000000;
@@ -299,7 +297,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MB() {
 
-        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemSize.MB);
+        long maxAllocMemory = getMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
 
         // Fill 80MB of input Array
         int size = 20000000;
@@ -336,7 +334,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBInteger() {
 
-        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemSize.MB);
+        long maxAllocMemory = getMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
 
         // Fill 80MB of input Array
         int size = 20000000;
@@ -372,7 +370,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBShort() {
 
-        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemSize.MB);
+        long maxAllocMemory = getMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
 
         // Fill 160MB of input Array
         int size = 80000000;
@@ -409,7 +407,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBDouble() {
 
-        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemSize.MB);
+        long maxAllocMemory = getMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
 
         int size = 20000000;
         // or as much as we can
@@ -444,7 +442,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test50MBLong() {
 
-        long maxAllocMemory = checkMaxHeapAllocationOnDevice(50, MemSize.MB);
+        long maxAllocMemory = getMaxHeapAllocationOnDevice(50, MemoryUnit.MB);
 
         // Fill 160MB of input Array
         int size = 20000000;
@@ -480,7 +478,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeRestriction() {
         // total input size mismatch for IntArray
-        checkMaxHeapAllocationOnDevice(5, MemSize.MB);
+        getMaxHeapAllocationOnDevice(5, MemoryUnit.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntArray a1 = new IntArray(3 * 1_000_000);
 
@@ -497,7 +495,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeRestrictionJavaArrays() {
         // total input size mismatch for int[]
-        checkMaxHeapAllocationOnDevice(5, MemSize.MB);
+        getMaxHeapAllocationOnDevice(5, MemoryUnit.MB);
         int[] a0 = new int[2 * 1_000_000];
         int[] a1 = new int[3 * 1_000_000];
 
@@ -514,7 +512,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputTypeRestriction() {
         // IntArray is NOT compatible with LongArray even if the total input size is equal
-        checkMaxHeapAllocationOnDevice(6, MemSize.MB);
+        getMaxHeapAllocationOnDevice(6, MemoryUnit.MB);
         IntArray a0 = new IntArray(4 * 1_000_000);
         LongArray a1 = new LongArray(2 * 1_000_000);
 
@@ -531,7 +529,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputTypeRestrictionJavaArrays() {
         // int[] is NOT compatible with long[] even if the total input size is equal
-        checkMaxHeapAllocationOnDevice(6, MemSize.MB);
+        getMaxHeapAllocationOnDevice(6, MemoryUnit.MB);
         int[] a0 = new int[4 * 1_000_000];
         long[] a1 = new long[2 * 1_000_000];
 
@@ -548,7 +546,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSize() {
         // IntArray is compatible with FloatArray for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
+        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
         FloatArray a1 = new FloatArray(2 * 1_000_000);
@@ -570,7 +568,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeJavaArrays() {
         // int[] is compatible with float[] for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
+        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         int[] a0 = new int[2 * 1_000_000];
         IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
         float[] a1 = new float[2 * 1_000_000];
@@ -592,7 +590,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeJavaToTornado() {
         // int[] is compatible with FloatArray for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
+        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         int[] a0 = new int[2 * 1_000_000];
         IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
         FloatArray a1 = new FloatArray(2 * 1_000_000);
@@ -614,7 +612,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeTornadoToJava() {
         // IntArray is compatible with float[] for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
+        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
         float[] a1 = new float[2 * 1_000_000];
@@ -636,7 +634,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeJavaToTornado() {
         // int[] is compatible with IntArray for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
+        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         int[] a0 = new int[2 * 1_000_000];
         IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
         IntArray a1 = new IntArray(2 * 1_000_000);
@@ -658,7 +656,7 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeTornadoToJava() {
         // IntArray is compatible with int[] for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemSize.MB);
+        getMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
         IntArray a0 = new IntArray(2 * 1_000_000);
         IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
         int[] a1 = new int[2 * 1_000_000];
@@ -711,25 +709,24 @@ public class TestBatches extends TornadoTestBase {
 
     }
 
-    private long checkMaxHeapAllocationOnDevice(int size, MemSize memSize) throws UnsupportedConfigurationException {
+    private long getMaxHeapAllocationOnDevice(int size, MemoryUnit memoryUnit) throws UnsupportedConfigurationException {
         long maxAllocMemory = getTornadoRuntime().getDefaultDevice().getDeviceContext().getMemoryManager().getHeapSize();
 
-        long memThreshold = switch (memSize) {
+        long memThreshold = switch (memoryUnit) {
             case GB -> (long) size * 1024 * 1024 * 1024;
             case MB -> (long) size * 1024 * 1024;
             case TB -> (long) size * 1024 * 1024 * 1024 * 1024;
-            default -> throw new IllegalStateException(STR."Unexpected value: \{memSize}");
+            default -> throw new IllegalStateException(STR."Unexpected value: \{memoryUnit}");
         };
 
         // check if there is enough memory for at least one chunk
         if (maxAllocMemory < memThreshold) {
             throw new UnsupportedConfigurationException("Not enough memory to run the test");
         }
-
         return maxAllocMemory;
     }
 
-    private enum MemSize {
+    private enum MemoryUnit {
         MB, GB, TB
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memoryplan/TestMemoryLimit.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memoryplan/TestMemoryLimit.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 public class TestMemoryLimit extends TornadoTestBase {
 
     /**
-     * Set the number of elements to select ~300MB per array
+     * Set the number of elements to select ~300MB per array.
      */
     private static final int NUM_ELEMENTS = 78643200;   // 314MB for an array of Integers
     private static IntArray a = new IntArray(NUM_ELEMENTS);


### PR DESCRIPTION
#### Description

This fixes and adds support for batch processing when having a `TaskGraph` with multiple tasks. 
Besides, it removes old/unreachable methods that are not needed anymore. 

However, this PR still has the issue of incorrect results when the task-graph does not perform a copy-in. 
I added two more unit-tests, one with copy in and the other without. It seems that without copy-in, the batch processing works (compiler and internals of the runtime), but the results are not correct. 

For task-graphs with copy-in/out (which was the original intended use), multiple tasks in a taskgraph with batch processing now works. 
We can go ahead this is partial fix, and add a new extension on top of this to process also for only outputs. 

#### Problem description

The issue was that, when having multiple tasks in a task-graph, the TornadoVM interpreter was not invalidating the code cache (to force recompilation). 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make
$ tornado-test -V --fast --debug --threadInfo --printKernel --printBytecode uk.ac.manchester.tornado.unittests.batches.TestBatches#testBatchNotEven
$ tornado-test -V --fast --debug --threadInfo --printKernel --printBytecode uk.ac.manchester.tornado.unittests.batches.TestBatches#testBatchNotEven2
```

