### PR TITLE
[fix] Problem with FPGA execution for multiple tasks and the default scheduler

### DIFF
--- a/etc/intel-oneapi-fpga.conf
+++ b/etc/intel-oneapi-fpga.conf
@@ -1,0 +1,7 @@
+# Configure the fields for FPGA compilation & execution
+# [device]
+DEVICE_NAME = fpga_fast_emu
+# [compiler]
+COMPILER = aocl-ioc64
+# [options]
+DIRECTORY_BITSTREAM = fpga-source-comp/ # Specify the directory

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -626,8 +626,8 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
     }
 
     @Override
-    public OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean shouldCompile, boolean printKernel) {
-        return codeCache.installFPGASource(id, entryPoint, code, shouldCompile, printKernel);
+    public OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean printKernel) {
+        return codeCache.installFPGASource(id, entryPoint, code, printKernel);
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
@@ -42,7 +42,7 @@ public interface OCLDeviceContextInterface extends TornadoDeviceContext {
 
     OCLInstalledCode getInstalledCode(String id, String entryPoint);
 
-    OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean shouldCompile, boolean printKernel);
+    OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean printKernel);
 
     OCLInstalledCode installCode(OCLCompilationResult result);
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLFPGAScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLFPGAScheduler.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -25,11 +25,15 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl;
 
+import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+
+import java.util.Arrays;
 
 public class OCLFPGAScheduler extends OCLKernelScheduler {
 
-    public static final int[] DEFAULT_LOCAL_WORK_SIZE = { 64, 1, 1 };
+    public static final long[] DEFAULT_LOCAL_WORK_SIZE = { 64, 1, 1 };
+    public static final String WARNING_FPGA_DEFAULT_LOCAL = "[TornadoVM OCL] Warning: TornadoVM uses as default local work group size for FPGAs: " + Arrays.toString(DEFAULT_LOCAL_WORK_SIZE) + ".";
     private static final int WARP = 32;
 
     public OCLFPGAScheduler(final OCLDeviceContext context) {
@@ -50,7 +54,7 @@ public class OCLFPGAScheduler extends OCLKernelScheduler {
 
     @Override
     public void calculateLocalWork(final TaskMetaData meta) {
-        final long[] localWork = meta.initLocalWork();
+        final long[] localWork = DEFAULT_LOCAL_WORK_SIZE;
         switch (meta.getDims()) {
             case 3:
                 setLocalWork(3, localWork, meta);
@@ -66,10 +70,32 @@ public class OCLFPGAScheduler extends OCLKernelScheduler {
         }
     }
 
+    @Override
+    public int launch(long executionPlanId, final OCLKernel kernel, final TaskMetaData meta, final int[] waitEvents, long batchThreads) {
+        if (meta.isWorkerGridAvailable()) {
+            WorkerGrid grid = meta.getWorkerGrid(meta.getId());
+            long[] global = grid.getGlobalWork();
+            long[] offset = grid.getGlobalOffset();
+            long[] local = grid.getLocalWork();
+            return deviceContext.enqueueNDRangeKernel(executionPlanId, kernel, grid.dimension(), offset, global, local, waitEvents);
+        } else {
+            if (meta.shouldUseOpenCLDriverScheduling()) {
+                System.out.println(WARNING_FPGA_DEFAULT_LOCAL);
+            }
+            return deviceContext.enqueueNDRangeKernel(executionPlanId, kernel, meta.getDims(), meta.getGlobalOffset(), meta.getGlobalWork(), meta.getLocalWork(), waitEvents);
+        }
+    }
+
+    @Override
+    public long[] getDefaultLocalWorkGroup() {
+        return DEFAULT_LOCAL_WORK_SIZE;
+    }
+
     private void setLocalWork(final int dimensions, long[] localWork, final TaskMetaData meta) {
         for (int i = 0; i < dimensions; i++) {
             localWork[i] = calculateGroupSize(DEFAULT_LOCAL_WORK_SIZE[i], meta.getGlobalWork()[i]);
         }
+        meta.setLocalWork(localWork);
     }
 
     private int calculateGroupSize(long maxWorkItemSizes, long globalWorkSize) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLGridInfo.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLGridInfo.java
@@ -25,9 +25,8 @@ package uk.ac.manchester.tornado.drivers.opencl;
 import uk.ac.manchester.tornado.drivers.common.GridInfo;
 
 import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+
+import static uk.ac.manchester.tornado.drivers.opencl.OCLFPGAScheduler.DEFAULT_LOCAL_WORK_SIZE;
 
 public class OCLGridInfo implements GridInfo {
     OCLDeviceContext deviceContext;
@@ -38,12 +37,24 @@ public class OCLGridInfo implements GridInfo {
         this.localWork = localWork;
     }
 
+    private boolean checkFPGADefaultLocalWorkGroup() {
+        if (Arrays.equals(localWork, DEFAULT_LOCAL_WORK_SIZE)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     @Override
     public boolean checkGridDimensions() {
-        long[] blockMaxWorkGroupSize = deviceContext.getDevice().getDeviceMaxWorkGroupSize();
-        long maxWorkGroupSize = Arrays.stream(blockMaxWorkGroupSize).sum();
-        long totalThreads = Arrays.stream(localWork).reduce(1, (a, b) -> a * b);
+        if (deviceContext.isPlatformFPGA()) {
+            return checkFPGADefaultLocalWorkGroup();
+        } else {
+            long[] blockMaxWorkGroupSize = deviceContext.getDevice().getDeviceMaxWorkGroupSize();
+            long maxWorkGroupSize = Arrays.stream(blockMaxWorkGroupSize).sum();
+            long totalThreads = Arrays.stream(localWork).reduce(1, (a, b) -> a * b);
 
-        return totalThreads <= maxWorkGroupSize;
+            return totalThreads <= maxWorkGroupSize;
+        }
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLKernelScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLKernelScheduler.java
@@ -37,8 +37,9 @@ public abstract class OCLKernelScheduler {
     protected double min;
     protected double max;
 
-    public static final String WARNING_FPGA_THREAD_LOCAL = "[TornadoVM OCL] Warning: TornadoVM changed the user-defined local size to: " + Arrays.toString(
-            OCLFPGAScheduler.DEFAULT_LOCAL_WORK_SIZE) + ".";
+    public final String WARNING_FPGA_THREAD_LOCAL = "[TornadoVM OCL] Warning: TornadoVM changed the user-defined local size to: " + ((getDefaultLocalWorkGroup() != null)
+            ? Arrays.toString(getDefaultLocalWorkGroup())
+            : "null") + ".";
 
     public static final String WARNING_THREAD_LOCAL = "[TornadoVM OCL] Warning: TornadoVM changed the user-defined local size to null. Now, the OpenCL driver will select the best configuration.";
 
@@ -49,6 +50,10 @@ public abstract class OCLKernelScheduler {
     public abstract void calculateGlobalWork(final TaskMetaData meta, long batchThreads);
 
     public abstract void calculateLocalWork(final TaskMetaData meta);
+
+    public long[] getDefaultLocalWorkGroup() {
+        return null;
+    }
 
     public int submit(long executionPlanId, final OCLKernel kernel, final TaskMetaData meta, long batchThreads) {
         return submit(executionPlanId, kernel, meta, null, batchThreads);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -286,7 +286,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
             OCLInstalledCode installedCode;
             if (OCLBackend.isDeviceAnFPGAAccelerator(deviceContext)) {
                 // A) for FPGA
-                installedCode = deviceContext.installCode(result.getId(), result.getName(), result.getTargetCode(), task.shouldCompile(), task.meta().isPrintKernelEnabled());
+                installedCode = deviceContext.installCode(result.getId(), result.getName(), result.getTargetCode(), task.meta().isPrintKernelEnabled());
             } else {
                 // B) for CPU multi-core or GPU
                 installedCode = deviceContext.installCode(result);
@@ -321,7 +321,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
             OCLInstalledCode installedCode;
             if (OCLBackend.isDeviceAnFPGAAccelerator(deviceContext)) {
                 // A) for FPGA
-                installedCode = deviceContext.installCode(task.getId(), executable.getEntryPoint(), source, task.shouldCompile(), task.meta().isPrintKernelEnabled());
+                installedCode = deviceContext.installCode(task.getId(), executable.getEntryPoint(), source, task.meta().isPrintKernelEnabled());
             } else {
                 // B) for CPU multi-core or GPU
                 installedCode = deviceContext.installCode(executable.meta(), task.getId(), executable.getEntryPoint(), source);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
@@ -219,7 +219,7 @@ public class VirtualOCLDeviceContext implements OCLDeviceContextInterface {
     }
 
     @Override
-    public OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean shouldCompile, boolean printKernel) {
+    public OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean printKernel) {
         return null;
     }
 


### PR DESCRIPTION
#### Description

This PR provides a fix for the issue described in #401.

**Note**: This PR is tested on Intel Emulation mode. I do not have access to Xilinx FPGA to test it.

#### Problem description

There are two identified problems:

1. In the `OCLCodeCache` class we have a method that checks if force compilation has been triggered, and the FPGA compilers for Intel are triggered to compile only if the check is true. This seems to have been an old check that we had from the time we had the `lookupbuffer` kernel, and we were waiting till all `LAUNCH` bytecodes that corresponds to all task indices (all tasks within a `TaskGraph`) are issued, in order to trigger the `forceCompilation()` method from the `TornadoVM` class. See [here](https://github.com/beehive-lab/TornadoVM/commit/e5048f0b90613f756a428faf8b1a9fd5511e57b5#diff-b7deca83123f6c4da0543fdc6c77cc6364452e8b0ecb9ff1539f7926c40c813b).
2. The `executor.withDefaultScheduler()` configuration in the `ExecutionPlan` seems to break the execution and results in OpenCL error (`CL_INVALID_WORK_GROUP_SIZE`) when the `clEnqueueNDRangeKernel` function is invoked.

**To fix the first problem**, I removed the `shouldCompile` check that existed in `OCLCodeCache`. To my understanding this is an old check, and it is not required since we deprecated the `lookupbuffer` kernel.

**To fix the second problem**, I performed a short refactoring in the `OCLKernelScheduler` (i.e., an abstract class) and the `OCLFPGAScheduler` which extends the abstract class, to assess the default scheduling local work group for FPGAs when the `executor.withDefaultScheduler()` is enabled in a `TornadoExecutionPlan`. 

This change made me think of testing also to run the BlurFilter example with a WorkerGrid, and applied a small update in the `OCLGridInfo` to check the default FPGA local work group.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [x] Yes
- [ ] No

#### How to test the new patch?

- First you need to have an image in the /tmp directory named (image.jpg). You can use this one:
![image](https://github.com/beehive-lab/TornadoVM/assets/34061419/77ad1eb0-37ca-406f-bed0-7d6974cce84f)

Then, you can run, as described also in the issue #401: 
```bash
rm -rf fpga-source-comp
tornado --debug --threadInfo --jvm="-Dblur.red.device=0:3 -Dblur.green.device=0:3 -Dblur.blue.device=0:3 -Dtornado.recover.bailout=False" -m tornado.examples/uk.ac.manchester.tornado.examples.compute.BlurFilter
```

Output:
```bash
WARNING: Using incubator modules: jdk.incubator.vector
[DEBUG] JIT compilation for the FPGA
Task info: blur.red
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [448, 640]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : [7, 640]

[TornadoVM OCL] Warning: TornadoVM uses as default local work group size for FPGAs: [64, 1, 1].
Task info: blur.green
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [448, 640]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : [7, 640]

[TornadoVM OCL] Warning: TornadoVM uses as default local work group size for FPGAs: [64, 1, 1].
Task info: blur.blue
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [448, 640]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : [7, 640]

[TornadoVM OCL] Warning: TornadoVM uses as default local work group size for FPGAs: [64, 1, 1].
Parallel Total time: 
	ns = 2340610196
	seconds = 2.340610196
[DEBUG] JIT compilation for the FPGA
Task info: blur.red
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [448, 640]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : [7, 640]

[TornadoVM OCL] Warning: TornadoVM uses as default local work group size for FPGAs: [64, 1, 1].
Task info: blur.green
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [448, 640]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : [7, 640]

[TornadoVM OCL] Warning: TornadoVM uses as default local work group size for FPGAs: [64, 1, 1].
Task info: blur.blue
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0]
	Global work size  : [448, 640]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : [7, 640]

[TornadoVM OCL] Warning: TornadoVM uses as default local work group size for FPGAs: [64, 1, 1].
Parallel Total time: 
	ns = 156405899
	seconds = 0.15640589900000001
```

- To test with GridScheduler and FPGAs, I have this [patch](https://drive.google.com/file/d/1qwlzUcLJJ9rf8euo7gpnf5A_Igd-L4Va/view?usp=sharing) that uses a grid with a local work group (128, 1, 1) that is different from the default one.

You can download, apply the patch and build TornadoVM:
```bash
git apply fpga_gridscheduler.patch
make
```

and then run the same example:
```bash
rm -rf fpga-source-comp
tornado --debug --threadInfo --jvm="-Dblur.red.device=0:3 -Dblur.green.device=0:3 -Dblur.blue.device=0:3 -Dtornado.recover.bailout=False" -m tornado.examples/uk.ac.manchester.tornado.examples.compute.BlurFilter
```

Output:
```bash
WARNING: Using incubator modules: jdk.incubator.vector
[DEBUG] JIT compilation for the FPGA
[TornadoVM] Warning: The loop bounds will be configured by the GridScheduler. Check the grid by using the flag --threadInfo.
[TornadoVM OCL] Warning: TornadoVM changed the user-defined local size to: [64, 1, 1].
Task info: blur.red
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0, 0]
	Global work size  : [448, 640, 1]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : null

Task info: blur.green
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0, 0]
	Global work size  : [448, 640, 1]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : null

Task info: blur.blue
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0, 0]
	Global work size  : [448, 640, 1]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : null

Parallel Total time: 
	ns = 2347304227
	seconds = 2.347304227
[DEBUG] JIT compilation for the FPGA
[TornadoVM OCL] Warning: TornadoVM changed the user-defined local size to: [64, 1, 1].
Task info: blur.red
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0, 0]
	Global work size  : [448, 640, 1]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : null

Task info: blur.green
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0, 0]
	Global work size  : [448, 640, 1]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : null

Task info: blur.blue
	Backend           : OPENCL
	Device            : Intel(R) FPGA Emulation Device CL_DEVICE_TYPE_ACCELERATOR (available)
	Dims              : 2
	Global work offset: [0, 0, 0]
	Global work size  : [448, 640, 1]
	Local  work size  : [64, 1, 1]
	Number of workgroups  : null

Parallel Total time: 
	ns = 161529220
	seconds = 0.16152922
```

- To test with multiple tasks that will run on the FPGA, I have this [patch](https://drive.google.com/file/d/1IofOhPaa9Y7C_iAPY2qXaN8HtuRGZYLF/view?usp=sharing) that updates the `MultipleTasks` example that runs two kernels on the FPGA.

You can download, apply the patch and build TornadoVM:
```bash
git apply fpga_multiple_tasks.patch
make
```

and then run the same example:
```bash
rm -rf fpga-source-comp
tornado --threadInfo --jvm="-Dexample.foo.device=0:3 -Dexample.bar.device=0:3" -m tornado.examples/uk.ac.manchester.tornado.examples.MultipleTasks
```

----------------------------------------------------------------------------
