### PR TITLE
New Iteration for achieving Multi-Threaded Execution Plans

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/DeviceBufferState.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/DeviceBufferState.java
@@ -19,11 +19,11 @@ package uk.ac.manchester.tornado.api.memory;
 
 public interface DeviceBufferState {
 
-    void setObjectBuffer(XPUBuffer value);
+    void setXPUBuffer(XPUBuffer value);
 
     boolean hasObjectBuffer();
 
-    XPUBuffer getObjectBuffer();
+    XPUBuffer getXPUBuffer();
 
     boolean isAtomicRegionPresent();
 

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -120,7 +120,6 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleFunctions"),
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleTasksMultipleDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.vm.concurrency.TestConcurrentBackends"),
-    TestEntry("uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.tensors.TestTensorTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.tensors.TestTensorAPIWithOnnx"),
@@ -155,6 +154,9 @@ __TEST_THE_WORLD__ = [
                   "-Dtornado.device.desc=" + os.environ["TORNADO_SDK"] + "/examples/virtual-device-CPU.json",
                   "-Dtornado.virtual.device=True", "-Dtornado.feature.extraction=True",
                   "-Dtornado.features.dump.dir=" + os.environ["TORNADO_SDK"] + "/virtualFeaturesOut.out"]),
+
+    TestEntry(testName="uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans",
+              testParameters=["-Dtornado.device.memory=4GB"]),
 
     TestEntry(testName="uk.ac.manchester.tornado.unittests.memory.TestStressDeviceMemory",
               testParameters=[

--- a/tornado-drivers/opencl-jni/src/main/cpp/CMakeLists.txt
+++ b/tornado-drivers/opencl-jni/src/main/cpp/CMakeLists.txt
@@ -53,16 +53,16 @@ endif()
 
 if(APPLE)
     include_directories(
-	source/
-	${JNI_INCLUDE_DIRS}
-	${OPENCL_INCLUDE_DIRS}
-	)
+	    source/
+	    ${JNI_INCLUDE_DIRS}
+	    ${OPENCL_INCLUDE_DIRS}
+	    )
 else()
     include_directories(
-	source/
-	headers/include
-	${JNI_INCLUDE_DIRS}
-	${OPENCL_INCLUDE_DIRS}
+	    source/
+	    headers/include
+	    ${JNI_INCLUDE_DIRS}
+	    ${OPENCL_INCLUDE_DIRS}
 	)
 endif()
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OpenCL.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OpenCL.java
@@ -38,9 +38,9 @@ import uk.ac.manchester.tornado.drivers.opencl.runtime.OCLTornadoDevice;
 import uk.ac.manchester.tornado.drivers.opencl.virtual.VirtualDeviceDescriptor;
 import uk.ac.manchester.tornado.drivers.opencl.virtual.VirtualJSONParser;
 import uk.ac.manchester.tornado.drivers.opencl.virtual.VirtualOCLPlatform;
-import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 import uk.ac.manchester.tornado.runtime.tasks.DataObjectState;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
@@ -198,7 +198,7 @@ public class OpenCL {
 
         // Pass arguments to the call callWrapper
         for (int i = 0; i < numArgs; i++) {
-            callWrapper.addCallArgument(states.get(i).getObjectBuffer().toBuffer(), true);
+            callWrapper.addCallArgument(states.get(i).getXPUBuffer().toBuffer(), true);
         }
 
         // Run the code

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -413,7 +413,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     public int[] updateAtomicRegionAndObjectState(SchedulableTask task, int[] array, int paramIndex, Object value, XPUDeviceBufferState objectState) {
         int[] atomicsArray = checkAtomicsForTask(task, array, paramIndex, value);
         mappingAtomics.put(value, getAtomicsGlobalIndexForTask(task, paramIndex));
-        XPUBuffer bufferAtomics = objectState.getObjectBuffer();
+        XPUBuffer bufferAtomics = objectState.getXPUBuffer();
         bufferAtomics.setIntBuffer(atomicsArray);
         setAtomicRegion(bufferAtomics);
         objectState.setAtomicRegion(bufferAtomics);
@@ -570,7 +570,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         final XPUBuffer buffer;
         TornadoInternalError.guarantee(deviceObjectState.isAtomicRegionPresent() || !deviceObjectState.hasObjectBuffer(), "A device memory leak might be occurring.");
         buffer = createDeviceBuffer(object.getClass(), object, (OCLDeviceContext) getDeviceContext(), batchSize);
-        deviceObjectState.setObjectBuffer(buffer);
+        deviceObjectState.setXPUBuffer(buffer);
         buffer.allocate(object, batchSize);
         return buffer;
     }
@@ -579,7 +579,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     public int allocate(Object object, long batchSize, DeviceBufferState state) {
         final XPUBuffer buffer;
         if (state.hasObjectBuffer() && state.isLockedBuffer()) {
-            buffer = state.getObjectBuffer();
+            buffer = state.getXPUBuffer();
             if (batchSize != 0) {
                 buffer.setSizeSubRegion(batchSize);
             }
@@ -594,14 +594,13 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public synchronized int deallocate(DeviceBufferState state) {
-        if (state.isLockedBuffer()) {
+    public synchronized int deallocate(DeviceBufferState deviceBufferState) {
+        if (deviceBufferState.isLockedBuffer()) {
             return -1;
         }
-
-        state.getObjectBuffer().deallocate();
-        state.setContents(false);
-        state.setObjectBuffer(null);
+        deviceBufferState.getXPUBuffer().deallocate();
+        deviceBufferState.setContents(false);
+        deviceBufferState.setXPUBuffer(null);
         return -1;
     }
 
@@ -609,7 +608,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     public List<Integer> ensurePresent(long executionPlanId, Object object, DeviceBufferState state, int[] events, long batchSize, long offset) {
         if (!state.hasContent() || BENCHMARKING_MODE) {
             state.setContents(true);
-            return state.getObjectBuffer().enqueueWrite(executionPlanId, object, batchSize, offset, events, events == null);
+            return state.getXPUBuffer().enqueueWrite(executionPlanId, object, batchSize, offset, events, events == null);
         }
         return null;
     }
@@ -617,13 +616,13 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     @Override
     public List<Integer> streamIn(long executionPlanId, Object object, long batchSize, long offset, DeviceBufferState state, int[] events) {
         state.setContents(true);
-        return state.getObjectBuffer().enqueueWrite(executionPlanId, object, batchSize, offset, events, events == null);
+        return state.getXPUBuffer().enqueueWrite(executionPlanId, object, batchSize, offset, events, events == null);
     }
 
     @Override
     public int streamOut(long executionPlanId, Object object, long offset, DeviceBufferState state, int[] events) {
         TornadoInternalError.guarantee(state.hasObjectBuffer(), "invalid variable");
-        int event = state.getObjectBuffer().enqueueRead(executionPlanId, object, offset, events, events == null);
+        int event = state.getXPUBuffer().enqueueRead(executionPlanId, object, offset, events, events == null);
         if (events != null) {
             return event;
         }
@@ -635,7 +634,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         long partialCopySize = state.getPartialCopySize();
         if (state.isAtomicRegionPresent()) {
             // Read for Atomics
-            int eventID = state.getObjectBuffer().enqueueRead(executionPlanId, null, 0, null, false);
+            int eventID = state.getXPUBuffer().enqueueRead(executionPlanId, null, 0, null, false);
             if (object instanceof AtomicInteger) {
                 int[] arr = getAtomic().getIntBuffer();
                 int indexFromGlobalRegion = mappingAtomics.get(object);
@@ -645,7 +644,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         } else {
             // Read for any other buffer that is not an atomic buffer
             TornadoInternalError.guarantee(state.hasObjectBuffer(), "invalid variable");
-            return state.getObjectBuffer().read(executionPlanId, object, hostOffset, partialCopySize, events, events == null);
+            return state.getXPUBuffer().read(executionPlanId, object, hostOffset, partialCopySize, events, events == null);
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLJITCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLJITCompiler.java
@@ -143,9 +143,9 @@ public class TestOpenCLJITCompiler {
         // Fill header of call callWrapper with empty values
         callWrapper.setKernelContext(new HashMap<>());
 
-        callWrapper.addCallArgument(objectStateA.getObjectBuffer().toBuffer(), true);
-        callWrapper.addCallArgument(objectStateB.getObjectBuffer().toBuffer(), true);
-        callWrapper.addCallArgument(objectStateC.getObjectBuffer().toBuffer(), true);
+        callWrapper.addCallArgument(objectStateA.getXPUBuffer().toBuffer(), true);
+        callWrapper.addCallArgument(objectStateB.getXPUBuffer().toBuffer(), true);
+        callWrapper.addCallArgument(objectStateC.getXPUBuffer().toBuffer(), true);
 
         // Run the code
         openCLCode.launchWithoutDependencies(contextID, callWrapper, null, taskMeta, 0);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
@@ -30,9 +30,9 @@ import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXInstalledCode;
 import uk.ac.manchester.tornado.drivers.ptx.runtime.PTXTornadoDevice;
-import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 import uk.ac.manchester.tornado.runtime.tasks.DataObjectState;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
@@ -126,7 +126,7 @@ public class PTX {
 
         // Pass arguments to the call callWrapper
         for (int i = 0; i < numArgs; i++) {
-            callWrapper.addCallArgument(states.get(i).getObjectBuffer().toBuffer(), true);
+            callWrapper.addCallArgument(states.get(i).getXPUBuffer().toBuffer(), true);
         }
 
         // Run the code

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -304,10 +304,10 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
         if (!state.hasObjectBuffer() || !state.isLockedBuffer()) {
             TornadoInternalError.guarantee(state.isAtomicRegionPresent() || !state.hasObjectBuffer(), "A device memory leak might be occurring.");
             buffer = createDeviceBuffer(object.getClass(), object, batchSize);
-            state.setObjectBuffer(buffer);
+            state.setXPUBuffer(buffer);
             buffer.allocate(object, batchSize);
         } else {
-            buffer = state.getObjectBuffer();
+            buffer = state.getXPUBuffer();
             if (batchSize != 0) {
                 buffer.setSizeSubRegion(batchSize);
             }
@@ -321,9 +321,9 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
             return -1;
         }
 
-        state.getObjectBuffer().deallocate();
+        state.getXPUBuffer().deallocate();
         state.setContents(false);
-        state.setObjectBuffer(null);
+        state.setXPUBuffer(null);
         return -1;
     }
 
@@ -395,7 +395,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     public List<Integer> ensurePresent(long executionPlanId, Object object, DeviceBufferState objectState, int[] events, long batchSize, long hostOffset) {
         if (!objectState.hasContent() || BENCHMARKING_MODE) {
             objectState.setContents(true);
-            return objectState.getObjectBuffer().enqueueWrite(executionPlanId, object, batchSize, hostOffset, events, events != null);
+            return objectState.getXPUBuffer().enqueueWrite(executionPlanId, object, batchSize, hostOffset, events, events != null);
         }
         return null;
     }
@@ -422,7 +422,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     @Override
     public List<Integer> streamIn(long executionPlanId, Object object, long batchSize, long hostOffset, DeviceBufferState objectState, int[] events) {
         objectState.setContents(true);
-        return objectState.getObjectBuffer().enqueueWrite(executionPlanId, object, batchSize, hostOffset, events, events != null);
+        return objectState.getXPUBuffer().enqueueWrite(executionPlanId, object, batchSize, hostOffset, events, events != null);
     }
 
     /**
@@ -444,7 +444,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     @Override
     public int streamOut(long executionPlanId, Object object, long hostOffset, DeviceBufferState objectState, int[] events) {
         TornadoInternalError.guarantee(objectState.hasObjectBuffer(), "invalid variable");
-        int event = objectState.getObjectBuffer().enqueueRead(executionPlanId, object, hostOffset, events, events != null);
+        int event = objectState.getXPUBuffer().enqueueRead(executionPlanId, object, hostOffset, events, events != null);
         if (events != null) {
             return event;
         }
@@ -470,7 +470,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     @Override
     public int streamOutBlocking(long executionPlanId, Object object, long hostOffset, DeviceBufferState objectState, int[] events) {
         TornadoInternalError.guarantee(objectState.hasObjectBuffer(), "invalid variable");
-        return objectState.getObjectBuffer().read(executionPlanId, object, hostOffset, objectState.getPartialCopySize(), events, events != null);
+        return objectState.getXPUBuffer().read(executionPlanId, object, hostOffset, objectState.getPartialCopySize(), events, events != null);
     }
 
     /**

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXJITCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXJITCompiler.java
@@ -140,9 +140,9 @@ public class TestPTXJITCompiler {
 
         callWrapper.setKernelContext(new HashMap<>());
 
-        callWrapper.addCallArgument(objectStateA.getObjectBuffer().toBuffer(), true);
-        callWrapper.addCallArgument(objectStateB.getObjectBuffer().toBuffer(), true);
-        callWrapper.addCallArgument(objectStateC.getObjectBuffer().toBuffer(), true);
+        callWrapper.addCallArgument(objectStateA.getXPUBuffer().toBuffer(), true);
+        callWrapper.addCallArgument(objectStateB.getXPUBuffer().toBuffer(), true);
+        callWrapper.addCallArgument(objectStateC.getXPUBuffer().toBuffer(), true);
 
         // Run the code
         ptxCode.launchWithoutDependencies(executionPlanId, callWrapper, null, taskMeta, 0);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -330,7 +330,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
         final XPUBuffer buffer;
         TornadoInternalError.guarantee(state.isAtomicRegionPresent() || !state.hasObjectBuffer(), "A device memory leak might be occurring.");
         buffer = createDeviceBuffer(object.getClass(), object, getDeviceContext(), batchSize);
-        state.setObjectBuffer(buffer);
+        state.setXPUBuffer(buffer);
         buffer.allocate(object, batchSize);
         return buffer;
     }
@@ -339,7 +339,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     public int allocate(Object object, long batchSize, DeviceBufferState state) {
         final XPUBuffer buffer;
         if (state.hasObjectBuffer() && state.isLockedBuffer()) {
-            buffer = state.getObjectBuffer();
+            buffer = state.getXPUBuffer();
             if (batchSize != 0) {
                 buffer.setSizeSubRegion(batchSize);
             }
@@ -359,9 +359,9 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
             return -1;
         }
 
-        state.getObjectBuffer().deallocate();
+        state.getXPUBuffer().deallocate();
         state.setContents(false);
-        state.setObjectBuffer(null);
+        state.setXPUBuffer(null);
         return -1;
     }
 
@@ -387,7 +387,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     public List<Integer> ensurePresent(long executionPlanId, Object object, DeviceBufferState objectState, int[] events, long batchSize, long offset) {
         if (!objectState.hasContent() || BENCHMARKING_MODE) {
             objectState.setContents(true);
-            return objectState.getObjectBuffer().enqueueWrite(executionPlanId, object, batchSize, offset, events, events == null);
+            return objectState.getXPUBuffer().enqueueWrite(executionPlanId, object, batchSize, offset, events, events == null);
         }
         return null;
     }
@@ -395,13 +395,13 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     @Override
     public List<Integer> streamIn(long executionPlanId, Object object, long batchSize, long hostOffset, DeviceBufferState objectState, int[] events) {
         objectState.setContents(true);
-        return objectState.getObjectBuffer().enqueueWrite(executionPlanId, object, batchSize, hostOffset, events, events == null);
+        return objectState.getXPUBuffer().enqueueWrite(executionPlanId, object, batchSize, hostOffset, events, events == null);
     }
 
     @Override
     public int streamOut(long executionPlanId, Object object, long hostOffset, DeviceBufferState objectState, int[] events) {
         TornadoInternalError.guarantee(objectState.hasObjectBuffer(), "invalid variable");
-        int event = objectState.getObjectBuffer().enqueueRead(executionPlanId, object, hostOffset, events, events == null);
+        int event = objectState.getXPUBuffer().enqueueRead(executionPlanId, object, hostOffset, events, events == null);
         if (events != null) {
             return event;
         }
@@ -412,14 +412,14 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     public int streamOutBlocking(long executionPlanId, Object object, long hostOffset, DeviceBufferState objectState, int[] events) {
         long partialSize = objectState.getPartialCopySize();
         if (objectState.isAtomicRegionPresent()) {
-            int eventID = objectState.getObjectBuffer().enqueueRead(executionPlanId, null, 0, null, false);
+            int eventID = objectState.getXPUBuffer().enqueueRead(executionPlanId, null, 0, null, false);
             if (object instanceof AtomicInteger) {
                 throw new RuntimeException("Atomics Not supported yet");
             }
             return eventID;
         } else {
             TornadoInternalError.guarantee(objectState.hasObjectBuffer(), "invalid variable");
-            int event = objectState.getObjectBuffer().read(executionPlanId, object, hostOffset, partialSize, events, events == null);
+            int event = objectState.getXPUBuffer().read(executionPlanId, object, hostOffset, partialSize, events, events == null);
             // We force a blocking copy -> we need to close the command list and command queue
             flush(executionPlanId);
             return event;
@@ -586,6 +586,6 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
      * Move Data from the device region that corresponds to buffer A into buffer B.
      */
     public void moveDataFromDeviceBufferToHost(long executionPlanId, XPUDeviceBufferState objectStateA, Object b) {
-        objectStateA.getObjectBuffer().read(executionPlanId, b, 0, 0, null, false);
+        objectStateA.getXPUBuffer().read(executionPlanId, b, 0, 0, null, false);
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVJITCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVJITCompiler.java
@@ -142,9 +142,9 @@ public class TestSPIRVJITCompiler {
         callWrapper.setKernelContext(new HashMap<>());
 
         // Add kernel arguments to the SPIR-V Call Stack
-        callWrapper.addCallArgument(objectStateA.getObjectBuffer().toBuffer(), true);
-        callWrapper.addCallArgument(objectStateB.getObjectBuffer().toBuffer(), true);
-        callWrapper.addCallArgument(objectStateC.getObjectBuffer().toBuffer(), true);
+        callWrapper.addCallArgument(objectStateA.getXPUBuffer().toBuffer(), true);
+        callWrapper.addCallArgument(objectStateB.getXPUBuffer().toBuffer(), true);
+        callWrapper.addCallArgument(objectStateC.getXPUBuffer().toBuffer(), true);
 
         // Launch the generated kernel
         installedCode.launchWithoutDependencies(executionPlanId, callWrapper, null, taskMeta, 0);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/XPUDeviceBufferState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/XPUDeviceBufferState.java
@@ -110,4 +110,10 @@ public class XPUDeviceBufferState implements DeviceBufferState {
     public long getPartialCopySize() {
         return this.partialSize;
     }
+
+    public XPUDeviceBufferState createSnapshot() {
+        XPUDeviceBufferState xpuDeviceBufferState = new XPUDeviceBufferState();
+        xpuDeviceBufferState.setLockBuffer(this.isLockedBuffer());
+        return xpuDeviceBufferState;
+    }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/XPUDeviceBufferState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/XPUDeviceBufferState.java
@@ -25,12 +25,12 @@ package uk.ac.manchester.tornado.runtime.common;
 
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
 
-import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.api.memory.DeviceBufferState;
+import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 
 public class XPUDeviceBufferState implements DeviceBufferState {
 
-    private XPUBuffer objectBuffer;
+    private XPUBuffer xpuBuffer;
     private boolean atomicRegionPresent;
 
     private boolean contents;
@@ -40,23 +40,27 @@ public class XPUDeviceBufferState implements DeviceBufferState {
     public XPUDeviceBufferState() {
     }
 
-    public void setObjectBuffer(XPUBuffer value) {
-        objectBuffer = value;
+    @Override
+    public void setXPUBuffer(XPUBuffer value) {
+        xpuBuffer = value;
     }
 
     public void setAtomicRegion(XPUBuffer buffer) {
-        this.objectBuffer = buffer;
+        this.xpuBuffer = buffer;
         atomicRegionPresent = true;
     }
 
+    @Override
     public boolean hasObjectBuffer() {
-        return objectBuffer != null;
+        return xpuBuffer != null;
     }
 
-    public XPUBuffer getObjectBuffer() {
-        return objectBuffer;
+    @Override
+    public XPUBuffer getXPUBuffer() {
+        return xpuBuffer;
     }
 
+    @Override
     public boolean isLockedBuffer() {
         return lockBuffer;
     }
@@ -65,10 +69,12 @@ public class XPUDeviceBufferState implements DeviceBufferState {
         this.lockBuffer = lockBuffer;
     }
 
+    @Override
     public boolean hasContent() {
         return contents;
     }
 
+    @Override
     public void setContents(boolean value) {
         contents = value;
     }
@@ -82,7 +88,7 @@ public class XPUDeviceBufferState implements DeviceBufferState {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         if (hasObjectBuffer()) {
-            sb.append(String.format(" buffer=0x%x, size=%s ", objectBuffer.toBuffer(), humanReadableByteCount(objectBuffer.size(), true)));
+            sb.append(String.format(" buffer=0x%x, size=%s ", xpuBuffer.toBuffer(), humanReadableByteCount(xpuBuffer.size(), true)));
         } else {
             sb.append(" <unbuffered>");
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -539,7 +539,7 @@ public class TornadoExecutionContext {
                     value += event.getElapsedTime();
                     profiler.setTimer(ProfilerType.COPY_OUT_TIME_SYNC, value);
                     XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceBufferState(meta().getLogicDevice());
-                    profiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getObjectBuffer().size());
+                    profiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getXPUBuffer().size());
                 }
             }
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -456,7 +456,7 @@ public class TornadoVMInterpreter {
                 copyInTimer += event.getElapsedTime();
                 timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
 
-                timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getObjectBuffer().size());
+                timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
 
                 long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
                 dispatchValue += event.getDriverDispatchTime();
@@ -489,7 +489,7 @@ public class TornadoVMInterpreter {
                 copyInTimer += event.getElapsedTime();
                 timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
 
-                timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getObjectBuffer().size());
+                timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
 
                 long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
                 dispatchValue += event.getDriverDispatchTime();
@@ -524,7 +524,7 @@ public class TornadoVMInterpreter {
             value += event.getElapsedTime();
             timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
 
-            timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getObjectBuffer().size());
+            timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
 
             long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
             dispatchValue += event.getDriverDispatchTime();
@@ -559,7 +559,7 @@ public class TornadoVMInterpreter {
             value += event.getElapsedTime();
             timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
 
-            timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getObjectBuffer().size());
+            timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
 
             long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
             dispatchValue += event.getDriverDispatchTime();
@@ -694,7 +694,7 @@ public class TornadoVMInterpreter {
 
                 if (!isObjectInAtomicRegion(objectState, deviceForInterpreter, task)) {
                     // Add a reference (arrays, vector types, panama regions)
-                    stackFrame.addCallArgument(objectState.getObjectBuffer().toBuffer(), true);
+                    stackFrame.addCallArgument(objectState.getXPUBuffer().toBuffer(), true);
                 } else {
                     atomicsArray = deviceForInterpreter.updateAtomicRegionAndObjectState(task, atomicsArray, i, objects.get(argIndex), objectState);
                 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/DataObjectState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/DataObjectState.java
@@ -54,12 +54,10 @@ public class DataObjectState implements ObjectState {
     public DataObjectState clone() {
         DataObjectState dataObjectState = new DataObjectState();
         dataObjectState.deviceStates = new ConcurrentHashMap<>();
-        for (TornadoXPUDevice device : deviceStates.keySet()) {
-            XPUDeviceBufferState oldDeviceBufferState = deviceStates.get(device);
-            XPUDeviceBufferState xpuDeviceBufferState = new XPUDeviceBufferState();
-            xpuDeviceBufferState.setLockBuffer(oldDeviceBufferState.isLockedBuffer());
+        deviceStates.keySet().forEach(device -> {
+            XPUDeviceBufferState xpuDeviceBufferState = deviceStates.get(device).createSnapshot();
             dataObjectState.deviceStates.put(device, xpuDeviceBufferState);
-        }
+        });
         return dataObjectState;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/DataObjectState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/DataObjectState.java
@@ -28,8 +28,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.ObjectState;
-import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
+import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 
 public class DataObjectState implements ObjectState {
 
@@ -42,7 +42,7 @@ public class DataObjectState implements ObjectState {
     @Override
     public XPUDeviceBufferState getDeviceBufferState(TornadoDevice device) {
         if (!(device instanceof TornadoXPUDevice)) {
-            throw new TornadoRuntimeException("[ERROR] Device not compatible");
+            throw new TornadoRuntimeException("[ERROR] Device not compatible: " + device.getClass());
         }
         if (!deviceStates.containsKey(device)) {
             deviceStates.put((TornadoXPUDevice) device, new XPUDeviceBufferState());
@@ -53,7 +53,7 @@ public class DataObjectState implements ObjectState {
     @Override
     public DataObjectState clone() {
         DataObjectState dataObjectState = new DataObjectState();
-        dataObjectState.deviceStates = new ConcurrentHashMap<>(deviceStates);
+        dataObjectState.deviceStates = new ConcurrentHashMap<>();
         return dataObjectState;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/DataObjectState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/DataObjectState.java
@@ -54,6 +54,12 @@ public class DataObjectState implements ObjectState {
     public DataObjectState clone() {
         DataObjectState dataObjectState = new DataObjectState();
         dataObjectState.deviceStates = new ConcurrentHashMap<>();
+        for (TornadoXPUDevice device : deviceStates.keySet()) {
+            XPUDeviceBufferState oldDeviceBufferState = deviceStates.get(device);
+            XPUDeviceBufferState xpuDeviceBufferState = new XPUDeviceBufferState();
+            xpuDeviceBufferState.setLockBuffer(oldDeviceBufferState.isLockedBuffer());
+            dataObjectState.deviceStates.put(device, xpuDeviceBufferState);
+        }
         return dataObjectState;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -1109,7 +1109,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         final TornadoXPUDevice device = meta().getLogicDevice();
         final XPUDeviceBufferState deviceBufferState = dataObjectState.getDeviceBufferState(device);
         if (deviceBufferState.isLockedBuffer()) {
-            deviceBufferState.getObjectBuffer().setSizeSubRegion(bufferSize);
+            deviceBufferState.getXPUBuffer().setSizeSubRegion(bufferSize);
             return device.resolveEvent(executionPlanId, device.streamOutBlocking(executionPlanId, object, hostOffset, deviceBufferState, null));
         }
         return null;
@@ -1181,7 +1181,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME_SYNC, value);
                 LocalObjectState localState = executionContext.getLocalStateObject(objects[i]);
                 XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceBufferState(meta().getLogicDevice());
-                timeProfiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getObjectBuffer().size());
+                timeProfiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getXPUBuffer().size());
             }
             updateProfiler();
         }
@@ -1212,7 +1212,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME_SYNC, value);
                 LocalObjectState localState = executionContext.getLocalStateObject(object);
                 XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceBufferState(meta().getLogicDevice());
-                timeProfiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getObjectBuffer().size());
+                timeProfiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getXPUBuffer().size());
                 updateProfiler();
             }
         }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/multithreaded/TestMultiThreadedExecutionPlans.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/multithreaded/TestMultiThreadedExecutionPlans.java
@@ -31,6 +31,7 @@ import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
@@ -43,7 +44,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  *
  * <p>
  * <code>
- * $ tornado-test -V --fast uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans
+ * $ tornado-test --jvm="-Dtornado.device.memory=2GB" -V --fast uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans
  * </code>
  * </p>
  */
@@ -62,6 +63,17 @@ public class TestMultiThreadedExecutionPlans extends TornadoTestBase {
         }
     }
 
+    /**
+     * Two execution plan instances coming from the same task-graph.
+     *
+     * <p>
+     * In practice, each execution plan has its own instance of an Immutable Task Graph.
+     * However, some internal data structure might be shared. This test checks that
+     * TornadoVM can run with multiple execution plans using the same graph of computation.
+     * </p>
+     *
+     * @throws InterruptedException
+     */
     @Test
     public void test01() throws InterruptedException {
 
@@ -69,10 +81,13 @@ public class TestMultiThreadedExecutionPlans extends TornadoTestBase {
         Thread t1;
 
         KernelContext context = new KernelContext();
-        final int size = 1024 * 1024 * 32;
+
+        final int size = 1024 * 1024 * 64;   // ~ 256MB per Float Array
         FloatArray input = new FloatArray(size);
-        input.init(1.0f);
         FloatArray output = new FloatArray(size);
+
+        // Init data
+        input.init(1.0f);
 
         TaskGraph taskGraph = new TaskGraph("check") //
                 .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
@@ -85,15 +100,21 @@ public class TestMultiThreadedExecutionPlans extends TornadoTestBase {
         t0 = new Thread(() -> {
             System.out.print("Running thread t0");
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-            TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-            executionPlan.withGridScheduler(gridScheduler).execute();
+            try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+                executionPlan.withGridScheduler(gridScheduler).execute();
+            } catch (TornadoExecutionPlanException e) {
+                throw new RuntimeException(e);
+            }
         });
 
         t1 = new Thread(() -> {
             System.out.print("Running thread t1");
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-            TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-            executionPlan.withGridScheduler(gridScheduler).execute();
+            try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+                executionPlan.withGridScheduler(gridScheduler).execute();
+            } catch (TornadoExecutionPlanException e) {
+                throw new RuntimeException(e);
+            }
         });
 
         t0.start();
@@ -121,14 +142,20 @@ public class TestMultiThreadedExecutionPlans extends TornadoTestBase {
 
         t0 = new Thread(() -> {
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-            TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-            executionPlan.execute();
+            try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+                executionPlan.execute();
+            } catch (TornadoExecutionPlanException e) {
+                throw new RuntimeException(e);
+            }
         });
 
         t1 = new Thread(() -> {
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-            TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-            executionPlan.execute();
+            try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+                executionPlan.execute();
+            } catch (TornadoExecutionPlanException e) {
+                throw new RuntimeException(e);
+            }
         });
 
         t0.start();

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorAPIWithOnnx.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorAPIWithOnnx.java
@@ -17,18 +17,6 @@
  */
 package uk.ac.manchester.tornado.unittests.tensors;
 
-import ai.onnxruntime.OnnxTensor;
-import ai.onnxruntime.OnnxValue;
-import ai.onnxruntime.OrtEnvironment;
-import ai.onnxruntime.OrtException;
-import ai.onnxruntime.OrtSession;
-
-import org.junit.Assert;
-import org.junit.Test;
-import uk.ac.manchester.tornado.api.types.tensors.Shape;
-import uk.ac.manchester.tornado.api.types.tensors.TensorFP32;
-import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
-
 import java.io.BufferedInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -40,6 +28,26 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.Assert;
+import org.junit.Test;
+
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OnnxValue;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
+import uk.ac.manchester.tornado.api.types.tensors.Shape;
+import uk.ac.manchester.tornado.api.types.tensors.TensorFP32;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.tensors.TestTensorAPIWithOnnx
+ * </code>
+ */
 public class TestTensorAPIWithOnnx extends TornadoTestBase {
 
     private final String INPUT_TENSOR_NAME = "data";

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorTypes.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorTypes.java
@@ -36,6 +36,14 @@ import uk.ac.manchester.tornado.api.types.tensors.TensorInt32;
 import uk.ac.manchester.tornado.api.types.tensors.TensorInt64;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
+/**
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.tensors.TestTensorTypes
+ * </code>
+ */
 public class TestTensorTypes extends TornadoTestBase {
 
     public static void tensorAdditionFloat16(TensorFP16 tensorA, TensorFP16 tensorB, TensorFP16 tensorC) {


### PR DESCRIPTION
#### Description

This PR fixes an issue sharing the `dataObjectState` with multiple Java threads. 

#### Problem description

 The problem was that this state must be per thread (private), otherwise, when a buffer is allocated/removed, the device buffer taken might end-up being deallocated twice, thus, provoking a seg-fault from the driver side. This PR solves this issue. 

Disclaimer: I can run without errors using the OpenCL and SPIR-V backends. However, when running with the PTX backend, I still get random errors in the JNI side, mostly related to events. But IMO, this is not related to this fix.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make 
$ make tests 
$ tornado-test --jvm="-Dtornado.device.memory=4GB" --debug -V --fast uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans

# Pass also the batch processing examples or each backend:
$ tornado-test -V --fast uk.ac.manchester.tornado.unittests.batches.TestBatches
```

#### Additional context

- GAIA kernels are also passing.
- TornadoVM-RayTracer passes with the OpenCL backend


