### PR TITLE
Support lazy copy-out for batch processing

### DIFF
--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
@@ -115,7 +115,7 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
         } else if (batchSize <= 0) {
             returnEvent = deviceContext.readBuffer(executionPlanId, toBuffer(), numBytes, segment.address(), hostOffset, (useDeps) ? events : null);
         } else {
-            returnEvent = deviceContext.readBuffer(executionPlanId, toBuffer() + TornadoNativeArray.ARRAY_HEADER, bufferSize, segment.address(), hostOffset + TornadoNativeArray.ARRAY_HEADER, (useDeps)
+            returnEvent = deviceContext.readBuffer(executionPlanId, toBuffer() + TornadoNativeArray.ARRAY_HEADER, numBytes, segment.address(), hostOffset + TornadoNativeArray.ARRAY_HEADER, (useDeps)
                     ? events
                     : null);
         }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -264,6 +264,41 @@ public class TestBatches extends TornadoTestBase {
     }
 
     @Test
+    public void test100MBLazy() {
+
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(100, MemoryUnit.MB);
+
+        // Fill 800MB of float array
+        int size = 200000000;
+        // or as much as we can
+        if (size * 4 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 4 / 2) * 0.9);
+        }
+        FloatArray arrayA = new FloatArray(size);
+        FloatArray arrayB = new FloatArray(size);
+
+        IntStream.range(0, arrayA.getSize()).sequential().forEach(idx -> arrayA.set(idx, 0));
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, arrayA) //
+                .task("t0", TestBatches::compute, arrayA, arrayB) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, arrayB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+        TornadoExecutionResult tornadoExecutionResult = executionPlan.withBatch("100MB") // Slots of 100 MB
+                .execute();
+
+        tornadoExecutionResult.transferToHost(arrayB);
+
+        for (int i = 0; i < arrayB.getSize(); i++) {
+            assertEquals(arrayA.get(i) + 100, arrayB.get(i), 0.1f);
+        }
+
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
     public void test300MB() {
 
         long maxAllocMemory = checkMaxHeapAllocationOnDevice(300, MemoryUnit.MB);
@@ -298,6 +333,42 @@ public class TestBatches extends TornadoTestBase {
     }
 
     @Test
+    public void test300MBLazy() {
+
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(300, MemoryUnit.MB);
+
+        // Fill 1.0GB
+        int size = 250_000_000;
+        // Or as much as we can
+        if (size * 4 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 4 / 2) * 0.9);
+        }
+        FloatArray arrayA = new FloatArray(size);
+        FloatArray arrayB = new FloatArray(size);
+
+        Random r = new Random();
+        IntStream.range(0, arrayA.getSize()).sequential().forEach(idx -> arrayA.set(idx, r.nextFloat()));
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, arrayA) //
+                .task("t0", TestBatches::compute, arrayA, arrayB) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, arrayB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+        TornadoExecutionResult tornadoExecutionResult = executionPlan.withBatch("300MB") // Slots of 300 MB
+                .execute();
+
+        tornadoExecutionResult.transferToHost(arrayB);
+
+        for (int i = 0; i < arrayB.getSize(); i++) {
+            assertEquals(arrayA.get(i) + 100, arrayB.get(i), 1.0f);
+        }
+
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
     public void test512MB() {
 
         long maxAllocMemory = checkMaxHeapAllocationOnDevice(512, MemoryUnit.MB);
@@ -321,6 +392,40 @@ public class TestBatches extends TornadoTestBase {
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
         executionPlan.withBatch("512MB") // Slots of 512 MB
                 .execute();
+
+        for (int i = 0; i < arrayA.getSize(); i++) {
+            assertEquals(i, arrayA.get(i), 0.1f);
+        }
+
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void test512MBLazy() {
+
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(512, MemoryUnit.MB);
+
+        // Fill 800MB
+        int size = 200000000;
+        // or as much as we can
+        if (size * 4 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 4) * 0.9);
+        }
+        FloatArray arrayA = new FloatArray(size);
+
+        IntStream.range(0, arrayA.getSize()).sequential().forEach(idx -> arrayA.set(idx, idx));
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, arrayA) //
+                .task("t0", TestBatches::compute, arrayA) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, arrayA);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+        TornadoExecutionResult tornadoExecutionResult = executionPlan.withBatch("512MB") // Slots of 512 MB
+                .execute();
+
+        tornadoExecutionResult.transferToHost(arrayA);
 
         for (int i = 0; i < arrayA.getSize(); i++) {
             assertEquals(i, arrayA.get(i), 0.1f);
@@ -768,6 +873,34 @@ public class TestBatches extends TornadoTestBase {
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot());
         executionPlan.withBatch("10MB") // Batches of 10MB
                 .execute();
+
+        for (int i = 0; i < array.getSize(); i++) {
+            assertEquals(array2.get(i) * 4, array.get(i), 0.01f);
+        }
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void testBatchNotEven2Lazy() {
+        checkMaxHeapAllocationOnDevice(64, MemoryUnit.MB);
+
+        // Allocate ~ 64MB
+        FloatArray array = new FloatArray(1024 * 1024 * 16);
+        FloatArray array2 = new FloatArray(1024 * 1024 * 16);
+        array.init(1.0f);
+        array2.init(1.0f);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, array) //
+                .task("t1", TestBatches::compute2, array) //
+                .task("t2", TestBatches::compute2, array) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, array);
+
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot());
+        TornadoExecutionResult tornadoExecutionResult = executionPlan.withBatch("10MB") // Batches of 10MB
+                .execute();
+
+        tornadoExecutionResult.transferToHost(array);
 
         for (int i = 0; i < array.getSize(); i++) {
             assertEquals(array2.get(i) * 4, array.get(i), 0.01f);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -195,6 +195,41 @@ public class TestBatches extends TornadoTestBase {
     }
 
     @Test
+    public void test100MBSmallLazy() {
+
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(100, MemoryUnit.MB);
+
+        // Fill 120MB of float array
+        int size = 30000000;
+        // or as much as we can
+        if (size * 4 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 4 / 2) * 0.9);
+        }
+        FloatArray arrayA = new FloatArray(size);
+        FloatArray arrayB = new FloatArray(size);
+
+        IntStream.range(0, arrayA.getSize()).sequential().forEach(idx -> arrayA.set(idx, 0));
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, arrayA) //
+                .task("t0", TestBatches::compute, arrayA, arrayB) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, arrayB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+        TornadoExecutionResult tornadoExecutionResult = executionPlan.withBatch("60MB") // Slots of 100 MB
+                .execute();
+
+        tornadoExecutionResult.transferToHost(arrayB);
+
+        for (int i = 0; i < arrayB.getSize(); i++) {
+            assertEquals(arrayA.get(i) + 100, arrayB.get(i), 0.1f);
+        }
+
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
     public void test100MB() {
 
         long maxAllocMemory = checkMaxHeapAllocationOnDevice(100, MemoryUnit.MB);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2020, 2024, APT Group, Department of Computer Science,
  * The University of Manchester.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
#### Description

This PR provides support for lazy copy-out in batch processing. The fix is related to the issue #333.   

#### Problem description
When the mode of the copy-out was set to `UNDER_DEMAND` on a `TaskGraph` that uses batches, the `transferToHost` copied only the first batch of the output data. In this PR, the stream-out is invoked with the appropriate offsets for each batch, writing all the data to the host buffer. 

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Run the following unittests:
`tornado-test -V --fast uk.ac.manchester.tornado.unittests.batches.TestBatches#test100MBSmallLazy`
`tornado-test -V --fast uk.ac.manchester.tornado.unittests.batches.TestBatches#test100MBLazy`
`tornado-test -V --fast uk.ac.manchester.tornado.unittests.batches.TestBatches#test300MBLazy`
`tornado-test -V --fast uk.ac.manchester.tornado.unittests.batches.TestBatches#test512MBLazy`
`tornado-test -V --fast uk.ac.manchester.tornado.unittests.batches.TestBatches#testBatchNotEven2Lazy`

