### PR TITLE
Add constructors for concatinating multiple arrays of TornadoNativeType instances

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -63,6 +63,16 @@ public final class ByteArray extends TornadoNativeArray {
     }
 
     /**
+     * Constructs a new {@link ByteArray} instance by concatenating the contents of the given array of {@link ByteArray} instances.
+     *
+     * @param arrays
+     *     An array of {@link ByteArray} instances to be concatenated into the new instance.
+     */
+    public ByteArray(ByteArray... arrays) {
+        concat(arrays);
+    }
+
+    /**
      * Internal method used to create a new instance of the {@link ByteArray} from on-heap data.
      *
      * @param values

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -61,6 +61,16 @@ public final class CharArray extends TornadoNativeArray {
     }
 
     /**
+     * Constructs a new {@link CharArray} instance by concatenating the contents of the given array of {@link CharArray} instances.
+     *
+     * @param arrays
+     *     An array of {@link CharArray} instances to be concatenated into the new instance.
+     */
+    public CharArray(CharArray... arrays) {
+        concat(arrays);
+    }
+
+    /**
      * Internal method used to create a new instance of the {@link CharArray} from on-heap data.
      *
      * @param values

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -63,6 +63,16 @@ public final class DoubleArray extends TornadoNativeArray {
     }
 
     /**
+     * Constructs a new {@link DoubleArray} instance by concatenating the contents of the given array of {@link DoubleArray} instances.
+     *
+     * @param arrays
+     *     An array of {@link DoubleArray} instances to be concatenated into the new instance.
+     */
+    public DoubleArray(DoubleArray... arrays) {
+        concat(arrays);
+    }
+
+    /**
      * Internal method used to create a new instance of the {@link DoubleArray} from on-heap data.
      *
      * @param values

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -63,6 +63,16 @@ public final class FloatArray extends TornadoNativeArray {
     }
 
     /**
+     * Constructs a new {@link FloatArray} instance by concatenating the contents of the given array of {@link FloatArray} instances.
+     *
+     * @param arrays
+     *     An array of {@link FloatArray} instances to be concatenated into the new instance.
+     */
+    public FloatArray(FloatArray... arrays) {
+        concat(arrays);
+    }
+
+    /**
      * Internal method used to create a new instance of the {@link FloatArray} from on-heap data.
      *
      * @param values

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -65,6 +65,16 @@ public final class HalfFloatArray extends TornadoNativeArray {
     }
 
     /**
+     * Constructs a new {@link HalfFloatArray} instance by concatenating the contents of the given array of {@link HalfFloatArray} instances.
+     *
+     * @param arrays
+     *     An array of {@link HalfFloatArray} instances to be concatenated into the new instance.
+     */
+    public HalfFloatArray(HalfFloatArray... arrays) {
+        concat(arrays);
+    }
+
+    /**
      * Internal method used to create a new instance of the {@link HalfFloatArray} from on-heap data.
      *
      * @param values

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -60,6 +60,16 @@ public final class IntArray extends TornadoNativeArray {
     }
 
     /**
+     * Constructs a new {@link IntArray} instance by concatenating the contents of the given array of {@link IntArray} instances.
+     *
+     * @param arrays
+     *     An array of {@link IntArray} instances to be concatenated into the new instance.
+     */
+    public IntArray(IntArray... arrays) {
+        concat(arrays);
+    }
+
+    /**
      * Internal method used to create a new instance of the {@link IntArray} from on-heap data.
      *
      * @param values

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -61,6 +61,16 @@ public final class LongArray extends TornadoNativeArray {
     }
 
     /**
+     * Constructs a new {@link LongArray} instance by concatenating the contents of the given array of {@link LongArray} instances.
+     *
+     * @param arrays
+     *     An array of {@link LongArray} instances to be concatenated into the new instance.
+     */
+    public LongArray(LongArray... arrays) {
+        concat(arrays);
+    }
+
+    /**
      * Internal method used to create a new instance of the {@link LongArray} from on-heap data.
      *
      * @param values

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -62,6 +62,16 @@ public final class ShortArray extends TornadoNativeArray {
     }
 
     /**
+     * Constructs a new {@link ShortArray} instance by concatenating the contents of the given array of {@link ShortArray} instances.
+     *
+     * @param arrays
+     *     An array of {@link ShortArray} instances to be concatenated into the new instance.
+     */
+    public ShortArray(ShortArray... arrays) {
+        concat(arrays);
+    }
+
+    /**
      * Internal method used to create a new instance of the {@link ShortArray} from on-heap data.
      *
      * @param values


### PR DESCRIPTION
#### Description

This pull request introduces a new constructor to `TornadoNativeTypes`, enabling the creation of a single instance by concatenating the contents of multiple array instances. 
#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

The functioality is already tests with the: 
```bash 
tornado-test -V --fast uk.ac.manchester.tornado.unittests.api.TestConcat
```
----------------------------------------------------------------------------
