### PR TITLE
DFT benchmark in FP32

### DIFF
--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/ComputeKernels.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/ComputeKernels.java
@@ -19,7 +19,11 @@ package uk.ac.manchester.tornado.benchmarks;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.arrays.*;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.arrays.LongArray;
+import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.types.images.ImageByte3;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat3;
 import uk.ac.manchester.tornado.api.types.vectors.Byte3;

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/ComputeKernels.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/ComputeKernels.java
@@ -19,11 +19,7 @@ package uk.ac.manchester.tornado.benchmarks;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
-import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.arrays.LongArray;
-import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
+import uk.ac.manchester.tornado.api.types.arrays.*;
 import uk.ac.manchester.tornado.api.types.images.ImageByte3;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat3;
 import uk.ac.manchester.tornado.api.types.vectors.Byte3;
@@ -182,12 +178,27 @@ public class ComputeKernels {
     public static void computeDFT(DoubleArray inreal, DoubleArray inimag, DoubleArray outreal, DoubleArray outimag) {
         int n = inreal.getSize();
         for (@Parallel int k = 0; k < n; k++) { // For each output element
-            double sumReal = 0;
-            double simImag = 0;
+            float sumReal = 0;
+            float simImag = 0;
             for (int t = 0; t < n; t++) { // For each input element
                 double angle = (2 * Math.PI * t * k) / n;
                 sumReal += inreal.get(t) * Math.cos(angle) + inimag.get(t) * Math.sin(angle);
                 simImag += -inreal.get(t) * Math.sin(angle) + inimag.get(t) * Math.cos(angle);
+            }
+            outreal.set(k, sumReal);
+            outimag.set(k, simImag);
+        }
+    }
+
+    public static void computeDFT(FloatArray inreal, FloatArray inimag, FloatArray outreal, FloatArray outimag) {
+        int n = inreal.getSize();
+        for (@Parallel int k = 0; k < n; k++) { // For each output element
+            float sumReal = 0;
+            float simImag = 0;
+            for (int t = 0; t < n; t++) { // For each input element
+                float angle = (2 * TornadoMath.floatPI() * t * k) / n;
+                sumReal += inreal.get(t) * TornadoMath.cos(angle) + inimag.get(t) * TornadoMath.sin(angle);
+                simImag += -inreal.get(t) * TornadoMath.sin(angle) + inimag.get(t) * TornadoMath.cos(angle);
             }
             outreal.set(k, sumReal);
             outimag.set(k, simImag);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTTornado.java
@@ -23,7 +23,7 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 import uk.ac.manchester.tornado.benchmarks.ComputeKernels;
 
@@ -38,10 +38,10 @@ import uk.ac.manchester.tornado.benchmarks.ComputeKernels;
 public class DFTTornado extends BenchmarkDriver {
 
     private int size;
-    private DoubleArray inReal;
-    private DoubleArray inImag;
-    private DoubleArray outReal;
-    private DoubleArray outImag;
+    private FloatArray inReal;
+    private FloatArray inImag;
+    private FloatArray outReal;
+    private FloatArray outImag;
 
     public DFTTornado(int iterations, int size) {
         super(iterations);
@@ -49,13 +49,13 @@ public class DFTTornado extends BenchmarkDriver {
     }
 
     private void initData() {
-        inReal = new DoubleArray(size);
-        inImag = new DoubleArray(size);
-        outReal = new DoubleArray(size);
-        outImag = new DoubleArray(size);
+        inReal = new FloatArray(size);
+        inImag = new FloatArray(size);
+        outReal = new FloatArray(size);
+        outImag = new FloatArray(size);
         for (int i = 0; i < size; i++) {
-            inReal.set(i, (1 / (double) (i + 2)));
-            inImag.set(i, (1 / (double) (i + 2)));
+            inReal.set(i, (1 /  (i + 2)));
+            inImag.set(i, (1 /  (i + 2)));
         }
     }
 
@@ -75,8 +75,8 @@ public class DFTTornado extends BenchmarkDriver {
     @Override
     public boolean validate(TornadoDevice device) {
         boolean validation = true;
-        DoubleArray outRealTor = new DoubleArray(size);
-        DoubleArray outImagTor = new DoubleArray(size);
+        FloatArray outRealTor = new FloatArray(size);
+        FloatArray outImagTor = new FloatArray(size);
 
         executionPlan.withDevice(device) //
                 .withWarmUp() //


### PR DESCRIPTION
#### Description

This PR replaces the DFT application benchmark from using FP64 to FP32. 

#### Problem description

In some systems, such as Apple M1/M2, there are no FP64 support. However, TornadoVM can still process the application by processing with less precision.


#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [X] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
$ make
$ tornado -m tornado.benchmarks/uk.ac.manchester.tornado.benchmarks.BenchmarkRunner dft 15 8192
```

