### PR TITLE
[installer][fix] Fix for using TornadoVM with another provided JDK

### DIFF
--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -315,7 +315,7 @@ class TornadoInstaller:
 
         makeJDK = "jdk21"
         polyglotOption = ""
-        if (args.javaHome != None and "graal" in args.javaHome) or ("graal" in args.jdk):
+        if (args.javaHome != None and "graal" in args.javaHome) or (args.jdk != None and "graal" in args.jdk):
             makeJDK = "graal-jdk-21"
             polyglotOption = self.composePolyglotOption(args)
 


### PR DESCRIPTION
#### Description

Fix for using TornadoVM with another provided JDK

#### Problem description

See related issue #391 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Assuming there is another JDK installed (e.g., by using `sdkman`) use the following command:

```bash
$ ./bin/tornadovm-installer --backend opencl --javaHome /home/juan/.sdkman/candidates/java/current
```

