### PR TITLE
[fix] Links for LevelZero JNI and Beehive SPIR-V Toolkit fixed

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -144,7 +144,7 @@ def build_levelzero_jni_lib(rebuild=False):
             [
                 "git",
                 "clone",
-                "https://github.com/otabuzzman/levelzero-jni#winstall",
+                "https://github.com/beehive-lab/levelzero-jni",
             ],
         )
         build=True
@@ -184,7 +184,7 @@ def build_spirv_toolkit_and_level_zero(rebuild=False):
             [
                 "git",
                 "clone",
-                "https://github.com/otabuzzman/beehive-spirv-toolkit.git#winstall",
+                "https://github.com/beehive-lab/beehive-spirv-toolkit",
             ],
         )
         build = True

--- a/bin/tornadovm-installer.cmd
+++ b/bin/tornadovm-installer.cmd
@@ -131,7 +131,7 @@ if %spirv% equ 1 (
 		goto :repoL0JniCloned
 	)
 	cd %TORNADO_DIR%
-	git clone https://github.com/otabuzzman/levelzero-jni
+	git clone https://github.com/beehive-lab/levelzero-jni
 	cd levelzero-jni
 	git checkout winstall
 	:repoL0JniCloned
@@ -151,7 +151,7 @@ if %spirv% equ 1 (
 		goto :repoSpirvTkCloned
 	)
 	cd %TORNADO_DIR%
-	git clone https://github.com/otabuzzman/beehive-spirv-toolkit.git
+	git clone https://github.com/beehive-lab/beehive-spirv-toolkit
 	cd beehive-spirv-toolkit
 	git checkout winstall
 	:repoSpirvTkCloned


### PR DESCRIPTION
#### Description

This PR fixes the links to obtain the dependencies for SPIR-V Toolkit and Level Zero JNI

#### Problem description

The problem was that there were some left-over dependencies to check the Native Windows installation. This PR fixes those with the official repos. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make BACKEND=opencl,spirv,ptx
make tests
```

