### PR TITLE
[chore] Checkstyle errors fixed

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -23,7 +23,6 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
-import java.nio.FloatBuffer;
 import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -21,7 +21,6 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
 import java.nio.IntBuffer;
 import java.util.Arrays;
 
@@ -136,7 +135,7 @@ public final class IntArray extends TornadoNativeArray {
         intArray.getSegment().copyFrom(MemorySegment.ofBuffer(buffer));
         return intArray;
     }
-    
+
     /**
      * Converts the int data from off-heap to on-heap, by copying the values of a {@link IntArray}
      * instance into a new on-heap array.

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java
@@ -50,7 +50,7 @@ public abstract class AbstractMetaData implements TaskMetaDataInterface {
     private static final String FALSE = "False";
     private final boolean isDeviceDefined;
 
-    private final HashSet<String> openCLBuiltOptions = new HashSet<>(Arrays.asList( //
+    private final HashSet<String> openCLBuiltOptions = new HashSet<>(Arrays.asList(//
             "-cl-single-precision-constant", //
             "-cl-denorms-are-zero", //
             "-cl-opt-disable", //

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestBuildFromByteBuffers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestBuildFromByteBuffers.java
@@ -67,7 +67,6 @@ public class TestBuildFromByteBuffers extends TornadoTestBase {
 
     @Test
     public void testBuildFromDoubleBuffer() {
-        final int SIZE = 10;
         DoubleBuffer buffer = DoubleBuffer.allocate(SIZE);
         buffer.put(new double[] { 1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0 });
         buffer.flip();
@@ -81,7 +80,6 @@ public class TestBuildFromByteBuffers extends TornadoTestBase {
 
     @Test
     public void testBuildFromIntBuffer() {
-        final int SIZE = 10;
         IntBuffer buffer = IntBuffer.allocate(SIZE);
         buffer.put(new int[] { 1, 2, 3, 4, 5, 1, 2, 3, 4, 5 });
         buffer.flip();
@@ -95,7 +93,6 @@ public class TestBuildFromByteBuffers extends TornadoTestBase {
 
     @Test
     public void testBuildFromLongBuffer() {
-        final int SIZE = 10;
         LongBuffer buffer = LongBuffer.allocate(SIZE);
         buffer.put(new long[] { 1L, 2L, 3L, 4L, 5L, 1L, 2L, 3L, 4L, 5L });
         buffer.flip();
@@ -109,7 +106,6 @@ public class TestBuildFromByteBuffers extends TornadoTestBase {
 
     @Test
     public void testBuildFromShortBuffer() {
-        final int SIZE = 10;
         ShortBuffer buffer = ShortBuffer.allocate(SIZE);
         buffer.put(new short[] { 1, 2, 3, 4, 5, 1, 2, 3, 4, 5 });
         buffer.flip();
@@ -123,7 +119,6 @@ public class TestBuildFromByteBuffers extends TornadoTestBase {
 
     @Test
     public void testBuildFromCharBuffer() {
-        final int SIZE = 10;
         CharBuffer buffer = CharBuffer.allocate(SIZE);
         buffer.put(new char[] { 'a', 'b', 'c', 'd', 'e', 'a', 'b', 'c', 'd', 'e' });
         buffer.flip();
@@ -137,7 +132,6 @@ public class TestBuildFromByteBuffers extends TornadoTestBase {
 
     @Test
     public void testBuildFromByteBuffer() {
-        final int SIZE = 10;
         ByteBuffer buffer = ByteBuffer.allocate(SIZE);
         buffer.put(new byte[] { 1, 2, 3, 4, 5, 1, 2, 3, 4, 5 });
         buffer.flip();


### PR DESCRIPTION
#### Description

There were some issues regarding the checkstyle of code base. 

```bash
make checkstyle
...
[INFO] There are 3 errors reported by Checkstyle 9.3 with tornado-assembly/src/etc/checkstyle.xml ruleset.
[ERROR] src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java:[24,8] (imports) UnusedImports: Unused import - java.lang.foreign.ValueLayout.
[ERROR] src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java:[139] (regexp) RegexpSinglelineJava: Illegal trailing whitespace(s) at the end of the line.
[ERROR] src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java:[26,8] (imports) UnusedImports: Unused import - java.nio.FloatBuffer.
```

This PR fixes them.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
make checkstyle
```

----------------------------------------------------------------------------
