### PR TITLE
Fix for Device Events (OpenCL and SPIR-V events) when running Multi-threaded Execution plans

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -126,7 +126,7 @@ public class ImmutableTaskGraph {
     }
 
     void resetDevice() {
-        taskGraph.getDevice().resetAll();
+        taskGraph.getDevice().clean();
     }
 
     void clearProfiles() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -126,7 +126,7 @@ public class ImmutableTaskGraph {
     }
 
     void resetDevice() {
-        taskGraph.getDevice().reset();
+        taskGraph.getDevice().resetAll();
     }
 
     void clearProfiles() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceContext.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceContext.java
@@ -17,6 +17,8 @@
  */
 package uk.ac.manchester.tornado.api;
 
+import java.util.Set;
+
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.memory.TornadoMemoryProvider;
 
@@ -46,4 +48,5 @@ public interface TornadoDeviceContext {
 
     int getDriverIndex();
 
+    Set<Long> getRegisteredPlanIds();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -471,7 +471,9 @@ public class TornadoExecutionPlan implements AutoCloseable {
         }
 
         void resetDevice() {
-            immutableTaskGraphList.forEach(ImmutableTaskGraph::resetDevice);
+            for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {
+                immutableTaskGraph.resetDevice();
+            }
         }
 
         long getTotalTime() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -471,9 +471,7 @@ public class TornadoExecutionPlan implements AutoCloseable {
         }
 
         void resetDevice() {
-            for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {
-                immutableTaskGraph.resetDevice();
-            }
+            immutableTaskGraphList.forEach(ImmutableTaskGraph::resetDevice);
         }
 
         long getTotalTime() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
@@ -151,7 +151,7 @@ public interface TornadoDevice {
 
     void flush(long executionPlanId);
 
-    void resetAll();
+    void clean();
 
     void dumpEvents(long executionPlanId);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
@@ -151,7 +151,7 @@ public interface TornadoDevice {
 
     void flush(long executionPlanId);
 
-    void reset();
+    void resetAll();
 
     void dumpEvents(long executionPlanId);
 

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/TornadoBufferProvider.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/TornadoBufferProvider.java
@@ -61,7 +61,7 @@ public abstract class TornadoBufferProvider {
 
     protected abstract void releaseBuffer(long buffer);
 
-    private long allocate(long size) {
+    private synchronized long allocate(long size) {
         long buffer = allocateBuffer(size);
         currentMemoryAvailable -= size;
         BufferContainer bufferInfo = new BufferContainer(buffer, size);
@@ -69,7 +69,7 @@ public abstract class TornadoBufferProvider {
         return bufferInfo.buffer;
     }
 
-    private void freeBuffers(long size) {
+    private synchronized void freeBuffers(long size) {
         // Attempts to free buffers of given size.
         long remainingSize = size;
         while (!freeBuffers.isEmpty() && remainingSize > 0) {
@@ -81,7 +81,7 @@ public abstract class TornadoBufferProvider {
         }
     }
 
-    private BufferContainer markBufferUsed(int freeBufferIndex) {
+    private synchronized BufferContainer markBufferUsed(int freeBufferIndex) {
         BufferContainer buffer = freeBuffers.get(freeBufferIndex);
         usedBuffers.add(buffer);
         freeBuffers.remove(buffer);
@@ -99,7 +99,7 @@ public abstract class TornadoBufferProvider {
      * @return returns the index position of a free buffer within the free buffer
      *     list. It returns -1 if a free buffer slot is not found.
      */
-    private int bufferIndexOfAFreeSpace(long sizeInBytes) {
+    private synchronized int bufferIndexOfAFreeSpace(long sizeInBytes) {
         int minBufferIndex = -1;
         for (int i = 0; i < freeBuffers.size(); i++) {
             BufferContainer bufferInfo = freeBuffers.get(i);
@@ -118,7 +118,7 @@ public abstract class TornadoBufferProvider {
      *     Size in bytes for the requested buffer.
      * @return It returns a buffer native pointer.
      */
-    private long freeUnusedNativeBufferAndAssignRegion(long sizeInBytes) {
+    private synchronized long freeUnusedNativeBufferAndAssignRegion(long sizeInBytes) {
         freeBuffers(sizeInBytes);
         if (sizeInBytes <= currentMemoryAvailable) {
             return allocate(sizeInBytes);
@@ -182,7 +182,7 @@ public abstract class TornadoBufferProvider {
         return freeBuffers.size() >= numBuffersRequired;
     }
 
-    public void resetBuffers() {
+    public synchronized void resetBuffers() {
         freeBuffers(DEVICE_AVAILABLE_MEMORY);
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -65,13 +65,9 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
     private final PowerMetric powerMetric;
     private final OCLMemoryManager memoryManager;
     private final OCLCodeCache codeCache;
-    //private final OCLEventPool oclEventPool;
-
     private final Map<Long, OCLEventPool> oclEventPool;
-
     private final TornadoBufferProvider bufferProvider;
     private boolean wasReset;
-
     private Set<Long> executionIDs;
 
     OCLDeviceContext(OCLTargetDevice device, OCLContext context) {
@@ -79,19 +75,16 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
         this.context = context;
         this.memoryManager = new OCLMemoryManager(this);
         this.codeCache = new OCLCodeCache(this);
-
+        this.oclEventPool = new ConcurrentHashMap<>();
+        this.bufferProvider = new OCLBufferProvider(this);
+        this.commandQueueTable = new ConcurrentHashMap<>();
+        this.device.setDeviceContext(this);
+        this.executionIDs = Collections.synchronizedSet(new HashSet<>());
         if (isDeviceContextOfNvidia()) {
             this.powerMetric = new OCLNvidiaPowerMetric(this);
         } else {
             this.powerMetric = new OCLEmptyPowerMetric();
         }
-
-        this.oclEventPool = new ConcurrentHashMap<>();
-        //new OCLEventPool(EVENT_WINDOW);
-        bufferProvider = new OCLBufferProvider(this);
-        commandQueueTable = new ConcurrentHashMap<>();
-        this.device.setDeviceContext(this);
-        this.executionIDs = Collections.synchronizedSet(new HashSet<>());
     }
 
     private boolean isDeviceContextOfNvidia() {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
@@ -50,7 +50,7 @@ public interface OCLDeviceContextInterface extends TornadoDeviceContext {
 
     boolean isKernelAvailable();
 
-    void reset();
+    void reset(long executionPlanId);
 
     TornadoXPUDevice asMapping();
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventPool.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventPool.java
@@ -38,11 +38,17 @@ import java.util.List;
 import uk.ac.manchester.tornado.drivers.common.utils.EventDescriptor;
 
 /**
- * Class which holds mapping between OpenCL events and TornadoVM local events
- * and handles event registration and serialization. Also contains extra
- * information such as events description and tag.
- * 
+ * Class which holds mapping between OpenCL events and TornadoVM runtime events,
+ * and handles event registration and serialization. It also keeps metadata such
+ * as events description and tag.
+ *
+ * <p>
  * Each device holds an event pool. Only one instance of the pool per device.
+ * </p>
+ *
+ * <p>
+ * Relationship: one instance of the {@link OCLEventPool} per {@link OCLDeviceContext}.
+ * </p>
  */
 class OCLEventPool {
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -37,7 +37,6 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
-import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.drivers.common.mm.PrimitiveSerialiser;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.drivers.opencl.OCLGPUScheduler;
@@ -265,7 +264,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
             }
 
             if (meta.shouldDumpProfiles()) {
-                deviceContext.retainEvent(task);
+                deviceContext.retainEvent(executionPlanId, task);
                 meta.addProfile(task);
             }
 
@@ -331,7 +330,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
         }
 
         if (meta.shouldDumpProfiles()) {
-            deviceContext.retainEvent(task);
+            deviceContext.retainEvent(executionPlanId, task);
             meta.addProfile(task);
         }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
@@ -38,12 +38,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import jdk.vm.ci.meta.AllocatableValue;
-import jdk.vm.ci.meta.JavaKind;
-import jdk.vm.ci.meta.JavaType;
-import jdk.vm.ci.meta.Local;
-import jdk.vm.ci.meta.ResolvedJavaMethod;
-import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.compiler.code.CompilationResult;
 import org.graalvm.compiler.core.common.CompilationIdentifier;
 import org.graalvm.compiler.core.common.alloc.RegisterAllocationConfig;
@@ -69,11 +63,15 @@ import jdk.vm.ci.code.CompilationRequest;
 import jdk.vm.ci.code.CompiledCode;
 import jdk.vm.ci.code.RegisterConfig;
 import jdk.vm.ci.hotspot.HotSpotCallingConventionType;
+import jdk.vm.ci.meta.AllocatableValue;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Local;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.meta.ResolvedJavaType;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
-import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.drivers.common.code.CodeUtil;
 import uk.ac.manchester.tornado.drivers.common.logging.Logger;
 import uk.ac.manchester.tornado.drivers.common.utils.BackendDeopt;
@@ -457,8 +455,8 @@ public class OCLBackend extends XPUBackend<OCLProviders> implements FrameMap.Ref
         return null;
     }
 
-    public void reset() {
-        getDeviceContext().reset();
+    public void reset(long executionPlanId) {
+        getDeviceContext().reset(executionPlanId);
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
@@ -183,8 +184,10 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public void reset() {
-        device.getDeviceContext().reset();
+    public void resetAll() {
+        Set<Long> ids = device.getDeviceContext().getRegisteredPlanIds();
+        ids.forEach(id -> device.getDeviceContext().reset(id));
+        ids.clear();
         disableProfilerOptions();
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -184,7 +184,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public void resetAll() {
+    public void clean() {
         Set<Long> ids = device.getDeviceContext().getRegisteredPlanIds();
         ids.forEach(id -> device.getDeviceContext().reset(id));
         ids.clear();

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
@@ -23,6 +23,8 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.virtual;
 
+import java.util.Set;
+
 import uk.ac.manchester.tornado.api.common.Event;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
@@ -37,7 +39,6 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResult;
 import uk.ac.manchester.tornado.drivers.opencl.mm.OCLMemoryManager;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class VirtualOCLDeviceContext implements OCLDeviceContextInterface {
@@ -46,24 +47,12 @@ public class VirtualOCLDeviceContext implements OCLDeviceContextInterface {
     private final VirtualOCLContext context;
     private final OCLCodeCache codeCache;
     private boolean wasReset;
-    private boolean useRelativeAddresses;
-    private boolean printOnce = true;
 
     protected VirtualOCLDeviceContext(OCLTargetDevice device, VirtualOCLContext context) {
         this.device = device;
         this.context = context;
         this.codeCache = new OCLCodeCache(this);
-
-        setRelativeAddressesFlag();
         device.setDeviceContext(this);
-    }
-
-    private void setRelativeAddressesFlag() {
-        if (isPlatformFPGA() && !Tornado.OPENCL_USE_RELATIVE_ADDRESSES) {
-            useRelativeAddresses = true;
-        } else {
-            useRelativeAddresses = Tornado.OPENCL_USE_RELATIVE_ADDRESSES;
-        }
     }
 
     public OCLTargetDevice getDevice() {
@@ -78,6 +67,11 @@ public class VirtualOCLDeviceContext implements OCLDeviceContextInterface {
     @Override
     public int getDriverIndex() {
         return TornadoRuntime.getTornadoRuntime().getBackendIndex(OCLBackendImpl.class);
+    }
+
+    @Override
+    public Set<Long> getRegisteredPlanIds() {
+        return Set.of();
     }
 
     @Override
@@ -153,7 +147,7 @@ public class VirtualOCLDeviceContext implements OCLDeviceContextInterface {
     }
 
     @Override
-    public void reset() {
+    public void reset(long executionPlanId) {
         wasReset = true;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import jdk.vm.ci.meta.ResolvedJavaMethod;
@@ -128,8 +129,12 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public void reset() {
-        device.getDeviceContext().reset();
+    public void resetAll() {
+        Set<Long> ids = device.getDeviceContext().getRegisteredPlanIds();
+        if (!ids.isEmpty()) {
+            ids.forEach(id -> device.getDeviceContext().reset(id));
+            ids.clear();
+        }
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -129,7 +129,7 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public void resetAll() {
+    public void clean() {
         Set<Long> ids = device.getDeviceContext().getRegisteredPlanIds();
         if (!ids.isEmpty()) {
             ids.forEach(id -> device.getDeviceContext().reset(id));

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -30,6 +30,8 @@ import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernel
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -68,6 +70,8 @@ public class PTXDeviceContext implements TornadoDeviceContext {
 
     private final Map<Long, PTXStreamTable> streamTable;
 
+    private Set<Long> executionIDs;
+
     public PTXDeviceContext(PTXDevice device) {
         this.device = device;
         streamTable = new ConcurrentHashMap<>();
@@ -77,6 +81,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         memoryManager = new PTXMemoryManager(this);
         bufferProvider = new PTXBufferProvider(this);
         wasReset = false;
+        executionIDs = Collections.synchronizedSet(new HashSet<>());
     }
 
     @Override
@@ -549,6 +554,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
     }
 
     private PTXStream getStream(long executionPlanId) {
+        executionIDs.add(executionPlanId);
         if (!streamTable.containsKey(executionPlanId)) {
             PTXStreamTable ptxStreamTable = new PTXStreamTable();
             ptxStreamTable.get(device);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -159,7 +159,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
 
     @Override
     public Set<Long> getRegisteredPlanIds() {
-        return Set.of();
+        return executionIDs;
     }
 
     @Override

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -32,6 +32,7 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
@@ -59,7 +60,6 @@ public class PTXDeviceContext implements TornadoDeviceContext {
 
     private final PTXDevice device;
     private final PTXMemoryManager memoryManager;
-    //    private final PTXStream stream;
     private final PTXCodeCache codeCache;
     private final PTXScheduler scheduler;
     private final TornadoBufferProvider bufferProvider;
@@ -150,6 +150,11 @@ public class PTXDeviceContext implements TornadoDeviceContext {
     @Override
     public int getDriverIndex() {
         return TornadoRuntime.getTornadoRuntime().getBackendIndex(PTXBackendImpl.class);
+    }
+
+    @Override
+    public Set<Long> getRegisteredPlanIds() {
+        return Set.of();
     }
 
     @Override

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -548,7 +548,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public void resetAll() {
+    public void clean() {
         IntStream.range(0, //
                 TornadoExecutionPlan.getTotalPlans()) //
                 .forEach(i -> device.getPTXContext().getDeviceContext().reset(i));

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -548,12 +548,10 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public void clean() {
-        Set<Long> ids = device.getPTXContext().getDeviceContext().getRegisteredPlanIds();
         // Reset only the execution plans attached to the PTX backend.
+        Set<Long> ids = device.getPTXContext().getDeviceContext().getRegisteredPlanIds();
         ids.forEach(id -> device.getPTXContext().getDeviceContext().reset(id));
-        if (!ids.isEmpty()) {
-            ids.clear();
-        }
+        ids.clear();
         disableProfilerOptions();
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -548,7 +548,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public void reset() {
+    public void resetAll() {
         IntStream.range(0, //
                 TornadoExecutionPlan.getTotalPlans()) //
                 .forEach(i -> device.getPTXContext().getDeviceContext().reset(i));

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -31,11 +31,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.IntStream;
 
 import jdk.vm.ci.meta.ResolvedJavaMethod;
-import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoTargetDevice;
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.Event;
@@ -549,9 +548,12 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public void clean() {
-        IntStream.range(0, //
-                TornadoExecutionPlan.getTotalPlans()) //
-                .forEach(i -> device.getPTXContext().getDeviceContext().reset(i));
+        Set<Long> ids = device.getPTXContext().getDeviceContext().getRegisteredPlanIds();
+        // Reset only the execution plans attached to the PTX backend.
+        ids.forEach(id -> device.getPTXContext().getDeviceContext().reset(id));
+        if (!ids.isEmpty()) {
+            ids.clear();
+        }
         disableProfilerOptions();
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackend.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackend.java
@@ -230,8 +230,8 @@ public class SPIRVBackend extends XPUBackend<SPIRVProviders> implements FrameMap
         return this.context;
     }
 
-    public void reset() {
-        getDeviceContext().reset();
+    public void reset(long executionPlanId) {
+        getDeviceContext().reset(executionPlanId);
     }
 
     @Override

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -478,7 +478,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public void resetAll() {
+    public void clean() {
         Set<Long> ids = device.getDeviceContext().getRegisteredPlanIds();
         ids.forEach(id -> device.getDeviceContext().reset(id));
         ids.clear();

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -477,7 +477,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public void reset() {
+    public void resetAll() {
         device.getDeviceContext().reset();
         disableProfilerOptions();
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -27,6 +27,7 @@ import java.lang.foreign.MemorySegment;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -478,7 +479,9 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public void resetAll() {
-        device.getDeviceContext().reset();
+        Set<Long> ids = device.getDeviceContext().getRegisteredPlanIds();
+        ids.forEach(id -> device.getDeviceContext().reset(id));
+        ids.clear();
         disableProfilerOptions();
     }
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/matrices/MatrixAddition2D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/matrices/MatrixAddition2D.java
@@ -64,7 +64,7 @@ public class MatrixAddition2D {
     private static void reset() {
         for (int i = 0; i < TornadoRuntime.getTornadoRuntime().getNumBackends(); i++) {
             final TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(i);
-            driver.getDefaultDevice().reset();
+            driver.getDefaultDevice().resetAll();
         }
     }
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/matrices/MatrixAddition2D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/matrices/MatrixAddition2D.java
@@ -64,7 +64,7 @@ public class MatrixAddition2D {
     private static void reset() {
         for (int i = 0; i < TornadoRuntime.getTornadoRuntime().getNumBackends(); i++) {
             final TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(i);
-            driver.getDefaultDevice().resetAll();
+            driver.getDefaultDevice().clean();
         }
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
@@ -23,6 +23,9 @@
  */
 package uk.ac.manchester.tornado.runtime;
 
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
 import uk.ac.manchester.tornado.api.TornadoTargetDevice;
 import uk.ac.manchester.tornado.api.common.Event;
@@ -30,17 +33,14 @@ import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
-import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.api.memory.DeviceBufferState;
 import uk.ac.manchester.tornado.api.memory.TornadoMemoryProvider;
+import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
-import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoSchedulingStrategy;
+import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
-
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class JVMMapping implements TornadoXPUDevice {
 
@@ -95,7 +95,7 @@ public class JVMMapping implements TornadoXPUDevice {
     }
 
     @Override
-    public void reset() {
+    public void resetAll() {
         TornadoInternalError.unimplemented();
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
@@ -95,7 +95,7 @@ public class JVMMapping implements TornadoXPUDevice {
     }
 
     @Override
-    public void resetAll() {
+    public void clean() {
         TornadoInternalError.unimplemented();
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestIO.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestIO.java
@@ -28,7 +28,6 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoExecutionResult;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.unittests.arrays.TestArrays;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
@@ -176,8 +175,6 @@ public class TestIO extends TornadoTestBase {
         FloatArray arrayA = createAndInitializeArray(N);
         FloatArray arrayB = createAndInitializeArray(N);
         FloatArray arrayC = new FloatArray(N);
-
-        TornadoRuntime.getTornadoRuntime().getDefaultDevice().reset();
 
         // Enable profiler
         System.setProperty("tornado.profiler", "True");

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -39,10 +39,10 @@ public abstract class TornadoTestBase {
 
     @Before
     public void before() {
-        for (int i = 0; i < TornadoRuntime.getTornadoRuntime().getNumBackends(); i++) {
-            final TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(i);
-            for (int j = 0; j < driver.getDeviceCount(); j++) {
-                driver.getDefaultDevice().clean();
+        for (int backendIndex = 0; backendIndex < TornadoRuntime.getTornadoRuntime().getNumBackends(); backendIndex++) {
+            final TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(backendIndex);
+            for (int deviceIndex = 0; deviceIndex < driver.getDeviceCount(); deviceIndex++) {
+                driver.getDevice(deviceIndex).clean();
             }
         }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -114,9 +114,9 @@ public abstract class TornadoTestBase {
     }
 
     /**
-     * It returns a TornadoDevice that supports SPIRV.
+     * It returns a TornadoDevice that supports SPIR-V.
      *
-     * @return {@link TornadoDevice} with SPIRV support, or null if not found.
+     * @return {@link TornadoDevice} with SPIR-V support, or null if not found.
      */
     protected TornadoDevice getSPIRVSupportedDevice() {
         Tuple2<Integer, Integer> driverAndDeviceIndex = getDriverAndDeviceIndex();

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -42,7 +42,7 @@ public abstract class TornadoTestBase {
         for (int i = 0; i < TornadoRuntime.getTornadoRuntime().getNumBackends(); i++) {
             final TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(i);
             for (int j = 0; j < driver.getDeviceCount(); j++) {
-                driver.getDefaultDevice().resetAll();
+                driver.getDefaultDevice().clean();
             }
         }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -42,7 +42,7 @@ public abstract class TornadoTestBase {
         for (int i = 0; i < TornadoRuntime.getTornadoRuntime().getNumBackends(); i++) {
             final TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(i);
             for (int j = 0; j < driver.getDeviceCount(); j++) {
-                driver.getDevice(j).reset();
+                driver.getDefaultDevice().resetAll();
             }
         }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/TestFails.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/TestFails.java
@@ -45,10 +45,10 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 public class TestFails extends TornadoTestBase {
 
     private void reset() {
-        for (int i = 0; i < TornadoRuntime.getTornadoRuntime().getNumBackends(); i++) {
-            final TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(i);
-            for (int j = 0; j < driver.getDeviceCount(); j++) {
-                driver.getDefaultDevice().clean();
+        for (int backendIndex = 0; backendIndex < TornadoRuntime.getTornadoRuntime().getNumBackends(); backendIndex++) {
+            final TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(backendIndex);
+            for (int deviceIndex = 0; deviceIndex < driver.getDeviceCount(); deviceIndex++) {
+                driver.getDevice(deviceIndex).clean();
             }
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/TestFails.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/TestFails.java
@@ -48,7 +48,7 @@ public class TestFails extends TornadoTestBase {
         for (int i = 0; i < TornadoRuntime.getTornadoRuntime().getNumBackends(); i++) {
             final TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(i);
             for (int j = 0; j < driver.getDeviceCount(); j++) {
-                driver.getDefaultDevice().resetAll();
+                driver.getDefaultDevice().clean();
             }
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/TestFails.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/TestFails.java
@@ -48,7 +48,7 @@ public class TestFails extends TornadoTestBase {
         for (int i = 0; i < TornadoRuntime.getTornadoRuntime().getNumBackends(); i++) {
             final TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(i);
             for (int j = 0; j < driver.getDeviceCount(); j++) {
-                driver.getDevice(j).reset();
+                driver.getDefaultDevice().resetAll();
             }
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
@@ -77,7 +77,7 @@ public class TestProfiler extends TornadoTestBase {
         // testProfilerDisabled might execute first. We must make sure that the code
         // cache is reset.
         // Otherwise, we get 0 compile time.
-        TornadoRuntime.getTornadoRuntime().getDefaultDevice().resetAll();
+        TornadoRuntime.getTornadoRuntime().getDefaultDevice().clean();
 
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b)//

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
@@ -77,7 +77,7 @@ public class TestProfiler extends TornadoTestBase {
         // testProfilerDisabled might execute first. We must make sure that the code
         // cache is reset.
         // Otherwise, we get 0 compile time.
-        TornadoRuntime.getTornadoRuntime().getDefaultDevice().reset();
+        TornadoRuntime.getTornadoRuntime().getDefaultDevice().resetAll();
 
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b)//


### PR DESCRIPTION
#### Description

This PR fixes the issue of sharing the `eventPool` associated to a backend-context within the TornadoVM runtime. 

This PR also updates one of the methods to reset all internal state associated to one backend. 


```diff
- driver.getDefaultDevice().reset();
+ driver.getDefaultDevice().clean();
```

This resets the code cache and all events associated to a command queue. This method can be also reached from the TornadoExecutionPlan:

```java
executionPlan.resetDevice();
```

#### Problem description

When running Tornado execution plans from many different Java threads, there was the possibility of accessing an internal data structure from many threads. This internal data structure holds the pointers to the associated low-level events in a list. However, this list is maintained by the `<Backend>DeviceContext`, which must be shared for all threads running on the same device. 

This PR extends the previous work to achieve a single command queue/ or stream, per Java thread. 


#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make
$ make tests
```
