### PR TITLE
Fix for the free memory marker of TornadoVM when running multi-threaded execution plans

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/ObjectState.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/ObjectState.java
@@ -21,7 +21,7 @@ import uk.ac.manchester.tornado.api.common.TornadoDevice;
 
 public interface ObjectState {
 
-    DeviceBufferState getDeviceState(TornadoDevice device);
+    DeviceBufferState getDeviceBufferState(TornadoDevice device);
 
     void clear();
 

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -118,7 +118,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleFunctions"),
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleTasksMultipleDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.vm.concurrency.TestConcurrentBackends"),
-    TestEntry("uk.ac.manchester.tornado.unittests.multithreaded.MultiThreaded"),
+    TestEntry("uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.tensors.TestTensorTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.tensors.TestTensorAPIWithOnnx"),

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OpenCL.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OpenCL.java
@@ -170,8 +170,8 @@ public class OpenCL {
             Access access = accesses[i];
             Object object = parameters[i];
 
-            DataObjectState globalState = new DataObjectState();
-            XPUDeviceBufferState deviceState = globalState.getDeviceState(tornadoDevice);
+            DataObjectState dataObjectState = new DataObjectState();
+            XPUDeviceBufferState deviceState = dataObjectState.getDeviceBufferState(tornadoDevice);
 
             switch (access) {
                 case READ_WRITE:

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
@@ -114,7 +114,7 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
     public void deallocate() {
         TornadoInternalError.guarantee(bufferId != INIT_VALUE, "Fatal error: trying to deallocate an invalid buffer");
 
-        deviceContext.getBufferProvider().markBufferReleased(bufferId, bufferSize);
+        deviceContext.getBufferProvider().markBufferReleased(bufferId);
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
@@ -199,7 +199,7 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
     @Override
     public void deallocate() throws TornadoMemoryException {
         TornadoInternalError.guarantee(bufferId != INIT_VALUE, "Fatal error: trying to deallocate an invalid buffer");
-        deviceContext.getBufferProvider().markBufferReleased(bufferId, bufferSize);
+        deviceContext.getBufferProvider().markBufferReleased(bufferId);
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
@@ -105,7 +105,7 @@ public class OCLVectorWrapper implements XPUBuffer {
     public void deallocate() {
         TornadoInternalError.guarantee(bufferId != INIT_VALUE, "Fatal error: trying to deallocate an invalid buffer");
 
-        deviceContext.getBufferProvider().markBufferReleased(bufferId, bufferSize);
+        deviceContext.getBufferProvider().markBufferReleased(bufferId);
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
@@ -180,7 +180,7 @@ public class OCLXPUBuffer implements XPUBuffer {
 
     @Override
     public void deallocate() throws TornadoMemoryException {
-        deviceContext.getBufferProvider().markBufferReleased(this.bufferId, size());
+        deviceContext.getBufferProvider().markBufferReleased(this.bufferId);
         bufferId = -1;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLJITCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLJITCompiler.java
@@ -120,13 +120,13 @@ public class TestOpenCLJITCompiler {
     public void run(OCLTornadoDevice tornadoDevice, OCLInstalledCode openCLCode, TaskMetaData taskMeta, int[] a, int[] b, float[] c) {
         // First we allocate, A, B and C
         DataObjectState stateA = new DataObjectState();
-        XPUDeviceBufferState objectStateA = stateA.getDeviceState(tornadoDevice);
+        XPUDeviceBufferState objectStateA = stateA.getDeviceBufferState(tornadoDevice);
 
         DataObjectState stateB = new DataObjectState();
-        XPUDeviceBufferState objectStateB = stateB.getDeviceState(tornadoDevice);
+        XPUDeviceBufferState objectStateB = stateB.getDeviceBufferState(tornadoDevice);
 
         DataObjectState stateC = new DataObjectState();
-        XPUDeviceBufferState objectStateC = stateC.getDeviceState(tornadoDevice);
+        XPUDeviceBufferState objectStateC = stateC.getDeviceBufferState(tornadoDevice);
 
         tornadoDevice.allocateObjects(new Object[] { a, b, c }, 0, new DeviceBufferState[] { objectStateA, objectStateB, objectStateC });
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
@@ -99,7 +99,7 @@ public class PTX {
             Object object = parameters[i];
 
             DataObjectState globalState = new DataObjectState();
-            XPUDeviceBufferState deviceState = globalState.getDeviceState(tornadoDevice);
+            XPUDeviceBufferState deviceState = globalState.getDeviceBufferState(tornadoDevice);
 
             switch (access) {
                 case READ_WRITE:

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
@@ -230,7 +230,7 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
     public void deallocate() throws TornadoMemoryException {
         TornadoInternalError.guarantee(buffer != INIT_VALUE, "Fatal error: trying to deallocate an invalid buffer");
 
-        deviceContext.getBufferProvider().markBufferReleased(buffer, bufferSize);
+        deviceContext.getBufferProvider().markBufferReleased(buffer);
         buffer = INIT_VALUE;
         bufferSize = INIT_VALUE;
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
@@ -191,7 +191,7 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
     @Override
     public void deallocate() throws TornadoMemoryException {
         TornadoInternalError.guarantee(bufferId != INIT_VALUE, "Fatal error: trying to deallocate an invalid buffer");
-        deviceContext.getBufferProvider().markBufferReleased(bufferId, bufferSize);
+        deviceContext.getBufferProvider().markBufferReleased(bufferId);
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
@@ -173,7 +173,7 @@ public class PTXObjectWrapper implements XPUBuffer {
 
     @Override
     public void deallocate() throws TornadoMemoryException {
-        deviceContext.getBufferProvider().markBufferReleased(address, getObjectSize());
+        deviceContext.getBufferProvider().markBufferReleased(address);
         address = -1;
         for (FieldBuffer buffer : wrappedFields) {
             if (buffer != null) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
@@ -108,7 +108,7 @@ public class PTXVectorWrapper implements XPUBuffer {
     public void deallocate() {
         TornadoInternalError.guarantee(buffer != INIT_VALUE, "Fatal error: trying to deallocate an invalid buffer");
 
-        deviceContext.getBufferProvider().markBufferReleased(buffer, bufferSize);
+        deviceContext.getBufferProvider().markBufferReleased(buffer);
         buffer = INIT_VALUE;
         bufferSize = INIT_VALUE;
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXJITCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXJITCompiler.java
@@ -119,13 +119,13 @@ public class TestPTXJITCompiler {
     public void run(PTXTornadoDevice tornadoDevice, PTXInstalledCode ptxCode, TaskMetaData taskMeta, int[] a, int[] b, float[] c) {
         // First we allocate, A, B and C
         DataObjectState stateA = new DataObjectState();
-        XPUDeviceBufferState objectStateA = stateA.getDeviceState(tornadoDevice);
+        XPUDeviceBufferState objectStateA = stateA.getDeviceBufferState(tornadoDevice);
 
         DataObjectState stateB = new DataObjectState();
-        XPUDeviceBufferState objectStateB = stateB.getDeviceState(tornadoDevice);
+        XPUDeviceBufferState objectStateB = stateB.getDeviceBufferState(tornadoDevice);
 
         DataObjectState stateC = new DataObjectState();
-        XPUDeviceBufferState objectStateC = stateC.getDeviceState(tornadoDevice);
+        XPUDeviceBufferState objectStateC = stateC.getDeviceBufferState(tornadoDevice);
 
         tornadoDevice.allocateObjects(new Object[] { a, b, c }, 0, new DeviceBufferState[] { objectStateA, objectStateB, objectStateC });
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroContext.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroContext.java
@@ -24,7 +24,6 @@
 package uk.ac.manchester.tornado.drivers.spirv;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
@@ -278,7 +278,7 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
     public void deallocate() {
         TornadoInternalError.guarantee(bufferId != INIT_VALUE, "Fatal error: trying to deallocate an invalid buffer");
 
-        deviceContext.getBufferProvider().markBufferReleased(bufferId, bufferSize);
+        deviceContext.getBufferProvider().markBufferReleased(bufferId);
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
@@ -191,7 +191,7 @@ public class SPIRVMemorySegmentWrapper implements XPUBuffer {
     @Override
     public void deallocate() throws TornadoMemoryException {
         TornadoInternalError.guarantee(bufferId != INIT_VALUE, "Fatal error: trying to deallocate an invalid buffer");
-        spirvDeviceContext.getBufferProvider().markBufferReleased(bufferId, bufferSize);
+        spirvDeviceContext.getBufferProvider().markBufferReleased(bufferId);
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
         if (Tornado.FULL_DEBUG) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
@@ -183,7 +183,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
 
     @Override
     public void deallocate() throws TornadoMemoryException {
-        deviceContext.getBufferProvider().markBufferReleased(this.bufferId, size());
+        deviceContext.getBufferProvider().markBufferReleased(this.bufferId);
         bufferId = -1;
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
@@ -106,7 +106,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
     public void deallocate() {
         TornadoInternalError.guarantee(bufferId != INIT_VALUE, "Fatal error: trying to deallocate an invalid buffer");
 
-        deviceContext.getBufferProvider().markBufferReleased(bufferId, bufferSize);
+        deviceContext.getBufferProvider().markBufferReleased(bufferId);
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVJITCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVJITCompiler.java
@@ -120,13 +120,13 @@ public class TestSPIRVJITCompiler {
     public void run(SPIRVTornadoDevice spirvTornadoDevice, SPIRVInstalledCode installedCode, TaskMetaData taskMeta, int[] a, int[] b, float[] c) {
         // First we allocate, A, B and C
         DataObjectState stateA = new DataObjectState();
-        XPUDeviceBufferState objectStateA = stateA.getDeviceState(spirvTornadoDevice);
+        XPUDeviceBufferState objectStateA = stateA.getDeviceBufferState(spirvTornadoDevice);
 
         DataObjectState stateB = new DataObjectState();
-        XPUDeviceBufferState objectStateB = stateB.getDeviceState(spirvTornadoDevice);
+        XPUDeviceBufferState objectStateB = stateB.getDeviceBufferState(spirvTornadoDevice);
 
         DataObjectState stateC = new DataObjectState();
-        XPUDeviceBufferState objectStateC = stateC.getDeviceState(spirvTornadoDevice);
+        XPUDeviceBufferState objectStateC = stateC.getDeviceBufferState(spirvTornadoDevice);
 
         spirvTornadoDevice.allocateObjects(new Object[] { a, b, c }, 0, new DeviceBufferState[] { objectStateA, objectStateB, objectStateC });
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestVM.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestVM.java
@@ -69,15 +69,15 @@ public class TestVM {
 
         // We allocate buffer A
         DataObjectState stateA = new DataObjectState();
-        XPUDeviceBufferState objectStateA = stateA.getDeviceState(device);
+        XPUDeviceBufferState objectStateA = stateA.getDeviceBufferState(device);
 
         // We allocate buffer B
         DataObjectState stateB = new DataObjectState();
-        XPUDeviceBufferState objectStateB = stateB.getDeviceState(device);
+        XPUDeviceBufferState objectStateB = stateB.getDeviceBufferState(device);
 
         // We allocate buffer C
         DataObjectState stateC = new DataObjectState();
-        XPUDeviceBufferState objectStateC = stateC.getDeviceState(device);
+        XPUDeviceBufferState objectStateC = stateC.getDeviceBufferState(device);
 
         // Allocate a
         device.allocate(a, 0, objectStateA);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -538,7 +538,7 @@ public class TornadoExecutionContext {
                     long value = profiler.getTimer(ProfilerType.COPY_OUT_TIME_SYNC);
                     value += event.getElapsedTime();
                     profiler.setTimer(ProfilerType.COPY_OUT_TIME_SYNC, value);
-                    XPUDeviceBufferState deviceObjectState = localState.getGlobalState().getDeviceState(meta().getLogicDevice());
+                    XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceState(meta().getLogicDevice());
                     profiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getObjectBuffer().size());
                 }
             }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -538,7 +538,7 @@ public class TornadoExecutionContext {
                     long value = profiler.getTimer(ProfilerType.COPY_OUT_TIME_SYNC);
                     value += event.getElapsedTime();
                     profiler.setTimer(ProfilerType.COPY_OUT_TIME_SYNC, value);
-                    XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceState(meta().getLogicDevice());
+                    XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceBufferState(meta().getLogicDevice());
                     profiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getObjectBuffer().size());
                 }
             }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -47,18 +47,18 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoFailureException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
-import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.api.memory.TaskMetaDataInterface;
+import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
-import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
-import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
+import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
+import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 import uk.ac.manchester.tornado.runtime.graph.TornadoExecutionContext;
 import uk.ac.manchester.tornado.runtime.graph.TornadoVMBytecodeResult;
 import uk.ac.manchester.tornado.runtime.graph.TornadoVMBytecodes;
@@ -82,7 +82,7 @@ public class TornadoVMInterpreter {
 
     private final List<Object> objects;
 
-    private final DataObjectState[] globalStates;
+    private final DataObjectState[] dataObjectStates;
     private final KernelStackFrame[] kernelStackFrame;
     private final int[][] events;
     private final int[] eventsIndexes;
@@ -147,7 +147,7 @@ public class TornadoVMInterpreter {
         TornadoLogger.debug("created %d event lists", events.length);
 
         objects = executionContext.getObjects();
-        globalStates = new DataObjectState[objects.size()];
+        dataObjectStates = new DataObjectState[objects.size()];
         fetchGlobalStates();
 
         rewindBufferToBegin();
@@ -168,7 +168,7 @@ public class TornadoVMInterpreter {
         for (int i = 0; i < objects.size(); i++) {
             final Object object = objects.get(i);
             TornadoInternalError.guarantee(object != null, "null object found in TornadoVM");
-            globalStates[i] = executionContext.getLocalStateObject(object).getGlobalState();
+            dataObjectStates[i] = executionContext.getLocalStateObject(object).getDataObjectState();
         }
     }
 
@@ -788,7 +788,7 @@ public class TornadoVMInterpreter {
     }
 
     private XPUDeviceBufferState resolveObjectState(int index) {
-        return globalStates[index].getDeviceState(deviceForInterpreter);
+        return dataObjectStates[index].getDeviceState(deviceForInterpreter);
     }
 
     private boolean isObjectKernelContext(Object object) {
@@ -840,7 +840,7 @@ public class TornadoVMInterpreter {
     }
 
     private DataObjectState resolveGlobalObjectState(int index) {
-        return globalStates[index];
+        return dataObjectStates[index];
     }
 
     private boolean isObjectInAtomicRegion(XPUDeviceBufferState objectState, TornadoXPUDevice device, SchedulableTask task) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -690,7 +690,7 @@ public class TornadoVMInterpreter {
                 }
 
                 final DataObjectState globalState = resolveGlobalObjectState(argIndex);
-                final XPUDeviceBufferState objectState = globalState.getDeviceState(deviceForInterpreter);
+                final XPUDeviceBufferState objectState = globalState.getDeviceBufferState(deviceForInterpreter);
 
                 if (!isObjectInAtomicRegion(objectState, deviceForInterpreter, task)) {
                     // Add a reference (arrays, vector types, panama regions)
@@ -788,7 +788,7 @@ public class TornadoVMInterpreter {
     }
 
     private XPUDeviceBufferState resolveObjectState(int index) {
-        return dataObjectStates[index].getDeviceState(deviceForInterpreter);
+        return dataObjectStates[index].getDeviceBufferState(deviceForInterpreter);
     }
 
     private boolean isObjectKernelContext(Object object) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/DataObjectState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/DataObjectState.java
@@ -39,7 +39,8 @@ public class DataObjectState implements ObjectState {
         deviceStates = new ConcurrentHashMap<>();
     }
 
-    public XPUDeviceBufferState getDeviceState(TornadoDevice device) {
+    @Override
+    public XPUDeviceBufferState getDeviceBufferState(TornadoDevice device) {
         if (!(device instanceof TornadoXPUDevice)) {
             throw new TornadoRuntimeException("[ERROR] Device not compatible");
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/LocalObjectState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/LocalObjectState.java
@@ -101,7 +101,7 @@ public class LocalObjectState {
     }
 
     public Event sync(long executionPlanId, Object object, TornadoDevice device) {
-        XPUDeviceBufferState deviceState = dataObjectState.getDeviceState(device);
+        XPUDeviceBufferState deviceState = dataObjectState.getDeviceBufferState(device);
         if (deviceState.isLockedBuffer()) {
             int eventId = device.streamOutBlocking(executionPlanId, object, 0, deviceState, null);
             return device.resolveEvent(executionPlanId, eventId);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/LocalObjectState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/LocalObjectState.java
@@ -57,13 +57,13 @@ public class LocalObjectState {
      * For each variable, we need to keep track of all devices in which there is a shadow
      * copy. This is achieved by using the {@link DataObjectState} object.
      */
-    private DataObjectState globalObjectState;
+    private DataObjectState dataObjectState;
 
     private Object object;
 
     public LocalObjectState(Object object) {
         this.object = object;
-        globalObjectState = new DataObjectState();
+        dataObjectState = new DataObjectState();
         streamIn = false;
         streamOut = false;
     }
@@ -96,30 +96,31 @@ public class LocalObjectState {
         this.streamOut = streamOut;
     }
 
-    public DataObjectState getGlobalState() {
-        return globalObjectState;
+    public DataObjectState getDataObjectState() {
+        return dataObjectState;
     }
 
     public Event sync(long executionPlanId, Object object, TornadoDevice device) {
-        XPUDeviceBufferState objectState = globalObjectState.getDeviceState(device);
-        if (objectState.isLockedBuffer()) {
-            int eventId = device.streamOutBlocking(executionPlanId, object, 0, objectState, null);
+        XPUDeviceBufferState deviceState = dataObjectState.getDeviceState(device);
+        if (deviceState.isLockedBuffer()) {
+            int eventId = device.streamOutBlocking(executionPlanId, object, 0, deviceState, null);
             return device.resolveEvent(executionPlanId, eventId);
         }
         return null;
     }
 
+    @Override
     public LocalObjectState clone() {
         LocalObjectState newLocalObjectState = new LocalObjectState(this.object);
         newLocalObjectState.streamIn = this.streamIn;
         newLocalObjectState.streamOut = this.streamOut;
         newLocalObjectState.forceStreamIn = this.forceStreamIn;
-        newLocalObjectState.globalObjectState = globalObjectState.clone();
+        newLocalObjectState.dataObjectState = dataObjectState.clone();
         return newLocalObjectState;
     }
 
     @Override
     public String toString() {
-        return STR."\{streamIn ? "SIN" : "--"}\{streamOut ? "SOUT" : "--"} \{globalObjectState} ";
+        return STR."\{streamIn ? "SIN" : "--"}\{streamOut ? "SOUT" : "--"} \{dataObjectState} ";
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -1105,12 +1105,12 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     private Event syncObjectInnerLazy(Object object, long hostOffset, long bufferSize) {
         final LocalObjectState localState = executionContext.getLocalStateObject(object);
-        final DataObjectState globalState = localState.getGlobalState();
+        final DataObjectState dataObjectState = localState.getDataObjectState();
         final TornadoXPUDevice device = meta().getLogicDevice();
-        final XPUDeviceBufferState deviceState = globalState.getDeviceState(device);
-        if (deviceState.isLockedBuffer()) {
-            deviceState.getObjectBuffer().setSizeSubRegion(bufferSize);
-            return device.resolveEvent(executionPlanId, device.streamOutBlocking(executionPlanId, object, hostOffset, deviceState, null));
+        final XPUDeviceBufferState deviceBufferState = dataObjectState.getDeviceBufferState(device);
+        if (deviceBufferState.isLockedBuffer()) {
+            deviceBufferState.getObjectBuffer().setSizeSubRegion(bufferSize);
+            return device.resolveEvent(executionPlanId, device.streamOutBlocking(executionPlanId, object, hostOffset, deviceBufferState, null));
         }
         return null;
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/multithreaded/TestMultiThreadedExecutionPlans.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/multithreaded/TestMultiThreadedExecutionPlans.java
@@ -156,7 +156,7 @@ public class TestMultiThreadedExecutionPlans extends TornadoTestBase {
 
     @Test
     public void test03() {
-        for (int i = 0; i < 20; i++) {
+        for (int i = 0; i < 100; i++) {
             int finalI = i;
             Thread t1 = new Thread(() -> compute(finalI));
             Thread t2 = new Thread(() -> compute(finalI));

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/multithreaded/TestMultiThreadedExecutionPlans.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/multithreaded/TestMultiThreadedExecutionPlans.java
@@ -17,7 +17,10 @@
  */
 package uk.ac.manchester.tornado.unittests.multithreaded;
 
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
+
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.KernelContext;
@@ -39,11 +42,11 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  *
  * <p>
  * <code>
- * $ tornado-test -V --fast uk.ac.manchester.tornado.unittests.multithreaded.MultiThreaded
+ * $ tornado-test -V --fast uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans
  * </code>
  * </p>
  */
-public class MultiThreaded extends TornadoTestBase {
+public class TestMultiThreadedExecutionPlans extends TornadoTestBase {
 
     private static void computeForThread1(FloatArray input, FloatArray output, KernelContext context) {
         int idx = context.globalIdx;
@@ -72,7 +75,7 @@ public class MultiThreaded extends TornadoTestBase {
 
         TaskGraph taskGraph = new TaskGraph("check") //
                 .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
-                .task("compute01", MultiThreaded::computeForThread1, input, output, context) //
+                .task("compute01", TestMultiThreadedExecutionPlans::computeForThread1, input, output, context) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
 
         WorkerGrid workerGrid = new WorkerGrid1D(size);
@@ -112,7 +115,7 @@ public class MultiThreaded extends TornadoTestBase {
 
         TaskGraph taskGraph = new TaskGraph("check") //
                 .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
-                .task("compute01", MultiThreaded::computeForThread2, input, output) //
+                .task("compute01", TestMultiThreadedExecutionPlans::computeForThread2, input, output) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
 
         t0 = new Thread(() -> {
@@ -132,5 +135,47 @@ public class MultiThreaded extends TornadoTestBase {
 
         t0.join();
         t1.join();
+    }
+
+    private void compute(int id) {
+        final int size = 1024 * 1024;
+        FloatArray input = new FloatArray(size);
+        input.init(1.0f);
+        FloatArray output = new FloatArray(size);
+
+        TaskGraph taskGraph = new TaskGraph("loop" + (id + 100)) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("compute01", TestMultiThreadedExecutionPlans::computeForThread2, input, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+        executionPlan.execute();
+        executionPlan.freeDeviceMemory();
+    }
+
+    @Test
+    public void test03() {
+        for (int i = 0; i < 20; i++) {
+            int finalI = i;
+            Thread t1 = new Thread(() -> compute(finalI));
+            Thread t2 = new Thread(() -> compute(finalI));
+
+            t1.start();
+            t2.start();
+
+            try {
+                t1.join();
+            } catch (InterruptedException e) {
+                assertTrue("Error", false);
+            }
+
+            try {
+                t2.join();
+            } catch (InterruptedException e) {
+                assertTrue("Error", false);
+            }
+
+        }
     }
 }


### PR DESCRIPTION
#### Description

This PR fixes the multi-threaded deallocation marker within the TornadoVM runtime. This PR also fixes the code in the GAIA project. 

#### Problem description

The issue was that we need to guarantee that the deallocator marker is executed in sychronized mode, and guarantee that the `unused` buffer item in the list was not `null`.  It can be `null` if it references the same host memory object (e.g., the same Panama-based array). 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make 
$ tornado-test -V --fast uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans
```
