### PR TITLE
Refactor memory limit checks to take into account primitve type wrappers  when using the `withMemoryLimit` API

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/enums/DataTypeSize.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/enums/DataTypeSize.java
@@ -26,13 +26,22 @@ package uk.ac.manchester.tornado.runtime.common.enums;
 import java.util.Arrays;
 
 public enum DataTypeSize {
+    // @formatter:off
     BYTE(byte.class, (byte) 1), //
     CHAR(char.class, (byte) 2), //
     SHORT(short.class, (byte) 2), //
     INT(int.class, (byte) 4), //
     FLOAT(float.class, (byte) 4), //
     LONG(long.class, (byte) 8), //
-    DOUBLE(double.class, (byte) 8);
+    DOUBLE(double.class, (byte) 8), //
+    BYTE_WRAPPER(Byte.class, (byte) 1),
+    CHAR_WRAPPER(Character.class, (byte) 2),
+    SHORT_WRAPPER(Short.class, (byte) 2),
+    INT_WRAPPER(Integer.class, (byte) 4),
+    FLOAT_WRAPPER(Float.class, (byte) 4),
+    LONG_WRAPPER(Long.class, (byte) 8),
+    DOUBLE_WRAPPER(Double.class, (byte) 8);
+    // @formatter:on
 
     private final Class<?> dataType;
     private final byte size;
@@ -42,15 +51,15 @@ public enum DataTypeSize {
         this.size = size;
     }
 
+    public static DataTypeSize findDataTypeSize(Class<?> dataType) {
+        return Arrays.stream(DataTypeSize.values()).filter(size -> size.getDataType().equals(dataType)).findFirst().orElse(null);
+    }
+
     public Class<?> getDataType() {
         return dataType;
     }
 
     public byte getSize() {
         return size;
-    }
-
-    public static DataTypeSize findDataTypeSize(Class<?> dataType) {
-        return Arrays.stream(DataTypeSize.values()).filter(size -> size.getDataType().equals(dataType)).findFirst().orElse(null);
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memoryplan/TestMemoryLimit.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memoryplan/TestMemoryLimit.java
@@ -17,18 +17,20 @@
  */
 package uk.ac.manchester.tornado.unittests.memoryplan;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.TestHello;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * How to test?
@@ -49,6 +51,8 @@ public class TestMemoryLimit extends TornadoTestBase {
     private static IntArray b = new IntArray(NUM_ELEMENTS);
     private static IntArray c = new IntArray(NUM_ELEMENTS);
 
+    private static int value = 10000000;
+
     @BeforeClass
     public static void setUpBeforeClass() {
         a = new IntArray(NUM_ELEMENTS);
@@ -58,12 +62,18 @@ public class TestMemoryLimit extends TornadoTestBase {
         b.init(2);
     }
 
+    public static void add(IntArray a, IntArray b, IntArray c, int value) {
+        for (@Parallel int i = 0; i < c.getSize(); i++) {
+            c.set(i, a.get(i) + b.get(i) + value);
+        }
+    }
+
     @Test
     public void testWithMemoryLimitOver() {
 
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
-                .task("t0", TestHello::add, a, b, c) //
+                .task("t0", TestMemoryLimit::add, a, b, c, value) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
@@ -73,7 +83,7 @@ public class TestMemoryLimit extends TornadoTestBase {
         executionPlan.withMemoryLimit("1GB").execute();
 
         for (int i = 0; i < c.getSize(); i++) {
-            assertEquals(a.get(i) + b.get(i), c.get(i), 0.001);
+            assertEquals(a.get(i) + b.get(i) + value, c.get(i), 0.001);
         }
         executionPlan.freeDeviceMemory();
     }


### PR DESCRIPTION
#### Description
This PR extends the support introduced in #323.

Now, memory limit checks takes into account fields along with arrays and TornadoNative types.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?
```bash
make jdk21  BACKEND=opencl
tornado-test -V uk.ac.manchester.tornado.unittests.memoryplan.TestMemoryLimit
``` 

----------------------------------------------------------------------------
