### PR TITLE
[fix] actual and expected values swap

### DIFF
--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorTypes.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorTypes.java
@@ -124,7 +124,7 @@ public class TestTensorTypes extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < tensorC.getSize(); i++) {
-            Assert.assertEquals(tensorC.get(i).getFloat32(), HalfFloat.add(tensorA.get(i), tensorB.get(i)).getFloat32(), 0.00f);
+            Assert.assertEquals(HalfFloat.add(tensorA.get(i), tensorB.get(i)).getFloat32(), tensorC.get(i).getFloat32(), 0.01f);
         }
 
     }
@@ -159,7 +159,7 @@ public class TestTensorTypes extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < tensorC.getSize(); i++) {
-            Assert.assertEquals(tensorC.get(i), tensorA.get(i) + tensorB.get(i), 0.00f);
+            Assert.assertEquals(tensorA.get(i) + tensorB.get(i), tensorC.get(i), 0.01f);
         }
 
     }
@@ -194,7 +194,7 @@ public class TestTensorTypes extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < tensorC.getSize(); i++) {
-            Assert.assertEquals(tensorC.get(i), tensorA.get(i) + tensorB.get(i), 0.00f);
+            Assert.assertEquals(tensorA.get(i) + tensorB.get(i), tensorC.get(i), 0.01f);
         }
 
     }
@@ -229,7 +229,7 @@ public class TestTensorTypes extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < tensorC.getSize(); i++) {
-            Assert.assertEquals(tensorC.get(i), tensorA.get(i) + tensorB.get(i), 0.00f);
+            Assert.assertEquals(tensorA.get(i) + tensorB.get(i), tensorC.get(i), 0.01f);
         }
 
     }
@@ -264,7 +264,7 @@ public class TestTensorTypes extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < tensorC.getSize(); i++) {
-            Assert.assertEquals(tensorC.get(i), tensorA.get(i) + tensorB.get(i), 0.00f);
+            Assert.assertEquals(tensorA.get(i) + tensorB.get(i), tensorC.get(i), 0.01f);
         }
     }
 
@@ -298,7 +298,7 @@ public class TestTensorTypes extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < tensorC.getSize(); i++) {
-            Assert.assertEquals(tensorC.get(i), tensorA.get(i) + tensorB.get(i), 0.00f);
+            Assert.assertEquals(tensorA.get(i) + tensorB.get(i), tensorC.get(i), 0.01f);
         }
     }
 
@@ -332,7 +332,7 @@ public class TestTensorTypes extends TornadoTestBase {
         executionPlan.execute();
 
         for (int i = 0; i < tensorC.getSize(); i++) {
-            Assert.assertEquals(tensorC.get(i), tensorA.get(i) + tensorB.get(i), 0.00f);
+            Assert.assertEquals(tensorA.get(i) + tensorB.get(i), tensorC.get(i), 0.01f);
         }
     }
 


### PR DESCRIPTION
#### Description

This PR swaps the actual and expected values from the Tensor unittests. 

The signature from JUnit:

```
public static void assertEquals(float expected, float actual, float delta) 
```

But this test set the expected as actual value. 

#### Problem description

n/a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-test -V --fast --threadInfo --debug uk.ac.manchester.tornado.unittests.tensors.TestTensorTypes
```

