### PR TITLE
[update] LevelZero-JNI dependency updated

### DIFF
--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>beehive-lab</groupId>
             <artifactId>beehive-levelzero-jni</artifactId>
-            <version>0.1.2</version>
+            <version>0.1.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
#### Description

This PR updates the dependency with our external JNI library for Level Zero. The 0.1.3 version brings Windows 10/11 installation and can be used for the TornadoVM windows native installation. 

#### Problem description

n/a.

#### Backend/s tested

This PR only affects the SPIR-V/LevelZero  backend

- [ ] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [X] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ rm -Rf levelzero-jni/
$ make BACKEND=spirv
$ make tests 
```
