### PR TITLE
Test VectorAPI with TornadoNative types through Memory Segments for 64 to 512Bit vector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,7 @@
                                 <arg>--enable-preview</arg>
                                 <arg>--add-modules</arg>
                                 <arg>ALL-SYSTEM</arg>
+                                <arg>--add-modules=jdk.incubator.vector</arg>
                                 <arg>--upgrade-module-path</arg>
                                 <arg>${user.dir}/graalJars</arg>
                                 <!-- Common exports-->

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -112,6 +112,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.atomics.TestAtomics"),
     TestEntry("uk.ac.manchester.tornado.unittests.compute.ComputeTests"),
     TestEntry("uk.ac.manchester.tornado.unittests.dynamic.TestDynamic"),
+    TestEntry("uk.ac.manchester.tornado.unittests.vector.api.TestVectorAPI"),
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleFunctions"),
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleTasksMultipleDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.vm.concurrency.TestConcurrentBackends"),

--- a/tornado-unittests/src/main/java/module-info.java
+++ b/tornado-unittests/src/main/java/module-info.java
@@ -3,6 +3,7 @@ open module tornado.unittests {
     requires transitive tornado.api;
     requires lucene.core;
     requires java.desktop;
+    requires jdk.incubator.vector;
 
     exports uk.ac.manchester.tornado.unittests;
     exports uk.ac.manchester.tornado.unittests.api;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
@@ -86,7 +86,7 @@ public class TestVectorAPI extends TornadoTestBase {
      */
     private float[] parallelVectorAdd(FloatArray vector1, FloatArray vector2, VectorSpecies<Float> species) {
         float[] result = new float[SIZE];
-        System.out.println("Species " + species.toString());
+        System.out.println(species.toString());
         int width = vector1.getSize() / species.length();
         IntStream.range(0, width).parallel().forEach(i -> {
             FloatVector vec1 = FloatVector.fromMemorySegment(species, vector1.getSegment(), (long) i * species.length() * Float.BYTES, ByteOrder.nativeOrder());

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
@@ -33,7 +33,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to run?
  * </p>
  * <code>
- * tornado-test -V Uk.ac.manchester.tornado.unittests.vector.api.TestVectorAPI
+ * tornado-test -V uk.ac.manchester.tornado.unittests.vector.api.TestVectorAPI
  * </code>
  */
 public class TestVectorAPI extends TornadoTestBase {
@@ -49,13 +49,9 @@ public class TestVectorAPI extends TornadoTestBase {
         VectorSpecies<Float> species = FloatVector.SPECIES_128;
 
         int width = length / species.length();
-        System.out.println(STR."Species \{species.length()}");
         IntStream.range(0, width).parallel().forEach(i -> {
-//            System.out.println("IDX " + i + " chunk " + (i * species.length()) + " width: "+ width);
             FloatVector vec1 = FloatVector.fromMemorySegment(species, vector1.getSegment(), (long) i * species.length(), ByteOrder.nativeOrder());
-            System.out.println("VFLOAT_A " + vec1.toString() + " idx " + i);
             FloatVector vec2 = FloatVector.fromMemorySegment(species, vector2.getSegment(), (long) i * species.length(), ByteOrder.nativeOrder());
-            System.out.println("VFLOAT_B " + vec2.toString() + " idx " + i);
             FloatVector resultVec = vec1.add(vec2);
             resultVec.intoArray(result, i * species.length());
         });
@@ -90,10 +86,5 @@ public class TestVectorAPI extends TornadoTestBase {
         res = vectorAddition(arrayA, arrayB, SIZE);
 
         arrayC = vectorAdditionTornado(arrayA, arrayB);
-
-        for (int i = 0; i < arrayA.getSize(); i++) {
-            //            assertEquals(fArrayB[i], dataB.get(i));
-            System.out.println("Vector API: " + res[i] + " Normal vadd " + arrayC.get(i));
-        }
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
@@ -41,6 +41,8 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 public class TestVectorAPI extends TornadoTestBase {
 
     private static final int SIZE = 2048;
+
+    private static final float DELTA = 0.001f;
     private static final Random rand = new Random();
     private static FloatArray arrayA;
     private static FloatArray arrayB;
@@ -106,7 +108,7 @@ public class TestVectorAPI extends TornadoTestBase {
     public void test64BitVectors() {
         VectorSpecies<Float> species = FloatVector.SPECIES_64;
         float[] result = parallelVectorAdd(arrayA, arrayB, species);
-        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), 0.001f);
+        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), DELTA);
     }
 
     /**
@@ -116,7 +118,7 @@ public class TestVectorAPI extends TornadoTestBase {
     public void test128BitVectors() {
         VectorSpecies<Float> species = FloatVector.SPECIES_128;
         float[] result = parallelVectorAdd(arrayA, arrayB, species);
-        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), 0.001f);
+        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), DELTA);
     }
 
     /**
@@ -126,7 +128,7 @@ public class TestVectorAPI extends TornadoTestBase {
     public void test256BitVectors() {
         VectorSpecies<Float> species = FloatVector.SPECIES_256;
         float[] result = parallelVectorAdd(arrayA, arrayB, species);
-        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), 0.001f);
+        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), DELTA);
     }
 
     /**
@@ -136,6 +138,6 @@ public class TestVectorAPI extends TornadoTestBase {
     public void test512BitVectors() {
         VectorSpecies<Float> species = FloatVector.SPECIES_512;
         float[] result = parallelVectorAdd(arrayA, arrayB, species);
-        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), 0.001f);
+        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), DELTA);
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
@@ -89,8 +89,9 @@ public class TestVectorAPI extends TornadoTestBase {
         System.out.println(species.toString());
         int width = vector1.getSize() / species.length();
         IntStream.range(0, width).parallel().forEach(i -> {
-            FloatVector vec1 = FloatVector.fromMemorySegment(species, vector1.getSegment(), (long) i * species.length() * Float.BYTES, ByteOrder.nativeOrder());
-            FloatVector vec2 = FloatVector.fromMemorySegment(species, vector2.getSegment(), (long) i * species.length() * Float.BYTES, ByteOrder.nativeOrder());
+            long offsetIndex = (long) i * species.length() * Float.BYTES;
+            FloatVector vec1 = FloatVector.fromMemorySegment(species, vector1.getSegment(), offsetIndex, ByteOrder.nativeOrder());
+            FloatVector vec2 = FloatVector.fromMemorySegment(species, vector2.getSegment(), offsetIndex, ByteOrder.nativeOrder());
             FloatVector resultVec = vec1.add(vec2);
             resultVec.intoArray(result, i * species.length());
         });
@@ -98,9 +99,9 @@ public class TestVectorAPI extends TornadoTestBase {
         return result;
     }
 
-    public void verifyOutput(float[] res) {
-        for (int i = 0; i < res.length; i++) {
-            Assert.assertEquals(res[i], referenceResult.get(i), 0.01f);
+    public void verifyOutput(float[] result) {
+        for (int i = 0; i < result.length; i++) {
+            Assert.assertEquals(result[i], referenceResult.get(i), 0.01f);
         }
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.vector.api;
+
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorSpecies;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V Uk.ac.manchester.tornado.unittests.vector.api.TestVectorAPI
+ * </code>
+ */
+public class TestVectorAPI extends TornadoTestBase {
+
+    private final int SIZE = 128;
+
+    public static float randFloat(float min, float max, Random rand) {
+        return rand.nextFloat() * (max - min) + min;
+    }
+
+    private float[] vectorAddition(FloatArray vector1, FloatArray vector2, int length) {
+        float[] result = new float[SIZE];
+        VectorSpecies<Float> species = FloatVector.SPECIES_128;
+
+        int width = length / species.length();
+        System.out.println(STR."Species \{species.length()}");
+        IntStream.range(0, width).parallel().forEach(i -> {
+//            System.out.println("IDX " + i + " chunk " + (i * species.length()) + " width: "+ width);
+            FloatVector vec1 = FloatVector.fromMemorySegment(species, vector1.getSegment(), (long) i * species.length(), ByteOrder.nativeOrder());
+            System.out.println("VFLOAT_A " + vec1.toString() + " idx " + i);
+            FloatVector vec2 = FloatVector.fromMemorySegment(species, vector2.getSegment(), (long) i * species.length(), ByteOrder.nativeOrder());
+            System.out.println("VFLOAT_B " + vec2.toString() + " idx " + i);
+            FloatVector resultVec = vec1.add(vec2);
+            resultVec.intoArray(result, i * species.length());
+        });
+
+        return result;
+    }
+
+    private FloatArray vectorAdditionTornado(FloatArray a, FloatArray b) {
+        FloatArray res = new FloatArray(SIZE);
+        for (int i = 0; i < a.getSize(); i++) {
+            res.set(i, a.get(i) + b.get(i));
+        }
+        return res;
+    }
+
+    @Test
+    public void testVectorAPIwithTornadoNativeTypes() {
+        Random rand = new Random();
+        FloatArray arrayA = new FloatArray(SIZE);
+        FloatArray arrayB = new FloatArray(SIZE);
+        FloatArray arrayC = new FloatArray(SIZE);
+
+        float[] res = new float[SIZE];
+
+        for (int i = 0; i < arrayA.getSize(); i++) {
+            arrayA.set(i, randFloat(0, 2f, rand));
+            arrayB.set(i, randFloat(0, 3f, rand));
+        }
+
+        arrayC.init(0f);
+
+        res = vectorAddition(arrayA, arrayB, SIZE);
+
+        arrayC = vectorAdditionTornado(arrayA, arrayB);
+
+        for (int i = 0; i < arrayA.getSize(); i++) {
+            //            assertEquals(fArrayB[i], dataB.get(i));
+            System.out.println("Vector API: " + res[i] + " Normal vadd " + arrayC.get(i));
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
@@ -99,20 +99,14 @@ public class TestVectorAPI extends TornadoTestBase {
         return result;
     }
 
-    public void verifyOutput(float[] result) {
-        for (int i = 0; i < result.length; i++) {
-            Assert.assertEquals(result[i], referenceResult.get(i), 0.01f);
-        }
-    }
-
     /**
      * Test method for vector addition with 64-bit vector species.
      */
     @Test
     public void test64BitVectors() {
         VectorSpecies<Float> species = FloatVector.SPECIES_64;
-        float[] res = parallelVectorAdd(arrayA, arrayB, species);
-        verifyOutput(res);
+        float[] result = parallelVectorAdd(arrayA, arrayB, species);
+        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), 0.001f);
     }
 
     /**
@@ -121,8 +115,8 @@ public class TestVectorAPI extends TornadoTestBase {
     @Test
     public void test128BitVectors() {
         VectorSpecies<Float> species = FloatVector.SPECIES_128;
-        float[] res = parallelVectorAdd(arrayA, arrayB, species);
-        verifyOutput(res);
+        float[] result = parallelVectorAdd(arrayA, arrayB, species);
+        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), 0.001f);
     }
 
     /**
@@ -131,8 +125,8 @@ public class TestVectorAPI extends TornadoTestBase {
     @Test
     public void test256BitVectors() {
         VectorSpecies<Float> species = FloatVector.SPECIES_256;
-        float[] res = parallelVectorAdd(arrayA, arrayB, species);
-        verifyOutput(res);
+        float[] result = parallelVectorAdd(arrayA, arrayB, species);
+        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), 0.001f);
     }
 
     /**
@@ -141,7 +135,7 @@ public class TestVectorAPI extends TornadoTestBase {
     @Test
     public void test512BitVectors() {
         VectorSpecies<Float> species = FloatVector.SPECIES_512;
-        float[] res = parallelVectorAdd(arrayA, arrayB, species);
-        verifyOutput(res);
+        float[] result = parallelVectorAdd(arrayA, arrayB, species);
+        Assert.assertArrayEquals(result, referenceResult.toHeapArray(), 0.001f);
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vector/api/TestVectorAPI.java
@@ -21,6 +21,7 @@ import java.nio.ByteOrder;
 import java.util.Random;
 import java.util.stream.IntStream;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import jdk.incubator.vector.FloatVector;
@@ -40,18 +41,40 @@ public class TestVectorAPI extends TornadoTestBase {
 
     private final int SIZE = 128;
 
+    /**
+     * Generates a random floating-point number within the specified range.
+     *
+     * @param min
+     *     The minimum value (inclusive).
+     * @param max
+     *     The maximum value (exclusive).
+     * @param rand
+     *     An instance of {@code Random} used to generate the random number.
+     * @return A random float value between {@code min} and {@code max}.
+     */
     public static float randFloat(float min, float max, Random rand) {
         return rand.nextFloat() * (max - min) + min;
     }
 
+    /**
+     * Performs vector addition using Java's Vector API with TornadoNativeTypes.
+     *
+     * @param vector1
+     *     The first {@ FloatArray} operand.
+     * @param vector2
+     *     The second {@ FloatArray} operand.
+     * @param length
+     *     The number of elements in the vectors to be added.
+     * @return A new float array containing the result of the vector addition.
+     */
     private float[] vectorAddition(FloatArray vector1, FloatArray vector2, int length) {
         float[] result = new float[SIZE];
         VectorSpecies<Float> species = FloatVector.SPECIES_128;
 
         int width = length / species.length();
         IntStream.range(0, width).parallel().forEach(i -> {
-            FloatVector vec1 = FloatVector.fromMemorySegment(species, vector1.getSegment(), (long) i * species.length(), ByteOrder.nativeOrder());
-            FloatVector vec2 = FloatVector.fromMemorySegment(species, vector2.getSegment(), (long) i * species.length(), ByteOrder.nativeOrder());
+            FloatVector vec1 = FloatVector.fromMemorySegment(species, vector1.getSegment(), (long) i * species.length() * Float.BYTES, ByteOrder.nativeOrder());
+            FloatVector vec2 = FloatVector.fromMemorySegment(species, vector2.getSegment(), (long) i * species.length() * Float.BYTES, ByteOrder.nativeOrder());
             FloatVector resultVec = vec1.add(vec2);
             resultVec.intoArray(result, i * species.length());
         });
@@ -59,6 +82,15 @@ public class TestVectorAPI extends TornadoTestBase {
         return result;
     }
 
+    /**
+     * Performs vector addition using TornadoVM's FloatArray types.
+     *
+     * @param a
+     *     The first vector operand.
+     * @param b
+     *     The second vector operand.
+     * @return A {@code FloatArray} containing the result of the vector addition.
+     */
     private FloatArray vectorAdditionTornado(FloatArray a, FloatArray b) {
         FloatArray res = new FloatArray(SIZE);
         for (int i = 0; i < a.getSize(); i++) {
@@ -67,14 +99,17 @@ public class TestVectorAPI extends TornadoTestBase {
         return res;
     }
 
+    /**
+     * Tests the vector addition operation using both Java's SIMD API and TornadoVM native types.
+     * It verifies the correctness of the vector addition operations by asserting the equivalence of results
+     * from both methods within a specified tolerance.
+     */
     @Test
     public void testVectorAPIwithTornadoNativeTypes() {
         Random rand = new Random();
         FloatArray arrayA = new FloatArray(SIZE);
         FloatArray arrayB = new FloatArray(SIZE);
         FloatArray arrayC = new FloatArray(SIZE);
-
-        float[] res = new float[SIZE];
 
         for (int i = 0; i < arrayA.getSize(); i++) {
             arrayA.set(i, randFloat(0, 2f, rand));
@@ -83,8 +118,12 @@ public class TestVectorAPI extends TornadoTestBase {
 
         arrayC.init(0f);
 
-        res = vectorAddition(arrayA, arrayB, SIZE);
+        float[] res = vectorAddition(arrayA, arrayB, SIZE);
 
         arrayC = vectorAdditionTornado(arrayA, arrayB);
+
+        for (int i = 0; i < res.length; i++) {
+            Assert.assertEquals(res[i], arrayC.get(i), 0.1f);
+        }
     }
 }


### PR DESCRIPTION
#### Description
This is a follow up PR to #350 .

The PR adds unit-tests to check the connection between TornadoVM native types (invoking the getSegment) and Java Vector API.
It adds the following tests:

```
 test64BitVector   ->  Species[float, 2, S_64_BIT]
 test128BitVector  ->  Species[float, 4, S_128_BIT]
 test256BitVector  ->  Species[float, 8, S_256_BIT]
 test512BitVector  ->  Species[float, 16, S_512_BIT]
```

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?

```bash 
make 
tornado-test -V uk.ac.manchester.tornado.unittests.vector.api.TestVectorAPI
```
----------------------------------------------------------------------------
