### PR TITLE
[fix] event list size increased to accomodate profiling of large appl…

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLByteBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLByteBuffer.java
@@ -23,11 +23,11 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.mm;
 
+import java.nio.ByteBuffer;
+
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
-
-import java.nio.ByteBuffer;
 
 /**
  * A buffer for inspecting data within an OpenCL device. It is not backed by any
@@ -89,7 +89,6 @@ public class OCLByteBuffer {
     }
 
     public int enqueueWrite(long executionPlanId, final int[] events) {
-        // XXX: offset 0
         return deviceContext.enqueueWriteBuffer(executionPlanId, toBuffer(), offset, bytes, buffer.array(), 0, events);
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -243,14 +243,29 @@ public class TornadoOptions {
      * default.
      */
     public static final boolean ENABLE_STREAM_OUT_BLOCKING = getBooleanValue("tornado.enable.streamOut.blocking", TRUE);
+
     /**
      * Option to run concurrently on multiple device in single or multi-backend
      * configuration. False by default.
      */
     public static final boolean CONCURRENT_INTERPRETERS = Boolean.parseBoolean(System.getProperty("tornado.concurrent.devices", "False"));
+
+    /**
+     * Panama Object Header in TornadoVM.
+     */
     public static final long PANAMA_OBJECT_HEADER_SIZE = TornadoNativeArray.ARRAY_HEADER;
+
+    /**
+     * Option to define the maximum number of internal events related to OpenCL/PTX/SPIR-V events to keep alive.
+     * This is application specific. In a large application, there are probably many events that need to keep alive
+     * to perform the sync.
+     */
+    public static final int MAX_EVENTS = getIntValue("tornado.max.events", "32768");
+
     public static boolean TORNADO_PROFILER_LOG = false;
+
     public static boolean TORNADO_PROFILER = false;
+
     /**
      * Option to load FPGA pre-compiled binaries.
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -77,7 +77,7 @@ import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 public class TornadoVMInterpreter {
     private static final Event EMPTY_EVENT = new EmptyEvent();
 
-    private static final int MAX_EVENTS = 128;
+    private static final int MAX_EVENTS = TornadoOptions.MAX_EVENTS;
     private final boolean useDependencies;
 
     private final List<Object> objects;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/multithreaded/TestMultiThreadedExecutionPlans.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/multithreaded/TestMultiThreadedExecutionPlans.java
@@ -30,6 +30,7 @@ import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.ProfilerMode;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
@@ -137,8 +138,7 @@ public class TestMultiThreadedExecutionPlans extends TornadoTestBase {
         t1.join();
     }
 
-    private void compute(int id) {
-        final int size = 1024 * 1024;
+    private void compute(int size, int id, boolean profiling) {
         FloatArray input = new FloatArray(size);
         input.init(1.0f);
         FloatArray output = new FloatArray(size);
@@ -150,6 +150,11 @@ public class TestMultiThreadedExecutionPlans extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+
+        if (profiling) {
+            executionPlan.withProfiler(ProfilerMode.SILENT);
+        }
+
         executionPlan.execute();
         executionPlan.freeDeviceMemory();
     }
@@ -158,8 +163,33 @@ public class TestMultiThreadedExecutionPlans extends TornadoTestBase {
     public void test03() {
         for (int i = 0; i < 100; i++) {
             int finalI = i;
-            Thread t1 = new Thread(() -> compute(finalI));
-            Thread t2 = new Thread(() -> compute(finalI));
+            Thread t1 = new Thread(() -> compute(1014 * 1024, finalI, false));
+            Thread t2 = new Thread(() -> compute(1014 * 1024, finalI, false));
+
+            t1.start();
+            t2.start();
+
+            try {
+                t1.join();
+            } catch (InterruptedException e) {
+                assertTrue("Error", false);
+            }
+
+            try {
+                t2.join();
+            } catch (InterruptedException e) {
+                assertTrue("Error", false);
+            }
+
+        }
+    }
+
+    @Test
+    public void test04() {
+        for (int i = 0; i < 100; i++) {
+            int finalI = i;
+            Thread t1 = new Thread(() -> compute(1014 * 1024 * 64, finalI, true));
+            Thread t2 = new Thread(() -> compute(1014 * 1024 * 64, finalI, true));
 
             t1.start();
             t2.start();


### PR DESCRIPTION
#### Description

This PR increases the internal event list to process large applications. The event list size can be tuned using the following flag:

```java
-Dtornado.max.events=8192
```

#### Problem description

The issue was that, when processing large applications, the default size list was too small to accommodate all pending events. This fixes one of the GAIA kernels. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make 
$ tornado-test -V --fast uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans#test03
```
The number 4 (`test04` is expected to fail and is related to another issue with the `cleanup`. We will push a new PR with that fix. 
