### PR TITLE
[OCL] CPU Block Scheduler disabled by default and option to switch between thread schedulers

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLScheduler.java
@@ -46,7 +46,7 @@ public class OCLScheduler {
             case CL_DEVICE_TYPE_ACCELERATOR:
                 return context.isPlatformFPGA() ? new OCLFPGAScheduler(context) : new OCLCPUScheduler(context);
             case CL_DEVICE_TYPE_CPU:
-                return TornadoOptions.USE_CPU_SCHEDULER ? new OCLCPUScheduler(context) : getInstanceGPUScheduler(context);
+                return TornadoOptions.USE_BLOCK_SCHEDULER ? new OCLCPUScheduler(context) : getInstanceGPUScheduler(context);
             default:
                 Tornado.fatal("No scheduler available for device: %s", context);
                 break;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLScheduler.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of Tornado: A heterogeneous programming framework: 
+ * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
  * Copyright (c) 2013-2020, APT Group, Department of Computer Science,
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -25,6 +25,7 @@ package uk.ac.manchester.tornado.drivers.opencl;
 
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public class OCLScheduler {
 
@@ -45,7 +46,7 @@ public class OCLScheduler {
             case CL_DEVICE_TYPE_ACCELERATOR:
                 return context.isPlatformFPGA() ? new OCLFPGAScheduler(context) : new OCLCPUScheduler(context);
             case CL_DEVICE_TYPE_CPU:
-                return new OCLCPUScheduler(context);
+                return TornadoOptions.USE_CPU_SCHEDULER ? new OCLCPUScheduler(context) : getInstanceGPUScheduler(context);
             default:
                 Tornado.fatal("No scheduler available for device: %s", context);
                 break;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLScheduler.java
@@ -55,9 +55,6 @@ public class OCLScheduler {
     }
 
     public static OCLKernelScheduler create(final OCLDeviceContext context) {
-        if (Tornado.FORCE_ALL_TO_GPU) {
-            return getInstanceGPUScheduler(context);
-        }
         if (context.getDevice().getDeviceType() != null) {
             OCLDeviceType type = context.getDevice().getDeviceType();
             return instanceScheduler(type, context);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/enums/OCLDeviceType.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/enums/OCLDeviceType.java
@@ -46,27 +46,14 @@ public enum OCLDeviceType {
     }
 
     public static OCLDeviceType toDeviceType(final long v) {
-        OCLDeviceType result = null;
-        switch ((int) v) {
-            case 1:
-                result = OCLDeviceType.CL_DEVICE_TYPE_DEFAULT;
-                break;
-            case 1 << 1:
-                result = OCLDeviceType.CL_DEVICE_TYPE_CPU;
-                break;
-            case 1 << 2:
-                result = OCLDeviceType.CL_DEVICE_TYPE_GPU;
-                break;
-            case 1 << 3:
-                result = OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR;
-                break;
-            case 1 << 4:
-                result = OCLDeviceType.CL_DEVICE_TYPE_CUSTOM;
-                break;
-            case 0xFFFFFFFF:
-                result = OCLDeviceType.CL_DEVICE_TYPE_ALL;
-                break;
-        }
-        return result;
+        return switch ((int) v) {
+            case 1 -> OCLDeviceType.CL_DEVICE_TYPE_DEFAULT;
+            case 1 << 1 -> OCLDeviceType.CL_DEVICE_TYPE_CPU;
+            case 1 << 2 -> OCLDeviceType.CL_DEVICE_TYPE_GPU;
+            case 1 << 3 -> OCLDeviceType.CL_DEVICE_TYPE_ACCELERATOR;
+            case 1 << 4 -> OCLDeviceType.CL_DEVICE_TYPE_CUSTOM;
+            case 0xFFFFFFFF -> OCLDeviceType.CL_DEVICE_TYPE_ALL;
+            default -> OCLDeviceType.Unknown;
+        };
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -203,7 +203,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
                 return TornadoSchedulingStrategy.PER_ITERATION;
             }
             case CL_DEVICE_TYPE_CPU -> {
-                if (TornadoOptions.USE_CPU_SCHEDULER) {
+                if (TornadoOptions.USE_BLOCK_SCHEDULER) {
                     return TornadoSchedulingStrategy.PER_BLOCK;
                 } else {
                     return TornadoSchedulingStrategy.PER_ITERATION;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -57,9 +58,9 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompiler;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.TornadoSchedulingStrategy;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
@@ -144,19 +145,22 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public TornadoSchedulingStrategy getPreferredSchedule() {
-        if (null != device.getDeviceType()) {
-
-            if (Tornado.FORCE_ALL_TO_GPU) {
+        switch (Objects.requireNonNull(device.getDeviceType())) {
+            case CL_DEVICE_TYPE_GPU, CL_DEVICE_TYPE_ACCELERATOR, CL_DEVICE_TYPE_CUSTOM, CL_DEVICE_TYPE_ALL -> {
                 return TornadoSchedulingStrategy.PER_ITERATION;
             }
-
-            if (device.getDeviceType() == OCLDeviceType.CL_DEVICE_TYPE_CPU) {
-                return TornadoSchedulingStrategy.PER_BLOCK;
+            case CL_DEVICE_TYPE_CPU -> {
+                if (TornadoOptions.USE_CPU_SCHEDULER) {
+                    return TornadoSchedulingStrategy.PER_BLOCK;
+                } else {
+                    return TornadoSchedulingStrategy.PER_ITERATION;
+                }
             }
-            return TornadoSchedulingStrategy.PER_ITERATION;
+            default -> {
+                TornadoInternalError.shouldNotReachHere();
+                return TornadoSchedulingStrategy.PER_ITERATION;
+            }
         }
-        TornadoInternalError.shouldNotReachHere();
-        return TornadoSchedulingStrategy.PER_ITERATION;
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -150,7 +150,7 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
                 return TornadoSchedulingStrategy.PER_ITERATION;
             }
             case CL_DEVICE_TYPE_CPU -> {
-                if (TornadoOptions.USE_CPU_SCHEDULER) {
+                if (TornadoOptions.USE_BLOCK_SCHEDULER) {
                     return TornadoSchedulingStrategy.PER_BLOCK;
                 } else {
                     return TornadoSchedulingStrategy.PER_ITERATION;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -35,12 +35,12 @@ import uk.ac.manchester.tornado.api.TornadoCI;
 public final class Tornado implements TornadoCI {
 
     public static final TornadoLogger log = new TornadoLogger(TornadoLogger.class);
+
     private static final Properties settings = System.getProperties();
     public static final boolean VALIDATE_ARRAY_HEADERS = Boolean.parseBoolean(settings.getProperty("tornado.opencl.array.validate", "False"));
     public static final boolean TORNADO_LOOPS_REVERSE = Boolean.parseBoolean(settings.getProperty("tornado.loops.reverse", "True"));
     public static final boolean MARKER_USE_BARRIER = Boolean.parseBoolean(settings.getProperty("tornado.opencl.marker.asbarrier", "False"));
     public static final boolean DEBUG_KERNEL_ARGS = Boolean.parseBoolean(settings.getProperty("tornado.debug.kernelargs", "False"));
-    public static final boolean FORCE_ALL_TO_GPU = Boolean.parseBoolean(settings.getProperty("tornado.opencl.forcegpu", "False"));
     public static final boolean USE_SYNC_FLUSH = Boolean.parseBoolean(settings.getProperty("tornado.opencl.syncflush", "False"));
     public static final boolean USE_VM_FLUSH = Boolean.parseBoolean(settings.getProperty("tornado.opencl.vmflush", "True"));
     public static final int EVENT_WINDOW = Integer.parseInt(getProperty("tornado.eventpool.size", "1024"));

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -56,7 +56,7 @@ public class TornadoOptions {
      */
     public static final int OPENCL_BACKEND_PRIORITY = Integer.parseInt(Tornado.getProperty("tornado.opencl.priority", "10"));
     /**
-     * Priority of the SPIRV Backend. The higher the number, the more priority over
+     * Priority of the SPIR-V Backend. The higher the number, the more priority over
      * the rest of the backends.
      */
     public static final int SPIRV_BACKEND_PRIORITY = Integer.parseInt(Tornado.getProperty("tornado.spirv.priority", "11"));
@@ -261,6 +261,11 @@ public class TornadoOptions {
      * to perform the sync.
      */
     public static final int MAX_EVENTS = getIntValue("tornado.max.events", "32768");
+
+    /**
+     * When running on CPUs, use the default CPU scheduler instead of the GPU scheduler.
+     */
+    public static boolean USE_CPU_SCHEDULER = getBooleanValue("tornado.cpu.scheduler", TRUE);
 
     public static boolean TORNADO_PROFILER_LOG = false;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2024, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -263,9 +263,10 @@ public class TornadoOptions {
     public static final int MAX_EVENTS = getIntValue("tornado.max.events", "32768");
 
     /**
-     * When running on CPUs, use the default CPU scheduler instead of the GPU scheduler.
+     * Partitions the iteration space into blocks. When running on CPUs, the number of blocks is equal to the
+     * number of CPU visible cores at runtime. False by default.
      */
-    public static boolean USE_CPU_SCHEDULER = getBooleanValue("tornado.cpu.scheduler", TRUE);
+    public static boolean USE_BLOCK_SCHEDULER = getBooleanValue("tornado.scheduler.block", FALSE);
 
     public static boolean TORNADO_PROFILER_LOG = false;
 


### PR DESCRIPTION
#### Description

This PR provides an enhancement for the thread-block scheduler when running on the CPUs. The default thread scheduler assigns a CPU thread per CPU core. This might not be the best strategy and it really depends on the OpenCL runtime/driver implementation. This patch, provides a switch for CPU-Block versus fine-grained scheduler, and it sets, by default, the CPU thread scheduler to the fine-grained. 

#### Problem description

The main problem is performance. For example, when running on the CPU using the PoCL OpenCL implementation, the CPU implementation takes, in average ~46 seconds to complete, while the Intel oneAPI takes ~5 seconds. 

If, instead of the block-scheduler for CPU, we use the "iteration" of the fine-grained scheduler, TornadoVM with PoCL runs in ~2.9-3.2 (s) per iteration. 

Here's a trace with PoCL with block and without block scheduler:  The application is taken from the TornadoVM-Examples repository: https://github.com/jjfumero/tornadovm-examples 

```bash
$ tornado --jvm="-Dtornado.scheduler.block=True" --threadInfo  -cp target/tornadovm-examples-1.0-SNAPSHOT.jar io.github.jjfumero.BlurFilter tornado device=0:3 

WARNING: Using incubator modules: jdk.incubator.vector
Task info: blur.red
	Backend           : OPENCL
	Device            : cpu-haswell-12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [20, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

Task info: blur.green
	Backend           : OPENCL
	Device            : cpu-haswell-12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [20, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

Task info: blur.blue
	Backend           : OPENCL
	Device            : cpu-haswell-12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [20, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

TornadoVM Total Time (ns) = 47729662509 -- seconds = 47.729662509
```

Using the fine-grained scheduler: 

```bash
tornado --jvm="-Dtornado.scheduler.block=False" --threadInfo  -cp target/tornadovm-examples-1.0-SNAPSHOT.jar io.github.jjfumero.BlurFilter tornado device=0:3 
WARNING: Using incubator modules: jdk.incubator.vector
Task info: blur.red
	Backend           : OPENCL
	Device            : cpu-haswell-12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [3888, 5184]
	Local  work size  : [54, 64, 1]
	Number of workgroups  : [72, 81]

Task info: blur.green
	Backend           : OPENCL
	Device            : cpu-haswell-12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [3888, 5184]
	Local  work size  : [54, 64, 1]
	Number of workgroups  : [72, 81]

Task info: blur.blue
	Backend           : OPENCL
	Device            : cpu-haswell-12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [3888, 5184]
	Local  work size  : [54, 64, 1]
	Number of workgroups  : [72, 81]

TornadoVM Total Time (ns) = 3513510495 -- seconds = 3.5135104950000002
```

Speedup on CPUs is 13x compared to the previous default scheduler in TornadoVM. 

We can find also speedups using the Intel oneAPI OpenCL runtime instead of PoCL:

With Block Scheduler: 

```bash
tornado --jvm="-Dtornado.scheduler.block=True" --threadInfo  -cp target/tornadovm-examples-1.0-SNAPSHOT.jar io.github.jjfumero.BlurFilter tornado device=0:2 
WARNING: Using incubator modules: jdk.incubator.vector
Task info: blur.red
	Backend           : OPENCL
	Device            : 12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [20, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

Task info: blur.green
	Backend           : OPENCL
	Device            : 12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [20, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

Task info: blur.blue
	Backend           : OPENCL
	Device            : 12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [20, 1]
	Local  work size  : null
	Number of workgroups  : [0, 0]

TornadoVM Total Time (ns) = 5649483400 -- seconds = 5.6494834
```



With fine-grained scheduler: 

```bash
tornado --jvm="-Dtornado.scheduler.block=False" --threadInfo  -cp target/tornadovm-examples-1.0-SNAPSHOT.jar io.github.jjfumero.BlurFilter tornado device=0:2 
WARNING: Using incubator modules: jdk.incubator.vector
Task info: blur.red
	Backend           : OPENCL
	Device            : 12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [3888, 5184]
	Local  work size  : [81, 81, 1]
	Number of workgroups  : [48, 64]

Task info: blur.green
	Backend           : OPENCL
	Device            : 12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [3888, 5184]
	Local  work size  : [81, 81, 1]
	Number of workgroups  : [48, 64]

Task info: blur.blue
	Backend           : OPENCL
	Device            : 12th Gen Intel(R) Core(TM) i7-12700K CL_DEVICE_TYPE_CPU (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [3888, 5184]
	Local  work size  : [81, 81, 1]
	Number of workgroups  : [48, 64]

TornadoVM Total Time (ns) = 2347847562 -- seconds = 2.347847562
```

Speedup from the first iteration is 2.4x

##### Performance Gains 

Using PoCL, this is the performance graph compared to the version in develop (gets block-thread as default) vs this branch. The Baseline is block thread and, if the value is higher than 1, the iteration-scheduler (fine-grained) is faster. 


![Fine-Grained Iteration vs Block Iteration (Speedups)](https://github.com/beehive-lab/TornadoVM/assets/5602565/53d73b7d-2033-4e42-8b75-5480d2f5da4c)

Interactive graph: 

https://docs.google.com/spreadsheets/d/e/2PACX-1vRJiSmP8Hewlbkcm6jyfagSd0u7_X06NF8eiWNCmjpLfLd6np6uA0qO3QIhlIopg8CZ0u1bVdm__XSG/pubchart?oid=1645903604&format=interactive


Speedups ranges from 5% to 13x in average. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make 

```
