### PR TITLE
Support to construct TornadoNativeArrays from ByteBuffers through memory segment direct copies

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -22,6 +22,8 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
 import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
@@ -119,6 +121,20 @@ public final class ByteArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / BYTE_BYTES);
         ByteArray byteArray = new ByteArray(numElements);
         MemorySegment.copy(segment, 0, byteArray.segment, byteArray.baseIndex * BYTE_BYTES, byteSize);
+        return byteArray;
+    }
+
+    /**
+     * Creates a new instance of the {@link ByteArray} class from a {@link ByteBuffer}.
+     *
+     * @param buffer
+     *     The {@link ByteBuffer} containing the float data.
+     * @return A new {@link ByteArray} instance, initialized with the buffer data.
+     */
+    public static ByteArray fromByteBuffer(ByteBuffer buffer) {
+        int numElements = buffer.remaining();
+        ByteArray byteArray = new ByteArray(numElements);
+        byteArray.getSegment().copyFrom(MemorySegment.ofBuffer(buffer));
         return byteArray;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.nio.CharBuffer;
 import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
@@ -119,6 +120,20 @@ public final class CharArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / CHAR_BYTES);
         CharArray charArray = new CharArray(numElements);
         MemorySegment.copy(segment, 0, charArray.segment, charArray.baseIndex * CHAR_BYTES, byteSize);
+        return charArray;
+    }
+
+    /**
+     * Creates a new instance of the {@link CharArray} class from a {@link CharBuffer}.
+     *
+     * @param buffer
+     *     The {@link CharBuffer} containing the float data.
+     * @return A new {@link CharArray} instance, initialized with the buffer data.
+     */
+    public static CharArray fromCharBuffer(CharBuffer buffer) {
+        int numElements = buffer.remaining();
+        CharArray charArray = new CharArray(numElements);
+        charArray.getSegment().copyFrom(MemorySegment.ofBuffer(buffer));
         return charArray;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.nio.DoubleBuffer;
 import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
@@ -121,6 +122,20 @@ public final class DoubleArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / DOUBLE_BYTES);
         DoubleArray doubleArray = new DoubleArray(numElements);
         MemorySegment.copy(segment, 0, doubleArray.segment, doubleArray.baseIndex * DOUBLE_BYTES, byteSize);
+        return doubleArray;
+    }
+
+    /**
+     * Creates a new instance of the {@link DoubleArray} class from a {@link DoubleBuffer}.
+     *
+     * @param buffer
+     *     The {@link DoubleBuffer} containing the double data.
+     * @return A new {@link DoubleArray} instance, initialized with the buffer data.
+     */
+    public static DoubleArray fromDoubleBuffer(DoubleBuffer buffer) {
+        int numElements = buffer.remaining();
+        DoubleArray doubleArray = new DoubleArray(numElements);
+        doubleArray.getSegment().copyFrom(MemorySegment.ofBuffer(buffer));
         return doubleArray;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.nio.FloatBuffer;
 import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
@@ -121,6 +122,20 @@ public final class FloatArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / FLOAT_BYTES);
         FloatArray floatArray = new FloatArray(numElements);
         MemorySegment.copy(segment, 0, floatArray.segment, floatArray.baseIndex * FLOAT_BYTES, byteSize);
+        return floatArray;
+    }
+
+    /**
+     * Creates a new instance of the {@link FloatArray} class from a {@link FloatBuffer}.
+     *
+     * @param buffer
+     *     The {@link FloatBuffer} containing the float data.
+     * @return A new {@link FloatArray} instance, initialized with the buffer data.
+     */
+    public static FloatArray fromFloatBuffer(FloatBuffer buffer) {
+        int numElements = buffer.remaining();
+        FloatArray floatArray = new FloatArray(numElements);
+        floatArray.getSegment().copyFrom(MemorySegment.ofBuffer(buffer));
         return floatArray;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -21,6 +21,8 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.IntBuffer;
 import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
@@ -121,6 +123,20 @@ public final class IntArray extends TornadoNativeArray {
         return intArray;
     }
 
+    /**
+     * Creates a new instance of the {@link IntArray} class from a {@link IntBuffer}.
+     *
+     * @param buffer
+     *     The {@link IntBuffer} containing the int data.
+     * @return A new {@link IntArray} instance, initialized with the buffer data.
+     */
+    public static IntArray fromIntBuffer(IntBuffer buffer) {
+        int numElements = buffer.remaining();
+        IntArray intArray = new IntArray(numElements);
+        intArray.getSegment().copyFrom(MemorySegment.ofBuffer(buffer));
+        return intArray;
+    }
+    
     /**
      * Converts the int data from off-heap to on-heap, by copying the values of a {@link IntArray}
      * instance into a new on-heap array.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_LONG;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.nio.LongBuffer;
 import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
@@ -119,6 +120,20 @@ public final class LongArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / LONG_BYTES);
         LongArray longArray = new LongArray(numElements);
         MemorySegment.copy(segment, 0, longArray.segment, longArray.baseIndex * LONG_BYTES, byteSize);
+        return longArray;
+    }
+
+    /**
+     * Creates a new instance of the {@link LongArray} class from a {@link LongBuffer}.
+     *
+     * @param buffer
+     *     The {@link LongBuffer} containing the long data.
+     * @return A new {@link LongArray} instance, initialized with the buffer data.
+     */
+    public static LongArray fromLongBuffer(LongBuffer buffer) {
+        int numElements = buffer.remaining();
+        LongArray longArray = new LongArray(numElements);
+        longArray.getSegment().copyFrom(MemorySegment.ofBuffer(buffer));
         return longArray;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -22,6 +22,7 @@ import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.nio.ShortBuffer;
 import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
@@ -120,6 +121,20 @@ public final class ShortArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / SHORT_BYTES);
         ShortArray shortArray = new ShortArray(numElements);
         MemorySegment.copy(segment, 0, shortArray.segment, shortArray.baseIndex * SHORT_BYTES, byteSize);
+        return shortArray;
+    }
+
+    /**
+     * Creates a new instance of the {@link ShortArray} class from a {@link ShortBuffer}.
+     *
+     * @param buffer
+     *     The {@link ShortBuffer} containing the short data.
+     * @return A new {@link ShortArray} instance, initialized with the buffer data.
+     */
+    public static ShortArray fromShortBuffer(ShortBuffer buffer) {
+        int numElements = buffer.remaining();
+        ShortArray shortArray = new ShortArray(numElements);
+        shortArray.getSegment().copyFrom(MemorySegment.ofBuffer(buffer));
         return shortArray;
     }
 


### PR DESCRIPTION
#### Description

Currently, we support bulding TornadoNative arrays direclty from primitive arrays and MemorySegments, but we were missing support for Java NIO ByteBuffers. 


#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
make 
make tests
```
----------------------------------------------------------------------------
