### PR TITLE
Add support to create TornadoNativeArrays from a TornadoNativeArray slice 

### DIFF
--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -53,7 +53,7 @@ Additionally, developers can create an instance of a TornadoVM native array by i
    // from multiple TornadoVM native arrays to single TornadoVM native array
    public static FloatArray concat(FloatArray... arrays);
    // from a slice of a TornadoVM native array
-   public static FloatArray slice(FloatArray array, int offset,int length);
+   public FloatArray slice(int offset,int length);
 
 The main methods that the off-heap types expose to manage the Memory Segment of each type are presented in the list below. 
 

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -52,6 +52,8 @@ Additionally, developers can create an instance of a TornadoVM native array by i
    public static FloatArray fromSegment(MemorySegment segment);
    // from multiple TornadoVM native arrays to single TornadoVM native array
    public static FloatArray concat(FloatArray... arrays);
+   // from a slice of a TornadoVM native array
+   public static FloatArray slice(FloatArray array, int offset,int length);
 
 The main methods that the off-heap types expose to manage the Memory Segment of each type are presented in the list below. 
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -263,8 +263,6 @@ public final class ByteArray extends TornadoNativeArray {
      * Extracts a slice of elements from a given {@link ByteArray}, creating a new {@link ByteArray} instance.
      *
      *
-     * @param array
-     *     The {@link ByteArray} from which to extract the slice.
      * @param offset
      *     The starting index from which to begin the slice, inclusive.
      * @param length
@@ -273,14 +271,14 @@ public final class ByteArray extends TornadoNativeArray {
      * @throws IllegalArgumentException
      *     if the specified slice is out of the bounds of the original array.
      */
-    public static ByteArray slice(ByteArray array, int offset, int length) {
-        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+    public ByteArray slice(int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > getSize()) {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
         long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * BYTE_BYTES;
         long sliceByteLength = length * BYTE_BYTES;
-        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         ByteArray slice = fromSegment(sliceSegment);
         return slice;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -258,4 +258,30 @@ public final class ByteArray extends TornadoNativeArray {
         }
         return concatArray;
     }
+
+    /**
+     * Extracts a slice of elements from a given {@link ByteArray}, creating a new {@link ByteArray} instance.
+     *
+     *
+     * @param array
+     *     The {@link ByteArray} from which to extract the slice.
+     * @param offset
+     *     The starting index from which to begin the slice, inclusive.
+     * @param length
+     *     The number of elements to include in the slice.
+     * @return A new {@link ByteArray} instance representing the specified slice of the original array.
+     * @throws IllegalArgumentException
+     *     if the specified slice is out of the bounds of the original array.
+     */
+    public static ByteArray slice(ByteArray array, int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+            throw new IllegalArgumentException("Slice out of bounds");
+        }
+
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * BYTE_BYTES;
+        long sliceByteLength = length * BYTE_BYTES;
+        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        ByteArray slice = fromSegment(sliceSegment);
+        return slice;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -262,8 +262,6 @@ public final class CharArray extends TornadoNativeArray {
      * Extracts a slice of elements from a given {@link CharArray}, creating a new {@link CharArray} instance.
      *
      *
-     * @param array
-     *     The {@link CharArray} from which to extract the slice.
      * @param offset
      *     The starting index from which to begin the slice, inclusive.
      * @param length
@@ -272,14 +270,14 @@ public final class CharArray extends TornadoNativeArray {
      * @throws IllegalArgumentException
      *     if the specified slice is out of the bounds of the original array.
      */
-    public static CharArray slice(CharArray array, int offset, int length) {
-        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+    public CharArray slice(int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > getSize()) {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
         long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * CHAR_BYTES;
         long sliceByteLength = length * CHAR_BYTES;
-        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         CharArray slice = fromSegment(sliceSegment);
         return slice;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -257,4 +257,30 @@ public final class CharArray extends TornadoNativeArray {
         }
         return concatArray;
     }
+
+    /**
+     * Extracts a slice of elements from a given {@link CharArray}, creating a new {@link CharArray} instance.
+     *
+     *
+     * @param array
+     *     The {@link CharArray} from which to extract the slice.
+     * @param offset
+     *     The starting index from which to begin the slice, inclusive.
+     * @param length
+     *     The number of elements to include in the slice.
+     * @return A new {@link CharArray} instance representing the specified slice of the original array.
+     * @throws IllegalArgumentException
+     *     if the specified slice is out of the bounds of the original array.
+     */
+    public static CharArray slice(CharArray array, int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+            throw new IllegalArgumentException("Slice out of bounds");
+        }
+
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * CHAR_BYTES;
+        long sliceByteLength = length * CHAR_BYTES;
+        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        CharArray slice = fromSegment(sliceSegment);
+        return slice;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -264,8 +264,6 @@ public final class DoubleArray extends TornadoNativeArray {
      * Extracts a slice of elements from a given {@link DoubleArray}, creating a new {@link DoubleArray} instance.
      *
      *
-     * @param array
-     *     The {@link DoubleArray} from which to extract the slice.
      * @param offset
      *     The starting index from which to begin the slice, inclusive.
      * @param length
@@ -274,14 +272,14 @@ public final class DoubleArray extends TornadoNativeArray {
      * @throws IllegalArgumentException
      *     if the specified slice is out of the bounds of the original array.
      */
-    public static DoubleArray slice(DoubleArray array, int offset, int length) {
-        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+    public DoubleArray slice(int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > getSize()) {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
         long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * DOUBLE_BYTES;
         long sliceByteLength = length * DOUBLE_BYTES;
-        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         DoubleArray slice = fromSegment(sliceSegment);
         return slice;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -259,4 +259,30 @@ public final class DoubleArray extends TornadoNativeArray {
         }
         return concatArray;
     }
+
+    /**
+     * Extracts a slice of elements from a given {@link DoubleArray}, creating a new {@link DoubleArray} instance.
+     *
+     *
+     * @param array
+     *     The {@link DoubleArray} from which to extract the slice.
+     * @param offset
+     *     The starting index from which to begin the slice, inclusive.
+     * @param length
+     *     The number of elements to include in the slice.
+     * @return A new {@link DoubleArray} instance representing the specified slice of the original array.
+     * @throws IllegalArgumentException
+     *     if the specified slice is out of the bounds of the original array.
+     */
+    public static DoubleArray slice(DoubleArray array, int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+            throw new IllegalArgumentException("Slice out of bounds");
+        }
+
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * DOUBLE_BYTES;
+        long sliceByteLength = length * DOUBLE_BYTES;
+        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        DoubleArray slice = fromSegment(sliceSegment);
+        return slice;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -259,4 +259,30 @@ public final class FloatArray extends TornadoNativeArray {
         }
         return concatArray;
     }
+
+    /**
+     * Extracts a slice of elements from a given {@link FloatArray}, creating a new {@link FloatArray} instance.
+     *
+     * 
+     * @param array
+     *     The {@link FloatArray} from which to extract the slice.
+     * @param offset
+     *     The starting index from which to begin the slice, inclusive.
+     * @param length
+     *     The number of elements to include in the slice.
+     * @return A new {@link FloatArray} instance representing the specified slice of the original array.
+     * @throws IllegalArgumentException
+     *     if the specified slice is out of the bounds of the original array.
+     */
+    public static FloatArray slice(FloatArray array, int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+            throw new IllegalArgumentException("Slice out of bounds");
+        }
+
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * FLOAT_BYTES;
+        long sliceByteLength = length * FLOAT_BYTES;
+        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        FloatArray slice = fromSegment(sliceSegment);
+        return slice;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -263,9 +263,7 @@ public final class FloatArray extends TornadoNativeArray {
     /**
      * Extracts a slice of elements from a given {@link FloatArray}, creating a new {@link FloatArray} instance.
      *
-     * 
-     * @param array
-     *     The {@link FloatArray} from which to extract the slice.
+     *
      * @param offset
      *     The starting index from which to begin the slice, inclusive.
      * @param length
@@ -274,14 +272,14 @@ public final class FloatArray extends TornadoNativeArray {
      * @throws IllegalArgumentException
      *     if the specified slice is out of the bounds of the original array.
      */
-    public static FloatArray slice(FloatArray array, int offset, int length) {
-        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+    public FloatArray slice(int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > getSize()) {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
         long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * FLOAT_BYTES;
         long sliceByteLength = length * FLOAT_BYTES;
-        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         FloatArray slice = fromSegment(sliceSegment);
         return slice;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -95,7 +95,7 @@ public final class HalfFloatArray extends TornadoNativeArray {
      *
      * @param values
      *     The {@link HalfFloat} values to initialize the array with.
-     * @return A new {@link FloatArray} instance, initialized with the given values.
+     * @return A new {@linkHalfFloatArray} instance, initialized with the given values.
      */
     public static HalfFloatArray fromElements(HalfFloat... values) {
         return createSegment(values);
@@ -261,6 +261,32 @@ public final class HalfFloatArray extends TornadoNativeArray {
             currentPositionBytes += array.getNumBytesOfSegment();
         }
         return concatArray;
+    }
+
+    /**
+     * Extracts a slice of elements from a given {@linkHalfFloatArray}, creating a new {@linkHalfFloatArray} instance.
+     *
+     *
+     * @param array
+     *     The {@linkHalfFloatArray} from which to extract the slice.
+     * @param offset
+     *     The starting index from which to begin the slice, inclusive.
+     * @param length
+     *     The number of elements to include in the slice.
+     * @return A new {@linkHalfFloatArray} instance representing the specified slice of the original array.
+     * @throws IllegalArgumentException
+     *     if the specified slice is out of the bounds of the original array.
+     */
+    public static HalfFloatArray slice(HalfFloatArray array, int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+            throw new IllegalArgumentException("Slice out of bounds");
+        }
+
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * HALF_FLOAT_BYTES;
+        long sliceByteLength = length * HALF_FLOAT_BYTES;
+        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        HalfFloatArray slice = fromSegment(sliceSegment);
+        return slice;
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -277,14 +277,14 @@ public final class HalfFloatArray extends TornadoNativeArray {
      * @throws IllegalArgumentException
      *     if the specified slice is out of the bounds of the original array.
      */
-    public static HalfFloatArray slice(HalfFloatArray array, int offset, int length) {
-        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+    public HalfFloatArray slice( int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > getSize()) {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
         long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * HALF_FLOAT_BYTES;
         long sliceByteLength = length * HALF_FLOAT_BYTES;
-        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         HalfFloatArray slice = fromSegment(sliceSegment);
         return slice;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -257,4 +257,29 @@ public final class IntArray extends TornadoNativeArray {
         return concatArray;
     }
 
+    /**
+     * Extracts a slice of elements from a given {@linkIntArray}, creating a new {@linkIntArray} instance.
+     *
+     *
+     * @param array
+     *     The {@linkIntArray} from which to extract the slice.
+     * @param offset
+     *     The starting index from which to begin the slice, inclusive.
+     * @param length
+     *     The number of elements to include in the slice.
+     * @return A new {@linkIntArray} instance representing the specified slice of the original array.
+     * @throws IllegalArgumentException
+     *     if the specified slice is out of the bounds of the original array.
+     */
+    public static IntArray slice(IntArray array, int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+            throw new IllegalArgumentException("Slice out of bounds");
+        }
+
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * INT_BYTES;
+        long sliceByteLength = length * INT_BYTES;
+        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        IntArray slice = fromSegment(sliceSegment);
+        return slice;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -261,8 +261,6 @@ public final class IntArray extends TornadoNativeArray {
      * Extracts a slice of elements from a given {@linkIntArray}, creating a new {@linkIntArray} instance.
      *
      *
-     * @param array
-     *     The {@linkIntArray} from which to extract the slice.
      * @param offset
      *     The starting index from which to begin the slice, inclusive.
      * @param length
@@ -271,14 +269,14 @@ public final class IntArray extends TornadoNativeArray {
      * @throws IllegalArgumentException
      *     if the specified slice is out of the bounds of the original array.
      */
-    public static IntArray slice(IntArray array, int offset, int length) {
-        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+    public IntArray slice(int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > getSize()) {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
         long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * INT_BYTES;
         long sliceByteLength = length * INT_BYTES;
-        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         IntArray slice = fromSegment(sliceSegment);
         return slice;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -257,4 +257,30 @@ public final class LongArray extends TornadoNativeArray {
         }
         return concatArray;
     }
+
+    /**
+     * Extracts a slice of elements from a given {@link LongArray}, creating a new {@link LongArray} instance.
+     *
+     *
+     * @param array
+     *     The {@link LongArray} from which to extract the slice.
+     * @param offset
+     *     The starting index from which to begin the slice, inclusive.
+     * @param length
+     *     The number of elements to include in the slice.
+     * @return A new {@link LongArray} instance representing the specified slice of the original array.
+     * @throws IllegalArgumentException
+     *     if the specified slice is out of the bounds of the original array.
+     */
+    public static LongArray slice(LongArray array, int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+            throw new IllegalArgumentException("Slice out of bounds");
+        }
+
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * LONG_BYTES;
+        long sliceByteLength = length * LONG_BYTES;
+        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        LongArray slice = fromSegment(sliceSegment);
+        return slice;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -262,8 +262,6 @@ public final class LongArray extends TornadoNativeArray {
      * Extracts a slice of elements from a given {@link LongArray}, creating a new {@link LongArray} instance.
      *
      *
-     * @param array
-     *     The {@link LongArray} from which to extract the slice.
      * @param offset
      *     The starting index from which to begin the slice, inclusive.
      * @param length
@@ -272,14 +270,14 @@ public final class LongArray extends TornadoNativeArray {
      * @throws IllegalArgumentException
      *     if the specified slice is out of the bounds of the original array.
      */
-    public static LongArray slice(LongArray array, int offset, int length) {
-        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+    public LongArray slice(int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > getSize()) {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
         long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * LONG_BYTES;
         long sliceByteLength = length * LONG_BYTES;
-        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         LongArray slice = fromSegment(sliceSegment);
         return slice;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -262,9 +262,6 @@ public final class ShortArray extends TornadoNativeArray {
     /**
      * Extracts a slice of elements from a given {@link ShortArray}, creating a new {@link ShortArray} instance.
      *
-     *
-     * @param array
-     *     The {@link ShortArray} from which to extract the slice.
      * @param offset
      *     The starting index from which to begin the slice, inclusive.
      * @param length
@@ -273,14 +270,14 @@ public final class ShortArray extends TornadoNativeArray {
      * @throws IllegalArgumentException
      *     if the specified slice is out of the bounds of the original array.
      */
-    public static ShortArray slice(ShortArray array, int offset, int length) {
-        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+    public ShortArray slice(int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > getSize()) {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
         long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * SHORT_BYTES;
         long sliceByteLength = length * SHORT_BYTES;
-        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         ShortArray slice = fromSegment(sliceSegment);
         return slice;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -258,4 +258,30 @@ public final class ShortArray extends TornadoNativeArray {
         }
         return concatArray;
     }
+
+    /**
+     * Extracts a slice of elements from a given {@link ShortArray}, creating a new {@link ShortArray} instance.
+     *
+     *
+     * @param array
+     *     The {@link ShortArray} from which to extract the slice.
+     * @param offset
+     *     The starting index from which to begin the slice, inclusive.
+     * @param length
+     *     The number of elements to include in the slice.
+     * @return A new {@link ShortArray} instance representing the specified slice of the original array.
+     * @throws IllegalArgumentException
+     *     if the specified slice is out of the bounds of the original array.
+     */
+    public static ShortArray slice(ShortArray array, int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > array.getSize()) {
+            throw new IllegalArgumentException("Slice out of bounds");
+        }
+
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * SHORT_BYTES;
+        long sliceByteLength = length * SHORT_BYTES;
+        MemorySegment sliceSegment = array.segment.asSlice(sliceOffsetInBytes, sliceByteLength);
+        ShortArray slice = fromSegment(sliceSegment);
+        return slice;
+    }
 }

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -115,6 +115,8 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.compute.ComputeTests"),
     TestEntry("uk.ac.manchester.tornado.unittests.dynamic.TestDynamic"),
     TestEntry("uk.ac.manchester.tornado.unittests.vector.api.TestVectorAPI"),
+    TestEntry("uk.ac.manchester.tornado.unittests.vector.api.TestConcat"),
+    TestEntry("uk.ac.manchester.tornado.unittests.vector.api.TestSlice"),
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleFunctions"),
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleTasksMultipleDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.vm.concurrency.TestConcurrentBackends"),

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSlice.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSlice.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import org.junit.Test;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
+import uk.ac.manchester.tornado.api.types.arrays.CharArray;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.arrays.LongArray;
+import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * How to run?
+ *
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.api.TestSlice
+ * </code>
+ * </p>
+ */
+public class TestSlice extends TornadoTestBase {
+    private final int numElements = 256;
+
+    @Test
+    public void testFloatArrayConcat() {
+
+        FloatArray a = new FloatArray(numElements);
+        FloatArray b = new FloatArray(numElements);
+        FloatArray e = new FloatArray(numElements);
+
+        a.init(100.0f);
+        b.init(5.0f);
+        e.init(12f);
+
+        FloatArray c = FloatArray.concat(a, b, e);
+
+        FloatArray slice = FloatArray.slice(c, 256, numElements);
+
+        for (int i = 0; i < slice.getSize(); i++) {
+            assertEquals("Mismatch in second part of slice", 5.0f, slice.get(i), 0.0f);
+        }
+
+    }
+
+    @Test
+    public void testDoubleArrayConcat() {
+
+        DoubleArray a = new DoubleArray(numElements);
+        DoubleArray b = new DoubleArray(numElements);
+        DoubleArray e = new DoubleArray(numElements);
+
+        a.init(100.0d);
+        b.init(5d);
+        e.init(12d);
+
+        DoubleArray c = DoubleArray.concat(a, b, e);
+
+        DoubleArray slice = DoubleArray.slice(c, 256, numElements);
+
+        for (int i = 0; i < slice.getSize(); i++) {
+            assertEquals("Mismatch in second part of slice", 5.0d, slice.get(i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testByteArrayConcat() {
+
+        ByteArray a = new ByteArray(numElements);
+        ByteArray b = new ByteArray(numElements);
+        ByteArray e = new ByteArray(numElements);
+
+        a.init((byte) 100);
+        b.init((byte) 5);
+        e.init((byte) 12);
+
+        ByteArray c = ByteArray.concat(a, b, e);
+
+        ByteArray slice = ByteArray.slice(c, 256, numElements);
+
+        for (int i = 0; i < slice.getSize(); i++) {
+            assertEquals("Mismatch in second part of slice", 5.0, slice.get(i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testLongArrayConcat() {
+
+        LongArray a = new LongArray(numElements);
+        LongArray b = new LongArray(numElements);
+        LongArray e = new LongArray(numElements);
+
+        a.init(100L);
+        b.init(5L);
+        e.init(12L);
+
+        LongArray c = LongArray.concat(a, b, e);
+        LongArray slice = LongArray.slice(c, 256, numElements);
+
+        for (int i = 0; i < slice.getSize(); i++) {
+            assertEquals("Mismatch in second part of slice", 5.0, slice.get(i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testIntArrayConcat() {
+
+        IntArray a = new IntArray(numElements);
+        IntArray b = new IntArray(numElements);
+        IntArray e = new IntArray(numElements);
+
+        a.init(100);
+        b.init(5);
+        e.init(12);
+
+        IntArray c = IntArray.concat(a, b, e);
+
+        IntArray slice = IntArray.slice(c, 256, numElements);
+
+        for (int i = 0; i < slice.getSize(); i++) {
+            assertEquals("Mismatch in second part of slice", 5.0d, slice.get(i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testShortArrayConcat() {
+
+        ShortArray a = new ShortArray(numElements);
+        ShortArray b = new ShortArray(numElements);
+        ShortArray e = new ShortArray(numElements);
+
+        a.init((short) 100);
+        b.init((short) 5);
+        e.init((short) 12);
+
+        ShortArray c = ShortArray.concat(a, b, e);
+
+        ShortArray slice = ShortArray.slice(c, 256, numElements);
+
+        for (int i = 0; i < slice.getSize(); i++) {
+            assertEquals("Mismatch in second part of slice", 5.0, slice.get(i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testCharArrayConcat() {
+
+        CharArray a = new CharArray(numElements);
+        CharArray b = new CharArray(numElements);
+        CharArray e = new CharArray(numElements);
+
+        a.init((char) 100);
+        b.init((char) 5);
+        e.init((char) 12);
+
+        CharArray c = CharArray.concat(a, b, e);
+        CharArray slice = CharArray.slice(c, 256, numElements);
+
+        for (int i = 0; i < slice.getSize(); i++) {
+            assertEquals("Mismatch in second part of slice", 5.0d, slice.get(i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testHalfFloatArrayConcat() {
+
+        HalfFloatArray a = new HalfFloatArray(numElements);
+        HalfFloatArray b = new HalfFloatArray(numElements);
+        HalfFloatArray e = new HalfFloatArray(numElements);
+
+        a.init(new HalfFloat(100));
+        b.init(new HalfFloat(5));
+        e.init(new HalfFloat(12));
+
+        HalfFloatArray c = HalfFloatArray.concat(a, b, e);
+
+        HalfFloatArray slice = HalfFloatArray.slice(c, 256, numElements);
+
+        for (int i = 0; i < slice.getSize(); i++) {
+            assertEquals("Mismatch in second part of slice", 5.0d, slice.get(i).getFloat32(), 0.0f);
+        }
+
+    }
+
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSlice.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSlice.java
@@ -44,7 +44,7 @@ public class TestSlice extends TornadoTestBase {
     private final int numElements = 256;
 
     @Test
-    public void testFloatArrayConcat() {
+    public void testFloatArraySlice() {
 
         FloatArray a = new FloatArray(numElements);
         FloatArray b = new FloatArray(numElements);
@@ -65,7 +65,7 @@ public class TestSlice extends TornadoTestBase {
     }
 
     @Test
-    public void testDoubleArrayConcat() {
+    public void testDoubleArraySlice() {
 
         DoubleArray a = new DoubleArray(numElements);
         DoubleArray b = new DoubleArray(numElements);
@@ -85,7 +85,7 @@ public class TestSlice extends TornadoTestBase {
     }
 
     @Test
-    public void testByteArrayConcat() {
+    public void testByteArraySlice() {
 
         ByteArray a = new ByteArray(numElements);
         ByteArray b = new ByteArray(numElements);
@@ -105,7 +105,7 @@ public class TestSlice extends TornadoTestBase {
     }
 
     @Test
-    public void testLongArrayConcat() {
+    public void testLongArraySlice() {
 
         LongArray a = new LongArray(numElements);
         LongArray b = new LongArray(numElements);
@@ -124,7 +124,7 @@ public class TestSlice extends TornadoTestBase {
     }
 
     @Test
-    public void testIntArrayConcat() {
+    public void testIntArraySlice() {
 
         IntArray a = new IntArray(numElements);
         IntArray b = new IntArray(numElements);
@@ -144,7 +144,7 @@ public class TestSlice extends TornadoTestBase {
     }
 
     @Test
-    public void testShortArrayConcat() {
+    public void testShortArraySlice() {
 
         ShortArray a = new ShortArray(numElements);
         ShortArray b = new ShortArray(numElements);
@@ -164,7 +164,7 @@ public class TestSlice extends TornadoTestBase {
     }
 
     @Test
-    public void testCharArrayConcat() {
+    public void testCharArraySlice() {
 
         CharArray a = new CharArray(numElements);
         CharArray b = new CharArray(numElements);
@@ -183,7 +183,7 @@ public class TestSlice extends TornadoTestBase {
     }
 
     @Test
-    public void testHalfFloatArrayConcat() {
+    public void testHalfFloatArraySlice() {
 
         HalfFloatArray a = new HalfFloatArray(numElements);
         HalfFloatArray b = new HalfFloatArray(numElements);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSlice.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSlice.java
@@ -56,7 +56,7 @@ public class TestSlice extends TornadoTestBase {
 
         FloatArray c = FloatArray.concat(a, b, e);
 
-        FloatArray slice = FloatArray.slice(c, 256, numElements);
+        FloatArray slice = c.slice(256, numElements);
 
         for (int i = 0; i < slice.getSize(); i++) {
             assertEquals("Mismatch in second part of slice", 5.0f, slice.get(i), 0.0f);
@@ -77,7 +77,7 @@ public class TestSlice extends TornadoTestBase {
 
         DoubleArray c = DoubleArray.concat(a, b, e);
 
-        DoubleArray slice = DoubleArray.slice(c, 256, numElements);
+        DoubleArray slice = c.slice(256, numElements);
 
         for (int i = 0; i < slice.getSize(); i++) {
             assertEquals("Mismatch in second part of slice", 5.0d, slice.get(i), 0.0f);
@@ -97,7 +97,7 @@ public class TestSlice extends TornadoTestBase {
 
         ByteArray c = ByteArray.concat(a, b, e);
 
-        ByteArray slice = ByteArray.slice(c, 256, numElements);
+        ByteArray slice = c.slice(256, numElements);
 
         for (int i = 0; i < slice.getSize(); i++) {
             assertEquals("Mismatch in second part of slice", 5.0, slice.get(i), 0.0f);
@@ -116,7 +116,7 @@ public class TestSlice extends TornadoTestBase {
         e.init(12L);
 
         LongArray c = LongArray.concat(a, b, e);
-        LongArray slice = LongArray.slice(c, 256, numElements);
+        LongArray slice = c.slice(256, numElements);
 
         for (int i = 0; i < slice.getSize(); i++) {
             assertEquals("Mismatch in second part of slice", 5.0, slice.get(i), 0.0f);
@@ -136,7 +136,7 @@ public class TestSlice extends TornadoTestBase {
 
         IntArray c = IntArray.concat(a, b, e);
 
-        IntArray slice = IntArray.slice(c, 256, numElements);
+        IntArray slice = c.slice(256, numElements);
 
         for (int i = 0; i < slice.getSize(); i++) {
             assertEquals("Mismatch in second part of slice", 5.0d, slice.get(i), 0.0f);
@@ -156,7 +156,7 @@ public class TestSlice extends TornadoTestBase {
 
         ShortArray c = ShortArray.concat(a, b, e);
 
-        ShortArray slice = ShortArray.slice(c, 256, numElements);
+        ShortArray slice = c.slice(256, numElements);
 
         for (int i = 0; i < slice.getSize(); i++) {
             assertEquals("Mismatch in second part of slice", 5.0, slice.get(i), 0.0f);
@@ -175,7 +175,7 @@ public class TestSlice extends TornadoTestBase {
         e.init((char) 12);
 
         CharArray c = CharArray.concat(a, b, e);
-        CharArray slice = CharArray.slice(c, 256, numElements);
+        CharArray slice = c.slice(256, numElements);
 
         for (int i = 0; i < slice.getSize(); i++) {
             assertEquals("Mismatch in second part of slice", 5.0d, slice.get(i), 0.0f);
@@ -195,7 +195,7 @@ public class TestSlice extends TornadoTestBase {
 
         HalfFloatArray c = HalfFloatArray.concat(a, b, e);
 
-        HalfFloatArray slice = HalfFloatArray.slice(c, 256, numElements);
+        HalfFloatArray slice = c.slice(256, numElements);
 
         for (int i = 0; i < slice.getSize(); i++) {
             assertEquals("Mismatch in second part of slice", 5.0d, slice.get(i).getFloat32(), 0.0f);


### PR DESCRIPTION
#### Description
This PR adds support for the TornadoNativeArray types to create arrays from segment slice of an array.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
tornado-test -V --fast uk.ac.manchester.tornado.unittests.api.TestSlice

```
----------------------------------------------------------------------------
