### PR TITLE
Extend the TestFields unittest with lazy and partial copy-out tests and fix reading offsets

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
@@ -113,7 +113,8 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
         final long numBytes = getSizeSubRegionSize() > 0 ? getSizeSubRegionSize() : bufferSize;
         if (partialReadSize != 0) {
             // Partial Copy Out due to an under demand copy by the user
-            returnEvent = deviceContext.readBuffer(executionPlanId, toBuffer(), TornadoNativeArray.ARRAY_HEADER, partialReadSize, segment.address(), hostOffset, (useDeps) ? events : null);
+            // in this case the host offset is equal to the device offset
+            returnEvent = deviceContext.readBuffer(executionPlanId, toBuffer(), hostOffset, partialReadSize, segment.address(), hostOffset, (useDeps) ? events : null);
         } else if (batchSize <= 0) {
             // Partial Copy Out due to batch processing
             returnEvent = deviceContext.readBuffer(executionPlanId, toBuffer(), bufferOffset, numBytes, segment.address(), hostOffset, (useDeps) ? events : null);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
@@ -111,7 +111,8 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
         final long numBytes = getSizeSubRegionSize() > 0 ? getSizeSubRegionSize() : bufferSize;
         if (partialReadSize != 0) {
             // Partial Copy Out due to a copy under demand copy by the user
-            returnEvent = deviceContext.readBuffer(executionPlanId, toBuffer() + TornadoNativeArray.ARRAY_HEADER, partialReadSize, segment.address(), hostOffset, (useDeps) ? events : null);
+            // in this case the host offset is equal to the device offset
+            returnEvent = deviceContext.readBuffer(executionPlanId, toBuffer() + hostOffset, partialReadSize, segment.address(), hostOffset, (useDeps) ? events : null);
         } else if (batchSize <= 0) {
             returnEvent = deviceContext.readBuffer(executionPlanId, toBuffer(), numBytes, segment.address(), hostOffset, (useDeps) ? events : null);
         } else {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
@@ -115,7 +115,8 @@ public class SPIRVMemorySegmentWrapper implements XPUBuffer {
 
         if (partialReadSize != 0) {
             // Partial Copy Out due to a copy under demand copy by the user
-            returnEvent = spirvDeviceContext.readBuffer(executionPlanId, toBuffer(), TornadoNativeArray.ARRAY_HEADER, partialReadSize, segment.address(), hostOffset, waitEvents);
+            // in this case the host offset is equal to the device offset
+            returnEvent = spirvDeviceContext.readBuffer(executionPlanId, toBuffer(), hostOffset, partialReadSize, segment.address(), hostOffset, waitEvents);
         } else if (batchSize <= 0) {
             // Partial Copy Out due to batch processing
             returnEvent = spirvDeviceContext.readBuffer(executionPlanId, toBuffer(), bufferOffset, numBytes, segment.address(), hostOffset, waitEvents);


### PR DESCRIPTION
#### Description

This PR extends the `TestFields` unittest by providing three new tests. The first test uses the `DataRange` object to implement a partial copy-out. The second uses the `UNDER_DEMAND` mode to lazily copy-out the output data. Finally, the third test is a combination of the two. In addition, the device offset in the reading function is fixed to read the full dataset from the device. The problem was that the device offset was set to always be equal to the header size, so only the first part of the dataset was copied back to the host. 
 
#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Run the three new tests: 
`tornado-test -V uk.ac.manchester.tornado.unittests.fields.TestFields#testFieldsPartialCopyout`
`tornado-test -V uk.ac.manchester.tornado.unittests.fields.TestFields#testFieldsLazyCopyout`
`tornado-test -V uk.ac.manchester.tornado.unittests.fields.TestFields#testFieldsPartialLazyCopyout`
