### PR TITLE
Update GraalVM download links and remove ValueAnchorNode usage

### DIFF
--- a/bin/installer_config.py
+++ b/bin/installer_config.py
@@ -73,12 +73,12 @@ JDK = {
     },
     __GRAALVM21__: {
         __LINUX__: {
-            __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-x64_bin.tar.gz",
-            __ARM__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-aarch64_bin.tar.gz",
+            __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_linux-x64_bin.tar.gz",
+            __ARM__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_linux-aarch64_bin.tar.gz",
         },
         __APPLE__: {
-            __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_macos-x64_bin.tar.gz",
-            __ARM__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_macos-aarch64_bin.tar.gz",
+            __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_macos-x64_bin.tar.gz",
+            __ARM__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.2/graalvm-community-jdk-21.0.2_macos-aarch64_bin.tar.gz",
         },
     },
     __CORRETTO21__: {

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/guards/ExceptionSuppression.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/guards/ExceptionSuppression.java
@@ -30,7 +30,6 @@ import org.graalvm.compiler.nodes.GuardNode;
 import org.graalvm.compiler.nodes.LogicNode;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.extended.GuardedNode;
-import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
 import org.graalvm.compiler.phases.BasePhase;
 
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
@@ -56,14 +55,6 @@ public class ExceptionSuppression extends BasePhase<TornadoHighTierContext> {
                 guards.add(guard);
                 guardedNode.setGuard(null);
 
-            }
-        });
-
-        graph.getNodes().filter(ValueAnchorNode.class).forEach(anchor -> {
-            if (anchor.getAnchoredNode() instanceof GuardNode guard) {
-                guards.add(guard);
-                conditions.add(guard.getCondition());
-                anchor.removeAnchoredNode();
             }
         });
 


### PR DESCRIPTION
#### Description

Updated GraalVM download links to point to the newer version, jdk-21.0.2. Removed the handling of ValueAnchorNode class in the ExceptionSuppression.java, as it was noted to no longer be necessary. 


#### Problem description

There is no backwards compatibility with GraalVM 21.0.1 due to refactoring on ValueAnchorNode
#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?
```bash
make graal-jdk-21
make tests
```

Provide instructions about how to test the new patch. 

----------------------------------------------------------------------------
