### PR TITLE
New calls to profile the Execution Plan: withThreadInfo and withPrintKernel 

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -177,12 +177,27 @@ public class ImmutableTaskGraph {
         taskGraph.disableProfiler(profilerMode);
     }
 
-    public void withConcurrentDevices() {
+    void withConcurrentDevices() {
         taskGraph.withConcurrentDevices();
     }
 
-    public void withoutConcurrentDevices() {
+    void withoutConcurrentDevices() {
         taskGraph.withoutConcurrentDevices();
     }
 
+    void withThreadInfo() {
+        taskGraph.withThreadInfo();
+    }
+
+    void withoutThreadInfo() {
+        taskGraph.withoutThreadInfo();
+    }
+
+    void withPrintKernel() {
+        taskGraph.withPrintKernel();
+    }
+
+    void withoutPrintKernel() {
+        taskGraph.withoutPrintKernel();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -897,12 +897,27 @@ public class TaskGraph implements TaskGraphInterface {
         taskGraphImpl.disableProfiler(profilerMode);
     }
 
-    public void withConcurrentDevices() {
+    void withConcurrentDevices() {
         taskGraphImpl.withConcurrentDevices();
     }
 
-    public void withoutConcurrentDevices() {
+    void withoutConcurrentDevices() {
         taskGraphImpl.withoutConcurrentDevices();
     }
 
+    void withThreadInfo() {
+        taskGraphImpl.withThreadInfo();
+    }
+
+    void withoutThreadInfo() {
+        taskGraphImpl.withoutThreadInfo();
+    }
+
+    void withPrintKernel() {
+        taskGraphImpl.withPrintKernel();
+    }
+
+    void withoutPrintKernel() {
+        taskGraphImpl.withoutPrintKernel();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -336,6 +336,26 @@ public class TornadoExecutionPlan {
         return this;
     }
 
+    public TornadoExecutionPlan withThreadInfo() {
+        tornadoExecutor.withThreadInfo();
+        return this;
+    }
+
+    public TornadoExecutionPlan withoutThreadInfo() {
+        tornadoExecutor.withoutThreadInfo();
+        return this;
+    }
+
+    public TornadoExecutionPlan withPrintKernel() {
+        tornadoExecutor.withPrintKernel();
+        return this;
+    }
+
+    public TornadoExecutionPlan withoutPrintKernel() {
+        tornadoExecutor.withoutPrintKernel();
+        return this;
+    }
+
     static class TornadoExecutor {
 
         private List<ImmutableTaskGraph> immutableTaskGraphList;
@@ -496,6 +516,22 @@ public class TornadoExecutionPlan {
 
         void disableProfiler(ProfilerMode profilerMode) {
             immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.disableProfiler(profilerMode));
+        }
+
+        void withThreadInfo() {
+            immutableTaskGraphList.forEach(ImmutableTaskGraph::withThreadInfo);
+        }
+
+        void withoutThreadInfo() {
+            immutableTaskGraphList.forEach(ImmutableTaskGraph::withoutThreadInfo);
+        }
+
+        void withPrintKernel() {
+            immutableTaskGraphList.forEach(ImmutableTaskGraph::withPrintKernel);
+        }
+
+        void withoutPrintKernel() {
+            immutableTaskGraphList.forEach(ImmutableTaskGraph::withoutPrintKernel);
         }
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -115,4 +115,12 @@ public interface TornadoTaskGraphInterface extends ProfileInterface {
     void withConcurrentDevices();
 
     void withoutConcurrentDevices();
+
+    void withThreadInfo();
+
+    void withoutThreadInfo();
+
+    void withPrintKernel();
+
+    void withoutPrintKernel();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/TaskMetaDataInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/TaskMetaDataInterface.java
@@ -51,4 +51,8 @@ public interface TaskMetaDataInterface {
     int getDeviceIndex();
 
     void setDevice(TornadoDevice device);
+
+    boolean isPrintKernelEnabled();
+
+    void setPrintKernelFlag(boolean printKernelEnabled);
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -62,7 +62,6 @@ import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 public class OCLCodeCache {
 
     private static final String FALSE = "False";
-    private static final String TRUE = "True";
     private static final int SPIRV_MAGIC_NUMBER = 119734787;
     private static final String OPENCL_SOURCE_SUFFIX = ".cl";
     private final boolean OPENCL_CACHE_ENABLE = Boolean.parseBoolean(getProperty("tornado.opencl.codecache.enable", FALSE));

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -478,7 +478,7 @@ public class OCLCodeCache {
         return deviceContext.getPlatformContext().getPlatform().getVendor().toLowerCase().split("\\(")[0];
     }
 
-    OCLInstalledCode installFPGASource(String id, String entryPoint, byte[] source, boolean shouldCompile) { // TODO Override this method for each FPGA backend
+    OCLInstalledCode installFPGASource(String id, String entryPoint, byte[] source, boolean shouldCompile, boolean printKernel) { // TODO Override this method for each FPGA backend
         String[] compilationCommand;
         final String inputFile = fpgaSourceDir + entryPoint + OPENCL_SOURCE_SUFFIX;
         final String outputFile = fpgaSourceDir + entryPoint;
@@ -486,7 +486,9 @@ public class OCLCodeCache {
 
         appendSourceToFile(source, entryPoint);
 
-        RuntimeUtilities.maybePrintSource(source);
+        if (printKernel) {
+            RuntimeUtilities.dumpKernel(source);
+        }
 
         String[] commandRename;
         String[] linkCommand = null;
@@ -583,7 +585,9 @@ public class OCLCodeCache {
             appendSourceToFile(source, entryPoint);
         }
 
-        RuntimeUtilities.maybePrintSource(source);
+        if (meta.isPrintKernelEnabled()) {
+            RuntimeUtilities.dumpKernel(source);
+        }
 
         final long t0 = System.nanoTime();
         program.build(meta.getCompilerFlags());
@@ -599,16 +603,16 @@ public class OCLCodeCache {
                 debug(log);
             }
             final Path outDir = resolveLogDirectory();
-            final String identifier = id + "-" + entryPoint;
+            final String identifier = STR."\{id}-\{entryPoint}";
             error("Unable to compile task %s: check logs at %s/%s.log", identifier, outDir.toAbsolutePath(), identifier);
 
-            File file = new File(outDir + "/" + identifier + ".log");
+            File file = new File(STR."\{outDir}/\{identifier}.log");
             try (FileOutputStream fos = new FileOutputStream(file)) {
                 fos.write(log.getBytes());
             } catch (IOException e) {
                 error("unable to write error log: ", e.getMessage());
             }
-            file = new File(outDir + "/" + identifier + OPENCL_SOURCE_SUFFIX);
+            file = new File(STR."\{outDir}/\{identifier}\{OPENCL_SOURCE_SUFFIX}");
             try (FileOutputStream fos = new FileOutputStream(file)) {
                 fos.write(source);
             } catch (IOException e) {
@@ -633,13 +637,13 @@ public class OCLCodeCache {
             if (meta.shouldPrintCompileTimes()) {
                 debug("compile: kernel %s opencl %.9f\n", entryPoint, (t1 - t0) * 1e-9f);
             }
-            cache.put(id + "-" + entryPoint, code);
+            cache.put(STR."\{id}-\{entryPoint}", code);
 
             // BUG Apple does not seem to like implementing the OpenCL spec
-            // properly, this causes a sigfault.
+            // properly, this causes a SIGFAULT.
             if ((OPENCL_CACHE_ENABLE || OPENCL_DUMP_BINS) && !deviceContext.getPlatformContext().getPlatform().getVendor().equalsIgnoreCase("Apple")) {
                 final Path outDir = resolveCacheDirectory();
-                program.dumpBinaries(outDir.toAbsolutePath() + "/" + entryPoint);
+                program.dumpBinaries(STR."\{outDir.toAbsolutePath()}/\{entryPoint}");
             }
         } else {
             warn("\tunable to compile %s", entryPoint);
@@ -672,11 +676,11 @@ public class OCLCodeCache {
             long afterLoad = (TornadoOptions.TIME_IN_NANOSECONDS) ? System.nanoTime() : System.currentTimeMillis();
 
             if (PRINT_LOAD_TIME) {
-                System.out.println("Binary load time: " + (afterLoad - beforeLoad) + (TornadoOptions.TIME_IN_NANOSECONDS ? " ns" : " ms") + " \n");
+                System.out.println(STR."Binary load time: \{afterLoad - beforeLoad}\{TornadoOptions.TIME_IN_NANOSECONDS ? " ns" : " ms"} \n");
             }
 
             if (program == null) {
-                throw new OCLException("unable to load binary for " + entryPoint);
+                throw new OCLException(STR."unable to load binary for \{entryPoint}");
             }
 
             program.build("");

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -394,16 +394,19 @@ public class OCLDeviceContext extends TornadoLogger implements OCLDeviceContextI
                 : null), EventDescriptor.DESC_READ_SEGMENT, queue);
     }
 
+    @Override
     public int enqueueBarrier(int[] events) {
         long oclEvent = queue.enqueueBarrier(oclEventPool.serialiseEvents(events, queue) ? oclEventPool.waitEventsBuffer : null);
         return queue.getOpenclVersion() < 120 ? -1 : oclEventPool.registerEvent(oclEvent, EventDescriptor.DESC_SYNC_BARRIER, queue);
     }
 
+    @Override
     public int enqueueMarker(int[] events) {
         long oclEvent = queue.enqueueMarker(oclEventPool.serialiseEvents(events, queue) ? oclEventPool.waitEventsBuffer : null);
         return queue.getOpenclVersion() < 120 ? -1 : oclEventPool.registerEvent(oclEvent, EventDescriptor.DESC_SYNC_MARKER, queue);
     }
 
+    @Override
     public void reset() {
         oclEventPool.reset();
         codeCache.reset();
@@ -483,6 +486,7 @@ public class OCLDeviceContext extends TornadoLogger implements OCLDeviceContextI
         oclEventPool.retainEvent(localEventId);
     }
 
+    @Override
     public Event resolveEvent(int event) {
         if (event == -1) {
             return EMPTY_EVENT;
@@ -490,6 +494,7 @@ public class OCLDeviceContext extends TornadoLogger implements OCLDeviceContextI
         return new OCLEvent(oclEventPool.getDescriptor(event).getNameDescription(), queue, event, oclEventPool.getOCLEvent(event));
     }
 
+    @Override
     public void flush() {
         queue.flush();
     }
@@ -498,10 +503,12 @@ public class OCLDeviceContext extends TornadoLogger implements OCLDeviceContextI
         queue.finish();
     }
 
+    @Override
     public void flushEvents() {
         queue.flushEvents();
     }
 
+    @Override
     public boolean isKernelAvailable() {
         return codeCache.isKernelAvailable();
     }
@@ -510,15 +517,18 @@ public class OCLDeviceContext extends TornadoLogger implements OCLDeviceContextI
         return installCode(result.getMeta(), result.getId(), result.getName(), result.getTargetCode());
     }
 
+    @Override
     public OCLInstalledCode installCode(TaskMetaData meta, String id, String entryPoint, byte[] code) {
         entryPoint = checkKernelName(entryPoint);
         return codeCache.installSource(meta, id, entryPoint, code);
     }
 
-    public OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean shouldCompile) {
-        return codeCache.installFPGASource(id, entryPoint, code, shouldCompile);
+    @Override
+    public OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean shouldCompile, boolean printKernel) {
+        return codeCache.installFPGASource(id, entryPoint, code, shouldCompile, printKernel);
     }
 
+    @Override
     public boolean isCached(String id, String entryPoint) {
         entryPoint = checkKernelName(entryPoint);
         return codeCache.isCached(id + "-" + entryPoint);
@@ -535,6 +545,7 @@ public class OCLDeviceContext extends TornadoLogger implements OCLDeviceContextI
         return codeCache.getInstalledCode(id, entryPoint);
     }
 
+    @Override
     public OCLCodeCache getCodeCache() {
         return this.codeCache;
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -42,7 +42,7 @@ public interface OCLDeviceContextInterface extends TornadoDeviceContext {
 
     OCLInstalledCode getInstalledCode(String id, String entryPoint);
 
-    OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean shouldCompile);
+    OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean shouldCompile, boolean printKernel);
 
     OCLInstalledCode installCode(OCLCompilationResult result);
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -283,7 +283,7 @@ public class OCLTornadoDevice implements TornadoAcceleratorDevice {
             OCLInstalledCode installedCode;
             if (OCLBackend.isDeviceAnFPGAAccelerator(deviceContext)) {
                 // A) for FPGA
-                installedCode = deviceContext.installCode(result.getId(), result.getName(), result.getTargetCode(), task.shouldCompile());
+                installedCode = deviceContext.installCode(result.getId(), result.getName(), result.getTargetCode(), task.shouldCompile(), task.meta().isPrintKernelEnabled());
             } else {
                 // B) for CPU multi-core or GPU
                 installedCode = deviceContext.installCode(result);
@@ -318,7 +318,7 @@ public class OCLTornadoDevice implements TornadoAcceleratorDevice {
             OCLInstalledCode installedCode;
             if (OCLBackend.isDeviceAnFPGAAccelerator(deviceContext)) {
                 // A) for FPGA
-                installedCode = deviceContext.installCode(task.getId(), executable.getEntryPoint(), source, task.shouldCompile());
+                installedCode = deviceContext.installCode(task.getId(), executable.getEntryPoint(), source, task.shouldCompile(), task.meta().isPrintKernelEnabled());
             } else {
                 // B) for CPU multi-core or GPU
                 installedCode = deviceContext.installCode(executable.meta(), task.getId(), executable.getEntryPoint(), source);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLTornadoCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLTornadoCompiler.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -71,7 +71,7 @@ public class TestOpenCLTornadoCompiler {
         OCLInstalledCode code = codeCache.installSource(meta, "saxpy", "saxpy", source);
 
         String generatedSourceCode = code.getGeneratedSourceCode();
-        if (TornadoOptions.PRINT_SOURCE) {
+        if (meta.isPrintKernelEnabled()) {
             System.out.println("Compiled code: " + generatedSourceCode);
         }
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -153,10 +153,12 @@ public class VirtualOCLDeviceContext extends TornadoLogger implements OCLDeviceC
     public void flushEvents() {
     }
 
+    @Override
     public void reset() {
         wasReset = true;
     }
 
+    @Override
     public VirtualOCLTornadoDevice asMapping() {
         return new VirtualOCLTornadoDevice(context.getPlatformIndex(), device.getIndex());
     }
@@ -165,6 +167,7 @@ public class VirtualOCLDeviceContext extends TornadoLogger implements OCLDeviceC
         return String.format("opencl-%d-%d", context.getPlatformIndex(), device.getIndex());
     }
 
+    @Override
     public void dumpEvents() {
     }
 
@@ -212,30 +215,37 @@ public class VirtualOCLDeviceContext extends TornadoLogger implements OCLDeviceC
         return context.getPlatformIndex();
     }
 
+    @Override
     public boolean isKernelAvailable() {
         return true;
     }
 
+    @Override
     public OCLInstalledCode installCode(OCLCompilationResult result) {
         return null;
     }
 
+    @Override
     public OCLInstalledCode installCode(TaskMetaData meta, String id, String entryPoint, byte[] code) {
         return null;
     }
 
-    public OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean shouldCompile) {
+    @Override
+    public OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean shouldCompile, boolean printKernel) {
         return null;
     }
 
+    @Override
     public boolean isCached(String id, String entryPoint) {
         return false;
     }
 
+    @Override
     public OCLInstalledCode getInstalledCode(String id, String entryPoint) {
         return null;
     }
 
+    @Override
     public OCLCodeCache getCodeCache() {
         return codeCache;
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -190,7 +190,9 @@ public class VirtualOCLTornadoDevice implements TornadoAcceleratorDevice {
             profiler.stop(ProfilerType.TASK_COMPILE_GRAAL_TIME, taskMeta.getId());
             profiler.sum(ProfilerType.TOTAL_GRAAL_COMPILE_TIME, profiler.getTaskTimer(ProfilerType.TASK_COMPILE_GRAAL_TIME, taskMeta.getId()));
 
-            RuntimeUtilities.maybePrintSource(result.getTargetCode());
+            if (taskMeta.isPrintKernelEnabled()) {
+                RuntimeUtilities.dumpKernel(result.getTargetCode());
+            }
 
             return null;
         } catch (Exception e) {
@@ -208,8 +210,9 @@ public class VirtualOCLTornadoDevice implements TornadoAcceleratorDevice {
         TornadoInternalError.guarantee(path.toFile().exists(), "file does not exist: %s", executable.getFilename());
         try {
             final byte[] source = Files.readAllBytes(path);
-
-            RuntimeUtilities.maybePrintSource(source);
+            if (task.meta().isPrintKernelEnabled()) {
+                RuntimeUtilities.dumpKernel(source);
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXCodeCache.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXCodeCache.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -28,7 +28,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class PTXCodeCache {
 
@@ -40,24 +39,25 @@ public class PTXCodeCache {
         cache = new ConcurrentHashMap<>();
     }
 
-    public PTXInstalledCode installSource(String name, byte[] targetCode, String resolvedMethodName) {
-        String cacheKey = name;
+    public PTXInstalledCode installSource(String name, byte[] targetCode, String resolvedMethodName, boolean debugKernel) {
 
-        if (!cache.containsKey(cacheKey)) {
-            RuntimeUtilities.maybePrintSource(targetCode);
+        if (!cache.containsKey(name)) {
+            if (debugKernel) {
+                RuntimeUtilities.dumpKernel(targetCode);
+            }
 
             PTXModule module = new PTXModule(resolvedMethodName, targetCode, name);
 
             if (module.isPTXJITSuccess()) {
                 PTXInstalledCode code = new PTXInstalledCode(name, module, deviceContext);
-                cache.put(cacheKey, code);
+                cache.put(name, code);
                 return code;
             } else {
                 throw new TornadoBailoutRuntimeException("PTX JIT compilation failed!");
             }
         }
 
-        return cache.get(cacheKey);
+        return cache.get(name);
     }
 
     public PTXInstalledCode getCachedCode(String name) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -116,11 +116,11 @@ public class PTXDeviceContext extends TornadoLogger implements TornadoDeviceCont
     }
 
     public TornadoInstalledCode installCode(PTXCompilationResult result, String resolvedMethodName) {
-        return codeCache.installSource(result.getName(), result.getTargetCode(), resolvedMethodName);
+        return codeCache.installSource(result.getName(), result.getTargetCode(), resolvedMethodName, result.metaData().isPrintKernelEnabled());
     }
 
-    public TornadoInstalledCode installCode(String name, byte[] code, String resolvedMethodName) {
-        return codeCache.installSource(name, code, resolvedMethodName);
+    public TornadoInstalledCode installCode(String name, byte[] code, String resolvedMethodName, boolean printKernel) {
+        return codeCache.installSource(name, code, resolvedMethodName, printKernel);
     }
 
     public TornadoInstalledCode getInstalledCode(String name) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -210,7 +210,7 @@ public class PTXTornadoDevice implements TornadoAcceleratorDevice {
         try {
             byte[] source = Files.readAllBytes(path);
             source = PTXCodeUtil.getCodeWithAttachedPTXHeader(source, getBackend());
-            return deviceContext.installCode(functionName, source, executable.getEntryPoint());
+            return deviceContext.installCode(functionName, source, executable.getEntryPoint(), task.meta().isPrintKernelEnabled());
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXTornadoCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXTornadoCompiler.java
@@ -88,10 +88,10 @@ public class TestPTXTornadoCompiler {
 
         byte[] source = PTX_KERNEL.getBytes();
         source = PTXCodeUtil.getCodeWithAttachedPTXHeader(source, backend);
-        PTXInstalledCode code = codeCache.installSource("add", source, "add");
+        PTXInstalledCode code = codeCache.installSource("add", source, "add", meta.isPrintKernelEnabled());
 
         String generatedSourceCode = code.getGeneratedSourceCode();
-        if (TornadoOptions.PRINT_SOURCE) {
+        if (meta.isPrintKernelEnabled()) {
             System.out.println("Compiled code: " + generatedSourceCode);
         }
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -140,7 +140,7 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
             throw new TornadoBailoutRuntimeException("[Build SPIR-V ERROR]" + errorMessage[0]);
         }
 
-        if (TornadoOptions.PRINT_SOURCE) {
+        if (meta.isPrintKernelEnabled()) {
             SPVFileReader reader = null;
             try {
                 reader = new SPVFileReader(pathToFile);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVTornadoCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVTornadoCompiler.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -34,7 +34,7 @@ import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
  * How to test?
  *
  * <code>
- *     $ tornado uk.ac.manchester.tornado.drivers.spirv.tests.TestSPIRVTornadoCompiler
+ * $ tornado uk.ac.manchester.tornado.drivers.spirv.tests.TestSPIRVTornadoCompiler
  * </code>
  */
 public class TestSPIRVTornadoCompiler {
@@ -56,7 +56,7 @@ public class TestSPIRVTornadoCompiler {
         SPIRVInstalledCode code = codeCache.installSPIRVBinary(task, "add", "add", pathToSPIRVBinaryFile);
         String generatedCode = code.getGeneratedSourceCode();
 
-        if (TornadoOptions.PRINT_SOURCE) {
+        if (scheduleMetaData.isPrintKernelEnabled()) {
             System.out.println(generatedCode);
         }
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -56,7 +56,7 @@ import uk.ac.manchester.tornado.runtime.tasks.TornadoTaskGraph;
  * parallel device (e.g., a GPU).
  */
 public class TornadoVM extends TornadoLogger {
-    private final TornadoExecutionContext executionContext;
+    private TornadoExecutionContext executionContext;
 
     private TornadoProfiler timeProfiler;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
@@ -25,17 +25,9 @@ package uk.ac.manchester.tornado.runtime.common;
 
 import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
-import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.PRINT_SOURCE;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.PRINT_SOURCE_DIRECTORY;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
+import java.io.*;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -382,22 +374,20 @@ public final class RuntimeUtilities {
         }
     }
 
-    public static void maybePrintSource(byte[] source) {
-        if (PRINT_SOURCE) {
-            String sourceCode = new String(source);
-            if (PRINT_SOURCE_DIRECTORY.isEmpty()) {
-                System.out.println(sourceCode);
-            } else {
-                File fileLog = new File(PRINT_SOURCE_DIRECTORY);
-                try {
-                    try (FileWriter file = new FileWriter(fileLog, fileLog.exists())) {
-                        file.write(sourceCode);
-                        file.write("\n");
-                        file.flush();
-                    }
-                } catch (IOException e) {
-                    e.printStackTrace();
+    public static void dumpKernel(byte[] source) {
+        String sourceCode = new String(source);
+        if (PRINT_SOURCE_DIRECTORY.isEmpty()) {
+            System.out.println(sourceCode);
+        } else {
+            File fileLog = new File(PRINT_SOURCE_DIRECTORY);
+            try {
+                try (FileWriter file = new FileWriter(fileLog, fileLog.exists())) {
+                    file.write(sourceCode);
+                    file.write("\n");
+                    file.flush();
                 }
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -92,10 +92,7 @@ public class TornadoOptions {
      * Enable/Disable events dumping on program finish. False by default.
      */
     public static final boolean DUMP_EVENTS = Boolean.parseBoolean(getProperty("tornado.events.dump", FALSE));
-    /**
-     * Prints the generated code by the TornadoVM compiler. Default is False.
-     */
-    public static final boolean PRINT_SOURCE = Boolean.parseBoolean(getProperty("tornado.print.kernel", FALSE));
+
     /**
      * Prints the generated code by the TornadoVM compiler. Default is False.
      */
@@ -300,5 +297,4 @@ public class TornadoOptions {
         String contextEmulatorXilinxFPGA = System.getenv("XCL_EMULATION_MODE");
         return (contextEmulatorIntelFPGA != null && (contextEmulatorIntelFPGA.equals("1"))) || (contextEmulatorXilinxFPGA != null && (contextEmulatorXilinxFPGA.equals("sw_emu")));
     }
-
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -34,6 +34,17 @@ public class TornadoOptions {
     public static final boolean TIME_IN_NANOSECONDS = Boolean.parseBoolean(System.getProperty("tornado.ns.time", TRUE));
     public static final int DEFAULT_DRIVER_INDEX = Integer.parseInt(Tornado.getProperty("tornado.driver", "0"));
     public static final int DEFAULT_DEVICE_INDEX = Integer.parseInt(Tornado.getProperty("tornado.device", "0"));
+
+    /**
+     * Enable thread deployment debugging from the TornadoVM runtime and code dispatcher.
+     */
+    public static final boolean THREAD_INFO = getBooleanValue("tornado.threadInfo", FALSE);
+
+    /**
+     * Enable the runtime to dump the generated code (e.g., OpenCL, CUDA PTX or SPIR-V) from the TornadoVM JIT Compiler.
+     */
+    public static final boolean PRINT_KERNEL_SOURCE = getBooleanValue("tornado.print.kernel", FALSE);
+
     /**
      * Priority of the PTX Backend. The higher the number, the more priority over
      * the rest of the backends.

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -70,7 +70,7 @@ public class TornadoExecutionContext {
     private final int MAX_TASKS = 256;
     private final int INITIAL_DEVICE_CAPACITY = 16;
     private final String name;
-    private final ScheduleMetaData meta;
+    private ScheduleMetaData meta;
     private final KernelArgs[] callWrappers;
     private List<SchedulableTask> tasks;
     private List<Object> constants;
@@ -93,6 +93,7 @@ public class TornadoExecutionContext {
     private TornadoProfiler profiler;
 
     public static int INIT_VALUE = -1;
+    private boolean isPrintKernel;
 
     public TornadoExecutionContext(String id) {
         name = id;
@@ -586,6 +587,9 @@ public class TornadoExecutionContext {
         Set<TornadoAcceleratorDevice> lastDeviceCopy = new HashSet<>(lastDevices);
         executionContext.lastDevices = lastDeviceCopy;
 
+        executionContext.meta = meta;
+        executionContext.isPrintKernel = this.isPrintKernel;
+
         executionContext.profiler = this.profiler;
         executionContext.nextTask = this.nextTask;
     }
@@ -624,4 +628,5 @@ public class TornadoExecutionContext {
     public void withProfiler(TornadoProfiler timeProfiler) {
         this.profiler = timeProfiler;
     }
+
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -48,6 +48,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.ObjectBuffer;
+import uk.ac.manchester.tornado.api.memory.TaskMetaDataInterface;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
@@ -602,6 +603,8 @@ public class TornadoVMInterpreter extends TornadoLogger {
 
         final int[] waitList = (useDependencies && eventList != -1) ? events[eventList] : null;
         final SchedulableTask task = tasks.get(taskIndex);
+        TaskMetaDataInterface meta = task.meta();
+        meta.setPrintKernelFlag(executionContext.meta().isPrintKernelEnabled());
 
         // Check if a different batch size was used for the same kernel. If true, then
         // the kernel needs to be recompiled.
@@ -755,9 +758,10 @@ public class TornadoVMInterpreter extends TornadoLogger {
             throw new TornadoRuntimeException("task.meta is not instanceof TaskMetadata");
         }
 
-        // We attach the profiler
+        // We attach the profiler information
         metadata.attachProfiler(timeProfiler);
         metadata.setGridScheduler(gridScheduler);
+        metadata.setThreadInfo(executionContext.meta().isThreadInfoEnabled());
 
         try {
             int lastEvent = useDependencies

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/ReduceTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/ReduceTaskGraph.java
@@ -633,6 +633,18 @@ class ReduceTaskGraph {
             executionPlan.withoutProfiler();
         }
 
+        if (originalTaskGraph.meta().isPrintKernelEnabled()) {
+            executionPlan.withPrintKernel();
+        } else {
+            executionPlan.withoutPrintKernel();
+        }
+
+        if (originalTaskGraph.meta().isThreadInfoEnabled()) {
+            executionPlan.withThreadInfo();
+        } else {
+            executionPlan.withoutThreadInfo();
+        }
+
         // check parameter list
         if (TornadoOptions.FORCE_CHECK_PARAMETERS) {
             checkAllArgumentsPerTask();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -450,6 +450,26 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
+    public void withThreadInfo() {
+        meta().enableThreadInfo();
+    }
+
+    @Override
+    public void withoutThreadInfo() {
+        meta().disableThreadInfo();
+    }
+
+    @Override
+    public void withPrintKernel() {
+        meta().enablePrintKernel();
+    }
+
+    @Override
+    public void withoutPrintKernel() {
+        meta().disablePrintKernel();
+    }
+
+    @Override
     public SchedulableTask getTask(String id) {
         return executionContext.getTask(id);
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
@@ -65,7 +65,7 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
     /*
      * Forces the executing kernel to output its arguments before execution
      */
-    private final boolean threadInfo;
+    private boolean threadInfo;
     private final boolean debug;
     private final boolean dumpEvents;
     private final boolean dumpProfiles;
@@ -113,6 +113,7 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
      * Allows the OpenCL driver to select the size of local work groups
      */
     private boolean openclUseDriverScheduling;
+    private boolean printKernel;
 
     AbstractMetaData(String id, AbstractMetaData parent) {
         this.id = id;
@@ -153,6 +154,7 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
         enableVectors = parseBoolean(getDefault("vectors.enable", id, TRUE));
         openclEnableBifs = parseBoolean(getDefault("bifs.enable", id, FALSE));
         threadInfo = parseBoolean(getDefault("threadInfo", id, FALSE));
+        printKernel = parseBoolean(getDefault("print.kernel", "null", FALSE));
         debug = parseBoolean(getDefault("debug", id, FALSE));
         enableMemChecks = parseBoolean(getDefault("memory.check", id, FALSE));
         dumpEvents = parseBoolean(getDefault("events.dump", id, TRUE));
@@ -499,5 +501,35 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
 
     public boolean isGridSchedulerEnabled() {
         return this.useGridScheduler;
+    }
+
+    public void enableThreadInfo() {
+        this.threadInfo = true;
+    }
+
+    public void disableThreadInfo() {
+        this.threadInfo = false;
+    }
+
+    @Override
+    public boolean isPrintKernelEnabled() {
+        return printKernel;
+    }
+
+    @Override
+    public void setPrintKernelFlag(boolean printKernelEnabled) {
+        this.printKernel = printKernelEnabled;
+    }
+
+    public void enablePrintKernel() {
+        this.printKernel = true;
+    }
+
+    public void disablePrintKernel() {
+        this.printKernel = false;
+    }
+
+    public void setThreadInfo(boolean threadInfoEnabled) {
+        this.threadInfo = threadInfoEnabled;
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
@@ -153,8 +153,8 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
 
         enableVectors = parseBoolean(getDefault("vectors.enable", id, TRUE));
         openclEnableBifs = parseBoolean(getDefault("bifs.enable", id, FALSE));
-        threadInfo = parseBoolean(getDefault("threadInfo", id, FALSE));
-        printKernel = parseBoolean(getDefault("print.kernel", "null", FALSE));
+        threadInfo = TornadoOptions.THREAD_INFO;
+        printKernel = TornadoOptions.PRINT_KERNEL_SOURCE;
         debug = parseBoolean(getDefault("debug", id, FALSE));
         enableMemChecks = parseBoolean(getDefault("memory.check", id, FALSE));
         dumpEvents = parseBoolean(getDefault("events.dump", id, TRUE));

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleMetaData.java
@@ -28,4 +28,5 @@ public class ScheduleMetaData extends AbstractMetaData {
     public ScheduleMetaData(String id) {
         super(id, null);
     }
+
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
@@ -60,7 +60,7 @@ public class TaskMetaData extends AbstractMetaData {
     private boolean globalWorkDefined;
 
     public TaskMetaData(ScheduleMetaData scheduleMetaData, String taskID, int numParameters) {
-        super(scheduleMetaData.getId() + "." + taskID, scheduleMetaData);
+        super(STR."\{scheduleMetaData.getId()}.\{taskID}", scheduleMetaData);
         this.scheduleMetaData = scheduleMetaData;
         this.constantSize = 0;
         this.localSize = 0;
@@ -424,8 +424,8 @@ public class TaskMetaData extends AbstractMetaData {
         return super.isCpuConfigDefined() || scheduleMetaData.isCpuConfigDefined();
     }
 
-    @Override
-    public String toString() {
-        return String.format("task meta data: domain=%s, global workgroup size=%s%n", domain, (getGlobalWork() == null) ? "null" : formatWorkDimensionArray(getGlobalWork(), "1"));
-    }
+    //    @Override
+    //    public String toString() {
+    //        return String.format("task meta data: domain=%s, global workgroup size=%s%n", domain, (getGlobalWork() == null) ? "null" : formatWorkDimensionArray(getGlobalWork(), "1"));
+    //    }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
@@ -424,8 +424,8 @@ public class TaskMetaData extends AbstractMetaData {
         return super.isCpuConfigDefined() || scheduleMetaData.isCpuConfigDefined();
     }
 
-    //    @Override
-    //    public String toString() {
-    //        return String.format("task meta data: domain=%s, global workgroup size=%s%n", domain, (getGlobalWork() == null) ? "null" : formatWorkDimensionArray(getGlobalWork(), "1"));
-    //    }
+    @Override
+    public String toString() {
+        return String.format("task meta data: domain=%s, global workgroup size=%s%n", domain, (getGlobalWork() == null) ? "null" : formatWorkDimensionArray(getGlobalWork(), "1"));
+    }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestIntegers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestIntegers.java
@@ -152,4 +152,62 @@ public class TestIntegers extends TornadoTestBase {
 
     }
 
+    @Test
+    public void test06() {
+        final int numElements = 8192 * 16;
+        IntArray a = new IntArray(numElements);
+        IntArray b = new IntArray(numElements);
+
+        a.init(0);
+        b.init(0);
+
+        IntArray expectedResultA = new IntArray(numElements);
+        IntArray expectedResultB = new IntArray(numElements);
+        expectedResultA.init(100);
+        expectedResultB.init(500);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .task("t0", TestKernels::init, a, b) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a, b);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+        executionPlan.withPrintKernel().execute();
+
+        for (int i = 0; i < numElements; i++) {
+            assertEquals(expectedResultA.get(i), a.get(i));
+            assertEquals(expectedResultB.get(i), b.get(i));
+        }
+    }
+
+    @Test
+    public void test07() {
+        final int numElements = 8192 * 16;
+        IntArray a = new IntArray(numElements);
+        IntArray b = new IntArray(numElements);
+
+        a.init(0);
+        b.init(0);
+
+        IntArray expectedResultA = new IntArray(numElements);
+        IntArray expectedResultB = new IntArray(numElements);
+        expectedResultA.init(100);
+        expectedResultB.init(500);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .task("t0", TestKernels::init, a, b) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a, b);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+        executionPlan.withThreadInfo().execute();
+        executionPlan.withoutThreadInfo().execute();
+
+        for (int i = 0; i < numElements; i++) {
+            assertEquals(expectedResultA.get(i), a.get(i));
+            assertEquals(expectedResultB.get(i), b.get(i));
+        }
+
+    }
+
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
@@ -336,4 +336,50 @@ public class TestProfiler extends TornadoTestBase {
         kernelTime = executionResult.getProfilerResult().getDeviceKernelTime();
         assertTrue(kernelTime > 0);
     }
+
+    @Test
+    public void testKernelOnAndOff() {
+
+        final int size = 1024;
+        float[] inputArray = new float[size];
+        float[] outputArray = new float[1];
+
+        Random r = new Random(71);
+        IntStream.range(0, size).forEach(i -> inputArray[i] = r.nextFloat());
+
+        TaskGraph taskGraph = new TaskGraph("compute");
+        taskGraph.transferToDevice(DataTransferMode.FIRST_EXECUTION, inputArray) //
+                .task("reduce", TestProfiler::reduction, inputArray, outputArray) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, outputArray);
+
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot());
+        // Enable print kernel
+        executionPlan.withPrintKernel().execute();
+
+        // disable print kernel
+        executionPlan.withoutPrintKernel().execute();
+    }
+
+    @Test
+    public void testThreadInfoOnAndOff() {
+
+        final int size = 1024;
+        float[] inputArray = new float[size];
+        float[] outputArray = new float[1];
+
+        Random r = new Random(71);
+        IntStream.range(0, size).forEach(i -> inputArray[i] = r.nextFloat());
+
+        TaskGraph taskGraph = new TaskGraph("compute");
+        taskGraph.transferToDevice(DataTransferMode.FIRST_EXECUTION, inputArray) //
+                .task("reduce", TestProfiler::reduction, inputArray, outputArray) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, outputArray);
+
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot());
+        // Enable print kernel
+        executionPlan.withThreadInfo().execute();
+
+        // disable print kernel
+        executionPlan.withoutThreadInfo().execute();
+    }
 }


### PR DESCRIPTION
#### Description

This PR enables two more methods in the `TornadoExecutionPlan` API to debug the kernels and the code dispatcher (number of threads and device in which each task in an immutable task-graph will be executed). 

This PR introduces the following methods in the task-graph:

```java
TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
executionPlan
       .withThreadInfo()  // new method to print the thread deployment - same action as --threadInfo from the command line
       .withPrintKernel() // new method to dump the generated kernel. Same action as the --printKernel from the command line 
       .execute();
```


#### Problem description

Apart from the

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make 
$ tornado-test -V uk.ac.manchester.tornado.unittests.foundation.TestIntegers#test06
$ tornado-test -V uk.ac.manchester.tornado.unittests.foundation.TestIntegers#test07
$ tornado-test -V uk.ac.manchester.tornado.unittests.profiler.TestProfiler#testKernelOnAndOff 
$ tornado-test -V uk.ac.manchester.tornado.unittests.profiler.TestProfiler#testThreadInfoOnAndOff
$ make tests 
```
