### PR TITLE
[API] Launch an exception when Driver/Devices indexes are not found

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -79,6 +79,12 @@ public class TornadoExecutionPlan {
      *     Integer value that identifies the device within the backend to be
      *     used.
      * @return {@link TornadoDevice}
+     *
+     * @throws {@link
+     *     uk.ac.manchester.tornado.api.exceptions.TornadoDeviceNotFound} if a device index is not found.
+     *
+     * @throws {@link
+     *     uk.ac.manchester.tornado.api.exceptions.TornadoDriverNotFound} if a driver index is not found.
      */
     public static TornadoDevice getDevice(int driverIndex, int deviceIndex) {
         return TornadoRuntime.getTornadoRuntime().getDriver(driverIndex).getDevice(deviceIndex);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoDeviceNotFound.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoDeviceNotFound.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.exceptions;
+
+public class TornadoDeviceNotFound extends TornadoRuntimeException {
+
+    public TornadoDeviceNotFound(String msg) {
+        super(msg);
+    }
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoDriverNotFound.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoDriverNotFound.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.exceptions;
+
+public class TornadoDriverNotFound extends TornadoRuntimeException {
+    public TornadoDriverNotFound(String msg) {
+        super(msg);
+    }
+}

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -116,6 +116,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleTasksMultipleDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.vm.concurrency.TestConcurrentBackends"),
     TestEntry("uk.ac.manchester.tornado.unittests.multithreaded.MultiThreaded"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestDevices"),
 
     ## Test for function calls - We force not to inline methods
     TestEntry(testName="uk.ac.manchester.tornado.unittests.tasks.TestMultipleFunctions",

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDriver.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDriver.java
@@ -154,7 +154,7 @@ public final class OCLDriver implements TornadoAcceleratorDriver {
         if (index < flatBackends.length) {
             return flatBackends[index].getDeviceContext().asMapping();
         } else {
-            throw new TornadoDeviceNotFound("[ERROR] device required not found: " + index + " - Max: " + flatBackends.length);
+            throw new TornadoDeviceNotFound(STR."[ERROR] device required not found: \{index} - Max: \{flatBackends.length}");
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDriver.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDriver.java
@@ -41,15 +41,15 @@ import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
-import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoDeviceNotFound;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLHotSpotBackendFactory;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLSuitesProvider;
 import uk.ac.manchester.tornado.drivers.opencl.graal.backend.OCLBackend;
 import uk.ac.manchester.tornado.runtime.TornadoAcceleratorDriver;
 import uk.ac.manchester.tornado.runtime.TornadoVMConfigAccess;
-import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 
 public final class OCLDriver implements TornadoAcceleratorDriver {
     protected static final List<OCLDeviceType> DEVICE_TYPE_LIST = Arrays.asList( //
@@ -154,7 +154,7 @@ public final class OCLDriver implements TornadoAcceleratorDriver {
         if (index < flatBackends.length) {
             return flatBackends[index].getDeviceContext().asMapping();
         } else {
-            throw new TornadoRuntimeException("[ERROR] device required not found: " + index + " - Max: " + flatBackends.length);
+            throw new TornadoDeviceNotFound("[ERROR] device required not found: " + index + " - Max: " + flatBackends.length);
         }
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDriver.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDriver.java
@@ -119,7 +119,7 @@ public final class PTXDriver implements TornadoAcceleratorDriver {
         if (index < backends.length) {
             return backends[index].getDeviceContext().asMapping();
         } else {
-            throw new TornadoDeviceNotFound("[ERROR]-[PTX-DRIVER] Device required not found: " + index + " - Max: " + backends.length);
+            throw new TornadoDeviceNotFound(STR."[ERROR]-[PTX-DRIVER] Device required not found: \{index} - Max: \{backends.length}");
         }
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDriver.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDriver.java
@@ -32,13 +32,13 @@ import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
-import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoDeviceNotFound;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXHotSpotBackendFactory;
 import uk.ac.manchester.tornado.drivers.ptx.graal.backend.PTXBackend;
 import uk.ac.manchester.tornado.runtime.TornadoAcceleratorDriver;
 import uk.ac.manchester.tornado.runtime.TornadoVMConfigAccess;
-import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoSuitesProvider;
 
 public final class PTXDriver implements TornadoAcceleratorDriver {
@@ -119,7 +119,7 @@ public final class PTXDriver implements TornadoAcceleratorDriver {
         if (index < backends.length) {
             return backends[index].getDeviceContext().asMapping();
         } else {
-            throw new TornadoRuntimeException("[ERROR]-[PTX-DRIVER] Device required not found: " + index + " - Max: " + backends.length);
+            throw new TornadoDeviceNotFound("[ERROR]-[PTX-DRIVER] Device required not found: " + index + " - Max: " + backends.length);
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDriver.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDriver.java
@@ -31,13 +31,13 @@ import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
-import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoDeviceNotFound;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVHotSpotBackendFactory;
 import uk.ac.manchester.tornado.runtime.TornadoAcceleratorDriver;
 import uk.ac.manchester.tornado.runtime.TornadoVMConfigAccess;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
-import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoSuitesProvider;
 
 public final class SPIRVDriver implements TornadoAcceleratorDriver {
@@ -155,7 +155,7 @@ public final class SPIRVDriver implements TornadoAcceleratorDriver {
         if (index < flatBackends.length) {
             return flatBackends[index].getDeviceContext().asMapping();
         } else {
-            throw new TornadoRuntimeException("[ERROR]-[SPIRV-DRIVER] Device required not found: " + index + " - Max: " + backends.length);
+            throw new TornadoDeviceNotFound("[ERROR]-[SPIRV-DRIVER] Device required not found: " + index + " - Max: " + backends.length);
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDriver.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDriver.java
@@ -155,7 +155,7 @@ public final class SPIRVDriver implements TornadoAcceleratorDriver {
         if (index < flatBackends.length) {
             return flatBackends[index].getDeviceContext().asMapping();
         } else {
-            throw new TornadoDeviceNotFound("[ERROR]-[SPIRV-DRIVER] Device required not found: " + index + " - Max: " + backends.length);
+            throw new TornadoDeviceNotFound(STR."[ERROR]-[SPIRV-DRIVER] Device required not found: \{index} - Max: \{backends.length}");
         }
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
@@ -53,9 +53,10 @@ import jdk.vm.ci.runtime.JVMCIBackend;
 import uk.ac.manchester.tornado.api.TornadoDriver;
 import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoDriverNotFound;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
-import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
+import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.enums.TornadoDrivers;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoSnippetReflectionProvider;
 
@@ -192,6 +193,9 @@ public final class TornadoCoreRuntime implements TornadoRuntimeInterface {
 
     @Override
     public TornadoAcceleratorDriver getDriver(int index) {
+        if (index > tornadoVMDrivers.length) {
+            throw new TornadoDriverNotFound("Tornado Driver Not Found");
+        }
         return tornadoVMDrivers[index];
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDevices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDevices.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.exceptions.TornadoDeviceNotFound;
+import uk.ac.manchester.tornado.api.exceptions.TornadoDriverNotFound;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * How to run?
+ *
+ * <p>
+ * <code>
+ * $ tornado-test -V uk.ac.manchester.tornado.unittests.api.TestDevices
+ * </code>
+ * </p>
+ */
+public class TestDevices extends TornadoTestBase {
+
+    /**
+     * We ask, on purpose, for a driver index that does not exist to
+     * check that the exception {@link TornadoDriverNotFound} in thrown.
+     */
+    @Test(expected = TornadoDriverNotFound.class)
+    public void test01() {
+        TornadoDevice device = TornadoExecutionPlan.getDevice(100, 0);
+    }
+
+    /**
+     * We ask, on purpose, for a device index that does not exist to
+     * check that the exception {@link TornadoDeviceNotFound} in thrown.
+     */
+    @Test(expected = TornadoDeviceNotFound.class)
+    public void test02() {
+        TornadoDevice device = TornadoExecutionPlan.getDevice(0, 100);
+    }
+
+}


### PR DESCRIPTION
#### Description

This PR improves the driver and device handling in TornadoVM from the user side. When a Driver or Device is requested using the corresponding indexes, the TornadoVM runtime will throw an exception if the driver/device is not present.

#### Problem description

The main issue was that the exception thrown was generic, and it did not contain information about the problem.  

#### Backend/s tested

This PR has been tested on OSx with the OpenCL backend. However, it should work for any of the backends. 

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [X] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make
$ tornado-test -V uk.ac.manchester.tornado.unittests.api.TestDevices
$ make tests
```
