### PR TITLE
Implement Multi-Array Concatenation using Memory Segment Copy

### DIFF
--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -50,7 +50,7 @@ Additionally, developers can create an instance of a TornadoVM native array by i
    public static FloatArray fromElements(float... values);
    // from Memory Segment to TornadoVM native array
    public static FloatArray fromSegment(MemorySegment segment);
-   // from multiple TornadoVM native arrays to single Tornado Native Array
+   // from multiple TornadoVM native arrays to single TornadoVM native array
    public static FloatArray concat(FloatArray... arrays);
 
 The main methods that the off-heap types expose to manage the Memory Segment of each type are presented in the list below. 

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -49,7 +49,9 @@ Additionally, developers can create an instance of a TornadoVM native array by i
    // from individual items to TornadoVM native array
    public static FloatArray fromElements(float... values);
    // from Memory Segment to TornadoVM native array
-   public static FloatArray fromSegment(MemorySegment segment); 
+   public static FloatArray fromSegment(MemorySegment segment);
+   // from multiple TornadoVM native arrays to single Tornado Native Array
+   public static FloatArray concat(FloatArray... arrays);
 
 The main methods that the off-heap types expose to manage the Memory Segment of each type are presented in the list below. 
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -250,7 +250,6 @@ public final class ByteArray extends TornadoNativeArray {
      */
     public static ByteArray concat(ByteArray... arrays) {
         int newSize = Arrays.stream(arrays).mapToInt(ByteArray::getSize).sum();
-
         ByteArray concatArray = new ByteArray(newSize);
 
         long currentPositionBytes = 0;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -239,4 +239,28 @@ public final class ByteArray extends TornadoNativeArray {
         }
     }
 
+    /**
+     * Concatenates multiple {@link ByteArray} instances into a single {@link ByteArray}.
+     *
+     * @param arrays
+     *     Variable number of {@link ByteArray} objects to be concatenated.
+     * @return A new {@link ByteArray} instance containing all the elements of the input arrays,
+     *     concatenated in the order they were provided.
+     */
+    public static ByteArray concat(ByteArray... arrays) {
+        long totalSizeBytes = 0;
+        for (ByteArray array : arrays) {
+            totalSizeBytes += array.getNumBytesOfSegment();
+        }
+
+        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+
+        long currentPositionBytes = 0;
+        for (ByteArray array : arrays) {
+            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            currentPositionBytes += array.getNumBytesOfSegment();
+        }
+
+        return fromSegment(newSegment);
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -251,13 +251,11 @@ public final class ByteArray extends TornadoNativeArray {
     public static ByteArray concat(ByteArray... arrays) {
         int newSize = Arrays.stream(arrays).mapToInt(ByteArray::getSize).sum();
         ByteArray concatArray = new ByteArray(newSize);
-
         long currentPositionBytes = 0;
         for (ByteArray array : arrays) {
             MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
-
         return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
@@ -248,10 +249,7 @@ public final class ByteArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static ByteArray concat(ByteArray... arrays) {
-        int newSize = 0;
-        for (ByteArray array : arrays) {
-            newSize += array.getSize();
-        }
+        int newSize = Arrays.stream(arrays).mapToInt(ByteArray::getSize).sum();
 
         ByteArray concatArray = new ByteArray(newSize);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -248,19 +248,19 @@ public final class ByteArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static ByteArray concat(ByteArray... arrays) {
-        long totalSizeBytes = 0;
+        int newSize = 0;
         for (ByteArray array : arrays) {
-            totalSizeBytes += array.getNumBytesOfSegment();
+            newSize += array.getSize();
         }
 
-        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+        ByteArray concatArray = new ByteArray(newSize);
 
         long currentPositionBytes = 0;
         for (ByteArray array : arrays) {
-            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
 
-        return fromSegment(newSegment);
+        return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -250,13 +250,11 @@ public final class CharArray extends TornadoNativeArray {
     public static CharArray concat(CharArray... arrays) {
         int newSize = Arrays.stream(arrays).mapToInt(CharArray::getSize).sum();
         CharArray concatArray = new CharArray(newSize);
-
         long currentPositionBytes = 0;
         for (CharArray array : arrays) {
             MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
-
         return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -247,19 +247,19 @@ public final class CharArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static CharArray concat(CharArray... arrays) {
-        long totalSizeBytes = 0;
+        int newSize = 0;
         for (CharArray array : arrays) {
-            totalSizeBytes += array.getNumBytesOfSegment();
+            newSize += array.getSize();
         }
 
-        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+        CharArray concatArray = new CharArray(newSize);
 
         long currentPositionBytes = 0;
         for (CharArray array : arrays) {
-            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
 
-        return fromSegment(newSegment);
+        return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
@@ -247,11 +248,7 @@ public final class CharArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static CharArray concat(CharArray... arrays) {
-        int newSize = 0;
-        for (CharArray array : arrays) {
-            newSize += array.getSize();
-        }
-
+        int newSize = Arrays.stream(arrays).mapToInt(CharArray::getSize).sum();
         CharArray concatArray = new CharArray(newSize);
 
         long currentPositionBytes = 0;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -238,4 +238,28 @@ public final class CharArray extends TornadoNativeArray {
         }
     }
 
+    /**
+     * Concatenates multiple {@link CharArray} instances into a single {@link CharArray}.
+     *
+     * @param arrays
+     *     Variable number of {@link CharArray} objects to be concatenated.
+     * @return A new {@link CharArray} instance containing all the elements of the input arrays,
+     *     concatenated in the order they were provided.
+     */
+    public static CharArray concat(CharArray... arrays) {
+        long totalSizeBytes = 0;
+        for (CharArray array : arrays) {
+            totalSizeBytes += array.getNumBytesOfSegment();
+        }
+
+        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+
+        long currentPositionBytes = 0;
+        for (CharArray array : arrays) {
+            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            currentPositionBytes += array.getNumBytesOfSegment();
+        }
+
+        return fromSegment(newSegment);
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -252,13 +252,11 @@ public final class DoubleArray extends TornadoNativeArray {
     public static DoubleArray concat(DoubleArray... arrays) {
         int newSize = Arrays.stream(arrays).mapToInt(DoubleArray::getSize).sum();
         DoubleArray concatArray = new DoubleArray(newSize);
-
         long currentPositionBytes = 0;
         for (DoubleArray array : arrays) {
             MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
-
         return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
@@ -249,19 +250,15 @@ public final class DoubleArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static DoubleArray concat(DoubleArray... arrays) {
-        long totalSizeBytes = 0;
-        for (DoubleArray array : arrays) {
-            totalSizeBytes += array.getNumBytesOfSegment();
-        }
-
-        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+        int newSize = Arrays.stream(arrays).mapToInt(DoubleArray::getSize).sum();
+        DoubleArray concatArray = new DoubleArray(newSize);
 
         long currentPositionBytes = 0;
         for (DoubleArray array : arrays) {
-            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
 
-        return fromSegment(newSegment);
+        return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -240,4 +240,28 @@ public final class DoubleArray extends TornadoNativeArray {
         }
     }
 
+    /**
+     * Concatenates multiple {@link DoubleArray} instances into a single {@link DoubleArray}.
+     *
+     * @param arrays
+     *     Variable number of {@link DoubleArray} objects to be concatenated.
+     * @return A new {@link DoubleArray} instance containing all the elements of the input arrays,
+     *     concatenated in the order they were provided.
+     */
+    public static DoubleArray concat(DoubleArray... arrays) {
+        long totalSizeBytes = 0;
+        for (DoubleArray array : arrays) {
+            totalSizeBytes += array.getNumBytesOfSegment();
+        }
+
+        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+
+        long currentPositionBytes = 0;
+        for (DoubleArray array : arrays) {
+            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            currentPositionBytes += array.getNumBytesOfSegment();
+        }
+
+        return fromSegment(newSegment);
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -239,4 +239,29 @@ public final class FloatArray extends TornadoNativeArray {
             array.set(i, value);
         }
     }
+
+    /**
+     * Concatenates multiple {@link FloatArray} instances into a single {@link FloatArray}.
+     *
+     * @param arrays
+     *     Variable number of {@link FloatArray} objects to be concatenated.
+     * @return A new {@link FloatArray} instance containing all the elements of the input arrays,
+     *     concatenated in the order they were provided.
+     */
+    public static FloatArray concat(FloatArray... arrays) {
+        long totalSizeBytes = 0;
+        for (FloatArray array : arrays) {
+            totalSizeBytes += array.getNumBytesOfSegment();
+        }
+
+        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+
+        long currentPositionBytes = 0;
+        for (FloatArray array : arrays) {
+            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            currentPositionBytes += array.getNumBytesOfSegment();
+        }
+
+        return fromSegment(newSegment);
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
@@ -249,11 +250,7 @@ public final class FloatArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static FloatArray concat(FloatArray... arrays) {
-        int newSize = 0;
-        for (FloatArray array : arrays) {
-            newSize += array.getSize();
-        }
-
+        int newSize = Arrays.stream(arrays).mapToInt(FloatArray::getSize).sum();
         FloatArray concatArray = new FloatArray(newSize);
 
         long currentPositionBytes = 0;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -252,13 +252,11 @@ public final class FloatArray extends TornadoNativeArray {
     public static FloatArray concat(FloatArray... arrays) {
         int newSize = Arrays.stream(arrays).mapToInt(FloatArray::getSize).sum();
         FloatArray concatArray = new FloatArray(newSize);
-
         long currentPositionBytes = 0;
         for (FloatArray array : arrays) {
             MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
-
         return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -249,19 +249,19 @@ public final class FloatArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static FloatArray concat(FloatArray... arrays) {
-        long totalSizeBytes = 0;
+        int newSize = 0;
         for (FloatArray array : arrays) {
-            totalSizeBytes += array.getNumBytesOfSegment();
+            newSize += array.getSize();
         }
 
-        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+        FloatArray concatArray = new FloatArray(newSize);
 
         long currentPositionBytes = 0;
         for (FloatArray array : arrays) {
-            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
 
-        return fromSegment(newSegment);
+        return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -243,4 +243,29 @@ public final class HalfFloatArray extends TornadoNativeArray {
         }
     }
 
+    /**
+     * Concatenates multiple {@link HalfFloatArray} instances into a single {@link HalfFloatArray}.
+     *
+     * @param arrays
+     *     Variable number of {@link HalfFloatArray} objects to be concatenated.
+     * @return A new {@link HalfFloatArray} instance containing all the elements of the input arrays,
+     *     concatenated in the order they were provided.
+     */
+    public static HalfFloatArray concat(HalfFloatArray... arrays) {
+        long totalSizeBytes = 0;
+        for (HalfFloatArray array : arrays) {
+            totalSizeBytes += array.getNumBytesOfSegment();
+        }
+
+        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+
+        long currentPositionBytes = 0;
+        for (HalfFloatArray array : arrays) {
+            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            currentPositionBytes += array.getNumBytesOfSegment();
+        }
+
+        return fromSegment(newSegment);
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
@@ -252,11 +253,7 @@ public final class HalfFloatArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static HalfFloatArray concat(HalfFloatArray... arrays) {
-        int newSize = 0;
-        for (HalfFloatArray array : arrays) {
-            newSize += array.getSize();
-        }
-
+        int newSize = Arrays.stream(arrays).mapToInt(HalfFloatArray::getSize).sum();
         HalfFloatArray concatArray = new HalfFloatArray(newSize);
 
         long currentPositionBytes = 0;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -255,13 +255,11 @@ public final class HalfFloatArray extends TornadoNativeArray {
     public static HalfFloatArray concat(HalfFloatArray... arrays) {
         int newSize = Arrays.stream(arrays).mapToInt(HalfFloatArray::getSize).sum();
         HalfFloatArray concatArray = new HalfFloatArray(newSize);
-
         long currentPositionBytes = 0;
         for (HalfFloatArray array : arrays) {
             MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
-
         return concatArray;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -252,20 +252,20 @@ public final class HalfFloatArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static HalfFloatArray concat(HalfFloatArray... arrays) {
-        long totalSizeBytes = 0;
+        int newSize = 0;
         for (HalfFloatArray array : arrays) {
-            totalSizeBytes += array.getNumBytesOfSegment();
+            newSize += array.getSize();
         }
 
-        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+        HalfFloatArray concatArray = new HalfFloatArray(newSize);
 
         long currentPositionBytes = 0;
         for (HalfFloatArray array : arrays) {
-            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
 
-        return fromSegment(newSegment);
+        return concatArray;
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -246,20 +246,20 @@ public final class IntArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static IntArray concat(IntArray... arrays) {
-        long totalSizeBytes = 0;
+        int newSize = 0;
         for (IntArray array : arrays) {
-            totalSizeBytes += array.getNumBytesOfSegment();
+            newSize += array.getSize();
         }
 
-        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+        IntArray concatArray = new IntArray(newSize);
 
         long currentPositionBytes = 0;
         for (IntArray array : arrays) {
-            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
 
-        return fromSegment(newSegment);
+        return concatArray;
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -237,4 +237,29 @@ public final class IntArray extends TornadoNativeArray {
         }
     }
 
+    /**
+     * Concatenates multiple {@link IntArray} instances into a single {@link IntArray}.
+     *
+     * @param arrays
+     *     Variable number of {@link IntArray} objects to be concatenated.
+     * @return A new {@link IntArray} instance containing all the elements of the input arrays,
+     *     concatenated in the order they were provided.
+     */
+    public static IntArray concat(IntArray... arrays) {
+        long totalSizeBytes = 0;
+        for (IntArray array : arrays) {
+            totalSizeBytes += array.getNumBytesOfSegment();
+        }
+
+        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+
+        long currentPositionBytes = 0;
+        for (IntArray array : arrays) {
+            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            currentPositionBytes += array.getNumBytesOfSegment();
+        }
+
+        return fromSegment(newSegment);
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -249,13 +249,11 @@ public final class IntArray extends TornadoNativeArray {
     public static IntArray concat(IntArray... arrays) {
         int newSize = Arrays.stream(arrays).mapToInt(IntArray::getSize).sum();
         IntArray concatArray = new IntArray(newSize);
-
         long currentPositionBytes = 0;
         for (IntArray array : arrays) {
             MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
-
         return concatArray;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -21,6 +21,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
@@ -246,11 +247,7 @@ public final class IntArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static IntArray concat(IntArray... arrays) {
-        int newSize = 0;
-        for (IntArray array : arrays) {
-            newSize += array.getSize();
-        }
-
+        int newSize = Arrays.stream(arrays).mapToInt(IntArray::getSize).sum();
         IntArray concatArray = new IntArray(newSize);
 
         long currentPositionBytes = 0;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -250,13 +250,11 @@ public final class LongArray extends TornadoNativeArray {
     public static LongArray concat(LongArray... arrays) {
         int newSize = Arrays.stream(arrays).mapToInt(LongArray::getSize).sum();
         LongArray concatArray = new LongArray(newSize);
-
         long currentPositionBytes = 0;
         for (LongArray array : arrays) {
             MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
-
         return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
@@ -247,10 +248,7 @@ public final class LongArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static LongArray concat(LongArray... arrays) {
-        int newSize = 0;
-        for (LongArray array : arrays) {
-            newSize += array.getSize();
-        }
+        int newSize = Arrays.stream(arrays).mapToInt(LongArray::getSize).sum();
 
         LongArray concatArray = new LongArray(newSize);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -249,7 +249,6 @@ public final class LongArray extends TornadoNativeArray {
      */
     public static LongArray concat(LongArray... arrays) {
         int newSize = Arrays.stream(arrays).mapToInt(LongArray::getSize).sum();
-
         LongArray concatArray = new LongArray(newSize);
 
         long currentPositionBytes = 0;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -247,19 +247,19 @@ public final class LongArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static LongArray concat(LongArray... arrays) {
-        long totalSizeBytes = 0;
+        int newSize = 0;
         for (LongArray array : arrays) {
-            totalSizeBytes += array.getNumBytesOfSegment();
+            newSize += array.getSize();
         }
 
-        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+        LongArray concatArray = new LongArray(newSize);
 
         long currentPositionBytes = 0;
         for (LongArray array : arrays) {
-            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
 
-        return fromSegment(newSegment);
+        return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -237,4 +237,29 @@ public final class LongArray extends TornadoNativeArray {
             array.set(i, value);
         }
     }
+
+    /**
+     * Concatenates multiple {@link LongArray} instances into a single {@link LongArray}.
+     *
+     * @param arrays
+     *     Variable number of {@link LongArray} objects to be concatenated.
+     * @return A new {@link LongArray} instance containing all the elements of the input arrays,
+     *     concatenated in the order they were provided.
+     */
+    public static LongArray concat(LongArray... arrays) {
+        long totalSizeBytes = 0;
+        for (LongArray array : arrays) {
+            totalSizeBytes += array.getNumBytesOfSegment();
+        }
+
+        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+
+        long currentPositionBytes = 0;
+        for (LongArray array : arrays) {
+            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            currentPositionBytes += array.getNumBytesOfSegment();
+        }
+
+        return fromSegment(newSegment);
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -238,4 +238,29 @@ public final class ShortArray extends TornadoNativeArray {
             array.set(i, value);
         }
     }
+
+    /**
+     * Concatenates multiple {@link ShortArray} instances into a single {@link ShortArray}.
+     *
+     * @param arrays
+     *     Variable number of {@link ShortArray} objects to be concatenated.
+     * @return A new {@link ShortArray} instance containing all the elements of the input arrays,
+     *     concatenated in the order they were provided.
+     */
+    public static ShortArray concat(ShortArray... arrays) {
+        long totalSizeBytes = 0;
+        for (ShortArray array : arrays) {
+            totalSizeBytes += array.getNumBytesOfSegment();
+        }
+
+        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+
+        long currentPositionBytes = 0;
+        for (ShortArray array : arrays) {
+            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            currentPositionBytes += array.getNumBytesOfSegment();
+        }
+
+        return fromSegment(newSegment);
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
@@ -248,11 +249,7 @@ public final class ShortArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static ShortArray concat(ShortArray... arrays) {
-        int newSize = 0;
-        for (ShortArray array : arrays) {
-            newSize += array.getSize();
-        }
-
+        int newSize = Arrays.stream(arrays).mapToInt(ShortArray::getSize).sum();
         ShortArray concatArray = new ShortArray(newSize);
 
         long currentPositionBytes = 0;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -248,19 +248,19 @@ public final class ShortArray extends TornadoNativeArray {
      *     concatenated in the order they were provided.
      */
     public static ShortArray concat(ShortArray... arrays) {
-        long totalSizeBytes = 0;
+        int newSize = 0;
         for (ShortArray array : arrays) {
-            totalSizeBytes += array.getNumBytesOfSegment();
+            newSize += array.getSize();
         }
 
-        MemorySegment newSegment = Arena.ofAuto().allocate(totalSizeBytes, 1);
+        ShortArray concatArray = new ShortArray(newSize);
 
         long currentPositionBytes = 0;
         for (ShortArray array : arrays) {
-            MemorySegment.copy(array.getSegment(), 0, newSegment, currentPositionBytes, array.getNumBytesOfSegment());
+            MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
 
-        return fromSegment(newSegment);
+        return concatArray;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -251,13 +251,11 @@ public final class ShortArray extends TornadoNativeArray {
     public static ShortArray concat(ShortArray... arrays) {
         int newSize = Arrays.stream(arrays).mapToInt(ShortArray::getSize).sum();
         ShortArray concatArray = new ShortArray(newSize);
-
         long currentPositionBytes = 0;
         for (ShortArray array : arrays) {
             MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
             currentPositionBytes += array.getNumBytesOfSegment();
         }
-
         return concatArray;
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestConcat.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestConcat.java
@@ -61,7 +61,7 @@ public class TestConcat extends TornadoTestBase {
         }
 
         for (int i = 0; i < e.getSize(); i++) {
-            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+            assertEquals("Mismatch in third part of c", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
         }
     }
 
@@ -86,7 +86,7 @@ public class TestConcat extends TornadoTestBase {
         }
 
         for (int i = 0; i < e.getSize(); i++) {
-            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+            assertEquals("Mismatch in third part of c", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
         }
     }
 
@@ -111,7 +111,7 @@ public class TestConcat extends TornadoTestBase {
         }
 
         for (int i = 0; i < e.getSize(); i++) {
-            assertEquals("Mismatch in third part of d", 12, c.get(a.getSize() + b.getSize() + i), 0.0f);
+            assertEquals("Mismatch in third part of c", 12, c.get(a.getSize() + b.getSize() + i), 0.0f);
         }
     }
 
@@ -136,7 +136,7 @@ public class TestConcat extends TornadoTestBase {
         }
 
         for (int i = 0; i < e.getSize(); i++) {
-            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+            assertEquals("Mismatch in third part of c", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
         }
     }
 
@@ -161,7 +161,7 @@ public class TestConcat extends TornadoTestBase {
         }
 
         for (int i = 0; i < e.getSize(); i++) {
-            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+            assertEquals("Mismatch in third part of c", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
         }
     }
 
@@ -186,7 +186,7 @@ public class TestConcat extends TornadoTestBase {
         }
 
         for (int i = 0; i < e.getSize(); i++) {
-            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+            assertEquals("Mismatch in third part of c", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
         }
     }
 
@@ -211,7 +211,7 @@ public class TestConcat extends TornadoTestBase {
         }
 
         for (int i = 0; i < e.getSize(); i++) {
-            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i).getFloat32(), 0.0f);
+            assertEquals("Mismatch in third part of c", 12f, c.get(a.getSize() + b.getSize() + i).getFloat32(), 0.0f);
         }
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestConcat.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestConcat.java
@@ -141,6 +141,31 @@ public class TestConcat extends TornadoTestBase {
     }
 
     @Test
+    public void testIntArrayConcat() {
+
+        IntArray a = new IntArray(numElements);
+        IntArray b = new IntArray(numElements);
+        IntArray e = new IntArray(numElements);
+
+        a.init(100);
+        b.init(5);
+        e.init(12);
+
+        IntArray c = IntArray.concat(a, b, e);
+
+        for (int i = 0; i < a.getSize(); i++) {
+            assertEquals("Mismatch in first part of c", 100.0f, c.get(i), 0.0f);
+        }
+        for (int i = 0; i < b.getSize(); i++) {
+            assertEquals("Mismatch in second part of c", 5.0f, c.get(a.getSize() + i), 0.0f);
+        }
+
+        for (int i = 0; i < e.getSize(); i++) {
+            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+        }
+    }
+
+    @Test
     public void testShortArrayConcat() {
 
         ShortArray a = new ShortArray(numElements);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestConcat.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestConcat.java
@@ -20,6 +20,7 @@ package uk.ac.manchester.tornado.unittests.api;
 import org.junit.Test;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
+import uk.ac.manchester.tornado.api.types.arrays.CharArray;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
@@ -177,6 +178,31 @@ public class TestConcat extends TornadoTestBase {
         e.init((short) 12);
 
         ShortArray c = ShortArray.concat(a, b, e);
+
+        for (int i = 0; i < a.getSize(); i++) {
+            assertEquals("Mismatch in first part of c", 100.0f, c.get(i), 0.0f);
+        }
+        for (int i = 0; i < b.getSize(); i++) {
+            assertEquals("Mismatch in second part of c", 5.0f, c.get(a.getSize() + i), 0.0f);
+        }
+
+        for (int i = 0; i < e.getSize(); i++) {
+            assertEquals("Mismatch in third part of c", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testCharArrayConcat() {
+
+        CharArray a = new CharArray(numElements);
+        CharArray b = new CharArray(numElements);
+        CharArray e = new CharArray(numElements);
+
+        a.init((char) 100);
+        b.init((char) 5);
+        e.init((char) 12);
+
+        CharArray c = CharArray.concat(a, b, e);
 
         for (int i = 0; i < a.getSize(); i++) {
             assertEquals("Mismatch in first part of c", 100.0f, c.get(i), 0.0f);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestConcat.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestConcat.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import org.junit.Test;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.arrays.LongArray;
+import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * How to run?
+ *
+ * <code>
+ * $ tornado-test -V --fast uk.ac.manchester.tornado.unittests.api.TestConcat
+ * </code>
+ */
+public class TestConcat extends TornadoTestBase {
+    public final int numElements = 256;
+
+    @Test
+    public void testFloatArrayConcat() {
+
+        FloatArray a = new FloatArray(numElements);
+        FloatArray b = new FloatArray(numElements);
+        FloatArray e = new FloatArray(numElements);
+
+        a.init(100.0f);
+        b.init(5.0f);
+        e.init(12f);
+
+        FloatArray c = FloatArray.concat(a, b, e);
+
+        for (int i = 0; i < a.getSize(); i++) {
+            assertEquals("Mismatch in first part of c", 100.0f, c.get(i), 0.0f);
+        }
+        for (int i = 0; i < b.getSize(); i++) {
+            assertEquals("Mismatch in second part of c", 5.0f, c.get(a.getSize() + i), 0.0f);
+        }
+
+        for (int i = 0; i < e.getSize(); i++) {
+            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testDoubleArrayConcat() {
+
+        DoubleArray a = new DoubleArray(numElements);
+        DoubleArray b = new DoubleArray(numElements);
+        DoubleArray e = new DoubleArray(numElements);
+
+        a.init(100.0d);
+        b.init(5d);
+        e.init(12d);
+
+        DoubleArray c = DoubleArray.concat(a, b, e);
+
+        for (int i = 0; i < a.getSize(); i++) {
+            assertEquals("Mismatch in first part of c", 100.0f, c.get(i), 0.0f);
+        }
+        for (int i = 0; i < b.getSize(); i++) {
+            assertEquals("Mismatch in second part of c", 5.0f, c.get(a.getSize() + i), 0.0f);
+        }
+
+        for (int i = 0; i < e.getSize(); i++) {
+            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testByteArrayConcat() {
+
+        ByteArray a = new ByteArray(numElements);
+        ByteArray b = new ByteArray(numElements);
+        ByteArray e = new ByteArray(numElements);
+
+        a.init((byte) 100);
+        b.init((byte) 5);
+        e.init((byte) 12);
+
+        ByteArray c = ByteArray.concat(a, b, e);
+
+        for (int i = 0; i < a.getSize(); i++) {
+            assertEquals("Mismatch in first part of c", 100, c.get(i), 0.0f);
+        }
+        for (int i = 0; i < b.getSize(); i++) {
+            assertEquals("Mismatch in second part of c", 5, c.get(a.getSize() + i), 0.0f);
+        }
+
+        for (int i = 0; i < e.getSize(); i++) {
+            assertEquals("Mismatch in third part of d", 12, c.get(a.getSize() + b.getSize() + i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testLongArrayConcat() {
+
+        LongArray a = new LongArray(numElements);
+        LongArray b = new LongArray(numElements);
+        LongArray e = new LongArray(numElements);
+
+        a.init(100L);
+        b.init(5L);
+        e.init(12l);
+
+        LongArray c = LongArray.concat(a, b, e);
+
+        for (int i = 0; i < a.getSize(); i++) {
+            assertEquals("Mismatch in first part of c", 100.0f, c.get(i), 0.0f);
+        }
+        for (int i = 0; i < b.getSize(); i++) {
+            assertEquals("Mismatch in second part of c", 5.0f, c.get(a.getSize() + i), 0.0f);
+        }
+
+        for (int i = 0; i < e.getSize(); i++) {
+            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testShortArrayConcat() {
+
+        ShortArray a = new ShortArray(numElements);
+        ShortArray b = new ShortArray(numElements);
+        ShortArray e = new ShortArray(numElements);
+
+        a.init((short) 100);
+        b.init((short) 5);
+        e.init((short) 12);
+
+        ShortArray c = ShortArray.concat(a, b, e);
+
+        for (int i = 0; i < a.getSize(); i++) {
+            assertEquals("Mismatch in first part of c", 100.0f, c.get(i), 0.0f);
+        }
+        for (int i = 0; i < b.getSize(); i++) {
+            assertEquals("Mismatch in second part of c", 5.0f, c.get(a.getSize() + i), 0.0f);
+        }
+
+        for (int i = 0; i < e.getSize(); i++) {
+            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testHalfFloatArrayConcat() {
+
+        HalfFloatArray a = new HalfFloatArray(numElements);
+        HalfFloatArray b = new HalfFloatArray(numElements);
+        HalfFloatArray e = new HalfFloatArray(numElements);
+
+        a.init(new HalfFloat(100));
+        b.init(new HalfFloat(5));
+        e.init(new HalfFloat(12));
+
+        HalfFloatArray c = HalfFloatArray.concat(a, b, e);
+
+        for (int i = 0; i < a.getSize(); i++) {
+            assertEquals("Mismatch in first part of c", 100.0f, c.get(i).getFloat32(), 0.0f);
+        }
+        for (int i = 0; i < b.getSize(); i++) {
+            assertEquals("Mismatch in second part of c", 5.0f, c.get(a.getSize() + i).getFloat32(), 0.0f);
+        }
+
+        for (int i = 0; i < e.getSize(); i++) {
+            assertEquals("Mismatch in third part of d", 12f, c.get(a.getSize() + b.getSize() + i).getFloat32(), 0.0f);
+        }
+    }
+
+}


### PR DESCRIPTION
#### Description

This pull request introduces a new method concat to multiple instances of TornadoNativeArray types into a single array. This aims at providing a straightforward and efficient way to merge several  arrays  by using Memory Segment copies and without the overhead of manual array copying.

Example usage:
```java
  IntArray a = new IntArray(numElements);
  IntArray b = new IntArray(numElements);
  IntArray e = new IntArray(numElements);

  a.init(100);
  b.init(5);
  e.init(12);

  IntArray c = IntArray.concat(a, b, e);

```
Example size output;
```bash
Array a size: 256
Array b size: 256
Array e size: 256
---------------------------------
Concat Array c size: 768
---------------------------------
```
#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?
```bash
make jdk21 backend=opencl
tornado-test -V --fast uk.ac.manchester.tornado.unittests.api.TestConcat
```
----------------------------------------------------------------------------
