### PR TITLE
[jit][cpu] Disable loop-interchange for CPU offloading

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoSketchTierContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoSketchTierContext.java
@@ -28,6 +28,8 @@ import org.graalvm.compiler.phases.util.Providers;
 
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.api.common.Access;
+import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.runtime.graal.phases.sketcher.TornadoDataflowAnalysis;
 
 public class TornadoSketchTierContext extends HighTierContext {
@@ -40,11 +42,19 @@ public class TornadoSketchTierContext extends HighTierContext {
      */
     private final Access[] argumentAccess;
 
-    public TornadoSketchTierContext(Providers providers, PhaseSuite<HighTierContext> graphBuilderSuite, OptimisticOptimizations optimisticOpts, ResolvedJavaMethod method) {
+    private TornadoDevice device;
+
+    public TornadoSketchTierContext(Providers providers, PhaseSuite<HighTierContext> graphBuilderSuite, OptimisticOptimizations optimisticOpts, ResolvedJavaMethod method, int backendIndex,
+            int deviceIndex) {
         super(providers, graphBuilderSuite, optimisticOpts);
         this.method = method;
         int parameterCount = method.getParameters().length;
         this.argumentAccess = new Access[method.isStatic() ? parameterCount : parameterCount + 1];
+        device = TornadoRuntime.getTornadoRuntime().getBackend(backendIndex).getDevice(deviceIndex);
+    }
+
+    public TornadoDevice getDevice() {
+        return device;
     }
 
     public ResolvedJavaMethod getMethod() {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoApiReplacement.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoApiReplacement.java
@@ -45,6 +45,8 @@ import org.graalvm.compiler.nodes.loop.LoopsData;
 import org.graalvm.compiler.phases.BasePhase;
 
 import jdk.vm.ci.meta.ResolvedJavaMethod;
+import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoCompilationException;
 import uk.ac.manchester.tornado.runtime.ASMClassVisitorProvider;
@@ -92,6 +94,7 @@ public class TornadoApiReplacement extends BasePhase<TornadoSketchTierContext> {
 
     private void replaceLocalAnnotations(StructuredGraph graph, TornadoSketchTierContext context) throws TornadoCompilationException {
         // build node -> annotation mapping
+        TornadoDevice device = context.getDevice();
         Map<ResolvedJavaMethod, ParallelAnnotationProvider[]> methodToAnnotations = new HashMap<>();
 
         methodToAnnotations.put(context.getMethod(), asmClassVisitorProvider.getParallelAnnotations(context.getMethod()));
@@ -123,7 +126,8 @@ public class TornadoApiReplacement extends BasePhase<TornadoSketchTierContext> {
             data.detectCountedLoops();
             int loopIndex = 0;
             final List<LoopEx> loops = data.outerFirst();
-            if (TORNADO_LOOPS_REVERSE) {
+            if (device.getDeviceType() != TornadoDeviceType.CPU && TORNADO_LOOPS_REVERSE) {
+                // We do not apply loop interchange for CPU-only execution. 
                 Collections.reverse(loops);
             }
 


### PR DESCRIPTION
#### Description

This PR disables the loop interchange when the code is specialised for the CPU multi-core. 

When running on Intel CPU i9-10885H and OpenCL CPU Runtime `2024.17.3.0.08_160000` from oneAPI, the time that takes to compute the [Blur Filter](https://github.com/jjfumero/tornadovm-examples/blob/master/src/main/java/io/github/jjfumero/BlurFilter.java) goes from ~57 seconds in the first iteration down to ~7 seconds (speedup of 7.9x). 


Execution trace in `develop`:  https://github.com/beehive-lab/TornadoVM/commit/fcdebe513dac9a06b569669f8322e72ed1725a55 

```bash
tornado --threadInfo -cp target/tornadovm-examples-1.0-SNAPSHOT.jar io.github.jjfumero.BlurFilter tornado device=0:2
WARNING: Using incubator modules: jdk.incubator.vector
Task info: blur.red
	Backend           : OPENCL
	Device            : Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [16, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

Task info: blur.green
	Backend           : OPENCL
	Device            : Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [16, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

Task info: blur.blue
	Backend           : OPENCL
	Device            : Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [16, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

TornadoVM Total Time (ns) = 57798473152 -- seconds = 57.79847315200001
```

Execution trace with this feature:

```bash
tornado --threadInfo -cp target/tornadovm-examples-1.0-SNAPSHOT.jar io.github.jjfumero.BlurFilter tornado device=0:2
WARNING: Using incubator modules: jdk.incubator.vector
Task info: blur.red
	Backend           : OPENCL
	Device            : Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [16, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

Task info: blur.green
	Backend           : OPENCL
	Device            : Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [16, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

Task info: blur.blue
	Backend           : OPENCL
	Device            : Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [16, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

TornadoVM Total Time (ns) = 7243037295 -- seconds = 7.243037295000001

```

#### Problem description

The TornadoVM JIT compiler specialises the thread-block when compiling and deploying the application for multi-core CPUs. By default, the TornadoVM JIT compiler transform from 2D to 1D kernels. The problem is that, when having 2D kernels, the loop interchange might end-up running slower than expected due to the inner loop having more work to do per thread. This PR disables loop interchange for this case. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make
make tests
```
