### PR TITLE
[fix][spirv] Reset LocalWorkSize when the device is changed

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/TaskMetaDataInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/TaskMetaDataInterface.java
@@ -55,4 +55,6 @@ public interface TaskMetaDataInterface {
     boolean isPrintKernelEnabled();
 
     void setPrintKernelFlag(boolean printKernelEnabled);
+
+    void resetThreadBlocks();
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -195,7 +195,7 @@ public class TaskUtils {
         return null;
     }
 
-    public static <T1> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task code) {
+    public static CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task code) {
         return createTask(meta, id, method, code, true);
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -530,6 +530,13 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 reuseDeviceBufferObject(localState, device);
             }
         }
+
+        // Set Thread-Schedulers to Default Value
+        for (int i = 0; i < executionContext.getTaskCount(); i++) {
+            SchedulableTask task = executionContext.getTask(i);
+            task.meta().resetThreadBlocks();
+        }
+
     }
 
     private void reuseDeviceBuffersForSameDevice(TornadoDevice device) {
@@ -566,6 +573,12 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 releaseObjectFromDeviceMemory(localState, oldDevice);
                 reuseDeviceBufferObject(localState, device);
             }
+        }
+
+        // Set Thread-Schedulers to Default Value
+        for (int i = 0; i < executionContext.getTaskCount(); i++) {
+            SchedulableTask task = executionContext.getTask(i);
+            task.meta().resetThreadBlocks();
         }
 
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
@@ -114,6 +114,7 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
      */
     private boolean openclUseDriverScheduling;
     private boolean printKernel;
+    private boolean resetThreads;
 
     AbstractMetaData(String id, AbstractMetaData parent) {
         this.id = id;
@@ -531,5 +532,17 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
 
     public void setThreadInfo(boolean threadInfoEnabled) {
         this.threadInfo = threadInfoEnabled;
+    }
+
+    public void resetThreadBlocks() {
+        this.resetThreads = true;
+    }
+
+    public boolean shouldResetThreadsBlock() {
+        return this.resetThreads;
+    }
+
+    public void disableResetThreadBlock() {
+        this.resetThreads = false;
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
@@ -133,6 +133,10 @@ public class TaskMetaData extends AbstractMetaData {
         localWork = null;
     }
 
+    public void setLocalWorkToNotDefined() {
+        localWorkDefined = false;
+    }
+
     public long[] initLocalWork() {
         localWork = new long[] { 1, 1, 1 };
         return localWork;


### PR DESCRIPTION
#### Description

This PR solves the problem of getting the wrong local work group sizes when the device is changed from the CPU using the OpenCL backend to the GPU using the SPIR-V backend. 

#### Problem description

The problem was that, in the SPIR-V backend, once the number of blocks is computed, is then stored in the `TaskMetaData` object. However, while the global work size for the same task will not change, there is no guarantee that the local work group size is the same. This patch solves the issue by resetting the local work size only when the device is updated. 
 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

The use case for this is the task-migration in Client/Server setup:

https://github.com/jjfumero/tornadovm-examples?tab=readme-ov-file#live-task-migration-client-server-app


```bash
## Run Server in one terminal
./runServer.sh

## Client in another terminal
./runClient.sh  ## Change device during runtime 

## Note: the application selects the backend 0:0 (default backend)

# type different <backend:deviceNumber> version from the client. 
# Examples:
# 0:1 
# 1:0 
## etc
```

