### PR TITLE
[release] TornadoVM 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <img align="left" width="250" height="250" src="etc/tornadoVM_Logo.jpg">
 
-TornadoVM is a plug-in to OpenJDK and GraalVM that allows programmers to automatically run Java programs on heterogeneous hardware.
+TornadoVM is a plug-in to OpenJDK and GraalVM that allows programmers to automatically run Java programs on
+heterogeneous hardware.
 TornadoVM targets OpenCL, PTX and SPIR-V compatible devices which include multi-core CPUs, dedicated
 GPUs (Intel, NVIDIA, AMD), integrated GPUs (Intel HD Graphics and ARM Mali), and FPGAs (Intel and Xilinx).
-
 
 TornadoVM has three backends that generate OpenCL C, NVIDIA CUDA PTX assembly, and SPIR-V binary.
 Developers can choose which backends to install and run.
@@ -18,13 +18,15 @@ Developers can choose which backends to install and run.
 
 For a quick introduction please read the following [FAQ](https://tornadovm.readthedocs.io/en/latest/).
 
-**Latest Release:** TornadoVM 1.0.2 - 29/02/2024 : See [CHANGELOG](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html).
+**Latest Release:** TornadoVM 1.0.3 - 27/03/2024 :
+See [CHANGELOG](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html).
 
 ----------------------
 
 ## 1. Installation
 
-In Linux and macOS, TornadoVM can be installed automatically with the [installation script](https://tornadovm.readthedocs.io/en/latest/installation.html). For example:
+In Linux and macOS, TornadoVM can be installed automatically with
+the [installation script](https://tornadovm.readthedocs.io/en/latest/installation.html). For example:
 
 ```bash
 $ ./bin/tornadovm-installer
@@ -42,10 +44,10 @@ optional arguments:
 ```
 
 **NOTE** Select the desired backend:
-  * `opencl`: Enables the OpenCL backend (requires OpenCL drivers)
-  * `ptx`: Enables the PTX backend (requires NVIDIA CUDA drivers)
-  * `spirv`: Enables the SPIRV backend (requires Intel Level Zero drivers)
 
+* `opencl`: Enables the OpenCL backend (requires OpenCL drivers)
+* `ptx`: Enables the PTX backend (requires NVIDIA CUDA drivers)
+* `spirv`: Enables the SPIRV backend (requires Intel Level Zero drivers)
 
 Example of installation:
 
@@ -57,44 +59,57 @@ $ ./bin/tornadovm-installer --jdk jdk21 --backend opencl
 $ ./bin/tornadovm-installer --jdk jdk21 --backend opencl,spirv,ptx
 ```
 
-Alternatively, TornadoVM can be installed either manually [from source](https://tornadovm.readthedocs.io/en/latest/installation.html#b-manual-installation) or by [using Docker](https://tornadovm.readthedocs.io/en/latest/docker.html).
+Alternatively, TornadoVM can be installed either
+manually [from source](https://tornadovm.readthedocs.io/en/latest/installation.html#b-manual-installation) or
+by [using Docker](https://tornadovm.readthedocs.io/en/latest/docker.html).
 
-If you are planning to use Docker with TornadoVM on GPUs, you can also follow [these](https://github.com/beehive-lab/docker-tornado#docker-for-tornadovm) guidelines.
+If you are planning to use Docker with TornadoVM on GPUs, you can also
+follow [these](https://github.com/beehive-lab/docker-tornado#docker-for-tornadovm) guidelines.
 
-You can also run TornadoVM on Amazon AWS CPUs, GPUs, and FPGAs following the instructions [here](https://tornadovm.readthedocs.io/en/latest/cloud.html).
-
+You can also run TornadoVM on Amazon AWS CPUs, GPUs, and FPGAs following the
+instructions [here](https://tornadovm.readthedocs.io/en/latest/cloud.html).
 
 ## 2. Usage Instructions
 
-TornadoVM is currently being used to accelerate machine learning and deep learning applications, computer vision, physics simulations, financial applications, computational photography, and signal processing.
+TornadoVM is currently being used to accelerate machine learning and deep learning applications, computer vision,
+physics simulations, financial applications, computational photography, and signal processing.
 
 Featured use-cases:
-- [kfusion-tornadovm](https://github.com/beehive-lab/kfusion-tornadovm): Java application for accelerating a computer-vision application using the Tornado-APIs to run on discrete and integrated GPUs.
-- [Java Ray-Tracer](https://github.com/Vinhixus/TornadoVM-Ray-Tracer): Java application accelerated with TornadoVM for real-time ray-tracing.
 
-We also have a set of [examples](https://github.com/beehive-lab/TornadoVM/tree/master/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples) that includes NBody, DFT, KMeans computation and matrix computations.
+- [kfusion-tornadovm](https://github.com/beehive-lab/kfusion-tornadovm): Java application for accelerating a
+  computer-vision application using the Tornado-APIs to run on discrete and integrated GPUs.
+- [Java Ray-Tracer](https://github.com/Vinhixus/TornadoVM-Ray-Tracer): Java application accelerated with TornadoVM for
+  real-time ray-tracing.
+
+We also have a set
+of [examples](https://github.com/beehive-lab/TornadoVM/tree/master/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples)
+that includes NBody, DFT, KMeans computation and matrix computations.
 
 **Additional Information**
 
- - [General Documentation](https://tornadovm.readthedocs.io/en/latest/introduction.html)
- - [Benchmarks](https://tornadovm.readthedocs.io/en/latest/benchmarking.html)
- - [How TornadoVM executes reductions](https://tornadovm.readthedocs.io/en/latest/programming.html#parallel-reductions)
- - [Execution Flags](https://tornadovm.readthedocs.io/en/latest/flags.html)
- - [FPGA execution](https://tornadovm.readthedocs.io/en/latest/fpga-programming.html)
- - [Profiler Usage](https://tornadovm.readthedocs.io/en/latest/profiler.html)
-
+- [General Documentation](https://tornadovm.readthedocs.io/en/latest/introduction.html)
+- [Benchmarks](https://tornadovm.readthedocs.io/en/latest/benchmarking.html)
+- [How TornadoVM executes reductions](https://tornadovm.readthedocs.io/en/latest/programming.html#parallel-reductions)
+- [Execution Flags](https://tornadovm.readthedocs.io/en/latest/flags.html)
+- [FPGA execution](https://tornadovm.readthedocs.io/en/latest/fpga-programming.html)
+- [Profiler Usage](https://tornadovm.readthedocs.io/en/latest/profiler.html)
 
 ## 3. Programming Model
 
-TornadoVM exposes to the programmer task-level, data-level and pipeline-level parallelism via a light Application Programming Interface (API). In addition, TornadoVM uses single-source property, in which the code to be accelerated and the host code live in the same Java program.
+TornadoVM exposes to the programmer task-level, data-level and pipeline-level parallelism via a light Application
+Programming Interface (API). In addition, TornadoVM uses single-source property, in which the code to be accelerated and
+the host code live in the same Java program.
 
 Compute-kernels in TornadoVM can be programmed using two different approaches (APIs):
 
 #### a) Loop Parallel API
 
-Compute kernels are written in a sequential form (tasks programmed for a single thread execution). To express parallelism, TornadoVM exposes two annotations that can be used in loops and parameters: a) `@Parallel` for annotating parallel loops; and b) `@Reduce` for annotating parameters used in reductions.
+Compute kernels are written in a sequential form (tasks programmed for a single thread execution). To express
+parallelism, TornadoVM exposes two annotations that can be used in loops and parameters: a) `@Parallel` for annotating
+parallel loops; and b) `@Reduce` for annotating parameters used in reductions.
 
-The following code snippet shows a full example to accelerate Matrix-Multiplication using TornadoVM and the loop-parallel API:
+The following code snippet shows a full example to accelerate Matrix-Multiplication using TornadoVM and the
+loop-parallel API:
 
 ```java
 public class Compute {
@@ -130,9 +145,11 @@ public class Compute {
 #### b) Kernel API
 
 Another way to express compute-kernels in TornadoVM is via the **kernel API**.
-To do so, TornadoVM exposes a `KernelContext` with which the application can directly access the thread-id, allocate memory in local memory (shared memory on NVIDIA devices), and insert barriers.
+To do so, TornadoVM exposes a `KernelContext` with which the application can directly access the thread-id, allocate
+memory in local memory (shared memory on NVIDIA devices), and insert barriers.
 This model is similar to programming compute-kernels in OpenCL and CUDA.
-Therefore, this API is more suitable for GPU/FPGA expert programmers that want more control or want to port existing CUDA/OpenCL compute kernels into TornadoVM.
+Therefore, this API is more suitable for GPU/FPGA expert programmers that want more control or want to port existing
+CUDA/OpenCL compute kernels into TornadoVM.
 
 The following code-snippet shows the Matrix Multiplication example using the kernel-parallel API:
 
@@ -169,13 +186,13 @@ public class Compute {
 
         // Execute the execution plan
         executionPlan.withGridScheduler(gridScheduler)
-                     .execute();
+                .execute();
     }
 }
 ```
 
-Additionally, the two modes of expressing parallelism (kernel and loop parallelization) can be combined in the same task graph object.
-
+Additionally, the two modes of expressing parallelism (kernel and loop parallelization) can be combined in the same task
+graph object.
 
 ## 4. Dynamic Reconfiguration
 
@@ -183,9 +200,11 @@ Dynamic reconfiguration is the ability of TornadoVM to perform live task migrati
 TornadoVM decides where to execute the code to increase performance (if possible). In other words, TornadoVM switches
 devices if it can detect that a specific device can yield better performance (compared to another).
 
-With the task-migration, the TornadoVM's approach is to only switch device if it detects an application can be executed faster
+With the task-migration, the TornadoVM's approach is to only switch device if it detects an application can be executed
+faster
 than the CPU execution using the code compiled by C2 or Graal-JIT, otherwise it will stay on the CPU. So TornadoVM can
-be seen as a complement to C2 and Graal JIT compilers. This is because there is no single hardware to best execute all workloads
+be seen as a complement to C2 and Graal JIT compilers. This is because there is no single hardware to best execute all
+workloads
 efficiently. GPUs are very good at exploiting SIMD applications, and FPGAs are very good at exploiting pipeline
 applications. If your applications follow those models, TornadoVM will likely select heterogeneous hardware. Otherwise,
 it will stay on the CPU using the default compilers (C2 or Graal).
@@ -196,24 +215,28 @@ For example:
 ```java
 // TornadoVM will execute the code in the best accelerator.
 executionPlan.withDynamicReconfiguration(Policy.PERFORMANCE, DRMode.PARALLEL)
-             .execute();
+             .
+
+execute();
 ```
 
 Further details and instructions on how to enable this feature can be found here.
 
-* Dynamic reconfiguration: [https://dl.acm.org/doi/10.1145/3313808.3313819](https://dl.acm.org/doi/10.1145/3313808.3313819)
-
+* Dynamic
+  reconfiguration: [https://dl.acm.org/doi/10.1145/3313808.3313819](https://dl.acm.org/doi/10.1145/3313808.3313819)
 
 ## 5. How to Use TornadoVM in your Projects?
 
 To use TornadoVM, you need two components:
 
 a) The TornadoVM `jar` file with the API. The API is licensed as GPLV2 with Classpath Exception.
-b) The core libraries of TornadoVM along with the dynamic library for the driver code (`.so` files for OpenCL, PTX and/or SPIRV/Level Zero).
+b) The core libraries of TornadoVM along with the dynamic library for the driver code (`.so` files for OpenCL, PTX
+and/or SPIRV/Level Zero).
 
 You can import the TornadoVM API by setting this the following dependency in the Maven `pom.xml` file:
 
 ```xml
+
 <repositories>
     <repository>
         <id>universityOfManchester-graal</id>
@@ -225,23 +248,23 @@ You can import the TornadoVM API by setting this the following dependency in the
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.3</version>
 </dependency>
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-matrices</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.3</version>
 </dependency>
 </dependencies>
 ```
 
-To run TornadoVM, you need to either install the TornadoVM extension for GraalVM/OpenJDK, or run with our Docker [images](https://github.com/beehive-lab/docker-tornado).
-
+To run TornadoVM, you need to either install the TornadoVM extension for GraalVM/OpenJDK, or run with our
+Docker [images](https://github.com/beehive-lab/docker-tornado).
 
 ## 6. Additional Resources
 
-[Here](https://tornadovm.readthedocs.io/en/latest/resources.html) you can find videos, presentations, tech-articles and artefacts describing TornadoVM, and how to use it.
-
+[Here](https://tornadovm.readthedocs.io/en/latest/resources.html) you can find videos, presentations, tech-articles and
+artefacts describing TornadoVM, and how to use it.
 
 ## 7. Academic Publications
 
@@ -285,11 +308,11 @@ If you are using **Tornado 0.1** (Initial release), please use the following cit
 
 Selected publications can be found [here](https://tornadovm.readthedocs.io/en/latest/publications.html).
 
-
 ## 8. Acknowledgments
 
 This work is partially funded by [Intel corporation](https://www.intel.com/content/www/us/en/homepage.html).
 In addition, it has been supported by the following EU & UKRI grants (most recent first):
+
 - EU Horizon Europe & UKRI [AERO 101092850](https://cordis.europa.eu/project/id/101092850).
 - EU Horizon Europe & UKRI [INCODE 101093069](https://cordis.europa.eu/project/id/101093069).
 - EU Horizon Europe & UKRI [ENCRYPT 101070670](https://encrypt-project.eu).
@@ -299,9 +322,9 @@ In addition, it has been supported by the following EU & UKRI grants (most recen
 - EU Horizon 2020 [ACTiCLOUD 732366](https://acticloud.eu).
 
 Furthermore, TornadoVM has been supported by the following [EPSRC](https://www.ukri.org/councils/epsrc/) grants:
+
 - [PAMELA EP/K008730/1](http://apt.cs.manchester.ac.uk/projects/PAMELA/).
 - [AnyScale Apps EP/L000725/1](https://gow.epsrc.ukri.org/NGBOViewGrant.aspx?GrantRef=EP/L000725/1).
-
 
 ## 9. Contributions and Collaborations
 
@@ -309,7 +332,8 @@ We welcome collaborations! Please see how to contribute to the project in the [C
 
 ### Write your questions and proposals:
 
-Additionally, you can open new proposals on the GitHub discussions [page](https://github.com/beehive-lab/TornadoVM/discussions).
+Additionally, you can open new proposals on the GitHub
+discussions [page](https://github.com/beehive-lab/TornadoVM/discussions).
 
 Alternatively, you can share a Google document with us.
 
@@ -317,11 +341,9 @@ Alternatively, you can share a Google document with us.
 
 For Academic & Industry collaborations, please contact [here](https://www.tornadovm.org/contact-us).
 
-
 ## 10. TornadoVM Team
 
 Visit our [website](https://tornadovm.org) to meet the [team](https://www.tornadovm.org/about-us).
-
 
 ## 11. Licenses
 
@@ -329,17 +351,17 @@ To use TornadoVM, you can link the TornadoVM API to your application which is un
 
 Each Java TornadoVM module is licensed as follows:
 
-|  Module | License  |
-|---|---|
-| Tornado-API       |  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)  |
-| Tornado-Runtime   |  [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html) + CLASSPATH Exception   |
-| Tornado-Assembly  |  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)  |
-| Tornado-Drivers   |  [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html) + CLASSPATH Exception   |
-| Tornado-Drivers-OpenCL-Headers |  [![License](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/KhronosGroup/OpenCL-Headers/blob/master/LICENSE) |
-| Tornado-scripts   |  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)  |
-| Tornado-Annotation|  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)  |
-| Tornado-Unittests |  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)  |
-| Tornado-Benchmarks|  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)  |
-| Tornado-Examples  |  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)  |
-| Tornado-Matrices  |  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)  |
-||
+| Module                         | License                                                                                                                                                       |
+|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Tornado-API                    | [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)       |
+| Tornado-Runtime                | [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html) + CLASSPATH Exception |
+| Tornado-Assembly               | [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)       |
+| Tornado-Drivers                | [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html) + CLASSPATH Exception |
+| Tornado-Drivers-OpenCL-Headers | [![License](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/KhronosGroup/OpenCL-Headers/blob/master/LICENSE)                   |
+| Tornado-scripts                | [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)       |
+| Tornado-Annotation             | [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)       |
+| Tornado-Unittests              | [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)       |
+| Tornado-Benchmarks             | [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)       |
+| Tornado-Examples               | [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)       |
+| Tornado-Matrices               | [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2)       |
+|                                |

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -5,6 +5,37 @@ TornadoVM Changelog
 
 This file summarizes the new features and major changes for each *TornadoVM* version.
 
+TornadoVM 1.0.3
+----------------
+27th March 2024
+
+Improvements
+~~~~~~~~~~~~~~~~~~
+
+- `#344 <https://github.com/beehive-lab/TornadoVM/pull/344>`_: Support for Multi-threaded Execution Plans.
+- `#347 <https://github.com/beehive-lab/TornadoVM/pull/347>`_: Enhanced examples.
+- `#350 <https://github.com/beehive-lab/TornadoVM/pull/350>`_: Obtain internal memory segment for the Tornado Native Arrays without the object header.
+- `#357 <https://github.com/beehive-lab/TornadoVM/pull/357>`_: API extensions to query and apply filters to backends and devices from the ``TornadoExecutionPlan``.
+- `#359 <https://github.com/beehive-lab/TornadoVM/pull/359>`_: Support Factory Methods for FFI-based array collections to be used/composed in TornadoVM Task-Graphs.
+
+Compatibility
+~~~~~~~~~~~~~~~~~~
+
+- `#351 <https://github.com/beehive-lab/TornadoVM/pull/351>`_: Compatibility of TornadoVM Native Arrays with the Java Vector API.
+- `#352 <https://github.com/beehive-lab/TornadoVM/pull/352>`_: Refactor memory limit to take into account primitive types and wrappers. 
+- `#354 <https://github.com/beehive-lab/TornadoVM/pull/354>`_: Add DFT-sample benchmark in FP32.
+- `#356 <https://github.com/beehive-lab/TornadoVM/pull/356>`_: Initial support for Windows 11 using Visual Studio Development tools. 
+- `#361 <https://github.com/beehive-lab/TornadoVM/pull/361>`_: Compatibility with the SPIR-V toolkit v0.0.4.
+- `#366 <https://github.com/beehive-lab/TornadoVM/pull/363>`_: Level Zero JNI Dependency updated to 0.1.3. 
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~
+
+- `#346 <https://github.com/beehive-lab/TornadoVM/pull/346>`_: Computation of local-work group sizes for the Level Zero/SPIR-V backend fixed. 
+- `#360 <https://github.com/beehive-lab/TornadoVM/pull/358>`_: Fix native tests to check the JIT compiler for each backend.
+- `#355 <https://github.com/beehive-lab/TornadoVM/pull/355>`_: Fix custom exceptions when a driver/device is not found.
+
+
 TornadoVM 1.0.2
 ----------------
 29/02/2024

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -953,14 +953,16 @@ Using IntelliJ
 
 
 Install plugins:
+
 - Eclipse Code Formatter
 - Save Actions
 
 Then :
-1. Open File > Settings > Eclipse Code Formatter
-2. Check the ``Use the Eclipse code`` formatter radio button
+
+1. Open File > Settings > Eclipse Code Formatter.
+2. Check the ``Use the Eclipse code`` formatter radio button.
 3. Set the Eclipse Java Formatter config file to the XML file stored in ``/scripts/templates/eclise-settings/Tornado.xml``.
-4. Set the Java formatter profile in Tornado
+4. Set the Java formatter profile in Tornado.
 
 
 TornadoVM Maven Projects
@@ -983,13 +985,13 @@ To use the TornadoVM API in your projects, you can checkout our maven repository
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>1.0.2</version>
+         <version>1.0.3</version>
       </dependency>
 
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>1.0.2</version>
+         <version>1.0.3</version>
       </dependency>
    </dependencies>
 
@@ -1000,6 +1002,7 @@ Notice that, for running with TornadoVM, you will need either the docker images 
 Versions available
 ========================
 
+* 1.0.3
 * 1.0.2
 * 1.0.1
 * 1.0

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>tornado</groupId>
     <artifactId>tornado</artifactId>
-    <version>1.0.3-dev</version>
+    <version>1.0.3</version>
     <packaging>pom</packaging>
     <name>tornado</name>
     <url>https://github.com/beehive-lab/tornadovm</url>

--- a/tornado-annotation/pom.xml
+++ b/tornado-annotation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>tornado-annotation</artifactId>

--- a/tornado-api/pom.xml
+++ b/tornado-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
 
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.3-dev</version>
+    <version>1.0.3</version>
 
     <name>tornado-api</name>
     <url>https://tornadovm.org</url>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-assembly</artifactId>
     <packaging>pom</packaging>

--- a/tornado-benchmarks/pom.xml
+++ b/tornado-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
 
     <artifactId>tornado-benchmarks</artifactId>

--- a/tornado-drivers/drivers-common/pom.xml
+++ b/tornado-drivers/drivers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tornado-drivers/opencl-jni/pom.xml
+++ b/tornado-drivers/opencl-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-drivers-opencl-jni</artifactId>
     <name>tornado-drivers-opencl-jni</name>

--- a/tornado-drivers/opencl/pom.xml
+++ b/tornado-drivers/opencl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-drivers-opencl</artifactId>
     <name>tornado-drivers-opencl</name>

--- a/tornado-drivers/pom.xml
+++ b/tornado-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-drivers</artifactId>
     <name>tornado-drivers</name>

--- a/tornado-drivers/ptx-jni/pom.xml
+++ b/tornado-drivers/ptx-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-drivers-ptx-jni</artifactId>
     <name>tornado-drivers-ptx-jni</name>

--- a/tornado-drivers/ptx/pom.xml
+++ b/tornado-drivers/ptx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tornado-drivers</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-drivers-ptx</artifactId>
     <name>tornado-drivers-ptx</name>

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-drivers-spirv</artifactId>
     <name>tornado-drivers-spirv</name>

--- a/tornado-examples/pom.xml
+++ b/tornado-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-examples</artifactId>
     <name>tornado-examples</name>

--- a/tornado-matrices/pom.xml
+++ b/tornado-matrices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-matrices</artifactId>
     <name>tornado-matrices</name>

--- a/tornado-runtime/pom.xml
+++ b/tornado-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-runtime</artifactId>
     <name>tornado-runtime</name>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.3-dev</version>
+        <version>1.0.3</version>
     </parent>
     <artifactId>tornado-unittests</artifactId>
     <name>tornado-unittests</name>


### PR DESCRIPTION
#### Description

TornadoVM 1.0.3 Release with the following changes:

##### Improvements

- #344  : Support for Multi-threaded Execution Plans.
- #347  : Enhanced examples.
- #350  : Obtain internal memory segment for the Tornado Native Arrays without the object header.
- #357  : API extensions to query and apply filters to backends and devices from the ``TornadoExecutionPlan``.
- #359  : Support Factory Methods for FFI-based array collections to be used/composed in TornadoVM Task-Graphs.

##### Compatibility

- #351 : Compatibility of TornadoVM Native Arrays with the Java Vector API.
- #352 : Refactor memory limit to take into account primitive types and wrappers.
- #354 : Add DFT-sample benchmark in FP32.
- #356 : Initial support for Windows 11 using Visual Studio Development tools.
- #361 : Compatibility with the SPIR-V toolkit v0.0.4.
- #366 : Level Zero JNI Dependency updated to 0.1.3.

##### Bug Fixes

- #346 : Computation of local-work group sizes for the Level Zero/SPIR-V backend fixed.
- #360 : Fix native tests to check the JIT compiler for each backend.
- #355 : Fix custom exceptions when a driver/device is not found.

#### Problem description

n/a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [X] OSx
- [X] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make 
make tests
```
