### PR TITLE
 Migrate from JUnit 4 to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
         <jmh.version>1.29</jmh.version>
         <tornadojmhjar.name>jmhbenchmarks</tornadojmhjar.name>
         <checkstyle.config.location>tornado-assembly/src/etc/checkstyle.xml</checkstyle.config.location>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <junit.platform.version>1.9.0</junit.platform.version>
     </properties>
 
     <profiles>
@@ -2007,9 +2009,19 @@
                 <version>10.12.3</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>${junit.platform.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-runner</artifactId>
+                <version>${junit.platform.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.lucene</groupId>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -26,11 +26,6 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.jupiter.version}</version>
         </dependency>
-        <!--        <dependency>-->
-        <!--            <groupId>org.junit.vintage</groupId>-->
-        <!--            <artifactId>junit-vintage-engine</artifactId>-->
-        <!--            <version>${junit.jupiter.version}</version>-->
-        <!--        </dependency>-->
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <junit.jupiter.version>5.9.0</junit.jupiter.version>
+        <junit.platform.version>1.9.0</junit.platform.version>
+    </properties>
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
@@ -18,13 +22,40 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+        </dependency>
+        <!--        <dependency>-->
+        <!--            <groupId>org.junit.vintage</groupId>-->
+        <!--            <artifactId>junit-vintage-engine</artifactId>-->
+        <!--            <version>${junit.jupiter.version}</version>-->
+        <!--        </dependency>-->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${junit.platform.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-runner</artifactId>
+            <version>${junit.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/tornado-unittests/src/main/java/module-info.java
+++ b/tornado-unittests/src/main/java/module-info.java
@@ -1,8 +1,11 @@
 open module tornado.unittests {
-    requires transitive junit;
     requires transitive tornado.api;
     requires lucene.core;
     requires java.desktop;
+    requires transitive org.junit.jupiter.api;
+    requires  org.junit.platform.commons;
+    requires  org.junit.jupiter.engine;
+    requires org.junit.platform.launcher;
 
     exports uk.ac.manchester.tornado.unittests;
     exports uk.ac.manchester.tornado.unittests.api;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/TestHello.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/TestHello.java
@@ -18,20 +18,21 @@
 
 package uk.ac.manchester.tornado.unittests;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.Debug;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * <p>
@@ -93,9 +94,9 @@ public class TestHello extends TornadoTestBase {
 
         try {
             executionPlan.execute();
-            assertTrue("Task was executed.", true);
+            assertTrue(true, "Task was executed.");
         } catch (Exception e) {
-            assertTrue("Task was not executed.", false);
+            assertTrue(false, "Task was not executed.");
         }
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
@@ -18,15 +18,15 @@
 
 package uk.ac.manchester.tornado.unittests.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.DataRange;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestIO.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestIO.java
@@ -17,11 +17,11 @@
  */
 package uk.ac.manchester.tornado.unittests.api;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestArrays.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestArrays.java
@@ -18,13 +18,13 @@
 
 package uk.ac.manchester.tornado.unittests.arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestBasicOperations.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestBasicOperations.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.unittests.arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
@@ -33,7 +33,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * How to test?

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestNewArrays.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestNewArrays.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,22 +17,22 @@
  */
 package uk.ac.manchester.tornado.unittests.arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.annotations.Reduce;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.unittests.common.TornadoNotSupported;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
@@ -40,7 +40,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to test?
  *
  * <code>
- *     tornado-test -V --fast uk.ac.manchester.tornado.unittests.arrays.TestNewArrays
+ * tornado-test -V --fast uk.ac.manchester.tornado.unittests.arrays.TestNewArrays
  * </code>
  */
 public class TestNewArrays extends TornadoTestBase {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/atomics/TestAtomics.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/atomics/TestAtomics.java
@@ -18,14 +18,14 @@
 
 package uk.ac.manchester.tornado.unittests.atomics;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -18,13 +18,13 @@
 
 package uk.ac.manchester.tornado.unittests.batches;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -32,7 +32,6 @@ import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
-import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
@@ -51,12 +50,6 @@ import uk.ac.manchester.tornado.unittests.tools.Exceptions.UnsupportedConfigurat
  * </p>
  */
 public class TestBatches extends TornadoTestBase {
-
-    @Override
-    public void before() {
-        super.before();
-        System.setProperty("tornado.reuse.device.buffers", "False");
-    }
 
     public static void compute(FloatArray array) {
         for (@Parallel int i = 0; i < array.getSize(); i++) {
@@ -162,6 +155,25 @@ public class TestBatches extends TornadoTestBase {
         }
     }
 
+    public static void parallelInitialization(FloatArray data) {
+        for (@Parallel int i = 0; i < data.getSize(); i++) {
+            data.set(i, i);
+        }
+    }
+
+    public static void compute2(FloatArray data) {
+        for (@Parallel int i = 0; i < data.getSize(); i++) {
+            float value = data.get(i);
+            data.set(i, value * 2);
+        }
+    }
+
+    @Override
+    public void before() {
+        super.before();
+        System.setProperty("tornado.reuse.device.buffers", "False");
+    }
+
     @Test
     public void test100MBSmall() {
 
@@ -231,33 +243,24 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void test300MB() {
 
-        long maxAllocMemory = checkMaxHeapAllocationOnDevice(300, MemoryUnit.MB);
+        long maxAllocMemory=checkMaxHeapAllocationOnDevice(300,MemoryUnit.MB);
 
         // Fill 1.0GB
-        int size = 250_000_000;
+        int size=250_000_000;
         // Or as much as we can
-        if (size * 4 > maxAllocMemory) {
-            size = (int) ((maxAllocMemory / 4 / 2) * 0.9);
-        }
-        FloatArray arrayA = new FloatArray(size);
-        FloatArray arrayB = new FloatArray(size);
+        if(size*4>maxAllocMemory){size=(int)((maxAllocMemory/4/2)*0.9);}FloatArray arrayA=new FloatArray(size);FloatArray arrayB=new FloatArray(size);
 
-        Random r = new Random();
-        IntStream.range(0, arrayA.getSize()).sequential().forEach(idx -> arrayA.set(idx, r.nextFloat()));
+        Random r=new Random();IntStream.range(0,arrayA.getSize()).sequential().forEach(idx->arrayA.set(idx,r.nextFloat()));
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, arrayA) //
-                .task("t0", TestBatches::compute, arrayA, arrayB) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, arrayB);
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,arrayA) //
+        .task("t0",TestBatches::compute,arrayA,arrayB) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,arrayB);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withBatch("300MB") // Slots of 300 MB
-                .execute();
+        ImmutableTaskGraph immutableTaskGraph=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(immutableTaskGraph);executionPlan.withBatch("300MB") // Slots of 300 MB
+        .execute();
 
-        for (int i = 0; i < arrayB.getSize(); i++) {
-            assertEquals(arrayA.get(i) + 100, arrayB.get(i), 1.0f);
-        }
+        for(int i=0;i<arrayB.getSize();i++){assertEquals(arrayA.get(i)+100,arrayB.get(i),1.0f);}
 
         executionPlan.freeDeviceMemory();
     }
@@ -478,214 +481,125 @@ public class TestBatches extends TornadoTestBase {
     @Test
     public void testSameInputSizeAndTypeRestriction() {
         // total input size mismatch for IntArray
-        checkMaxHeapAllocationOnDevice(5, MemoryUnit.MB);
-        IntArray a0 = new IntArray(2 * 1_000_000);
-        IntArray a1 = new IntArray(3 * 1_000_000);
+        checkMaxHeapAllocationOnDevice(5,MemoryUnit.MB);IntArray a0=new IntArray(2*1_000_000);IntArray a1=new IntArray(3*1_000_000);
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
-                .task("t0", TestBatches::compute, a0, a1) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
-        ImmutableTaskGraph snapshot = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
-        Assert.assertThrows(TornadoBailoutRuntimeException.class, () -> executionPlan.withBatch("1MB").execute());
-        executionPlan.freeDeviceMemory();
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,a0) //
+        .task("t0",TestBatches::compute,a0,a1) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,a1);ImmutableTaskGraph snapshot=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(snapshot);assertThrows(TornadoBailoutRuntimeException.class,()->executionPlan.withBatch("1MB").execute());executionPlan.freeDeviceMemory();
     }
 
     @Test
     public void testSameInputSizeAndTypeRestrictionJavaArrays() {
         // total input size mismatch for int[]
-        checkMaxHeapAllocationOnDevice(5, MemoryUnit.MB);
-        int[] a0 = new int[2 * 1_000_000];
-        int[] a1 = new int[3 * 1_000_000];
+        checkMaxHeapAllocationOnDevice(5,MemoryUnit.MB);int[]a0=new int[2*1_000_000];int[]a1=new int[3*1_000_000];
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
-                .task("t0", TestBatches::compute, a0, a1) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
-        ImmutableTaskGraph snapshot = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
-        Assert.assertThrows(TornadoBailoutRuntimeException.class, () -> executionPlan.withBatch("1MB").execute());
-        executionPlan.freeDeviceMemory();
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,a0) //
+        .task("t0",TestBatches::compute,a0,a1) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,a1);ImmutableTaskGraph snapshot=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(snapshot);assertThrows(TornadoBailoutRuntimeException.class,()->executionPlan.withBatch("1MB").execute());executionPlan.freeDeviceMemory();
     }
 
     @Test
     public void testSameInputTypeRestriction() {
         // IntArray is NOT compatible with LongArray even if the total input size is equal
-        checkMaxHeapAllocationOnDevice(6, MemoryUnit.MB);
-        IntArray a0 = new IntArray(4 * 1_000_000);
-        LongArray a1 = new LongArray(2 * 1_000_000);
+        checkMaxHeapAllocationOnDevice(6,MemoryUnit.MB);IntArray a0=new IntArray(4*1_000_000);LongArray a1=new LongArray(2*1_000_000);
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
-                .task("t0", TestBatches::compute, a0, a1) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
-        ImmutableTaskGraph snapshot = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
-        Assert.assertThrows(TornadoBailoutRuntimeException.class, () -> executionPlan.withBatch("1MB").execute());
-        executionPlan.freeDeviceMemory();
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,a0) //
+        .task("t0",TestBatches::compute,a0,a1) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,a1);ImmutableTaskGraph snapshot=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(snapshot);
+
+        assertThrows(TornadoBailoutRuntimeException.class,()->executionPlan.withBatch("1MB").execute());executionPlan.freeDeviceMemory();
     }
 
     @Test
     public void testSameInputTypeRestrictionJavaArrays() {
         // int[] is NOT compatible with long[] even if the total input size is equal
-        checkMaxHeapAllocationOnDevice(6, MemoryUnit.MB);
-        int[] a0 = new int[4 * 1_000_000];
-        long[] a1 = new long[2 * 1_000_000];
+        checkMaxHeapAllocationOnDevice(6,MemoryUnit.MB);int[]a0=new int[4*1_000_000];long[]a1=new long[2*1_000_000];
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
-                .task("t0", TestBatches::compute, a0, a1) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
-        ImmutableTaskGraph snapshot = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
-        Assert.assertThrows(TornadoBailoutRuntimeException.class, () -> executionPlan.withBatch("1MB").execute());
-        executionPlan.freeDeviceMemory();
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,a0) //
+        .task("t0",TestBatches::compute,a0,a1) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,a1);ImmutableTaskGraph snapshot=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(snapshot);assertThrows(TornadoBailoutRuntimeException.class,()->executionPlan.withBatch("1MB").execute());executionPlan.freeDeviceMemory();
     }
 
     @Test
     public void testSameInputSize() {
         // IntArray is compatible with FloatArray for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
-        IntArray a0 = new IntArray(2 * 1_000_000);
-        IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
-        FloatArray a1 = new FloatArray(2 * 1_000_000);
+        checkMaxHeapAllocationOnDevice(4,MemoryUnit.MB);IntArray a0=new IntArray(2*1_000_000);IntStream.range(0,a0.getSize()).forEach(i->a0.set(i,i));FloatArray a1=new FloatArray(2*1_000_000);
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
-                .task("t0", TestBatches::compute, a0, a1) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
-        ImmutableTaskGraph snapshot = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
-        executionPlan.withBatch("1MB").execute();
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,a0) //
+        .task("t0",TestBatches::compute,a0,a1) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,a1);ImmutableTaskGraph snapshot=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(snapshot);executionPlan.withBatch("1MB").execute();
 
-        for (int i = 0; i < a1.getSize(); i++) {
-            assertEquals(a0.get(i), a1.get(i), 1e-20);
-        }
-        executionPlan.freeDeviceMemory();
+        for(int i=0;i<a1.getSize();i++){assertEquals(a0.get(i),a1.get(i),1e-20);}executionPlan.freeDeviceMemory();
     }
 
     @Test
     public void testSameInputSizeJavaArrays() {
         // int[] is compatible with float[] for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
-        int[] a0 = new int[2 * 1_000_000];
-        IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
-        float[] a1 = new float[2 * 1_000_000];
+        checkMaxHeapAllocationOnDevice(4,MemoryUnit.MB);int[]a0=new int[2*1_000_000];IntStream.range(0,a0.length).forEach(i->a0[i]=i);float[]a1=new float[2*1_000_000];
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
-                .task("t0", TestBatches::compute, a0, a1) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
-        ImmutableTaskGraph snapshot = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
-        executionPlan.withBatch("1MB").execute();
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,a0) //
+        .task("t0",TestBatches::compute,a0,a1) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,a1);ImmutableTaskGraph snapshot=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(snapshot);executionPlan.withBatch("1MB").execute();
 
-        for (int i = 0; i < a1.length; i++) {
-            assertEquals(a0[i], a1[i], 1e-20);
-        }
-        executionPlan.freeDeviceMemory();
+        for(int i=0;i<a1.length;i++){assertEquals(a0[i],a1[i],1e-20);}executionPlan.freeDeviceMemory();
     }
 
     @Test
     public void testSameInputSizeJavaToTornado() {
         // int[] is compatible with FloatArray for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
-        int[] a0 = new int[2 * 1_000_000];
-        IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
-        FloatArray a1 = new FloatArray(2 * 1_000_000);
+        checkMaxHeapAllocationOnDevice(4,MemoryUnit.MB);int[]a0=new int[2*1_000_000];IntStream.range(0,a0.length).forEach(i->a0[i]=i);FloatArray a1=new FloatArray(2*1_000_000);
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
-                .task("t0", TestBatches::compute, a0, a1) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
-        ImmutableTaskGraph snapshot = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
-        executionPlan.withBatch("1MB").execute();
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,a0) //
+        .task("t0",TestBatches::compute,a0,a1) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,a1);ImmutableTaskGraph snapshot=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(snapshot);executionPlan.withBatch("1MB").execute();
 
-        for (int i = 0; i < a1.getSize(); i++) {
-            assertEquals(a0[i], a1.get(i), 1e-20);
-        }
-        executionPlan.freeDeviceMemory();
+        for(int i=0;i<a1.getSize();i++){assertEquals(a0[i],a1.get(i),1e-20);}executionPlan.freeDeviceMemory();
     }
 
     @Test
     public void testSameInputSizeTornadoToJava() {
         // IntArray is compatible with float[] for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
-        IntArray a0 = new IntArray(2 * 1_000_000);
-        IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
-        float[] a1 = new float[2 * 1_000_000];
+        checkMaxHeapAllocationOnDevice(4,MemoryUnit.MB);IntArray a0=new IntArray(2*1_000_000);IntStream.range(0,a0.getSize()).forEach(i->a0.set(i,i));float[]a1=new float[2*1_000_000];
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
-                .task("t0", TestBatches::compute, a0, a1) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
-        ImmutableTaskGraph snapshot = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
-        executionPlan.withBatch("1MB").execute();
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,a0) //
+        .task("t0",TestBatches::compute,a0,a1) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,a1);ImmutableTaskGraph snapshot=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(snapshot);executionPlan.withBatch("1MB").execute();
 
-        for (int i = 0; i < a1.length; i++) {
-            assertEquals(a0.get(i), a1[i], 1e-20);
-        }
-        executionPlan.freeDeviceMemory();
+        for(int i=0;i<a1.length;i++){assertEquals(a0.get(i),a1[i],1e-20);}executionPlan.freeDeviceMemory();
     }
 
     @Test
     public void testSameInputSizeAndTypeJavaToTornado() {
         // int[] is compatible with IntArray for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
-        int[] a0 = new int[2 * 1_000_000];
-        IntStream.range(0, a0.length).forEach(i -> a0[i] = i);
-        IntArray a1 = new IntArray(2 * 1_000_000);
+        checkMaxHeapAllocationOnDevice(4,MemoryUnit.MB);int[]a0=new int[2*1_000_000];IntStream.range(0,a0.length).forEach(i->a0[i]=i);IntArray a1=new IntArray(2*1_000_000);
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
-                .task("t0", TestBatches::compute, a0, a1) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
-        ImmutableTaskGraph snapshot = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
-        executionPlan.withBatch("1MB").execute();
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,a0) //
+        .task("t0",TestBatches::compute,a0,a1) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,a1);ImmutableTaskGraph snapshot=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(snapshot);executionPlan.withBatch("1MB").execute();
 
-        for (int i = 0; i < a1.getSize(); i++) {
-            assertEquals(a0[i], a1.get(i));
-        }
-        executionPlan.freeDeviceMemory();
+        for(int i=0;i<a1.getSize();i++){assertEquals(a0[i],a1.get(i));}executionPlan.freeDeviceMemory();
     }
 
     @Test
     public void testSameInputSizeAndTypeTornadoToJava() {
         // IntArray is compatible with int[] for the same # of elements
-        checkMaxHeapAllocationOnDevice(4, MemoryUnit.MB);
-        IntArray a0 = new IntArray(2 * 1_000_000);
-        IntStream.range(0, a0.getSize()).forEach(i -> a0.set(i, i));
-        int[] a1 = new int[2 * 1_000_000];
+        checkMaxHeapAllocationOnDevice(4,MemoryUnit.MB);IntArray a0=new IntArray(2*1_000_000);IntStream.range(0,a0.getSize()).forEach(i->a0.set(i,i));int[]a1=new int[2*1_000_000];
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a0) //
-                .task("t0", TestBatches::compute, a0, a1) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a1);
-        ImmutableTaskGraph snapshot = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(snapshot);
-        executionPlan.withBatch("1MB").execute();
+        TaskGraph taskGraph=new TaskGraph("s0") //
+        .transferToDevice(DataTransferMode.FIRST_EXECUTION,a0) //
+        .task("t0",TestBatches::compute,a0,a1) //
+        .transferToHost(DataTransferMode.EVERY_EXECUTION,a1);ImmutableTaskGraph snapshot=taskGraph.snapshot();TornadoExecutionPlan executionPlan=new TornadoExecutionPlan(snapshot);executionPlan.withBatch("1MB").execute();
 
-        for (int i = 0; i < a1.length; i++) {
-            assertEquals(a0.get(i), a1[i]);
-        }
-        executionPlan.freeDeviceMemory();
-    }
-
-    public static void parallelInitialization(FloatArray data) {
-        for (@Parallel int i = 0; i < data.getSize(); i++) {
-            data.set(i, i);
-        }
-    }
-
-    public static void compute2(FloatArray data) {
-        for (@Parallel int i = 0; i < data.getSize(); i++) {
-            float value = data.get(i);
-            data.set(i, value * 2);
-        }
+        for(int i=0;i<a1.length;i++){assertEquals(a0.get(i),a1[i]);}executionPlan.freeDeviceMemory();
     }
 
     @Test
@@ -755,7 +669,8 @@ public class TestBatches extends TornadoTestBase {
         return maxAllocMemory;
     }
 
-    private enum MemoryUnit {
+    private enum MemoryUnit
+    {
         MB, GB, TB
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/bitsets/BitSetTests.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/bitsets/BitSetTests.java
@@ -18,12 +18,12 @@
 
 package uk.ac.manchester.tornado.unittests.bitsets;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 
 import org.apache.lucene.util.LongBitSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/branching/TestConditionals.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/branching/TestConditionals.java
@@ -18,7 +18,7 @@
 
 package uk.ac.manchester.tornado.unittests.branching;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
@@ -29,7 +29,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * How to test?

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/CodeGen.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/CodeGen.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,23 +17,24 @@
  */
 package uk.ac.manchester.tornado.unittests.codegen;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
-
-import java.util.stream.IntStream;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * How to test?
@@ -140,7 +141,7 @@ public class CodeGen extends TornadoTestBase {
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void test03() {
         if (isRunningOnCPU()) {
             return;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -18,7 +18,7 @@
 
 package uk.ac.manchester.tornado.unittests.common;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import uk.ac.manchester.tornado.api.TornadoDriver;
 import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
@@ -37,7 +37,7 @@ public abstract class TornadoTestBase {
         return TornadoRuntime.getTornadoRuntime();
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         for (int i = 0; i < TornadoRuntime.getTornadoRuntime().getNumDrivers(); i++) {
             final TornadoDriver driver = TornadoRuntime.getTornadoRuntime().getDriver(i);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/ComputeTests.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/ComputeTests.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.unittests.compute;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -28,7 +28,7 @@ import java.util.stream.IntStream;
 
 import javax.imageio.ImageIO;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/dynamic/TestDynamic.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/dynamic/TestDynamic.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.dynamic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.DRMode;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/dynsize/Resize.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/dynsize/Resize.java
@@ -18,11 +18,11 @@
 
 package uk.ac.manchester.tornado.unittests.dynsize;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,23 +17,24 @@
  */
 package uk.ac.manchester.tornado.unittests.executor;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoExecutionResult;
 import uk.ac.manchester.tornado.api.TornadoProfilerResult;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.TestHello;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
-
-import java.util.Arrays;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * How to run?

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/HeapFail.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/HeapFail.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,9 +18,11 @@
 
 package uk.ac.manchester.tornado.unittests.fails;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -34,7 +36,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
  * How to run.
  * </p>
  * <code>
- *     tornado-test -V uk.ac.manchester.tornado.unittests.fails.HeapFail
+ * tornado-test -V uk.ac.manchester.tornado.unittests.fails.HeapFail
  * </code>
  */
 public class HeapFail {
@@ -54,25 +56,27 @@ public class HeapFail {
      * </code>
      *
      */
-    @Test(expected = TornadoOutOfMemoryException.class)
+    @Test
     public void test03() throws TornadoOutOfMemoryException {
-        // This test simulates small amount of memory on the target device and we
-        // allocate more than available. We should get a concrete error message back
-        // with the steps to take to increase the device's heap size
+        assertThrows(TornadoOutOfMemoryException.class, () -> {
+            // This test simulates small amount of memory on the target device and we
+            // allocate more than available. We should get a concrete error message back
+            // with the steps to take to increase the device's heap size
 
-        // We allocate 64MB of data on the device
-        float[] x = new float[16777216];
-        float[] y = new float[16777216];
+            // We allocate 64MB of data on the device
+            float[] x = new float[16777216];
+            float[] y = new float[16777216];
 
-        Arrays.fill(x, 2.0f);
+            Arrays.fill(x, 2.0f);
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.EVERY_EXECUTION, x) //
-                .task("s0", HeapFail::validKernel, x, y) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, y); //
+            TaskGraph taskGraph = new TaskGraph("s0") //
+                    .transferToDevice(DataTransferMode.EVERY_EXECUTION, x) //
+                    .task("s0", HeapFail::validKernel, x, y) //
+                    .transferToHost(DataTransferMode.EVERY_EXECUTION, y); //
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.execute();
+            ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+            TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+            executionPlan.execute();
+        });
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/RuntimeFail.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/RuntimeFail.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,17 @@
  */
 package uk.ac.manchester.tornado.unittests.fails;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoTaskRuntimeException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -33,7 +35,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to run?
  * </p>
  * <code>
- *     tornado-test -V uk.ac.manchester.tornado.unittests.fails.RuntimeFail
+ * tornado-test -V uk.ac.manchester.tornado.unittests.fails.RuntimeFail
  * </code>
  */
 public class RuntimeFail extends TornadoTestBase {
@@ -57,28 +59,29 @@ public class RuntimeFail extends TornadoTestBase {
      * How to run?
      *
      * <code>
-     *     tornado-test -V -pk --debug uk.ac.manchester.tornado.unittests.fails.RuntimeFail#test01
+     * tornado-test -V -pk --debug uk.ac.manchester.tornado.unittests.fails.RuntimeFail#test01
      * </code>
      */
-    @Test(expected = TornadoTaskRuntimeException.class)
+    @Test
     public void test01() {
-        FloatArray x = new FloatArray(8192);
-        FloatArray y = new FloatArray(8192);
-        FloatArray z = new FloatArray(8192);
+        assertThrows(TornadoTaskRuntimeException.class, () -> {
+            FloatArray x = new FloatArray(8192);
+            FloatArray y = new FloatArray(8192);
+            FloatArray z = new FloatArray(8192);
 
-        x.init(2.0f);
-        y.init(8.0f);
+            x.init(2.0f);
+            y.init(8.0f);
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, x, y) //
-                .task("t0", RuntimeFail::vectorAdd, x, y, z) //
-                .task("t0", RuntimeFail::square, z) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, z);
+            TaskGraph taskGraph = new TaskGraph("s0") //
+                    .transferToDevice(DataTransferMode.FIRST_EXECUTION, x, y) //
+                    .task("t0", RuntimeFail::vectorAdd, x, y, z) //
+                    .task("t0", RuntimeFail::square, z) //
+                    .transferToHost(DataTransferMode.EVERY_EXECUTION, z);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlanPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlanPlan.execute();
-
+            ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+            TornadoExecutionPlan executionPlanPlan = new TornadoExecutionPlan(immutableTaskGraph);
+            executionPlanPlan.execute();
+        });
     }
 
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fields/TestFields.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fields/TestFields.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.unittests.fields;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
@@ -31,7 +31,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * <p>

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/flatmap/TestFlatMap.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/flatmap/TestFlatMap.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.flatmap;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/MultipleRuns.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/MultipleRuns.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.foundation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestDoubles.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestDoubles.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.foundation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestFloats.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestFloats.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.foundation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestIf.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestIf.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.foundation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestIntegers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestIntegers.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.foundation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestLinearAlgebra.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestLinearAlgebra.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.foundation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestLong.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestLong.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.foundation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestShorts.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestShorts.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.foundation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/functional/TestLambdas.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/functional/TestLambdas.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,20 +18,20 @@
 
 package uk.ac.manchester.tornado.unittests.functional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -39,7 +39,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to run?
  * </p>
  * <code>
- *      tornado-test -V uk.ac.manchester.tornado.unittests.functional.TestLambdas
+ * tornado-test -V uk.ac.manchester.tornado.unittests.functional.TestLambdas
  * </code>
  */
 public class TestLambdas extends TornadoTestBase {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGrid.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGrid.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.grid;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGridScheduler.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGridScheduler.java
@@ -17,11 +17,11 @@
  */
 package uk.ac.manchester.tornado.unittests.grid;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/images/TestImages.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/images/TestImages.java
@@ -18,11 +18,11 @@
 
 package uk.ac.manchester.tornado.unittests.images;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/images/TestResizeImage.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/images/TestResizeImage.java
@@ -18,21 +18,21 @@
 
 package uk.ac.manchester.tornado.unittests.images;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.ac.manchester.tornado.api.math.TornadoMath.clamp;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.images.ImageFloat;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.images.ImageFloat;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/instances/LocalVariableInstance.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/instances/LocalVariableInstance.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,9 +18,9 @@
 
 package uk.ac.manchester.tornado.unittests.instances;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -33,7 +33,7 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
  * How to run?
  * </p>
  * <code>
- *      tornado-test -V uk.ac.manchester.tornado.unittests.instances.LocalVariableInstance
+ * tornado-test -V uk.ac.manchester.tornado.unittests.instances.LocalVariableInstance
  * </code>
  *
  */

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/instances/TestInstances.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/instances/TestInstances.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +18,15 @@
 
 package uk.ac.manchester.tornado.unittests.instances;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
-import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -34,20 +34,11 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to run?
  * </p>
  * <code>
- *      tornado-test -V uk.ac.manchester.tornado.unittests.instances.TestInstances
+ * tornado-test -V uk.ac.manchester.tornado.unittests.instances.TestInstances
  * </code>
  *
  */
 public class TestInstances extends TornadoTestBase {
-
-    public static class Foo {
-        // Parallel initialisation
-        public void compute(DoubleArray array, double initValue) {
-            for (int i = 0; i < array.getSize(); i++) {
-                array.set(i, initValue);
-            }
-        }
-    }
 
     @Test
     public void testInit() {
@@ -86,6 +77,15 @@ public class TestInstances extends TornadoTestBase {
 
         for (int i = 0; i < array.getSize(); i++) {
             assertEquals(2.1, array.get(i), 0.001);
+        }
+    }
+
+    public static class Foo {
+        // Parallel initialisation
+        public void compute(DoubleArray array, double initValue) {
+            for (int i = 0; i < array.getSize(); i++) {
+                array.set(i, initValue);
+            }
         }
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/Grids.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/Grids.java
@@ -17,7 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.kernelcontext.api;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
@@ -83,57 +85,59 @@ public class Grids extends TornadoTestBase {
 
     }
 
-    @Test(expected = TornadoRuntimeException.class)
+    @Test
     public void testWithIncorrectGraphName() {
-        FloatArray timesArray = new FloatArray(size);
-        FloatArray obsArray = new FloatArray(size);
+        assertThrows(TornadoRuntimeException.class, () -> {
+            FloatArray timesArray = new FloatArray(size);
+            FloatArray obsArray = new FloatArray(size);
 
-        FloatArray resArray = new FloatArray(100000);
-        resArray.init(0.0f);
+            FloatArray resArray = new FloatArray(100000);
+            resArray.init(0.0f);
 
-        WorkerGrid worker = new WorkerGrid1D(gridSize);
-        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
-        KernelContext context = new KernelContext();
-        worker.setLocalWork(gridSize, 1, 1);
+            WorkerGrid worker = new WorkerGrid1D(gridSize);
+            GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+            KernelContext context = new KernelContext();
+            worker.setLocalWork(gridSize, 1, 1);
 
-        TaskGraph taskGraph = new TaskGraph("foo");
+            TaskGraph taskGraph = new TaskGraph("foo");
 
-        taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, timesArray, obsArray) //
-                .task("t0", Grids::psKernel, context, timesArray, obsArray, resArray) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, resArray);
+            taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, timesArray, obsArray) //
+                    .task("t0", Grids::psKernel, context, timesArray, obsArray, resArray) //
+                    .transferToHost(DataTransferMode.EVERY_EXECUTION, resArray);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+            ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+            TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
 
-        executionPlan.withGridScheduler(gridScheduler) //
-                .execute();
-
+            executionPlan.withGridScheduler(gridScheduler) //
+                    .execute();
+        });
     }
 
-    @Test(expected = TornadoRuntimeException.class)
+    @Test
     public void testWithIncorrectGraphAndTaskName() {
-        FloatArray timesArray = new FloatArray(size);
-        FloatArray obsArray = new FloatArray(size);
+        assertThrows(TornadoRuntimeException.class, () -> {
+            FloatArray timesArray = new FloatArray(size);
+            FloatArray obsArray = new FloatArray(size);
 
-        FloatArray resArray = new FloatArray(100000);
-        resArray.init(0.0f);
+            FloatArray resArray = new FloatArray(100000);
+            resArray.init(0.0f);
 
-        WorkerGrid worker = new WorkerGrid1D(gridSize);
-        GridScheduler gridScheduler = new GridScheduler("foo.bar", worker);
-        KernelContext context = new KernelContext();
-        worker.setLocalWork(gridSize, 1, 1);
+            WorkerGrid worker = new WorkerGrid1D(gridSize);
+            GridScheduler gridScheduler = new GridScheduler("foo.bar", worker);
+            KernelContext context = new KernelContext();
+            worker.setLocalWork(gridSize, 1, 1);
 
-        TaskGraph taskGraph = new TaskGraph("t0");
+            TaskGraph taskGraph = new TaskGraph("t0");
 
-        taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, timesArray, obsArray) //
-                .task("t0", Grids::psKernel, context, timesArray, obsArray, resArray) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, resArray);
+            taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, timesArray, obsArray) //
+                    .task("t0", Grids::psKernel, context, timesArray, obsArray, resArray) //
+                    .transferToHost(DataTransferMode.EVERY_EXECUTION, resArray);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+            ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+            TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
 
-        executionPlan.withGridScheduler(gridScheduler) //
-                .execute();
-
+            executionPlan.withGridScheduler(gridScheduler) //
+                    .execute();
+        });
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/KernelContextWorkGroupTests.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/KernelContextWorkGroupTests.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.unittests.kernelcontext.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.KernelContext;
@@ -31,7 +31,7 @@ import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * <p>

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestCombinedTaskGraph.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestCombinedTaskGraph.java
@@ -17,11 +17,11 @@
  */
 package uk.ac.manchester.tornado.unittests.kernelcontext.api;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestVectorAdditionKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestVectorAdditionKernelContext.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.kernelcontext.api;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
@@ -28,8 +28,8 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -39,7 +39,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to run?
  * </p>
  * <code>
- *     tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestVectorAdditionKernelContext
+ * tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestVectorAdditionKernelContext
  * </code>
  */
 public class TestVectorAdditionKernelContext extends TornadoTestBase {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestMatrixMultiplicationKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestMatrixMultiplicationKernelContext.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.unittests.kernelcontext.matrices;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.KernelContext;
@@ -33,7 +33,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * <p>

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsDoublesKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsDoublesKernelContext.java
@@ -17,11 +17,11 @@
  */
 package uk.ac.manchester.tornado.unittests.kernelcontext.reductions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsFloatsKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsFloatsKernelContext.java
@@ -17,11 +17,11 @@
  */
 package uk.ac.manchester.tornado.unittests.kernelcontext.reductions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsIntegersKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsIntegersKernelContext.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.kernelcontext.reductions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsLongKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsLongKernelContext.java
@@ -17,11 +17,11 @@
  */
 package uk.ac.manchester.tornado.unittests.kernelcontext.reductions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/lambdas/TestLambdas.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/lambdas/TestLambdas.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.lambdas;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/logic/TestLogic.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/logic/TestLogic.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,19 +17,19 @@
  */
 package uk.ac.manchester.tornado.unittests.logic;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -37,7 +37,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to test?
  * </p>
  * <code>
- *     tornado-test -V uk.ac.manchester.tornado.unittests.logic.TestLogic
+ * tornado-test -V uk.ac.manchester.tornado.unittests.logic.TestLogic
  * </code>
  */
 public class TestLogic extends TornadoTestBase {
@@ -152,7 +152,7 @@ public class TestLogic extends TornadoTestBase {
         }
     }
 
-    @Ignore
+    @Disabled
     public void testLogic04() {
         final int N = 1024;
         IntArray data = new IntArray(N);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestLoopTransformations.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestLoopTransformations.java
@@ -18,7 +18,7 @@
 
 package uk.ac.manchester.tornado.unittests.loops;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoDriver;
@@ -32,7 +32,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * <p>

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestLoops.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestLoops.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,20 +17,20 @@
  */
 package uk.ac.manchester.tornado.unittests.loops;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
 import uk.ac.manchester.tornado.unittests.common.TornadoNotSupported;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
@@ -39,7 +39,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to test?
  * </p>
  * <code>
- *     tornado-test -V uk.ac.manchester.tornado.unittests.loops.TestLoops
+ * tornado-test -V uk.ac.manchester.tornado.unittests.loops.TestLoops
  * </code>
  */
 public class TestLoops extends TornadoTestBase {
@@ -61,7 +61,6 @@ public class TestLoops extends TornadoTestBase {
             a.set(i, 10);
         }
     }
-
 
     public static void forConstant04(Matrix2DFloat m, int n) {
         for (@Parallel int i = 0; i <= n; i++) {
@@ -92,7 +91,6 @@ public class TestLoops extends TornadoTestBase {
             a.set(i, 10);
         }
     }
-
 
     public static void steppedLoop(IntArray a, int size) {
         for (@Parallel int i = 0; i < size; i += 2) {
@@ -138,7 +136,6 @@ public class TestLoops extends TornadoTestBase {
             a.set(i, 200);
         }
     }
-
 
     public static void conditionalInLoop(IntArray a) {
         for (@Parallel int i = 0; i < a.getSize(); i++) {
@@ -331,6 +328,7 @@ public class TestLoops extends TornadoTestBase {
             assertEquals(10, a.get(i));
         }
     }
+
     @Test
     public void testForConstant02() {
         final int size = 256;
@@ -666,7 +664,7 @@ public class TestLoops extends TornadoTestBase {
         }
     }
 
-    @Ignore
+    @Disabled
     public void testTwoDLoopTwoDArray() {
         final int size = 10;
 
@@ -707,7 +705,7 @@ public class TestLoops extends TornadoTestBase {
         }
     }
 
-    @Ignore
+    @Disabled
     public void testNestedForLoopTwoDArray() {
         final int size = 10;
 
@@ -854,7 +852,7 @@ public class TestLoops extends TornadoTestBase {
         }
     }
 
-    @Ignore
+    @Disabled
     public void testInnerDoWhileLoop() {
         final int size = 100;
 
@@ -943,7 +941,7 @@ public class TestLoops extends TornadoTestBase {
 
         inTor.set(0, size / 4 - 1);
         inSeq.set(0, size / 4 - 1);
-       // inTor[0] = inSeq[0] = size / 4 - 1;
+        // inTor[0] = inSeq[0] = size / 4 - 1;
 
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, inTor) //
@@ -979,7 +977,7 @@ public class TestLoops extends TornadoTestBase {
 
         inTor.set(0, size / 4 - 1);
         inSeq.set(0, size / 4 - 1);
-       // inTor[0] = inSeq[0] = size / 4 - 1;
+        // inTor[0] = inSeq[0] = size / 4 - 1;
 
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, inTor) //

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestParallelDimensions.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/loops/TestParallelDimensions.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.unittests.loops;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestMath.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestMath.java
@@ -18,12 +18,12 @@
 
 package uk.ac.manchester.tornado.unittests.math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.math;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +18,15 @@
 
 package uk.ac.manchester.tornado.unittests.matrices;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -40,10 +40,10 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to run?
  * </p>
  * <code>
- *     tornado-test -V uk.ac.manchester.tornado.unittests.matrices.TestMatrices
+ * tornado-test -V uk.ac.manchester.tornado.unittests.matrices.TestMatrices
  * </code>
  */
-@Ignore
+@Disabled
 public class TestMatrices extends TornadoTestBase {
     // CHECKSTYLE:OFF
 
@@ -172,7 +172,7 @@ public class TestMatrices extends TornadoTestBase {
         }
     }
 
-    @Ignore
+    @Disabled
     @Test
     public void testFillMatrix() {
         final int numElements = 16;
@@ -718,7 +718,7 @@ public class TestMatrices extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < matrix.length; i++) {
-            Assert.assertArrayEquals(matrixSeq[i], matrix[i]);
+            assertArrayEquals(matrixSeq[i], matrix[i]);
         }
     }
 
@@ -760,7 +760,7 @@ public class TestMatrices extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < firstMatrix.length; i++) {
-            Assert.assertArrayEquals(firstMatrixSeq[i], firstMatrix[i], 0.01f);
+            assertArrayEquals(firstMatrixSeq[i], firstMatrix[i], 0.01f);
         }
     }
     // CHECKSTYLE:ON

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrixTypes.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrixTypes.java
@@ -18,29 +18,29 @@
 
 package uk.ac.manchester.tornado.unittests.matrices;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Random;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.vectors.Float4;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.collections.VectorDouble;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
+import uk.ac.manchester.tornado.api.types.collections.VectorInt;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix2DDouble;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat4;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix2DInt;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix3DFloat;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix3DFloat4;
-import uk.ac.manchester.tornado.api.types.collections.VectorDouble;
-import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
-import uk.ac.manchester.tornado.api.types.collections.VectorInt;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/multithreaded/MultiThreaded.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/multithreaded/MultiThreaded.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.unittests.multithreaded;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.KernelContext;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/neurocom/TestCase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/neurocom/TestCase.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.unittests.neurocom;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/numpromotion/Inlining.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/numpromotion/Inlining.java
@@ -17,11 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.numpromotion;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -136,7 +137,7 @@ public class Inlining extends TornadoTestBase {
         rgbToGreyKernel(rgbBytes, seq);
 
         for (int i = 0; i < seq.getSize(); i++) {
-            Assert.assertEquals(seq.get(i), greyInts.get(i));
+            assertEquals(seq.get(i), greyInts.get(i));
         }
 
     }
@@ -163,7 +164,7 @@ public class Inlining extends TornadoTestBase {
         rgbToGreyKernelInt(rgbBytes, seq);
 
         for (int i = 0; i < seq.getSize(); i++) {
-            Assert.assertEquals(seq.get(i), greyInts.get(i));
+            assertEquals(seq.get(i), greyInts.get(i));
         }
 
     }
@@ -191,7 +192,7 @@ public class Inlining extends TornadoTestBase {
         rgbToGreyKernelSmall(rgbBytes, seq);
 
         for (int i = 0; i < seq.getSize(); i++) {
-            Assert.assertEquals(seq.get(i), greyInts.get(i));
+            assertEquals(seq.get(i), greyInts.get(i));
         }
     }
 
@@ -216,7 +217,7 @@ public class Inlining extends TornadoTestBase {
         b2i(rgbBytes, seq);
 
         for (int i = 0; i < seq.getSize(); i++) {
-            Assert.assertEquals(seq.get(i), greyInts.get(i));
+            assertEquals(seq.get(i), greyInts.get(i));
         }
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/numpromotion/TestNumericPromotion.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/numpromotion/TestNumericPromotion.java
@@ -18,9 +18,9 @@
 
 package uk.ac.manchester.tornado.unittests.numpromotion;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/numpromotion/Types.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/numpromotion/Types.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.numpromotion;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/parameters/ParameterTests.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/parameters/ParameterTests.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,26 +17,27 @@
  */
 package uk.ac.manchester.tornado.unittests.parameters;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.arrays.LongArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.arrays.LongArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * How to test?
  *
  * <p>
  * <code>
- *     tornado-test -V --fast uk.ac.manchester.tornado.unittests.parameters.ParameterTests
+ * tornado-test -V --fast uk.ac.manchester.tornado.unittests.parameters.ParameterTests
  * </code>
  * </p>
  */
@@ -73,37 +74,41 @@ public class ParameterTests extends TornadoTestBase {
      * This test throws a {@link TornadoRuntimeException} because scalar values are
      * used as output parameters. This type of code is not legal in TornadoVM.
      */
-    @Test(expected = TornadoRuntimeException.class)
+    @Test
     public void testScalarParameters01() {
-        int x = 10;
-        int y = 20;
-        int z = 0;
+        assertThrows(TornadoRuntimeException.class, () -> {
+            int x = 10;
+            int y = 20;
+            int z = 0;
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, x, y) //
-                .task("t0", ParameterTests::testWithOnlyScalarValues, x, y, z) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, z);
+            TaskGraph taskGraph = new TaskGraph("s0") //
+                    .transferToDevice(DataTransferMode.FIRST_EXECUTION, x, y) //
+                    .task("t0", ParameterTests::testWithOnlyScalarValues, x, y, z) //
+                    .transferToHost(DataTransferMode.EVERY_EXECUTION, z);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.execute();
+            ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+            TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+            executionPlan.execute();
+        });
     }
 
     /**
      * This test throws a {@link TornadoRuntimeException} because scalar values are
      * used as output parameters. This type of code is not legal in TornadoVM.
      */
-    @Test(expected = TornadoRuntimeException.class)
+    @Test
     public void testScalarParameters02() {
-        int z = 0;
+        assertThrows(TornadoRuntimeException.class, () -> {
+            int z = 0;
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .task("t0", ParameterTests::testWithOnlyScalarValues2, z) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, z);
+            TaskGraph taskGraph = new TaskGraph("s0") //
+                    .task("t0", ParameterTests::testWithOnlyScalarValues2, z) //
+                    .transferToHost(DataTransferMode.EVERY_EXECUTION, z);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.execute();
+            ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+            TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+            executionPlan.execute();
+        });
     }
 
     @Test

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/PrebuiltTest.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/PrebuiltTest.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.prebuilt;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
@@ -33,11 +33,11 @@ import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -54,7 +54,7 @@ public class PrebuiltTest extends TornadoTestBase {
     private static String FILE_PATH;
     private static TornadoVMBackendType backendType;
 
-    @BeforeClass
+    @BeforeAll
     public static void init() {
         backendType = TornadoRuntime.getTornadoRuntime().getBackendType(0);
         defaultDevice = TornadoRuntime.getTornadoRuntime().getDriver(0).getDevice(0);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
@@ -17,13 +17,13 @@
  */
 package uk.ac.manchester.tornado.unittests.profiler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/InstanceReduction.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/InstanceReduction.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.reductions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/MultipleReductions.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/MultipleReductions.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.unittests.reductions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsAutomatic.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsAutomatic.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.reductions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsDoubles.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsDoubles.java
@@ -18,12 +18,12 @@
 
 package uk.ac.manchester.tornado.unittests.reductions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsFloats.java
@@ -17,22 +17,22 @@
  */
 package uk.ac.manchester.tornado.unittests.reductions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.annotations.Reduce;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -54,6 +54,124 @@ public class TestReductionsFloats extends TornadoTestBase {
         result.set(0, 0.0f);
         for (@Parallel int i = 0; i < input.getSize(); i++) {
             result.set(0, result.get(0) + input.get(i));
+        }
+    }
+
+    private static void reductionAddFloatsConstant(FloatArray input, @Reduce FloatArray result) {
+        result.set(0, 0.0f);
+        for (@Parallel int i = 0; i < SIZE; i++) {
+            result.set(0, result.get(0) + input.get(i));
+        }
+    }
+
+    private static void reductionAddFloatsLarge(FloatArray input, @Reduce FloatArray result) {
+        result.set(0, 0.0f);
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            result.set(0, result.get(0) + input.get(i));
+        }
+    }
+
+    private static void reductionAddFloats2(FloatArray input, @Reduce FloatArray result) {
+        float error = 2f;
+        result.set(0, 0.0f);
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            float v = (error * input.get(i));
+            result.set(0, result.get(0) + v);
+        }
+    }
+
+    private static void reductionAddFloats3(FloatArray input, @Reduce FloatArray result) {
+        float error = 2f;
+        result.set(0, 0.0f);
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            float v = (error * input.get(i));
+            result.set(0, result.get(0) + v);
+        }
+    }
+
+    private static void reductionAddFloats4(FloatArray inputA, FloatArray inputB, @Reduce FloatArray result) {
+        float error = 2f;
+        result.set(0, 0.0f);
+        for (@Parallel int i = 0; i < inputA.getSize(); i++) {
+            result.set(0, result.get(0) + (error * (inputA.get(i) + inputB.get(i))));
+        }
+    }
+
+    private static void multiplyFloats(FloatArray input, @Reduce FloatArray result) {
+        result.set(0, 1.0f);
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            result.set(0, result.get(0) * input.get(i));
+        }
+    }
+
+    private static void computeSum(final FloatArray values, @Reduce FloatArray result) {
+        result.set(0, 0.0f);
+        for (@Parallel int i = 0; i < values.getSize(); i++) {
+            result.set(0, result.get(0) + values.get(i));
+        }
+    }
+
+    private static void computeAvg(final int length, FloatArray result) {
+        result.set(0, result.get(0) / length);
+    }
+
+    private static void reductionAddFloatsConditionally(FloatArray input, @Reduce FloatArray result) {
+        result.set(0, 0.0f);
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            float v = 0.0f;
+            if (input.get(0) == -1) {
+                v = 1.0f;
+            }
+            result.set(0, result.get(0) + v);
+        }
+    }
+
+    private static void computePi(FloatArray input, @Reduce FloatArray result) {
+        result.set(0, 0.0f);
+        for (@Parallel int i = 1; i < input.getSize(); i++) {
+            float value = input.get(i) + (float) (TornadoMath.pow(-1, i + 1) / (2 * i - 1));
+            result.set(0, result.get(0) + value);
+        }
+    }
+
+    private static void maxReductionAnnotation(FloatArray input, @Reduce FloatArray result) {
+        result.set(0, 0.0f);
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            result.set(0, TornadoMath.max(result.get(0), input.get(i)));
+        }
+    }
+
+    private static void maxReductionAnnotation2(FloatArray input, @Reduce FloatArray result) {
+        result.set(0, 0.0f);
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            result.set(0, TornadoMath.max(result.get(0), input.get(i) * 100));
+        }
+    }
+
+    private static void minReductionAnnotation(FloatArray input, @Reduce FloatArray result, float neutral) {
+        result.set(0, neutral);
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            result.set(0, TornadoMath.min(result.get(0), input.get(i)));
+        }
+    }
+
+    private static void minReductionAnnotation2(FloatArray input, @Reduce FloatArray result, float neutral) {
+        result.set(0, neutral);
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            result.set(0, TornadoMath.min(result.get(0), input.get(i) * 50));
+        }
+    }
+
+    public static float f(float x) {
+        return (1 / ((x + 1) * TornadoMath.sqrt(x * TornadoMath.exp(x))));
+    }
+
+    public static void integrationTornado(FloatArray input, @Reduce FloatArray sum, final float a, final float b) {
+        final int size = input.getSize();
+        sum.set(0, 0.0f);
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            float value = f(a + (((i + 1) - (1 / 2)) * ((b - a) / size)));
+            sum.set(0, sum.get(0) + (input.get(i) + value));
         }
     }
 
@@ -85,13 +203,6 @@ public class TestReductionsFloats extends TornadoTestBase {
         assertEquals(sequential.get(0), result.get(0), 0.1f);
     }
 
-    private static void reductionAddFloatsConstant(FloatArray input, @Reduce FloatArray result) {
-        result.set(0, 0.0f);
-        for (@Parallel int i = 0; i < SIZE; i++) {
-            result.set(0, result.get(0) + input.get(i));
-        }
-    }
-
     @Test
     public void testSumFloatsConstant() {
         FloatArray input = new FloatArray(SIZE);
@@ -120,13 +231,6 @@ public class TestReductionsFloats extends TornadoTestBase {
         assertEquals(sequential.get(0), result.get(0), 0.1f);
     }
 
-    private static void reductionAddFloatsLarge(FloatArray input, @Reduce FloatArray result) {
-        result.set(0, 0.0f);
-        for (@Parallel int i = 0; i < input.getSize(); i++) {
-            result.set(0, result.get(0) + input.get(i));
-        }
-    }
-
     @Test
     public void testSumFloatsLarge() {
         FloatArray input = new FloatArray(LARGE_SIZE);
@@ -153,32 +257,6 @@ public class TestReductionsFloats extends TornadoTestBase {
 
         // Check result
         assertEquals(sequential.get(0), result.get(0), 1.f);
-    }
-
-    private static void reductionAddFloats2(FloatArray input, @Reduce FloatArray result) {
-        float error = 2f;
-        result.set(0, 0.0f);
-        for (@Parallel int i = 0; i < input.getSize(); i++) {
-            float v = (error * input.get(i));
-            result.set(0, result.get(0) + v);
-        }
-    }
-
-    private static void reductionAddFloats3(FloatArray input, @Reduce FloatArray result) {
-        float error = 2f;
-        result.set(0, 0.0f);
-        for (@Parallel int i = 0; i < input.getSize(); i++) {
-            float v = (error * input.get(i));
-            result.set(0, result.get(0) + v);
-        }
-    }
-
-    private static void reductionAddFloats4(FloatArray inputA, FloatArray inputB, @Reduce FloatArray result) {
-        float error = 2f;
-        result.set(0, 0.0f);
-        for (@Parallel int i = 0; i < inputA.getSize(); i++) {
-            result.set(0, result.get(0) + (error * (inputA.get(i) + inputB.get(i))));
-        }
     }
 
     @Test
@@ -233,24 +311,6 @@ public class TestReductionsFloats extends TornadoTestBase {
 
         // Check result
         assertEquals(sequential.get(0), result.get(0), 0.1f);
-    }
-
-    private static void multiplyFloats(FloatArray input, @Reduce FloatArray result) {
-        result.set(0, 1.0f);
-        for (@Parallel int i = 0; i < input.getSize(); i++) {
-            result.set(0, result.get(0) * input.get(i));
-        }
-    }
-
-    private static void computeSum(final FloatArray values, @Reduce FloatArray result) {
-        result.set(0, 0.0f);
-        for (@Parallel int i = 0; i < values.getSize(); i++) {
-            result.set(0, result.get(0) + values.get(i));
-        }
-    }
-
-    private static void computeAvg(final int length, FloatArray result) {
-        result.set(0, result.get(0) / length);
     }
 
     @Test
@@ -312,19 +372,8 @@ public class TestReductionsFloats extends TornadoTestBase {
         assertEquals(sequential.get(0), result.get(0), 0.1f);
     }
 
-    private static void reductionAddFloatsConditionally(FloatArray input, @Reduce FloatArray result) {
-        result.set(0, 0.0f);
-        for (@Parallel int i = 0; i < input.getSize(); i++) {
-            float v = 0.0f;
-            if (input.get(0) == -1) {
-                v = 1.0f;
-            }
-            result.set(0, result.get(0) + v);
-        }
-    }
-
     // This is currently not supported
-    @Ignore
+    @Disabled
     public void testSumFloatsCondition() {
         FloatArray input = new FloatArray(SIZE2);
         FloatArray result = new FloatArray(1);
@@ -350,14 +399,6 @@ public class TestReductionsFloats extends TornadoTestBase {
         assertEquals(sequential.get(0), result.get(0), 0.01f);
     }
 
-    private static void computePi(FloatArray input, @Reduce FloatArray result) {
-        result.set(0, 0.0f);
-        for (@Parallel int i = 1; i < input.getSize(); i++) {
-            float value = input.get(i) + (float) (TornadoMath.pow(-1, i + 1) / (2 * i - 1));
-            result.set(0, result.get(0) + value);
-        }
-    }
-
     @Test
     public void testComputePi() {
         FloatArray input = new FloatArray(PI_SIZE);
@@ -381,13 +422,6 @@ public class TestReductionsFloats extends TornadoTestBase {
         final float piValue = result.get(0) * 4;
 
         assertEquals(3.14, piValue, 0.01f);
-    }
-
-    private static void maxReductionAnnotation(FloatArray input, @Reduce FloatArray result) {
-        result.set(0, 0.0f);
-        for (@Parallel int i = 0; i < input.getSize(); i++) {
-            result.set(0, TornadoMath.max(result.get(0), input.get(i)));
-        }
     }
 
     @Test
@@ -417,13 +451,6 @@ public class TestReductionsFloats extends TornadoTestBase {
         assertEquals(sequential.get(0), result.get(0), 0.01f);
     }
 
-    private static void maxReductionAnnotation2(FloatArray input, @Reduce FloatArray result) {
-        result.set(0, 0.0f);
-        for (@Parallel int i = 0; i < input.getSize(); i++) {
-            result.set(0, TornadoMath.max(result.get(0), input.get(i) * 100));
-        }
-    }
-
     @Test
     public void testMaxReduction2() {
         FloatArray input = new FloatArray(SIZE);
@@ -448,13 +475,6 @@ public class TestReductionsFloats extends TornadoTestBase {
         maxReductionAnnotation2(input, sequential);
 
         assertEquals(sequential.get(0), result.get(0), 0.01f);
-    }
-
-    private static void minReductionAnnotation(FloatArray input, @Reduce FloatArray result, float neutral) {
-        result.set(0, neutral);
-        for (@Parallel int i = 0; i < input.getSize(); i++) {
-            result.set(0, TornadoMath.min(result.get(0), input.get(i)));
-        }
     }
 
     @Test
@@ -482,13 +502,6 @@ public class TestReductionsFloats extends TornadoTestBase {
         assertEquals(sequential.get(0), result.get(0), 0.01f);
     }
 
-    private static void minReductionAnnotation2(FloatArray input, @Reduce FloatArray result, float neutral) {
-        result.set(0, neutral);
-        for (@Parallel int i = 0; i < input.getSize(); i++) {
-            result.set(0, TornadoMath.min(result.get(0), input.get(i) * 50));
-        }
-    }
-
     @Test
     public void testMinReduction2() {
         FloatArray input = new FloatArray(SIZE);
@@ -512,19 +525,6 @@ public class TestReductionsFloats extends TornadoTestBase {
         minReductionAnnotation2(input, sequential, Float.MAX_VALUE);
 
         assertEquals(sequential.get(0), result.get(0), 0.01f);
-    }
-
-    public static float f(float x) {
-        return (1 / ((x + 1) * TornadoMath.sqrt(x * TornadoMath.exp(x))));
-    }
-
-    public static void integrationTornado(FloatArray input, @Reduce FloatArray sum, final float a, final float b) {
-        final int size = input.getSize();
-        sum.set(0, 0.0f);
-        for (@Parallel int i = 0; i < input.getSize(); i++) {
-            float value = f(a + (((i + 1) - (1 / 2)) * ((b - a) / size)));
-            sum.set(0, sum.get(0) + (input.get(i) + value));
-        }
     }
 
     @Test

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsIntegers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsIntegers.java
@@ -17,22 +17,22 @@
  */
 package uk.ac.manchester.tornado.unittests.reductions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.annotations.Reduce;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -511,7 +511,7 @@ public class TestReductionsIntegers extends TornadoTestBase {
      * Currently we cannot do this due to synchronisation between the first part and
      * the second part, unless an explicit barrier is used.
      */
-    @Ignore
+    @Disabled
     public void testMapReduceSameKernel() {
         IntArray a = new IntArray(BIG_SIZE);
         IntArray b = new IntArray(BIG_SIZE);
@@ -540,7 +540,7 @@ public class TestReductionsIntegers extends TornadoTestBase {
         assertEquals(sequential.get(0), result.get(0));
     }
 
-    @Ignore
+    @Disabled
     public void testMapReduce2() {
         IntArray a = new IntArray(BIG_SIZE);
         IntArray b = new IntArray(BIG_SIZE);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsLong.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/reductions/TestReductionsLong.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.reductions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/slam/GraphicsTests.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/slam/GraphicsTests.java
@@ -18,7 +18,7 @@
 
 package uk.ac.manchester.tornado.unittests.slam;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.ac.manchester.tornado.api.math.TornadoMath.min;
 import static uk.ac.manchester.tornado.api.math.TornadoMath.sqrt;
 import static uk.ac.manchester.tornado.api.types.vectors.Float2.mult;
@@ -30,9 +30,8 @@ import static uk.ac.manchester.tornado.unittests.slam.utils.GraphicsMath.rigidTr
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -499,7 +498,7 @@ public class GraphicsTests extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < scaledSize * scaledSize; i++) {
-            assertEquals("index = " + i, destSeq.get(i), dest.get(i), 0.001);
+            assertEquals(destSeq.get(i), dest.get(i), 0.001);
         }
     }
 
@@ -539,7 +538,7 @@ public class GraphicsTests extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < scaledSize * scaledSize; i++) {
-            assertEquals("index = " + i, destSeq.get(i), dest.get(i), 0.001);
+            assertEquals(destSeq.get(i), dest.get(i), 0.001);
         }
     }
 
@@ -797,9 +796,9 @@ public class GraphicsTests extends TornadoTestBase {
 
         Float3 o = vertices.get(0);
         Float3 s = verticesSeq.get(0);
-        Assert.assertEquals(s.getS0(), o.getS0(), 0.01);
-        Assert.assertEquals(s.getS1(), o.getS1(), 0.01);
-        Assert.assertEquals(s.getS2(), o.getS2(), 0.01);
+        assertEquals(s.getS0(), o.getS0(), 0.01);
+        assertEquals(s.getS1(), o.getS1(), 0.01);
+        assertEquals(s.getS2(), o.getS2(), 0.01);
 
     }
 
@@ -840,9 +839,9 @@ public class GraphicsTests extends TornadoTestBase {
 
         Float3 o = vertices.get(0);
         Float3 s = verticesSeq.get(0);
-        Assert.assertEquals(s.getS0(), o.getS0(), 0.01);
-        Assert.assertEquals(s.getS1(), o.getS1(), 0.01);
-        Assert.assertEquals(s.getS2(), o.getS2(), 0.01);
+        assertEquals(s.getS0(), o.getS0(), 0.01);
+        assertEquals(s.getS1(), o.getS1(), 0.01);
+        assertEquals(s.getS2(), o.getS2(), 0.01);
 
     }
 
@@ -1194,9 +1193,9 @@ public class GraphicsTests extends TornadoTestBase {
         for (int i = 0; i < output.getLength(); i++) {
             Float3 o = output.get(i);
             Float3 s = outputSeq.get(i);
-            Assert.assertEquals("difference on index " + i + " s0", s.getS0(), o.getS0(), 0.01f);
-            Assert.assertEquals("difference on index " + i + " s1", s.getS1(), o.getS1(), 0.01f);
-            Assert.assertEquals("difference on index " + i + " s2", s.getS2(), o.getS2(), 0.01f);
+            assertEquals(s.getS0(), o.getS0(), 0.01f);
+            assertEquals(s.getS1(), o.getS1(), 0.01f);
+            assertEquals(s.getS2(), o.getS2(), 0.01f);
         }
 
     }
@@ -1220,7 +1219,7 @@ public class GraphicsTests extends TornadoTestBase {
 
         for (int i = 0; i < m.getNumRows(); i++) {
             for (int j = 0; j < m.getNumColumns(); j++) {
-                Assert.assertEquals(seq.get(i, j), m.get(i, j), 0.01f);
+                assertEquals(seq.get(i, j), m.get(i, j), 0.01f);
             }
         }
 
@@ -1284,10 +1283,10 @@ public class GraphicsTests extends TornadoTestBase {
             for (int j = 0; j < output.Y(); j++) {
                 Byte4 o = output.get(i, j);
                 Byte4 s = outputSeq.get(i, j);
-                Assert.assertEquals("index = " + i + ", " + j, s.getX(), o.getX());
-                Assert.assertEquals("index = " + i + ", " + j, s.getY(), o.getY());
-                Assert.assertEquals("index = " + i + ", " + j, s.getZ(), o.getZ());
-                Assert.assertEquals("index = " + i + ", " + j, s.getW(), o.getW());
+                assertEquals(s.getX(), o.getX());
+                assertEquals(s.getY(), o.getY());
+                assertEquals(s.getZ(), o.getZ());
+                assertEquals(s.getW(), o.getW());
             }
         }
     }
@@ -1332,7 +1331,7 @@ public class GraphicsTests extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < output.getSize(); i++) {
-            Assert.assertEquals(outputSeq.get(i), output.get(i), 0.1f);
+            assertEquals(outputSeq.get(i), output.get(i), 0.1f);
         }
     }
 
@@ -1362,12 +1361,12 @@ public class GraphicsTests extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < output.getSize(); i++) {
-            Assert.assertEquals(outputSeq.get(i), output.get(i), 0.1f);
+            assertEquals(outputSeq.get(i), output.get(i), 0.1f);
         }
 
     }
 
-    @Ignore
+    @Disabled
     public void testMapReduceSlam3() {
 
         final int size = 16;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestMultipleFunctions.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestMultipleFunctions.java
@@ -17,22 +17,21 @@
  */
 package uk.ac.manchester.tornado.unittests.tasks;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.vectors.Float4;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -366,16 +365,16 @@ public class TestMultipleFunctions extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < testArrays.calleeReadTor.getSize(); i++) {
-            Assert.assertEquals(testArrays.calleeReadSeq.get(i), testArrays.calleeReadTor.get(i));
+            assertEquals(testArrays.calleeReadSeq.get(i), testArrays.calleeReadTor.get(i));
         }
         for (int i = 0; i < testArrays.callerReadCalleeWriteSeq.getSize(); i++) {
-            Assert.assertEquals(testArrays.callerReadCalleeWriteSeq.get(i), testArrays.callerReadCalleeWriteTor.get(i));
+            assertEquals(testArrays.callerReadCalleeWriteSeq.get(i), testArrays.callerReadCalleeWriteTor.get(i));
         }
         for (int i = 0; i < testArrays.callerReadSeq.getSize(); i++) {
-            Assert.assertEquals(testArrays.callerReadSeq.get(i), testArrays.callerReadTor.get(i));
+            assertEquals(testArrays.callerReadSeq.get(i), testArrays.callerReadTor.get(i));
         }
         for (int i = 0; i < testArrays.callerWriteSeq.getSize(); i++) {
-            Assert.assertEquals(testArrays.callerWriteSeq.get(i), testArrays.callerWriteSeq.get(i));
+            assertEquals(testArrays.callerWriteSeq.get(i), testArrays.callerWriteSeq.get(i));
         }
     }
 
@@ -409,16 +408,16 @@ public class TestMultipleFunctions extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < testArrays.calleeReadTor.getSize(); i++) {
-            Assert.assertEquals(testArrays.calleeReadSeq.get(i), testArrays.calleeReadTor.get(i));
+            assertEquals(testArrays.calleeReadSeq.get(i), testArrays.calleeReadTor.get(i));
         }
         for (int i = 0; i < testArrays.callerReadCalleeWriteSeq.getSize(); i++) {
-            Assert.assertEquals(testArrays.callerReadCalleeWriteSeq.get(i), testArrays.callerReadCalleeWriteTor.get(i));
+            assertEquals(testArrays.callerReadCalleeWriteSeq.get(i), testArrays.callerReadCalleeWriteTor.get(i));
         }
         for (int i = 0; i < testArrays.callerReadSeq.getSize(); i++) {
-            Assert.assertEquals(testArrays.callerReadSeq.get(i), testArrays.callerReadTor.get(i));
+            assertEquals(testArrays.callerReadSeq.get(i), testArrays.callerReadTor.get(i));
         }
         for (int i = 0; i < testArrays.callerWriteSeq.getSize(); i++) {
-            Assert.assertEquals(testArrays.callerWriteSeq.get(i), testArrays.callerWriteSeq.get(i));
+            assertEquals(testArrays.callerWriteSeq.get(i), testArrays.callerWriteSeq.get(i));
         }
     }
 
@@ -465,25 +464,25 @@ public class TestMultipleFunctions extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < arrays.calleeReadTor.getSize(); i++) {
-            Assert.assertEquals(arrays.calleeReadSeq.get(i), arrays.calleeReadTor.get(i));
+            assertEquals(arrays.calleeReadSeq.get(i), arrays.calleeReadTor.get(i));
         }
         for (int i = 0; i < arrays.callerReadCalleeWriteSeq.getSize(); i++) {
-            Assert.assertEquals(arrays.callerReadCalleeWriteSeq.get(i), arrays.callerReadCalleeWriteTor.get(i));
+            assertEquals(arrays.callerReadCalleeWriteSeq.get(i), arrays.callerReadCalleeWriteTor.get(i));
         }
         for (int i = 0; i < arrays.callerReadSeq.getSize(); i++) {
-            Assert.assertEquals(arrays.callerReadSeq.get(i), arrays.callerReadTor.get(i));
+            assertEquals(arrays.callerReadSeq.get(i), arrays.callerReadTor.get(i));
         }
         for (int i = 0; i < arrays.callerWriteSeq.getSize(); i++) {
-            Assert.assertEquals(arrays.callerWriteSeq.get(i), arrays.callerWriteSeq.get(i));
+            assertEquals(arrays.callerWriteSeq.get(i), arrays.callerWriteSeq.get(i));
         }
         for (int i = 0; i < arrays.callerReadWriteSeq.getSize(); i++) {
-            Assert.assertEquals(arrays.callerReadWriteSeq.get(i), arrays.callerReadWriteTor.get(i));
+            assertEquals(arrays.callerReadWriteSeq.get(i), arrays.callerReadWriteTor.get(i));
         }
         for (int i = 0; i < arrays.callee1WriteSeq.getSize(); i++) {
-            Assert.assertEquals(arrays.callee1WriteSeq.get(i), arrays.callee1WriteTor.get(i));
+            assertEquals(arrays.callee1WriteSeq.get(i), arrays.callee1WriteTor.get(i));
         }
         for (int i = 0; i < arrays.callee2ReadSeq.getSize(); i++) {
-            Assert.assertEquals(arrays.callee2ReadSeq.get(i), arrays.callee2ReadTor.get(i));
+            assertEquals(arrays.callee2ReadSeq.get(i), arrays.callee2ReadTor.get(i));
         }
     }
 
@@ -509,7 +508,7 @@ public class TestMultipleFunctions extends TornadoTestBase {
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
         executionPlan.execute();
 
-        Assert.assertEquals(-1, arr.get(0));
+        assertEquals(-1, arr.get(0));
     }
 
     //@formatter:off

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestMultipleTasksMultipleDevices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestMultipleTasksMultipleDevices.java
@@ -18,20 +18,20 @@
 
 package uk.ac.manchester.tornado.unittests.tasks;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 import uk.ac.manchester.tornado.unittests.common.TornadoVMMultiDeviceNotSupported;
 
@@ -83,7 +83,7 @@ public class TestMultipleTasksMultipleDevices extends TornadoTestBase {
         }
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass() {
         assertAvailableDevices();
         setDefaultDevices();

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestMultipleTasksSingleDevice.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestMultipleTasksSingleDevice.java
@@ -18,9 +18,9 @@
 
 package uk.ac.manchester.tornado.unittests.tasks;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestSingleTaskSingleDevice.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestSingleTaskSingleDevice.java
@@ -18,11 +18,11 @@
 
 package uk.ac.manchester.tornado.unittests.tasks;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/temporary/values/TestTemporaryValues.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/temporary/values/TestTemporaryValues.java
@@ -18,12 +18,12 @@
 
 package uk.ac.manchester.tornado.unittests.temporary.values;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tools/TornadoHelper.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tools/TornadoHelper.java
@@ -18,7 +18,6 @@
 
 package uk.ac.manchester.tornado.unittests.tools;
 
-import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 
 import java.io.BufferedWriter;
@@ -29,6 +28,7 @@ import java.lang.reflect.Method;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 
@@ -55,9 +55,7 @@ public class TornadoHelper {
 
     public static final boolean OPTIMIZE_LOAD_STORE_SPIRV = Boolean.parseBoolean(System.getProperty("tornado.spirv.loadstore", "False"));
 
-    //    private static void printResult(Result result) {
-    //        System.out.printf("Test ran: %s, Failed: %s%n", result.getRunCount(), result.getFailureCount());
-    //    }
+    public static final String SEPERATOR = " ................ ";
 
     private static void printResult(SummaryGeneratingListener result) {
         System.out.printf("Test ran: %s, Failed: %s%n", result.getSummary().getTestsStartedCount(), result.getSummary().getTestsFailedCount());
@@ -152,18 +150,14 @@ public class TornadoHelper {
             bufferFile.append(message);
 
             if (suite != null && suite.unsupportedMethods.contains(m)) {
-                message = String.format("%20s", " ................ " + ColorsTerminal.YELLOW + " [NOT VALID TEST: UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
+                message = String.format("%20s", SEPERATOR + ColorsTerminal.YELLOW + " [NOT VALID TEST: UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
                 bufferConsole.append(message);
                 bufferFile.append(message);
                 notSupported++;
                 continue;
             }
-            LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().selectors(selectClass(klass)).build();
 
-            //            Request request = Request.method(klass, m.getName());
-            //            Result result = new JUnitCore().run(request);
-
-            // Create a Launcher and register a listener if needed (e.g., to generate a summary)
+            LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().selectors(selectMethod(klass, m)).build();
             Launcher launcher = LauncherFactory.create();
             SummaryGeneratingListener listener = new SummaryGeneratingListener();
             launcher.registerTestExecutionListeners(listener);
@@ -172,15 +166,14 @@ public class TornadoHelper {
             launcher.execute(request);
 
             if (listener.getSummary().getTestsFailedCount() == 0) {
-                message = String.format("%20s", " ................ " + ColorsTerminal.GREEN + " [PASS] " + ColorsTerminal.RESET + "\n");
+                message = String.format("%20s", SEPERATOR + ColorsTerminal.GREEN + " [PASS] " + ColorsTerminal.RESET + "\n");
                 bufferConsole.append(message);
                 bufferFile.append(message);
                 successCounter++;
             } else {
-                // If UnsupportedConfigurationException is thrown this means that test did not
-                // fail, it simply can't be run on current configuration
+                // If UnsupportedConfigurationException is thrown this means that test did not fail, it simply can't be run on current configuration
                 if (listener.getSummary().getFailures().stream().filter(e -> (e.getException() instanceof UnsupportedConfigurationException)).count() > 0) {
-                    message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [UNSUPPORTED CONFIGURATION: At least 2 accelerators are required] " + ColorsTerminal.RESET + "\n");
+                    message = String.format("%20s", SEPERATOR + ColorsTerminal.PURPLE + " [UNSUPPORTED CONFIGURATION: At least 2 accelerators are required] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
                     notSupported++;
@@ -188,7 +181,7 @@ public class TornadoHelper {
                 }
 
                 if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMPTXNotSupported))) {
-                    message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [PTX CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
+                    message = String.format("%20s", SEPERATOR + ColorsTerminal.PURPLE + " [PTX CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
                     notSupported++;
@@ -196,7 +189,7 @@ public class TornadoHelper {
                 }
 
                 if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoNoOpenCLPlatformException))) {
-                    message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [OPENCL CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
+                    message = String.format("%20s", SEPERATOR + ColorsTerminal.PURPLE + " [OPENCL CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
                     notSupported++;
@@ -204,7 +197,7 @@ public class TornadoHelper {
                 }
 
                 if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMMultiDeviceNotSupported))) {
-                    message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [[UNSUPPORTED] MULTI-DEVICE CONFIGURATION REQUIRED] " + ColorsTerminal.RESET + "\n");
+                    message = String.format("%20s", SEPERATOR + ColorsTerminal.PURPLE + " [[UNSUPPORTED] MULTI-DEVICE CONFIGURATION REQUIRED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
                     notSupported++;
@@ -212,7 +205,7 @@ public class TornadoHelper {
                 }
 
                 if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMOpenCLNotSupported))) {
-                    message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [OPENCL CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
+                    message = String.format("%20s", SEPERATOR + ColorsTerminal.PURPLE + " [OPENCL CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
                     notSupported++;
@@ -220,7 +213,7 @@ public class TornadoHelper {
                 }
 
                 if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMSPIRVNotSupported))) {
-                    message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [SPIRV CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
+                    message = String.format("%20s", SEPERATOR + ColorsTerminal.PURPLE + " [SPIRV CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
                     notSupported++;
@@ -228,7 +221,7 @@ public class TornadoHelper {
                 }
 
                 if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof SPIRVOptNotSupported)) && OPTIMIZE_LOAD_STORE_SPIRV) {
-                    message = String.format("%20s", " ................ " + ColorsTerminal.RED + " [SPIRV OPTIMIZATION NOT SUPPORTED] " + ColorsTerminal.RESET + "\n");
+                    message = String.format("%20s", SEPERATOR + ColorsTerminal.RED + " [SPIRV OPTIMIZATION NOT SUPPORTED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
                     failedCounter++;
@@ -236,20 +229,21 @@ public class TornadoHelper {
                 }
 
                 if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoDeviceFP64NotSupported))) {
-                    message = String.format("%20s", " ................ " + ColorsTerminal.YELLOW + " [FP64 UNSUPPORTED FOR CURRENT DEVICE] " + ColorsTerminal.RESET + "\n");
+                    message = String.format("%20s", SEPERATOR + ColorsTerminal.YELLOW + " [FP64 UNSUPPORTED FOR CURRENT DEVICE] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
                     notSupported++;
                     continue;
                 }
 
-                message = String.format("%20s", " ................ " + ColorsTerminal.RED + " [FAILED] " + ColorsTerminal.RESET + "\n");
+                message = String.format("%20s", SEPERATOR + ColorsTerminal.RED + " [FAILED] " + ColorsTerminal.RESET + "\n");
                 bufferConsole.append(message);
                 bufferFile.append(message);
                 failedCounter++;
                 for (TestExecutionSummary.Failure failure : listener.getSummary().getFailures()) {
-                    bufferConsole.append("\t\t\\_[REASON] " + failure.toString() + "\n");
-                    bufferFile.append("\t\t\\_[REASON] " + failure.toString() + "\n\t" + failure.getException().getStackTrace().toString() + "\n" + failure.toString() + "\n" + failure.getException());
+                    bufferConsole.append("\t\t\\_[REASON] " + failure.getException().getMessage() + "\n");
+                    bufferFile.append("\t\t\\_[REASON] " + failure.getException().getMessage() + "\n\t" + Arrays.toString(failure.getException().getStackTrace()) + "\n" + failure
+                            .getException() + "\n");
                 }
             }
         }
@@ -269,7 +263,7 @@ public class TornadoHelper {
         }
     }
 
-    static void runTestClassAndMethod(String klassName, String methodName) throws ClassNotFoundException {
+    static void runTestClassAndMethod(String klassName, String methodName) {
         LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().selectors(selectMethod(klassName, methodName)).build();
         Launcher launcher = LauncherFactory.create();
         SummaryGeneratingListener listener = new SummaryGeneratingListener();
@@ -278,7 +272,7 @@ public class TornadoHelper {
         printResult(listener);
     }
 
-    static void runTestClass(String klassName) throws ClassNotFoundException {
+    static void runTestClass(String klassName) {
         LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().selectors(selectMethod(klassName)).build();
         Launcher launcher = LauncherFactory.create();
         SummaryGeneratingListener listener = new SummaryGeneratingListener();

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tools/TornadoHelper.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tools/TornadoHelper.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,6 +17,9 @@
  */
 
 package uk.ac.manchester.tornado.unittests.tools;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
@@ -29,10 +32,14 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 
-import org.junit.runner.JUnitCore;
-import org.junit.runner.Request;
-import org.junit.runner.Result;
-import org.junit.runner.notification.Failure;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
 
 import uk.ac.manchester.tornado.api.exceptions.TornadoDeviceFP64NotSupported;
 import uk.ac.manchester.tornado.api.exceptions.TornadoNoOpenCLPlatformException;
@@ -48,8 +55,12 @@ public class TornadoHelper {
 
     public static final boolean OPTIMIZE_LOAD_STORE_SPIRV = Boolean.parseBoolean(System.getProperty("tornado.spirv.loadstore", "False"));
 
-    private static void printResult(Result result) {
-        System.out.printf("Test ran: %s, Failed: %s%n", result.getRunCount(), result.getFailureCount());
+    //    private static void printResult(Result result) {
+    //        System.out.printf("Test ran: %s, Failed: %s%n", result.getRunCount(), result.getFailureCount());
+    //    }
+
+    private static void printResult(SummaryGeneratingListener result) {
+        System.out.printf("Test ran: %s, Failed: %s%n", result.getSummary().getTestsStartedCount(), result.getSummary().getTestsFailedCount());
     }
 
     private static void printResult(int success, int failed, int notSupported) {
@@ -90,9 +101,9 @@ public class TornadoHelper {
             boolean testEnabled = false;
             boolean ignoreTest = false;
             for (Annotation a : annotations) {
-                if (a instanceof org.junit.Ignore) {
+                if (a instanceof Disabled) {
                     ignoreTest = true;
-                } else if (a instanceof org.junit.Test) {
+                } else if (a instanceof Test) {
                     testEnabled = true;
                 } else if (a instanceof TornadoNotSupported) {
                     testEnabled = true;
@@ -147,11 +158,20 @@ public class TornadoHelper {
                 notSupported++;
                 continue;
             }
+            LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().selectors(selectClass(klass)).build();
 
-            Request request = Request.method(klass, m.getName());
-            Result result = new JUnitCore().run(request);
+            //            Request request = Request.method(klass, m.getName());
+            //            Result result = new JUnitCore().run(request);
 
-            if (result.wasSuccessful()) {
+            // Create a Launcher and register a listener if needed (e.g., to generate a summary)
+            Launcher launcher = LauncherFactory.create();
+            SummaryGeneratingListener listener = new SummaryGeneratingListener();
+            launcher.registerTestExecutionListeners(listener);
+
+            // Execute the request
+            launcher.execute(request);
+
+            if (listener.getSummary().getTestsFailedCount() == 0) {
                 message = String.format("%20s", " ................ " + ColorsTerminal.GREEN + " [PASS] " + ColorsTerminal.RESET + "\n");
                 bufferConsole.append(message);
                 bufferFile.append(message);
@@ -159,7 +179,7 @@ public class TornadoHelper {
             } else {
                 // If UnsupportedConfigurationException is thrown this means that test did not
                 // fail, it simply can't be run on current configuration
-                if (result.getFailures().stream().filter(e -> (e.getException() instanceof UnsupportedConfigurationException)).count() > 0) {
+                if (listener.getSummary().getFailures().stream().filter(e -> (e.getException() instanceof UnsupportedConfigurationException)).count() > 0) {
                     message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [UNSUPPORTED CONFIGURATION: At least 2 accelerators are required] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
@@ -167,7 +187,7 @@ public class TornadoHelper {
                     continue;
                 }
 
-                if (result.getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMPTXNotSupported))) {
+                if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMPTXNotSupported))) {
                     message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [PTX CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
@@ -175,7 +195,7 @@ public class TornadoHelper {
                     continue;
                 }
 
-                if (result.getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoNoOpenCLPlatformException))) {
+                if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoNoOpenCLPlatformException))) {
                     message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [OPENCL CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
@@ -183,7 +203,7 @@ public class TornadoHelper {
                     continue;
                 }
 
-                if (result.getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMMultiDeviceNotSupported))) {
+                if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMMultiDeviceNotSupported))) {
                     message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [[UNSUPPORTED] MULTI-DEVICE CONFIGURATION REQUIRED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
@@ -191,7 +211,7 @@ public class TornadoHelper {
                     continue;
                 }
 
-                if (result.getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMOpenCLNotSupported))) {
+                if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMOpenCLNotSupported))) {
                     message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [OPENCL CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
@@ -199,7 +219,7 @@ public class TornadoHelper {
                     continue;
                 }
 
-                if (result.getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMSPIRVNotSupported))) {
+                if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoVMSPIRVNotSupported))) {
                     message = String.format("%20s", " ................ " + ColorsTerminal.PURPLE + " [SPIRV CONFIGURATION UNSUPPORTED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
@@ -207,7 +227,7 @@ public class TornadoHelper {
                     continue;
                 }
 
-                if (result.getFailures().stream().anyMatch(e -> (e.getException() instanceof SPIRVOptNotSupported)) && OPTIMIZE_LOAD_STORE_SPIRV) {
+                if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof SPIRVOptNotSupported)) && OPTIMIZE_LOAD_STORE_SPIRV) {
                     message = String.format("%20s", " ................ " + ColorsTerminal.RED + " [SPIRV OPTIMIZATION NOT SUPPORTED] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
@@ -215,7 +235,7 @@ public class TornadoHelper {
                     continue;
                 }
 
-                if (result.getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoDeviceFP64NotSupported))) {
+                if (listener.getSummary().getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoDeviceFP64NotSupported))) {
                     message = String.format("%20s", " ................ " + ColorsTerminal.YELLOW + " [FP64 UNSUPPORTED FOR CURRENT DEVICE] " + ColorsTerminal.RESET + "\n");
                     bufferConsole.append(message);
                     bufferFile.append(message);
@@ -227,9 +247,9 @@ public class TornadoHelper {
                 bufferConsole.append(message);
                 bufferFile.append(message);
                 failedCounter++;
-                for (Failure failure : result.getFailures()) {
-                    bufferConsole.append("\t\t\\_[REASON] " + failure.getMessage() + "\n");
-                    bufferFile.append("\t\t\\_[REASON] " + failure.getMessage() + "\n\t" + failure.getTrace() + "\n" + failure.getDescription() + "\n" + failure.getException());
+                for (TestExecutionSummary.Failure failure : listener.getSummary().getFailures()) {
+                    bufferConsole.append("\t\t\\_[REASON] " + failure.toString() + "\n");
+                    bufferFile.append("\t\t\\_[REASON] " + failure.toString() + "\n\t" + failure.getException().getStackTrace().toString() + "\n" + failure.toString() + "\n" + failure.getException());
                 }
             }
         }
@@ -250,15 +270,21 @@ public class TornadoHelper {
     }
 
     static void runTestClassAndMethod(String klassName, String methodName) throws ClassNotFoundException {
-        Request request = Request.method(Class.forName(klassName), methodName);
-        Result result = new JUnitCore().run(request);
-        printResult(result);
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().selectors(selectMethod(klassName, methodName)).build();
+        Launcher launcher = LauncherFactory.create();
+        SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        launcher.registerTestExecutionListeners(listener);
+        launcher.execute(request);
+        printResult(listener);
     }
 
     static void runTestClass(String klassName) throws ClassNotFoundException {
-        Request request = Request.aClass(Class.forName(klassName));
-        Result result = new JUnitCore().run(request);
-        printResult(result);
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request().selectors(selectMethod(klassName)).build();
+        Launcher launcher = LauncherFactory.create();
+        SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        launcher.registerTestExecutionListeners(listener);
+        launcher.execute(request);
+        printResult(listener);
     }
 
     static class TestSuiteCollection {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestDoubles.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestDoubles.java
@@ -18,11 +18,11 @@
 
 package uk.ac.manchester.tornado.unittests.vectortypes;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
@@ -18,11 +18,13 @@
 
 package uk.ac.manchester.tornado.unittests.vectortypes;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -976,7 +978,8 @@ public class TestFloats extends TornadoTestBase {
         }
     }
 
-    @Test(timeout = 1000) //timeout of 1sec
+    @Test
+    @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
     public void testAllocationIssue() {
         int size = 8192 * 4096;
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestInts.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestInts.java
@@ -18,11 +18,11 @@
 
 package uk.ac.manchester.tornado.unittests.vectortypes;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestVectorAllocation.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestVectorAllocation.java
@@ -18,9 +18,9 @@
 
 package uk.ac.manchester.tornado.unittests.vectortypes;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceFeatureExtraction.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceFeatureExtraction.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,17 @@
  */
 package uk.ac.manchester.tornado.unittests.virtual;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -41,8 +43,8 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to run?
  * </p>
  * <code>
- *     tornado-test -V --jvm="-Dtornado.device.desc=virtual-device-CPU.json -Dtornado.print.kernel=True -Dtornado.virtual.device=True
- *     -Dtornado.print.kernel.dir=virtualKernelOut.out" uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceFeatureExtraction
+ * tornado-test -V --jvm="-Dtornado.device.desc=virtual-device-CPU.json -Dtornado.print.kernel=True -Dtornado.virtual.device=True
+ * -Dtornado.print.kernel.dir=virtualKernelOut.out" uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceFeatureExtraction
  * </code>
  */
 public class TestVirtualDeviceFeatureExtraction extends TornadoTestBase {
@@ -77,7 +79,7 @@ public class TestVirtualDeviceFeatureExtraction extends TornadoTestBase {
         return sourceSum == expectedSum;
     }
 
-    @After
+    @AfterEach
     public void after() {
         // make sure the source file generated is deleted
         File fileLog = new File(FEATURE_DUMP_DIR);
@@ -116,11 +118,11 @@ public class TestVirtualDeviceFeatureExtraction extends TornadoTestBase {
             expectedBytes = Files.readAllBytes(expectedKernelFile.toPath());
         } catch (IOException e) {
             e.printStackTrace();
-            Assert.fail();
+            fail();
         }
 
         boolean fileEquivalent = performComparison(inputBytes, expectedBytes);
-        Assert.assertTrue(fileEquivalent);
+        assertTrue(fileEquivalent);
     }
 
     @Test

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceKernel.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceKernel.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,17 @@
  */
 package uk.ac.manchester.tornado.unittests.virtual;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -41,8 +43,8 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * How to run?
  * </p>
  * <code>
- *     tornado-test -V --jvm="-Dtornado.device.desc=virtual-device-GPU.json -Dtornado.print.kernel=True -Dtornado.virtual.device=True
- *     -Dtornado.print.kernel.dir=virtualKernelOut.out" uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceKernel
+ * tornado-test -V --jvm="-Dtornado.device.desc=virtual-device-GPU.json -Dtornado.print.kernel=True -Dtornado.virtual.device=True
+ * -Dtornado.print.kernel.dir=virtualKernelOut.out" uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceKernel
  * </code>
  */
 public class TestVirtualDeviceKernel extends TornadoTestBase {
@@ -56,7 +58,7 @@ public class TestVirtualDeviceKernel extends TornadoTestBase {
         }
     }
 
-    @After
+    @AfterEach
     public void after() {
         // make sure the source file generated is deleted
         File fileLog = new File(SOURCE_DIR);
@@ -93,11 +95,11 @@ public class TestVirtualDeviceKernel extends TornadoTestBase {
             expectedKernel = Files.readAllBytes(expectedKernelFile.toPath());
         } catch (IOException e) {
             e.printStackTrace();
-            Assert.fail();
+            fail();
         }
 
         boolean fileEquivalent = TestVirtualDeviceFeatureExtraction.performComparison(generatedKernel, expectedKernel);
-        Assert.assertTrue("There is a mismatch between pre-compiled and JIT compiled kernels.", fileEquivalent);
+        assertTrue(fileEquivalent, "There is a mismatch between pre-compiled and JIT compiled kernels.");
     }
 
     @Test

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtualization/TestsVirtualLayer.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtualization/TestsVirtualLayer.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,26 +18,27 @@
 
 package uk.ac.manchester.tornado.unittests.virtualization;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoDriver;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 import uk.ac.manchester.tornado.unittests.common.TornadoVMMultiDeviceNotSupported;
-
-import java.util.stream.IntStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * <p>
@@ -77,7 +78,7 @@ public class TestsVirtualLayer extends TornadoTestBase {
     /**
      * Check if enough devices are available
      */
-    @Before
+    @BeforeEach
     public void enoughDevices() {
         super.before();
         TornadoDriver driver = getTornadoRuntime().getDriver(0);
@@ -188,7 +189,7 @@ public class TestsVirtualLayer extends TornadoTestBase {
         }
     }
 
-    @Ignore
+    @Disabled
     public void testVirtualLayer01() {
 
         TornadoDriver driver = getTornadoRuntime().getDriver(0);
@@ -229,7 +230,7 @@ public class TestsVirtualLayer extends TornadoTestBase {
      * This test is not legal in Tornado. This test executes everything on the same device, even if the user forces to change. A task schedule is always executed on the same device. Device can change
      * once the task is executed.
      */
-    @Ignore
+    @Disabled
     public void testVirtualLayer02() {
 
         TornadoDriver driver = getTornadoRuntime().getDriver(0);
@@ -359,7 +360,7 @@ public class TestsVirtualLayer extends TornadoTestBase {
         dataB.init(100);
 
         if (tornadoDriver.getDeviceCount() < 2) {
-            assertFalse("The current driver has less than 2 devices", true);
+            assertFalse(true, "The current driver has less than 2 devices");
         }
 
         TornadoRuntime.setProperty("s0.t0.device", "0:0");

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vm/concurrency/TestConcurrentBackends.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vm/concurrency/TestConcurrentBackends.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.vm.concurrency;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.IntStream;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -62,7 +62,7 @@ public class TestConcurrentBackends extends TornadoTestBase {
     private static IntArray d;
     private static IntArray e;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         setDefaultDevices();
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vm/concurrency/TestParallelTaskGraph.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vm/concurrency/TestParallelTaskGraph.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.unittests.vm.concurrency;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;


### PR DESCRIPTION
#### Description

Describe the patch. What does it enhance? What does it fix?

This PR implements the migration unit testing framework from JUnit 4 (JUnit 4.13.2 last updated Feb 13, 2021) to JUnit 5. This migration includes updating dependencies, annotations, assertions, and test instance lifecycle management.

Key changes:
* Updated Dependencies: Updated the Maven dependencies to include JUnit 5 libraries (junit-jupiter-api, junit-jupiter-engine).
* Annotations Updates: Migrated JUnit 4 annotations to their JUnit 5 counterparts (e.g., @Before to @BeforeEach, @After to @AfterEach, @BeforeClass to @BeforeAll, @AfterClass to @AfterAll).
* Assertions Updates: Transitioned to JUnit 5's assertion API which offers better assertion capabilities and error messages (org.junit.jupiter.api.Assertions).

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows


#### How to test the new patch?

```bash
make 
make tests
```
----------------------------------------------------------------------------
