### PR TITLE
[release] TornadoVM v1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Developers can choose which backends to install and run.
 
 For a quick introduction please read the following [FAQ](https://tornadovm.readthedocs.io/en/latest/).
 
-**Latest Release:** TornadoVM 1.0.3 - 27/03/2024 :
+**Latest Release:** TornadoVM 1.0.4 - 30/04/2024 :
 See [CHANGELOG](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html).
 
 ----------------------
@@ -248,12 +248,12 @@ You can import the TornadoVM API by setting this the following dependency in the
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 </dependency>
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-matrices</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
 </dependency>
 </dependencies>
 ```

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -32,7 +32,7 @@ import wget
 import installer_config as config
 
 __DIRECTORY_DEPENDENCIES__ = os.path.join("etc", "dependencies")
-__VERSION__ = "v1.0.4-dev"
+__VERSION__ = "v1.0.4"
 
 __SUPPORTED_JDKS__ = [
     config.__JDK21__,

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -5,6 +5,47 @@ TornadoVM Changelog
 
 This file summarizes the new features and major changes for each *TornadoVM* version.
 
+TornadoVM 1.0.4
+----------------
+30th April 2024
+
+Improvements
+~~~~~~~~~~~~~~~~~~
+
+- `#369 <https://github.com/beehive-lab/TornadoVM/pull/369>`_: Introduction of Tensor types in TornadoVM API and interoperability with ONNX Runtime.
+- `#370 <https://github.com/beehive-lab/TornadoVM/pull/370>`_ : Array concatenation operation for TornadoVM native arrays.
+- `#371 <https://github.com/beehive-lab/TornadoVM/pull/371>`_: TornadoVM installer script ported for Windows 10/11.
+- `#372 <https://github.com/beehive-lab/TornadoVM/pull/372>`_: Add support for ``HalfFloat`` (``Float16``) in vector types.
+- `#374 <https://github.com/beehive-lab/TornadoVM/pull/374>`_: Support for TornadoVM array concatenations from the constructor-level.
+- `#375 <https://github.com/beehive-lab/TornadoVM/pull/375>`_: Support for TornadoVM native arrays using slices from the Panama API.
+- `#376 <https://github.com/beehive-lab/TornadoVM/pull/376>`_: Support for lazy copy-outs in the batch processing mode.
+- `#377 <https://github.com/beehive-lab/TornadoVM/pull/377>`_: Expand the TornadoVM profiler with power metrics for NVIDIA GPUs (OpenCL and PTX backends).
+- `#384 <https://github.com/beehive-lab/TornadoVM/pull/384>`_: Auto-closable Execution Plans for automatic memory management.
+
+Compatibility
+~~~~~~~~~~~~~~~~~~
+
+- `#386 <https://github.com/beehive-lab/TornadoVM/issues/386>`_: OpenJDK 17 support removed.
+- `#390 <https://github.com/beehive-lab/TornadoVM/pull/390>`_: SapMachine OpenJDK 21 supported.
+- `#395 <https://github.com/beehive-lab/TornadoVM/issues/395>`_: OpenJDK 22 and GraalVM 22.0.1 supported.
+- TornadoVM tested with Apple M3 chips.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~
+
+- `#367 <https://github.com/beehive-lab/TornadoVM/pull/367>`_: Fix for Graal/Truffle languages in which some Java modules were not visible.
+- `#373 <https://github.com/beehive-lab/TornadoVM/pull/373>`_: Fix for data copies of the ``HalfFloat`` types for all backends.
+- `#378 <https://github.com/beehive-lab/TornadoVM/pull/378>`_: Fix free memory markers when running multi-thread execution plans.
+- `#379 <https://github.com/beehive-lab/TornadoVM/pull/379>`_: Refactoring package of vector api unit-tests.
+- `#380 <https://github.com/beehive-lab/TornadoVM/pull/380>`_: Fix event list sizes to accommodate profiling of large applications.
+- `#385 <https://github.com/beehive-lab/TornadoVM/pull/385>`_: Fix code check style.
+- `#387 <https://github.com/beehive-lab/TornadoVM/pull/387>`_: Fix TornadoVM internal events in OpenCL, SPIR-V and PTX for running multi-threaded execution plans.
+- `#388 <https://github.com/beehive-lab/TornadoVM/pull/388>`_: Fix of expected and actual values of tests.
+- `#392 <https://github.com/beehive-lab/TornadoVM/pull/392>`_: Fix installer for using existing JDKs.
+- `#389 <https://github.com/beehive-lab/TornadoVM/pull/389>`_: Fix ``DataObjectState`` for multi-thread execution plans.
+- `#396 <https://github.com/beehive-lab/TornadoVM/pull/396>`_: Fix JNI code for the CUDA NVML library access with OpenCL.
+
+
 TornadoVM 1.0.3
 ----------------
 27th March 2024

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -771,13 +771,13 @@ To use the TornadoVM API in your projects, you can checkout our maven repository
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>1.0.3</version>
+         <version>1.0.4</version>
       </dependency>
 
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>1.0.3</version>
+         <version>1.0.4</version>
       </dependency>
    </dependencies>
 
@@ -788,6 +788,7 @@ Notice that, for running with TornadoVM, you will need either the docker images 
 Versions available
 ========================
 
+* 1.0.4
 * 1.0.3
 * 1.0.2
 * 1.0.1

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>tornado</groupId>
     <artifactId>tornado</artifactId>
-    <version>1.0.4-dev</version>
+    <version>1.0.4</version>
     <packaging>pom</packaging>
     <name>tornado</name>
     <url>https://github.com/beehive-lab/tornadovm</url>

--- a/tornado-annotation/pom.xml
+++ b/tornado-annotation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
 
     <artifactId>tornado-annotation</artifactId>

--- a/tornado-api/pom.xml
+++ b/tornado-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
 
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.4-dev</version>
+    <version>1.0.4</version>
 
     <name>tornado-api</name>
     <url>https://tornadovm.org</url>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-assembly</artifactId>
     <packaging>pom</packaging>

--- a/tornado-benchmarks/pom.xml
+++ b/tornado-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
 
     <artifactId>tornado-benchmarks</artifactId>

--- a/tornado-drivers/drivers-common/pom.xml
+++ b/tornado-drivers/drivers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tornado-drivers/opencl-jni/pom.xml
+++ b/tornado-drivers/opencl-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-drivers-opencl-jni</artifactId>
     <name>tornado-drivers-opencl-jni</name>

--- a/tornado-drivers/opencl/pom.xml
+++ b/tornado-drivers/opencl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-drivers-opencl</artifactId>
     <name>tornado-drivers-opencl</name>

--- a/tornado-drivers/pom.xml
+++ b/tornado-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-drivers</artifactId>
     <name>tornado-drivers</name>

--- a/tornado-drivers/ptx-jni/pom.xml
+++ b/tornado-drivers/ptx-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-drivers-ptx-jni</artifactId>
     <name>tornado-drivers-ptx-jni</name>

--- a/tornado-drivers/ptx/pom.xml
+++ b/tornado-drivers/ptx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tornado-drivers</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-drivers-ptx</artifactId>
     <name>tornado-drivers-ptx</name>

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-drivers-spirv</artifactId>
     <name>tornado-drivers-spirv</name>

--- a/tornado-examples/pom.xml
+++ b/tornado-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-examples</artifactId>
     <name>tornado-examples</name>

--- a/tornado-matrices/pom.xml
+++ b/tornado-matrices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-matrices</artifactId>
     <name>tornado-matrices</name>

--- a/tornado-runtime/pom.xml
+++ b/tornado-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-runtime</artifactId>
     <name>tornado-runtime</name>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.4-dev</version>
+        <version>1.0.4</version>
     </parent>
     <artifactId>tornado-unittests</artifactId>
     <name>tornado-unittests</name>


### PR DESCRIPTION
#### Improvements

- [#369](https://github.com/beehive-lab/TornadoVM/pull/369): Introduction of Tensor types in TornadoVM API and interoperability with ONNX Runtime.
- [#370](https://github.com/beehive-lab/TornadoVM/pull/370): Array concatenation operation for TornadoVM native arrays.
- [#371](https://github.com/beehive-lab/TornadoVM/pull/371): TornadoVM installer script ported for Windows 10/11.
- [#372](https://github.com/beehive-lab/TornadoVM/pull/372): Add support for ``HalfFloat`` (``Float16``) in vector types.
- [#374](https://github.com/beehive-lab/TornadoVM/pull/374): Support for TornadoVM array concatenations from the constructor-level.
- [#375](https://github.com/beehive-lab/TornadoVM/pull/375): Support for TornadoVM native arrays using slices from the Panama API.
- [#376](https://github.com/beehive-lab/TornadoVM/pull/376): Support for lazy copy-outs in the batch processing mode.
- [#377](https://github.com/beehive-lab/TornadoVM/pull/377): Expand the TornadoVM profiler with power metrics for NVIDIA GPUs (OpenCL and PTX backends).
- [#384](https://github.com/beehive-lab/TornadoVM/pull/384): Auto-closable Execution Plans for automatic memory management.

#### Compatibility

- [#386](https://github.com/beehive-lab/TornadoVM/issues/386): OpenJDK 17 support removed.
- [#390](https://github.com/beehive-lab/TornadoVM/pull/390): SapMachine OpenJDK 21 supported.
- [#395](https://github.com/beehive-lab/TornadoVM/issues/395): OpenJDK 22 and GraalVM 22.0.1 supported.
- TornadoVM tested with Apple M3 chips.

#### Bug Fixes

- [#367](https://github.com/beehive-lab/TornadoVM/pull/367): Fix for Graal/Truffle languages in which some Java modules were not visible.
- [#373](https://github.com/beehive-lab/TornadoVM/pull/373): Fix for data copies of the ``HalfFloat`` types for all backends.
- [#378](https://github.com/beehive-lab/TornadoVM/pull/378): Fix free memory markers when running multi-thread execution plans.
- [#379](https://github.com/beehive-lab/TornadoVM/pull/379): Refactoring package of vector api unit-tests.
- [#380](https://github.com/beehive-lab/TornadoVM/pull/380): Fix event list sizes to accommodate profiling of large applications.
- [#385](https://github.com/beehive-lab/TornadoVM/pull/385): Fix code check style.
- [#387](https://github.com/beehive-lab/TornadoVM/pull/387): Fix TornadoVM internal events in OpenCL, SPIR-V and PTX for running multi-threaded execution plans.
- [#388](https://github.com/beehive-lab/TornadoVM/pull/388): Fix of expected and actual values of tests.
- [#392](https://github.com/beehive-lab/TornadoVM/pull/392): Fix installer for using existing JDKs.
- [#389](https://github.com/beehive-lab/TornadoVM/pull/389): Fix ``DataObjectState`` for multi-thread execution plans.
- [#396](https://github.com/beehive-lab/TornadoVM/pull/396): Fix JNI code for the CUDA NVML library access with OpenCL.


## How to test it?

```bash
make BACKEND=opencl,spirv,ptx
tornado --version
```


