### PR TITLE
[installer] install python dependent python modules with pip

### DIFF
--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -309,7 +309,7 @@ class TornadoInstaller:
     
 
     def check_or_install_python_modules(self):
-        command = "pip install -r bin/tornadoDepModules.txt"
+        command = "pip3 install -r bin/tornadoDepModules.txt"
         os.system(command)
 
 

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -299,14 +299,24 @@ class TornadoInstaller:
         backend = "BACKEND=" + backend
         return backend
 
-    def composePolyglotOption(sekf, args):
+
+    def composePolyglotOption(self, args):
         if args.polyglot:
             polyglotOption = "polyglot"
         else:
             polyglotOption = ""
         return polyglotOption
+    
+
+    def check_or_install_python_modules(self):
+        command = "pip install -r bin/tornadoDepModules.txt"
+        os.system(command)
+
 
     def install(self, args):
+
+        self.check_or_install_python_modules()
+
         if args.javaHome == None:
             self.checkJDKOption(args)
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -107,6 +107,9 @@ Windows example: to build TornadoVM with GraalVM and all supported backends (min
 
 .. code-block:: bash
 
+  rem invoke the Microsoft Visual Studio Tool Terminal 
+  .\bin\windowsMicrosoftStudioTools2022.cmd
+
   rem create and activate a virtual environment
 
   python -m venv .venv
@@ -123,7 +126,7 @@ Windows example: to build TornadoVM with GraalVM and all supported backends (min
 
   .. code-block:: bash
 
-    nmake /f Makefile.mak tests
+    tornado-test -V
 
 
 After the installation, the scripts create a directory with the TornadoVM SDK. The directory also includes a source file with all variables needed to start using TornadoVM.


### PR DESCRIPTION
#### Description

This PR adds automatic installation of all required python modules to compile and run TornadoVM. 

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Invoke the installer:

```bash
> .\bin\windowsMicrosoftStudioTools2022.cmd
> python -m venv .venv
> .venv\Scripts\activate.bat
> python .\bin\tornadovm-installer --jdk jdk21 --backend=opencl
```
