### PR TITLE
[spirv] Update the SPIR-V Toolkit dep. to 0.0.4

### DIFF
--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>beehive-lab</groupId>
             <artifactId>beehive-spirv-lib</artifactId>
-            <version>0.0.3</version>
+            <version>0.0.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
#### Description

This PR updates the dependency for the Beehive SPIR-V Toolkit to the latest version in preparation for the integration of the Windows Native Installer. 

#### Problem description

n/ a.

#### Backend/s tested

This PR only affects the SPIR-V backend.

- [ ] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

To test properly, I removed the m2/repo directory as well as the local directory with the dependencies

```bash
rm -Rf ~/.m2/repository/*
rm -Rf beehive-spirv-toolkit/ levelzero-jni/

make BACKEND=spirv
make tests
```

