### PR TITLE
[Refactor] Cleanup and refactor of the code for analysis of parallel loops and loop interchange

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/TaskMetaDataInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/TaskMetaDataInterface.java
@@ -46,7 +46,7 @@ public interface TaskMetaDataInterface {
 
     Object getCompiledResolvedJavaMethod();
 
-    int getDriverIndex();
+    int getBackendIndex();
 
     int getDeviceIndex();
 

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/utils/CompilerUtil.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/utils/CompilerUtil.java
@@ -65,8 +65,8 @@ public class CompilerUtil {
     }
 
     public static Sketch buildSketchForJavaMethod(ResolvedJavaMethod resolvedJavaMethod, TaskMetaData taskMetaData, Providers providers, TornadoSuitesProvider suites) {
-        new SketchRequest(resolvedJavaMethod, providers, suites.getGraphBuilderSuite(), suites.getSketchTier(), taskMetaData.getDriverIndex(), taskMetaData.getDeviceIndex())//
+        new SketchRequest(resolvedJavaMethod, providers, suites.getGraphBuilderSuite(), suites.getSketchTier(), taskMetaData.getBackendIndex(), taskMetaData.getDeviceIndex())//
                 .run();
-        return TornadoSketcher.lookup(resolvedJavaMethod, taskMetaData.getDriverIndex(), taskMetaData.getDeviceIndex());
+        return TornadoSketcher.lookup(resolvedJavaMethod, taskMetaData.getBackendIndex(), taskMetaData.getDeviceIndex());
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
@@ -409,7 +409,7 @@ public class OCLCompiler {
             } else {
                 nonInlinedCompiledMethods.add(currentMethod);
             }
-            Sketch currentSketch = TornadoSketcher.lookup(currentMethod, task.meta().getDriverIndex(), task.meta().getDeviceIndex());
+            Sketch currentSketch = TornadoSketcher.lookup(currentMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
             final StructuredGraph graph = (StructuredGraph) currentSketch.getGraph().copy(getDebugContext());
 
             String subKernelName = OCLDeviceContext.checkKernelName(currentMethod.getName());

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoParallelScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoParallelScheduler.java
@@ -24,8 +24,6 @@
 package uk.ac.manchester.tornado.drivers.opencl.graal.phases;
 
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
-import static uk.ac.manchester.tornado.runtime.common.TornadoSchedulingStrategy.PER_BLOCK;
-import static uk.ac.manchester.tornado.runtime.common.TornadoSchedulingStrategy.PER_ITERATION;
 
 import java.util.Optional;
 
@@ -44,8 +42,8 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.GlobalThreadIdNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.GlobalThreadSizeNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLIntBinaryIntrinsicNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.calc.DivNode;
-import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.TornadoSchedulingStrategy;
+import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.graal.nodes.AbstractParallelNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelOffsetNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
@@ -53,36 +51,29 @@ import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelStrideNode;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
 
 public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> {
-    private ValueNode blockSize;
 
     @Override
     public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
         return ALWAYS_APPLICABLE;
     }
 
-    private void replaceOffsetNode(TornadoSchedulingStrategy schedule, StructuredGraph graph, ParallelOffsetNode offset, ParallelRangeNode range) {
-        if (schedule == PER_BLOCK) {
-            replacePerBlock(graph, offset);
-        } else if (schedule == PER_ITERATION) {
-            replacePerIteration(graph, offset, range);
+    private void replaceOffsetNode(TornadoSchedulingStrategy schedule, StructuredGraph graph, ParallelOffsetNode offset, ParallelRangeNode range, ValueNode blockSize) {
+        switch (schedule) {
+            case PER_CPU_BLOCK -> replaceOffsetPerBlock(graph, offset, blockSize);
+            case PER_ACCELERATOR_ITERATION -> replaceOffsetPerIteration(graph, offset, range);
         }
     }
 
-    private void replacePerIteration(StructuredGraph graph, ParallelOffsetNode offset, ParallelRangeNode range) {
-
+    private void replaceOffsetPerIteration(StructuredGraph graph, ParallelOffsetNode offset, ParallelRangeNode range) {
         final ConstantNode index = graph.addOrUnique(ConstantNode.forInt(offset.index()));
-
         final GlobalThreadIdNode threadId = graph.addOrUnique(new GlobalThreadIdNode(index));
-
         final AddNode addNode = graph.addOrUnique(new AddNode(threadId, offset.value()));
-
         final MulNode mulNode = graph.addOrUnique(new MulNode(addNode, range.stride().value()));
-
         offset.replaceAtUsages(mulNode);
         offset.safeDelete();
     }
 
-    private void replacePerBlock(StructuredGraph graph, ParallelOffsetNode offset) {
+    private void replaceOffsetPerBlock(StructuredGraph graph, ParallelOffsetNode offset, ValueNode blockSize) {
         final GlobalThreadIdNode threadId = graph.addOrUnique(new GlobalThreadIdNode(ConstantNode.forInt(offset.index(), graph)));
         final MulNode newOffset = graph.addOrUnique(new MulNode(threadId, blockSize));
         offset.replaceAtUsages(newOffset);
@@ -90,39 +81,43 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
     }
 
     private void replaceStrideNode(TornadoSchedulingStrategy schedule, StructuredGraph graph, ParallelStrideNode stride) {
-        if (schedule == PER_BLOCK) {
-            replacePerBlock(stride);
-        } else if (schedule == PER_ITERATION) {
-            replacePerIteration(graph, stride);
+        switch (schedule) {
+            case PER_CPU_BLOCK -> replaceStridePerBlock(stride);
+            case PER_ACCELERATOR_ITERATION -> replaceStridePerIteration(graph, stride);
         }
     }
 
-    private void replacePerIteration(StructuredGraph graph, ParallelStrideNode stride) {
+    private void replaceStridePerIteration(StructuredGraph graph, ParallelStrideNode stride) {
         final ConstantNode index = graph.addOrUnique(ConstantNode.forInt(stride.index()));
         final GlobalThreadSizeNode threadCount = graph.addOrUnique(new GlobalThreadSizeNode(index));
         stride.replaceAtUsages(threadCount);
         stride.safeDelete();
     }
 
-    private void replacePerBlock(ParallelStrideNode stride) {
+    private void replaceStridePerBlock(ParallelStrideNode stride) {
         stride.replaceAtUsages(stride.value());
         stride.safeDelete();
     }
 
-    private void replaceRangeNode(TornadoSchedulingStrategy schedule, StructuredGraph graph, ParallelRangeNode range) {
-        if (schedule == PER_BLOCK) {
-            replacePerBlock(graph, range);
-        } else if (schedule == PER_ITERATION) {
-            replacePerIteration(range);
+    private ValueNode replaceRangeNode(TornadoSchedulingStrategy schedule, StructuredGraph graph, ParallelRangeNode range) {
+        switch (schedule) {
+            case PER_CPU_BLOCK -> {
+                return replaceRangePerBlock(graph, range);
+            }
+            case PER_ACCELERATOR_ITERATION -> {
+                replaceRangePerIteration(range);
+                return null;
+            }
         }
+        return null;
     }
 
-    private void replacePerIteration(ParallelRangeNode range) {
+    private void replaceRangePerIteration(ParallelRangeNode range) {
         range.replaceAtUsages(range.value());
     }
 
     // CPU-Scheduling with Stride
-    private void buildBlockSize(StructuredGraph graph, ParallelRangeNode range) {
+    private ValueNode buildBlockSize(StructuredGraph graph, ParallelRangeNode range) {
         final ValueNode rangeByStride = graph.addOrUnique(DivNode.create(range.value(), range.stride().value()));
         final SubNode trueRange = graph.addOrUnique(new SubNode(rangeByStride, range.offset().value()));
         final ConstantNode index = ConstantNode.forInt(range.index(), graph);
@@ -130,63 +125,27 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
         final SubNode threadCountM1 = graph.addOrUnique(new SubNode(threadCount, ConstantNode.forInt(1, graph)));
         final AddNode adjustedTrueRange = graph.addOrUnique(new AddNode(trueRange, threadCountM1));
         final ValueNode div = graph.addOrUnique(DivNode.create(adjustedTrueRange, threadCount));
-        blockSize = graph.addOrUnique(new MulNode(div, range.stride().value()));
+        return graph.addOrUnique(new MulNode(div, range.stride().value()));
     }
 
     // CPU-Scheduling with Stride
-    private void replacePerBlock(StructuredGraph graph, ParallelRangeNode range) {
-        buildBlockSize(graph, range);
-
+    private ValueNode replaceRangePerBlock(StructuredGraph graph, ParallelRangeNode range) {
+        ValueNode blockSize = buildBlockSize(graph, range);
         final GlobalThreadIdNode threadId = graph.addOrUnique(new GlobalThreadIdNode(ConstantNode.forInt(range.index(), graph)));
         final MulNode newOffset = graph.addOrUnique(new MulNode(threadId, blockSize));
         final AddNode newRange = graph.addOrUnique(new AddNode(newOffset, blockSize));
-
-        // Stride of 2
         final MulNode stride = graph.addOrUnique(new MulNode(newRange, range.stride().value()));
         final ValueNode adjustedRange = graph.addOrUnique(OCLIntBinaryIntrinsicNode.create(stride, range.value(), OCLIntBinaryIntrinsicNode.Operation.MIN, JavaKind.Int));
-
         range.replaceAtUsages(adjustedRange);
         range.safeDelete();
+        return blockSize;
     }
-
-    // ================================== DEPRECATED
-    // ========================================
-    // GPU-Scheduling
-    private void buildBlockSizeAccelerator(StructuredGraph graph, ParallelRangeNode range) {
-        final ValueNode rangeByStride = graph.addOrUnique(DivNode.create(range.value(), range.stride().value()));
-        final SubNode trueRange = graph.addOrUnique(new SubNode(rangeByStride, range.offset().value()));
-        final ConstantNode index = ConstantNode.forInt(range.index(), graph);
-        final GlobalThreadSizeNode threadCount = graph.addOrUnique(new GlobalThreadSizeNode(index));
-        final SubNode threadCountM1 = graph.addOrUnique(new SubNode(threadCount, ConstantNode.forInt(1, graph)));
-        final AddNode adjustedTrueRange = graph.addOrUnique(new AddNode(trueRange, threadCountM1));
-        blockSize = graph.addOrUnique(DivNode.create(adjustedTrueRange, threadCount));
-    }
-
-    // GPU-Scheduling
-    @SuppressWarnings("unused")
-    private void replacePerBlockAccelerator(StructuredGraph graph, ParallelRangeNode range) {
-        buildBlockSizeAccelerator(graph, range);
-
-        final GlobalThreadIdNode threadId = graph.addOrUnique(new GlobalThreadIdNode(ConstantNode.forInt(range.index(), graph)));
-        final MulNode newOffset = graph.addOrUnique(new MulNode(threadId, blockSize));
-
-        final AddNode newRange = graph.addOrUnique(new AddNode(newOffset, blockSize));
-
-        final ValueNode adjustedRange = graph.addOrUnique(OCLIntBinaryIntrinsicNode.create(newRange, range.value(), OCLIntBinaryIntrinsicNode.Operation.MIN, JavaKind.Int));
-
-        range.replaceAtUsages(adjustedRange);
-        range.safeDelete();
-    }
-    // ================================== END-DEPRECATED
-    // ========================================
 
     @Override
     protected void run(StructuredGraph graph, TornadoHighTierContext context) {
-
         if (context.getMeta() == null || context.getMeta().enableThreadCoarsener()) {
             return;
         }
-
         TornadoXPUDevice device = context.getDeviceMapping();
         final TornadoSchedulingStrategy strategy = device.getPreferredSchedule();
         long[] maxWorkItemSizes = device.getPhysicalDevice().getDeviceMaxWorkItemSizes();
@@ -195,8 +154,8 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
             if (context.getMeta().enableParallelization() && maxWorkItemSizes[node.index()] > 1) {
                 ParallelOffsetNode offset = node.offset();
                 ParallelStrideNode stride = node.stride();
-                replaceRangeNode(strategy, graph, node);
-                replaceOffsetNode(strategy, graph, offset, node);
+                ValueNode blockSize = replaceRangeNode(strategy, graph, node);
+                replaceOffsetNode(strategy, graph, offset, node, blockSize);
                 replaceStrideNode(strategy, graph, stride);
 
             } else {
@@ -207,6 +166,17 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
         graph.clearLastSchedule();
     }
 
+    private void serialiseLoop(ParallelRangeNode range) {
+        ParallelOffsetNode offset = range.offset();
+        ParallelStrideNode stride = range.stride();
+        range.replaceAtUsages(range.value());
+        killNode(range);
+        offset.replaceAtUsages(offset.value());
+        stride.replaceAtUsages(stride.value());
+        killNode(offset);
+        killNode(stride);
+    }
+
     private void killNode(AbstractParallelNode node) {
         if (node.inputs().isNotEmpty()) {
             node.clearInputs();
@@ -214,20 +184,5 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
         if (!node.isDeleted()) {
             node.safeDelete();
         }
-    }
-
-    private void serialiseLoop(ParallelRangeNode range) {
-        ParallelOffsetNode offset = range.offset();
-        ParallelStrideNode stride = range.stride();
-
-        range.replaceAtUsages(range.value());
-        killNode(range);
-
-        offset.replaceAtUsages(offset.value());
-        stride.replaceAtUsages(stride.value());
-
-        killNode(offset);
-        killNode(stride);
-
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -201,16 +201,16 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         if (null != device.getDeviceType()) {
 
             if (Tornado.FORCE_ALL_TO_GPU) {
-                return TornadoSchedulingStrategy.PER_ITERATION;
+                return TornadoSchedulingStrategy.PER_ACCELERATOR_ITERATION;
             }
 
             if (device.getDeviceType() == OCLDeviceType.CL_DEVICE_TYPE_CPU) {
-                return TornadoSchedulingStrategy.PER_BLOCK;
+                return TornadoSchedulingStrategy.PER_CPU_BLOCK;
             }
-            return TornadoSchedulingStrategy.PER_ITERATION;
+            return TornadoSchedulingStrategy.PER_ACCELERATOR_ITERATION;
         }
         TornadoInternalError.shouldNotReachHere();
-        return TornadoSchedulingStrategy.PER_ITERATION;
+        return TornadoSchedulingStrategy.PER_ACCELERATOR_ITERATION;
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -244,7 +244,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         final OCLDeviceContextInterface deviceContext = getDeviceContext();
         final CompilableTask executable = (CompilableTask) task;
         final ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(executable.getMethod());
-        final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getDriverIndex(), task.meta().getDeviceIndex());
+        final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
 
         // Return the code from the cache
         if (!task.shouldCompile() && deviceContext.isCached(task.getId(), resolvedMethod.getName())) {
@@ -365,7 +365,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         TaskMetaDataInterface meta = task.meta();
         if (meta instanceof TaskMetaData) {
             TaskMetaData metaData = (TaskMetaData) task.meta();
-            return task.getId() + ".device=" + metaData.getDriverIndex() + ":" + metaData.getDeviceIndex();
+            return task.getId() + ".device=" + metaData.getBackendIndex() + ":" + metaData.getDeviceIndex();
         } else {
             throw new RuntimeException("[ERROR] TaskMetadata expected");
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -180,7 +180,7 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
     private TornadoInstalledCode compileTask(SchedulableTask task) {
         final CompilableTask executable = (CompilableTask) task;
         final ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(executable.getMethod());
-        final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getDriverIndex(), task.meta().getDeviceIndex());
+        final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
 
         // copy meta data into task
         final TaskMetaData taskMeta = executable.meta();

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -147,16 +147,16 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
         if (null != device.getDeviceType()) {
 
             if (Tornado.FORCE_ALL_TO_GPU) {
-                return TornadoSchedulingStrategy.PER_ITERATION;
+                return TornadoSchedulingStrategy.PER_ACCELERATOR_ITERATION;
             }
 
             if (device.getDeviceType() == OCLDeviceType.CL_DEVICE_TYPE_CPU) {
-                return TornadoSchedulingStrategy.PER_BLOCK;
+                return TornadoSchedulingStrategy.PER_CPU_BLOCK;
             }
-            return TornadoSchedulingStrategy.PER_ITERATION;
+            return TornadoSchedulingStrategy.PER_ACCELERATOR_ITERATION;
         }
         TornadoInternalError.shouldNotReachHere();
-        return TornadoSchedulingStrategy.PER_ITERATION;
+        return TornadoSchedulingStrategy.PER_ACCELERATOR_ITERATION;
     }
 
     @Override

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
@@ -320,7 +320,7 @@ public class PTXCompiler {
             } else {
                 nonInlinedCompiledMethods.add(currentMethod);
             }
-            Sketch currentSketch = TornadoSketcher.lookup(currentMethod, task.meta().getDriverIndex(), task.meta().getDeviceIndex());
+            Sketch currentSketch = TornadoSketcher.lookup(currentMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
             final PTXCompilationResult compResult = new PTXCompilationResult(currentMethod.getName(), taskMeta);
             final StructuredGraph graph = (StructuredGraph) currentSketch.getGraph().copy(getDebugContext());
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoParallelScheduler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoParallelScheduler.java
@@ -10,7 +10,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -45,22 +45,18 @@ import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
 
 public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> {
 
-    private void replaceOffsetNode(StructuredGraph graph, ParallelOffsetNode offset, ParallelRangeNode range) {
-        final ConstantNode index = graph.addOrUnique(ConstantNode.forInt(offset.index()));
-
-        final GlobalThreadIdNode threadId = graph.addOrUnique(new GlobalThreadIdNode(index));
-
-        final AddNode addNode = graph.addOrUnique(new AddNode(threadId, offset.value()));
-
-        final MulNode mulNode = graph.addOrUnique(new MulNode(addNode, range.stride().value()));
-
-        offset.replaceAtUsages(mulNode);
-        offset.safeDelete();
-    }
-
     @Override
     public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
         return ALWAYS_APPLICABLE;
+    }
+
+    private void replaceOffsetNode(StructuredGraph graph, ParallelOffsetNode offset, ParallelRangeNode range) {
+        final ConstantNode index = graph.addOrUnique(ConstantNode.forInt(offset.index()));
+        final GlobalThreadIdNode threadId = graph.addOrUnique(new GlobalThreadIdNode(index));
+        final AddNode addNode = graph.addOrUnique(new AddNode(threadId, offset.value()));
+        final MulNode mulNode = graph.addOrUnique(new MulNode(addNode, range.stride().value()));
+        offset.replaceAtUsages(mulNode);
+        offset.safeDelete();
     }
 
     private void replaceStrideNode(StructuredGraph graph, ParallelStrideNode stride) {
@@ -91,7 +87,6 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
                 replaceRangeNode(node);
                 replaceOffsetNode(graph, offset, node);
                 replaceStrideNode(graph, stride);
-
             } else {
                 serialiseLoop(node);
             }
@@ -112,15 +107,11 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
     private void serialiseLoop(ParallelRangeNode range) {
         ParallelOffsetNode offset = range.offset();
         ParallelStrideNode stride = range.stride();
-
         range.replaceAtUsages(range.value());
         killNode(range);
-
         offset.replaceAtUsages(offset.value());
         stride.replaceAtUsages(stride.value());
-
         killNode(offset);
         killNode(stride);
-
     }
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -112,7 +112,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public TornadoSchedulingStrategy getPreferredSchedule() {
-        return TornadoSchedulingStrategy.PER_ITERATION;
+        return TornadoSchedulingStrategy.PER_ACCELERATOR_ITERATION;
     }
 
     @Override

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -166,7 +166,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
 
         final CompilableTask executable = (CompilableTask) task;
         final ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(executable.getMethod());
-        final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getDriverIndex(), task.meta().getDeviceIndex());
+        final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
 
         // copy meta data into task
         final TaskMetaData taskMeta = executable.meta();

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompiler.java
@@ -366,7 +366,7 @@ public class SPIRVCompiler {
         final Deque<ResolvedJavaMethod> workList = new ArrayDeque<>(kernelCompilationResult.getNonInlinedMethods());
         while (!workList.isEmpty()) {
             final ResolvedJavaMethod currentMethod = workList.pop();
-            Sketch currentSketch = TornadoSketcher.lookup(currentMethod, task.meta().getDriverIndex(), taskMeta.getDeviceIndex());
+            Sketch currentSketch = TornadoSketcher.lookup(currentMethod, task.meta().getBackendIndex(), taskMeta.getDeviceIndex());
             final StructuredGraph graph = (StructuredGraph) currentSketch.getGraph().copy(getDebugContext());
 
             final SPIRVCompilationResult compilationResult = new SPIRVCompilationResult(task.getId(), currentMethod.getName(), taskMeta);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoParallelScheduler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoParallelScheduler.java
@@ -13,7 +13,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -54,13 +54,9 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
 
     private void replaceOffsetNode(StructuredGraph graph, ParallelOffsetNode offset, ParallelRangeNode range) {
         final ConstantNode index = graph.addOrUnique(ConstantNode.forInt(offset.index()));
-
         final GlobalThreadIdNode threadId = graph.addOrUnique(new GlobalThreadIdNode(index));
-
         final AddNode addNode = graph.addOrUnique(new AddNode(threadId, offset.value()));
-
         final MulNode mulNode = graph.addOrUnique(new MulNode(addNode, range.stride().value()));
-
         offset.replaceAtUsages(mulNode);
         offset.safeDelete();
     }
@@ -113,15 +109,11 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
     private void serialiseLoop(ParallelRangeNode range) {
         ParallelOffsetNode offset = range.offset();
         ParallelStrideNode stride = range.stride();
-
         range.replaceAtUsages(range.value());
         killNode(range);
-
         offset.replaceAtUsages(offset.value());
         stride.replaceAtUsages(stride.value());
-
         killNode(offset);
         killNode(stride);
-
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -159,7 +159,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
         final SPIRVDeviceContext deviceContext = getDeviceContext();
 
         final ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(task.getMethod());
-        final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getDriverIndex(), task.meta().getDeviceIndex());
+        final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
 
         // copy meta data into task
         final TaskMetaData taskMeta = task.meta();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
@@ -91,7 +91,7 @@ public class JVMMapping implements TornadoXPUDevice {
 
     @Override
     public TornadoSchedulingStrategy getPreferredSchedule() {
-        return TornadoSchedulingStrategy.PER_BLOCK;
+        return TornadoSchedulingStrategy.PER_CPU_BLOCK;
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -37,7 +37,7 @@ public final class Tornado implements TornadoCI {
     public static final TornadoLogger log = new TornadoLogger(TornadoLogger.class);
     private static final Properties settings = System.getProperties();
     public static final boolean VALIDATE_ARRAY_HEADERS = Boolean.parseBoolean(settings.getProperty("tornado.opencl.array.validate", "False"));
-    public static final boolean TORNADO_LOOPS_REVERSE = Boolean.parseBoolean(settings.getProperty("tornado.loops.reverse", "True"));
+
     public static final boolean MARKER_USE_BARRIER = Boolean.parseBoolean(settings.getProperty("tornado.opencl.marker.asbarrier", "False"));
     public static final boolean DEBUG_KERNEL_ARGS = Boolean.parseBoolean(settings.getProperty("tornado.debug.kernelargs", "False"));
     public static final boolean FORCE_ALL_TO_GPU = Boolean.parseBoolean(settings.getProperty("tornado.opencl.forcegpu", "False"));
@@ -45,7 +45,6 @@ public final class Tornado implements TornadoCI {
     public static final boolean USE_VM_FLUSH = Boolean.parseBoolean(settings.getProperty("tornado.opencl.vmflush", "True"));
     public static final int EVENT_WINDOW = Integer.parseInt(getProperty("tornado.eventpool.size", "1024"));
     public static final int MAX_WAIT_EVENTS = Integer.parseInt(getProperty("tornado.eventpool.maxwaitevents", "32"));
-    public static final boolean OPENCL_USE_RELATIVE_ADDRESSES = Boolean.parseBoolean(settings.getProperty("tornado.opencl.userelative", "False"));
     public static final boolean DUMP_COMPILED_METHODS = Boolean.parseBoolean(getProperty("tornado.compiled.dump", "False"));
     public static final boolean ENABLE_PROFILING = Boolean.parseBoolean(settings.getProperty("tornado.profiling.enable", "True"));
     public static final boolean ENABLE_OOO_EXECUTION = Boolean.parseBoolean(settings.getProperty("tornado.ooo-execution.enable", "False"));

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -29,12 +29,29 @@ import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 
 public class TornadoOptions {
 
-    public static final String FALSE = "FALSE";
-    public static final String TRUE = "TRUE";
+    private static final String FALSE = "FALSE";
+    private static final String TRUE = "TRUE";
+
+    /**
+     * Use internal timers for profiling in ns if enabled, in ms if disabled. Default is ns (enabled).
+     */
     public static final boolean TIME_IN_NANOSECONDS = Boolean.parseBoolean(System.getProperty("tornado.ns.time", TRUE));
-    public static final int DEFAULT_DRIVER_INDEX = Integer.parseInt(Tornado.getProperty("tornado.driver", "0"));
+
+    /**
+     * Index for the default backend in TornadoVM. Default is 0.
+     */
+    public static final int DEFAULT_BACKEND_INDEX = Integer.parseInt(Tornado.getProperty("tornado.backend", "0"));
+
+    /**
+     * Index for the default device in TornadoVM. Default is 0.
+     */
     public static final int DEFAULT_DEVICE_INDEX = Integer.parseInt(Tornado.getProperty("tornado.device", "0"));
 
+    /**
+     * Enable/disable loop interchange optimization from the Sketcher compilation. This optimization is enabled
+     * by default. The optimization that reverses the ordering of the loops is:
+     * {@link uk.ac.manchester.tornado.runtime.graal.phases.sketcher.TornadoApiReplacement}.
+     */
     public static final boolean TORNADO_LOOP_INTERCHANGE = getBooleanValue("tornado.loop.interchange", "True");
 
     /**

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -35,7 +35,7 @@ public class TornadoOptions {
     public static final int DEFAULT_DRIVER_INDEX = Integer.parseInt(Tornado.getProperty("tornado.driver", "0"));
     public static final int DEFAULT_DEVICE_INDEX = Integer.parseInt(Tornado.getProperty("tornado.device", "0"));
 
-    public static final boolean TORNADO_LOOP_INTERCHANGE = getBooleanValue("tornado.loops.interchange", "True");
+    public static final boolean TORNADO_LOOP_INTERCHANGE = getBooleanValue("tornado.loop.interchange", "True");
 
     /**
      * Enable thread deployment debugging from the TornadoVM runtime and code dispatcher.

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -35,6 +35,8 @@ public class TornadoOptions {
     public static final int DEFAULT_DRIVER_INDEX = Integer.parseInt(Tornado.getProperty("tornado.driver", "0"));
     public static final int DEFAULT_DEVICE_INDEX = Integer.parseInt(Tornado.getProperty("tornado.device", "0"));
 
+    public static final boolean TORNADO_LOOP_INTERCHANGE = getBooleanValue("tornado.loops.interchange", "True");
+
     /**
      * Enable thread deployment debugging from the TornadoVM runtime and code dispatcher.
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoSchedulingStrategy.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoSchedulingStrategy.java
@@ -25,7 +25,7 @@ package uk.ac.manchester.tornado.runtime.common;
 
 public enum TornadoSchedulingStrategy {
     // @formatter:off
-    PER_BLOCK,
-	PER_ITERATION
+    PER_CPU_BLOCK,
+	PER_ACCELERATOR_ITERATION
 	// @formatter:on
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoApiReplacement.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoApiReplacement.java
@@ -21,8 +21,6 @@
  */
 package uk.ac.manchester.tornado.runtime.graal.phases.sketcher;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.TORNADO_LOOPS_REVERSE;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
@@ -49,6 +47,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoCompilationException;
 import uk.ac.manchester.tornado.runtime.ASMClassVisitorProvider;
 import uk.ac.manchester.tornado.runtime.common.ParallelAnnotationProvider;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelOffsetNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelStrideNode;
@@ -56,6 +55,11 @@ import uk.ac.manchester.tornado.runtime.graal.nodes.TornadoLoopsData;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoSketchTierContext;
 
 public class TornadoApiReplacement extends BasePhase<TornadoSketchTierContext> {
+
+    @Override
+    public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
+        return ALWAYS_APPLICABLE;
+    }
 
     /*
      * A singleton is used because we don't need to support all the logic of loading
@@ -75,14 +79,8 @@ public class TornadoApiReplacement extends BasePhase<TornadoSketchTierContext> {
             Constructor<?> constructor = klass.getConstructor();
             asmClassVisitorProvider = (ASMClassVisitorProvider) constructor.newInstance();
         } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | IllegalArgumentException | InvocationTargetException e) {
-            e.printStackTrace();
-            throw new RuntimeException("[ERROR] Tornado Annotation Implementation class not found");
+            throw new RuntimeException("[ERROR] Tornado Annotation Implementation class not found", e);
         }
-    }
-
-    @Override
-    public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
-        return ALWAYS_APPLICABLE;
     }
 
     @Override
@@ -91,39 +89,48 @@ public class TornadoApiReplacement extends BasePhase<TornadoSketchTierContext> {
     }
 
     private void replaceLocalAnnotations(StructuredGraph graph, TornadoSketchTierContext context) throws TornadoCompilationException {
-        // build node -> annotation mapping
+        Map<Node, ParallelAnnotationProvider> parallelNodes = getAnnotatedNodes(graph, context);
+        addParallelProcessingNodes(graph, parallelNodes);
+    }
+
+    private Map<Node, ParallelAnnotationProvider> getAnnotatedNodes(StructuredGraph graph, TornadoSketchTierContext context) {
         Map<ResolvedJavaMethod, ParallelAnnotationProvider[]> methodToAnnotations = new HashMap<>();
 
         methodToAnnotations.put(context.getMethod(), asmClassVisitorProvider.getParallelAnnotations(context.getMethod()));
 
-        for (ResolvedJavaMethod inlinee : graph.getMethods()) {
-            ParallelAnnotationProvider[] inlineParallelAnnotations = asmClassVisitorProvider.getParallelAnnotations(inlinee);
+        for (ResolvedJavaMethod resolvedJavaMethod : graph.getMethods()) {
+            ParallelAnnotationProvider[] inlineParallelAnnotations = asmClassVisitorProvider.getParallelAnnotations(resolvedJavaMethod);
             if (inlineParallelAnnotations.length > 0) {
-                methodToAnnotations.put(inlinee, inlineParallelAnnotations);
+                methodToAnnotations.put(resolvedJavaMethod, inlineParallelAnnotations);
             }
         }
-
         Map<Node, ParallelAnnotationProvider> parallelNodes = new HashMap<>();
 
-        graph.getNodes().filter(FrameState.class).forEach(fs -> {
-            if (methodToAnnotations.containsKey(fs.getMethod())) {
-                for (ParallelAnnotationProvider an : methodToAnnotations.get(fs.getMethod())) {
-                    if (fs.bci >= an.getStart() && fs.bci < an.getStart() + an.getLength()) {
-                        Node localNode = fs.localAt(an.getIndex());
+        graph.getNodes().filter(FrameState.class).forEach(frameState -> {
+            if (methodToAnnotations.containsKey(frameState.getMethod())) {
+                for (ParallelAnnotationProvider annotation : methodToAnnotations.get(frameState.getMethod())) {
+                    if (frameState.bci >= annotation.getStart() && frameState.bci < annotation.getStart() + annotation.getLength()) {
+                        Node localNode = frameState.localAt(annotation.getIndex());
                         if (!parallelNodes.containsKey(localNode)) {
-                            parallelNodes.put(localNode, an);
+                            parallelNodes.put(localNode, annotation);
                         }
                     }
                 }
             }
         });
+        return parallelNodes;
+    }
 
+    private void addParallelProcessingNodes(StructuredGraph graph, Map<Node, ParallelAnnotationProvider> parallelNodes) {
         if (graph.hasLoops()) {
             final LoopsData data = new TornadoLoopsData(graph);
             data.detectCountedLoops();
             int loopIndex = 0;
             final List<LoopEx> loops = data.outerFirst();
-            if (TORNADO_LOOPS_REVERSE) {
+
+            // Enable loop interchange - Parallel Loops are processed in the IR reversed order
+            // to set the ranges and offset of the corresponding <thread-ids> for each dimension.
+            if (TornadoOptions.TORNADO_LOOP_INTERCHANGE) {
                 Collections.reverse(loops);
             }
 
@@ -132,15 +139,10 @@ public class TornadoApiReplacement extends BasePhase<TornadoSketchTierContext> {
                     if (!parallelNodes.containsKey(iv.valueNode())) {
                         continue;
                     }
-                    ValueNode maxIterations;
                     List<IntegerLessThanNode> conditions = iv.valueNode().usages().filter(IntegerLessThanNode.class).snapshot();
-
                     final IntegerLessThanNode lessThan = conditions.getFirst();
-
-                    maxIterations = lessThan.getY();
-
+                    ValueNode maxIterations = lessThan.getY();
                     parallelizationReplacement(graph, iv, loopIndex, maxIterations, conditions);
-
                     loopIndex++;
                 }
             }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoAutoParalleliser.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoAutoParalleliser.java
@@ -128,11 +128,11 @@ public class TornadoAutoParalleliser extends BasePhase<TornadoSketchTierContext>
                     return;
                 }
 
-                final InductionVariable iv = ivs.get(0);
+                final InductionVariable iv = ivs.getFirst();
                 ValueNode maxIterations;
 
                 List<IntegerLessThanNode> conditions = iv.valueNode().usages().filter(IntegerLessThanNode.class).snapshot();
-                final IntegerLessThanNode lessThan = conditions.get(0);
+                final IntegerLessThanNode lessThan = conditions.getFirst();
                 maxIterations = lessThan.getY();
 
                 parallelizationReplacement(graph, iv, parallelDepth, maxIterations, conditions);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoGraphBuilder.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoGraphBuilder.java
@@ -226,7 +226,7 @@ public class TornadoGraphBuilder {
 
                 if (task instanceof CompilableTask) {
                     final ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(((CompilableTask) task).getMethod());
-                    Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getDriverIndex(), task.meta().getDeviceIndex());
+                    Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
                     accesses = sketch.getArgumentsAccess();
                 } else {
                     accesses = task.getArgumentsAccess();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -601,7 +601,7 @@ public class TornadoVMInterpreter {
         if (timeProfiler instanceof TimeProfiler) {
             // Register the backends only when the profiler is enabled
             timeProfiler.registerBackend(task.getId(), task.getDevice().getTornadoVMBackend().name());
-            timeProfiler.registerDeviceID(task.getId(), task.meta().getDriverIndex() + ":" + task.meta().getDeviceIndex());
+            timeProfiler.registerDeviceID(task.getId(), task.meta().getBackendIndex() + ":" + task.meta().getDeviceIndex());
             timeProfiler.registerDeviceName(task.getId(), task.getDevice().getPhysicalDevice().getDeviceName());
         }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -590,7 +590,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     private void updateInner(int index, SchedulableTask task) {
-        int driverIndex = task.meta().getDriverIndex();
+        int driverIndex = task.meta().getBackendIndex();
         Providers providers = TornadoCoreRuntime.getTornadoRuntime().getBackend(driverIndex).getProviders();
         TornadoSuitesProvider suites = TornadoCoreRuntime.getTornadoRuntime().getBackend(driverIndex).getSuitesProvider();
 
@@ -599,16 +599,16 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         if (task instanceof CompilableTask compilableTask) {
             final ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(compilableTask.getMethod());
             final TaskMetaData taskMetaData = compilableTask.meta();
-            new SketchRequest(resolvedMethod, providers, suites.getGraphBuilderSuite(), suites.getSketchTier(), taskMetaData.getDriverIndex(), taskMetaData.getDeviceIndex()).run();
+            new SketchRequest(resolvedMethod, providers, suites.getGraphBuilderSuite(), suites.getSketchTier(), taskMetaData.getBackendIndex(), taskMetaData.getDeviceIndex()).run();
 
-            Sketch sketchGraph = TornadoSketcher.lookup(resolvedMethod, taskMetaData.getDriverIndex(), taskMetaData.getDeviceIndex());
+            Sketch sketchGraph = TornadoSketcher.lookup(resolvedMethod, taskMetaData.getBackendIndex(), taskMetaData.getDeviceIndex());
             this.compilationGraph = sketchGraph.getGraph();
         }
     }
 
     @Override
     public void addInner(SchedulableTask task) {
-        int driverIndex = task.meta().getDriverIndex();
+        int driverIndex = task.meta().getBackendIndex();
         Providers providers = TornadoCoreRuntime.getTornadoRuntime().getBackend(driverIndex).getProviders();
         TornadoSuitesProvider suites = TornadoCoreRuntime.getTornadoRuntime().getBackend(driverIndex).getSuitesProvider();
 
@@ -617,9 +617,9 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         if (task instanceof CompilableTask compilableTask) {
             final ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(compilableTask.getMethod());
             final TaskMetaData taskMetaData = compilableTask.meta();
-            new SketchRequest(resolvedMethod, providers, suites.getGraphBuilderSuite(), suites.getSketchTier(), taskMetaData.getDriverIndex(), taskMetaData.getDeviceIndex()).run();
+            new SketchRequest(resolvedMethod, providers, suites.getGraphBuilderSuite(), suites.getSketchTier(), taskMetaData.getBackendIndex(), taskMetaData.getDeviceIndex()).run();
 
-            Sketch lookup = TornadoSketcher.lookup(resolvedMethod, compilableTask.meta().getDriverIndex(), compilableTask.meta().getDeviceIndex());
+            Sketch lookup = TornadoSketcher.lookup(resolvedMethod, compilableTask.meta().getBackendIndex(), compilableTask.meta().getDeviceIndex());
             this.compilationGraph = lookup.getGraph();
         }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
@@ -49,7 +49,8 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
     private static final String TRUE = "True";
     private static final String FALSE = "False";
     private final boolean isDeviceDefined;
-    private final HashSet<String> openCLBuiltOptions = new HashSet<>(Arrays.asList(//
+
+    private final HashSet<String> openCLBuiltOptions = new HashSet<>(Arrays.asList( //
             "-cl-single-precision-constant", //
             "-cl-denorms-are-zero", //
             "-cl-opt-disable", //
@@ -96,7 +97,7 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
     private final String cpuConfig;
     private String id;
     private TornadoXPUDevice device;
-    private int driverIndex;
+    private int backendIndex;
     private int deviceIndex;
     private boolean deviceManuallySet;
     private long numThreads;
@@ -122,13 +123,13 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
         isDeviceDefined = getProperty(id + ".device") != null;
         if (isDeviceDefined) {
             int[] a = MetaDataUtils.resolveDriverDeviceIndexes(getProperty(id + ".device"));
-            driverIndex = a[0];
+            backendIndex = a[0];
             deviceIndex = a[1];
         } else if (null != parent) {
-            driverIndex = parent.getDriverIndex();
+            backendIndex = parent.getBackendIndex();
             deviceIndex = parent.getDeviceIndex();
         } else {
-            driverIndex = TornadoOptions.DEFAULT_DRIVER_INDEX;
+            backendIndex = TornadoOptions.DEFAULT_BACKEND_INDEX;
             deviceIndex = TornadoOptions.DEFAULT_DEVICE_INDEX;
         }
 
@@ -189,7 +190,7 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
     }
 
     public TornadoXPUDevice getLogicDevice() {
-        return device != null ? device : (device = resolveDevice(Tornado.getProperty(id + ".device", driverIndex + ":" + deviceIndex)));
+        return device != null ? device : (device = resolveDevice(Tornado.getProperty(id + ".device", backendIndex + ":" + deviceIndex)));
     }
 
     private int getDeviceIndex(int driverIndex, TornadoDevice device) {
@@ -216,31 +217,17 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
      *     {@link TornadoDevice}
      */
     public void setDevice(TornadoDevice device) {
-        this.driverIndex = device.getDriverIndex();
-        this.deviceIndex = getDeviceIndex(driverIndex, device);
+        this.backendIndex = device.getDriverIndex();
+        this.deviceIndex = getDeviceIndex(backendIndex, device);
         if (device instanceof TornadoXPUDevice tornadoAcceleratorDevice) {
             this.device = tornadoAcceleratorDevice;
         }
         deviceManuallySet = true;
     }
 
-    /**
-     * Set a device from a specific Tornado driver.
-     *
-     * @param driverIndex
-     *     Driver Index
-     * @param device
-     *     {@link TornadoXPUDevice}
-     */
-    public void setDriverDevice(int driverIndex, TornadoXPUDevice device) {
-        this.driverIndex = driverIndex;
-        this.deviceIndex = getDeviceIndex(driverIndex, device);
-        this.device = device;
-    }
-
     @Override
-    public int getDriverIndex() {
-        return driverIndex;
+    public int getBackendIndex() {
+        return backendIndex;
     }
 
     @Override


### PR DESCRIPTION
#### Description

Cleanup and refactor of the code for analysis of parallel loops and loop interchange. This PR also eliminates old code no longer needed. Loop reordering option renamed to `loop.interchange`. This option is enabled by default. 

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make
make tests
```
