### PR TITLE
TornadoOptions and Logger improved

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoSettingInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoSettingInterface.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.api;
 
-public interface TornadoCI {
+public interface TornadoSettingInterface {
 
     void setTornadoProperty(String key, String value);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/runtime/TornadoAPIProvider.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/runtime/TornadoAPIProvider.java
@@ -22,8 +22,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import uk.ac.manchester.tornado.api.AbstractFactoryDevice;
-import uk.ac.manchester.tornado.api.TornadoCI;
 import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
+import uk.ac.manchester.tornado.api.TornadoSettingInterface;
 import uk.ac.manchester.tornado.api.TornadoTaskGraphInterface;
 import uk.ac.manchester.tornado.api.exceptions.TornadoAPIException;
 
@@ -55,13 +55,13 @@ public class TornadoAPIProvider {
         return runtime;
     }
 
-    public static TornadoCI loadTornado() {
-        TornadoCI tornado;
+    public static TornadoSettingInterface loadTornado() {
+        TornadoSettingInterface tornado;
         try {
             String tornadoImplementation = System.getProperty("tornado.load.tornado.implementation");
             Class<?> klass = Class.forName(tornadoImplementation);
             Constructor<?> constructor = klass.getConstructor();
-            tornado = (TornadoCI) constructor.newInstance();
+            tornado = (TornadoSettingInterface) constructor.newInstance();
         } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | SecurityException | IllegalArgumentException | InvocationTargetException | InstantiationException e) {
             throw new TornadoAPIException("[ERROR] Tornado Implementation class not found", e);
         }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/runtime/TornadoRuntime.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/runtime/TornadoRuntime.java
@@ -17,13 +17,13 @@
  */
 package uk.ac.manchester.tornado.api.runtime;
 
-import uk.ac.manchester.tornado.api.TornadoCI;
 import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
+import uk.ac.manchester.tornado.api.TornadoSettingInterface;
 
 public class TornadoRuntime {
 
     private static TornadoRuntimeInterface runtimeImpl;
-    private static TornadoCI tornadoImpl;
+    private static TornadoSettingInterface tornadoImpl;
 
     static {
         init();

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/analysis/TornadoShapeAnalysis.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/analysis/TornadoShapeAnalysis.java
@@ -36,7 +36,6 @@ import org.graalvm.compiler.nodes.loop.LoopFragmentInside;
 import org.graalvm.compiler.nodes.loop.LoopsData;
 import org.graalvm.compiler.phases.BasePhase;
 
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.domain.DomainTree;
 import uk.ac.manchester.tornado.runtime.domain.IntDomain;
@@ -106,7 +105,7 @@ public class TornadoShapeAnalysis extends BasePhase<TornadoHighTierContext> {
         }
 
         if (valid) {
-            Tornado.trace("loop nest depth = %d\n", domainTree.getDepth());
+            TornadoLogger.trace("loop nest depth = %d\n", domainTree.getDepth());
             TornadoLogger.debug("discovered parallel domain: %s\n", domainTree);
             context.getMeta().setDomain(domainTree);
         }

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/analysis/TornadoShapeAnalysis.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/analysis/TornadoShapeAnalysis.java
@@ -37,6 +37,7 @@ import org.graalvm.compiler.nodes.loop.LoopsData;
 import org.graalvm.compiler.phases.BasePhase;
 
 import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.domain.DomainTree;
 import uk.ac.manchester.tornado.runtime.domain.IntDomain;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
@@ -98,7 +99,7 @@ public class TornadoShapeAnalysis extends BasePhase<TornadoHighTierContext> {
                 domainTree.set(index, new IntDomain(getIntegerValue(range.offset().value()), getIntegerValue(range.stride().value()), getIntegerValue(range.value())));
             } else {
                 valid = false;
-                Tornado.info("unsupported multiple parallel loops");
+                TornadoLogger.info("unsupported multiple parallel loops");
                 break;
             }
             lastIndex = index;
@@ -106,7 +107,7 @@ public class TornadoShapeAnalysis extends BasePhase<TornadoHighTierContext> {
 
         if (valid) {
             Tornado.trace("loop nest depth = %d\n", domainTree.getDepth());
-            Tornado.debug("discovered parallel domain: %s\n", domainTree);
+            TornadoLogger.debug("discovered parallel domain: %s\n", domainTree);
             context.getMeta().setDomain(domainTree);
         }
     }

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/loops/TornadoPartialLoopUnroll.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/loops/TornadoPartialLoopUnroll.java
@@ -33,7 +33,7 @@ import org.graalvm.compiler.phases.common.CanonicalizerPhase;
 import org.graalvm.compiler.phases.common.DeadCodeEliminationPhase;
 import org.graalvm.compiler.phases.tiers.MidTierContext;
 
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graal.nodes.TornadoLoopsData;
 
 /**
@@ -68,7 +68,7 @@ public class TornadoPartialLoopUnroll extends BasePhase<MidTierContext> {
     }
 
     private static int getUnrollFactor() {
-        return (isPowerOfTwo(Tornado.UNROLL_FACTOR) && Tornado.UNROLL_FACTOR <= 32) ? Tornado.UNROLL_FACTOR : LOOP_UNROLL_FACTOR_DEFAULT;
+        return (isPowerOfTwo(TornadoOptions.UNROLL_FACTOR) && TornadoOptions.UNROLL_FACTOR <= 32) ? TornadoOptions.UNROLL_FACTOR : LOOP_UNROLL_FACTOR_DEFAULT;
     }
 
     private static int getUpperGraphLimit(int initialGraphNodeCount) {

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/mm/PrimitiveSerialiser.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/mm/PrimitiveSerialiser.java
@@ -26,7 +26,7 @@ package uk.ac.manchester.tornado.drivers.common.mm;
 import java.nio.ByteBuffer;
 
 import uk.ac.manchester.tornado.api.types.HalfFloat;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class PrimitiveSerialiser {
 
@@ -50,7 +50,7 @@ public class PrimitiveSerialiser {
             case Float floatValue -> buffer.putFloat(floatValue);
             case Long longValue -> buffer.putLong(longValue);
             case Double doubleValue -> buffer.putDouble(doubleValue);
-            case null, default -> Tornado.warn("unable to serialise: %s (%s)", value, value.getClass().getName());
+            case null, default -> TornadoLogger.warn("unable to serialise: %s (%s)", value, value.getClass().getName());
         }
 
         if (alignment != 0) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -27,10 +27,7 @@ package uk.ac.manchester.tornado.drivers.opencl;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLBuildStatus.CL_BUILD_SUCCESS;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.getProperty;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 
 import java.io.BufferedReader;
@@ -56,6 +53,7 @@ import uk.ac.manchester.tornado.drivers.opencl.exceptions.OCLException;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
@@ -322,8 +320,8 @@ public class OCLCodeCache {
             try {
                 Files.createDirectories(dir);
             } catch (IOException e) {
-                error("unable to create dir: %s", dir.toString());
-                error(e.getMessage());
+                TornadoLogger.error("unable to create dir: %s", dir.toString());
+                TornadoLogger.error(e.getMessage());
             }
         }
         guarantee(Files.isDirectory(dir), "target directory is not a directory: %s", dir.toAbsolutePath().toString());
@@ -549,19 +547,19 @@ public class OCLCodeCache {
     private void dumpKernelSource(String id, String entryPoint, String log, byte[] source) {
         final Path outDir = resolveLogDirectory();
         final String identifier = STR."\{id}-\{entryPoint}";
-        error("Unable to compile task %s: check logs at %s/%s.log", identifier, outDir.toAbsolutePath(), identifier);
+        TornadoLogger.error("Unable to compile task %s: check logs at %s/%s.log", identifier, outDir.toAbsolutePath(), identifier);
 
         File file = new File(STR."\{outDir}/\{identifier}.log");
         try (FileOutputStream fos = new FileOutputStream(file)) {
             fos.write(log.getBytes());
         } catch (IOException e) {
-            error("unable to write error log: ", e.getMessage());
+            TornadoLogger.error("unable to write error log: ", e.getMessage());
         }
         file = new File(STR."\{outDir}/\{identifier}\{OPENCL_SOURCE_SUFFIX}");
         try (FileOutputStream fos = new FileOutputStream(file)) {
             fos.write(source);
         } catch (IOException e) {
-            error("unable to write error log: ", e.getMessage());
+            TornadoLogger.error("unable to write error log: ", e.getMessage());
         }
 
     }
@@ -580,7 +578,7 @@ public class OCLCodeCache {
 
     public OCLInstalledCode installSource(TaskMetaData meta, String id, String entryPoint, byte[] source) {
 
-        info("Installing code for %s into code cache", entryPoint);
+        TornadoLogger.info("Installing code for %s into code cache", entryPoint);
 
         boolean isSPIRVBinary = isInputSourceSPIRVBinary(source);
         final OCLProgram program;
@@ -596,7 +594,7 @@ public class OCLCodeCache {
             try (FileOutputStream fos = new FileOutputStream(file)) {
                 fos.write(source);
             } catch (IOException e) {
-                error("unable to dump source: ", e.getMessage());
+                TornadoLogger.error("unable to dump source: ", e.getMessage());
             }
         }
 
@@ -613,7 +611,7 @@ public class OCLCodeCache {
         final long t1 = System.nanoTime();
 
         final OCLBuildStatus status = program.getStatus(deviceContext.getDeviceId());
-        debug("\tOpenCL compilation status = %s", status.toString());
+        TornadoLogger.debug("\tOpenCL compilation status = %s", status.toString());
 
         if (status == OCLBuildStatus.CL_BUILD_ERROR) {
             final String log = program.getBuildLog(deviceContext.getDeviceId());
@@ -630,9 +628,9 @@ public class OCLCodeCache {
 
         final OCLInstalledCode code = new OCLInstalledCode(entryPoint, source, (OCLDeviceContext) deviceContext, program, kernel, isSPIRVBinary);
         if (status == CL_BUILD_SUCCESS) {
-            debug("\tOpenCL Kernel id = 0x%x", kernel.getOclKernelID());
+            TornadoLogger.debug("\tOpenCL Kernel id = 0x%x", kernel.getOclKernelID());
             if (meta.shouldPrintCompileTimes()) {
-                debug("compile: kernel %s opencl %.9f\n", entryPoint, (t1 - t0) * 1e-9f);
+                TornadoLogger.debug("compile: kernel %s opencl %.9f\n", entryPoint, (t1 - t0) * 1e-9f);
             }
             installCodeInCodeCache(program, meta, id, entryPoint, code);
         } else {
@@ -644,7 +642,7 @@ public class OCLCodeCache {
     }
 
     private OCLInstalledCode installBinary(String id, String entryPoint, byte[] binary) throws OCLException {
-        info("Installing binary for %s into code cache", entryPoint);
+        TornadoLogger.info("Installing binary for %s into code cache", entryPoint);
 
         if (entryPoint.contains("-")) {
             entryPoint = entryPoint.split("-")[1];
@@ -676,11 +674,11 @@ public class OCLCodeCache {
             program.build("");
 
             status = program.getStatus(deviceContext.getDeviceId());
-            debug("\tOpenCL compilation status = %s", status.toString());
+            TornadoLogger.debug("\tOpenCL compilation status = %s", status.toString());
 
             final String log = program.getBuildLog(deviceContext.getDeviceId()).trim();
             if (!log.isEmpty()) {
-                debug(log);
+                TornadoLogger.debug(log);
             }
         }
 
@@ -688,7 +686,7 @@ public class OCLCodeCache {
         final OCLInstalledCode code = new OCLInstalledCode(entryPoint, binary, (OCLDeviceContext) deviceContext, program, kernel, isSPIRVBinary);
 
         if (status == CL_BUILD_SUCCESS) {
-            debug("\tOpenCL Kernel id = 0x%x", kernel.getOclKernelID());
+            TornadoLogger.debug("\tOpenCL Kernel id = 0x%x", kernel.getOclKernelID());
             cache.put(entryPoint, code);
 
             String taskScheduleName = splitTaskGraphAndTaskName(id)[0];
@@ -732,13 +730,13 @@ public class OCLCodeCache {
         final File file = lookupPath.toFile();
         OCLInstalledCode lookupCode = null;
         if (file.length() == 0) {
-            error("Empty input binary: %s", file);
+            TornadoLogger.error("Empty input binary: %s", file);
         }
         try {
             final byte[] binary = Files.readAllBytes(lookupPath);
             lookupCode = installBinary(id, entrypoint, binary);
         } catch (OCLException | IOException e) {
-            error("unable to load binary: %s (%s)", file, e.getMessage());
+            TornadoLogger.error("unable to load binary: %s (%s)", file, e.getMessage());
         }
         return lookupCode;
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -433,7 +433,7 @@ public class OCLCodeCache {
     private void invokeShellCommand(String[] command) {
         try {
             if (command != null) {
-                RuntimeUtilities.systemCall(command, Tornado.FPGA_DUMP_LOG, directoryBitstream);
+                RuntimeUtilities.systemCall(command, TornadoOptions.FULL_DEBUG, directoryBitstream);
             }
         } catch (IOException e) {
             throw new TornadoRuntimeException(e);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -28,7 +28,6 @@ package uk.ac.manchester.tornado.drivers.opencl;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLBuildStatus.CL_BUILD_SUCCESS;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.getProperty;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -634,7 +633,7 @@ public class OCLCodeCache {
             }
             installCodeInCodeCache(program, meta, id, entryPoint, code);
         } else {
-            warn("\tunable to compile %s", entryPoint);
+            TornadoLogger.warn("\tunable to compile %s", entryPoint);
             code.invalidate();
         }
 
@@ -708,7 +707,7 @@ public class OCLCodeCache {
                 RuntimeUtilities.writeToFile(outDir.toAbsolutePath().toString() + "/" + entryPoint, binary);
             }
         } else {
-            warn("\tunable to install binary for %s", entryPoint);
+            TornadoLogger.warn("\tunable to install binary for %s", entryPoint);
             code.invalidate();
         }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCommandQueue.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCommandQueue.java
@@ -26,7 +26,6 @@ package uk.ac.manchester.tornado.drivers.opencl;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLCommandQueueInfo.CL_QUEUE_CONTEXT;
 import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLCommandQueueInfo.CL_QUEUE_DEVICE;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.MARKER_USE_BARRIER;
 
 import java.nio.ByteBuffer;
 
@@ -407,9 +406,6 @@ public class OCLCommandQueue {
     }
 
     public long enqueueMarker(long[] waitEvents) {
-        if (MARKER_USE_BARRIER) {
-            return enqueueBarrier(waitEvents);
-        }
         return (openclVersion < 120) ? enqueueMarker11(waitEvents) : enqueueMarker12(waitEvents);
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCommandQueueTable.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCommandQueueTable.java
@@ -23,12 +23,11 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl;
 
-import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
-import uk.ac.manchester.tornado.drivers.opencl.exceptions.OCLException;
-
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.drivers.opencl.exceptions.OCLException;
 
 public class OCLCommandQueueTable {
 
@@ -57,7 +56,7 @@ public class OCLCommandQueueTable {
         public OCLCommandQueue get(long threadId, OCLTargetDevice device, OCLContext context) {
             if (!commandQueueMap.containsKey(threadId)) {
                 final int deviceVersion = device.deviceVersion();
-                long commandProperties = context.getProperties(device.getIndex());
+                long commandProperties = context.getProperties();
                 long commandQueuePtr;
                 try {
                     commandQueuePtr = context.clCreateCommandQueue(context.getContextId(), device.getId(), commandProperties);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLContext.java
@@ -186,7 +186,7 @@ public class OCLContext implements OCLExecutionEnvironment {
             clReleaseContext(contextID);
             long t2 = System.nanoTime();
 
-            if (Tornado.FULL_DEBUG) {
+            if (TornadoOptions.FULL_DEBUG) {
                 System.out.printf("cleanup: %-10s..........%.9f s%n", "programs", (t1 - t0) * 1e-9);
                 System.out.printf("cleanup: %-10s..........%.9f s%n", "context", (t2 - t1) * 1e-9);
                 System.out.printf("cleanup: %-10s..........%.9f s%n", "total", (t2 - t0) * 1e-9);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLContext.java
@@ -35,7 +35,6 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLCommandQueueProperties;
 import uk.ac.manchester.tornado.drivers.opencl.exceptions.OCLException;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
@@ -111,20 +110,21 @@ public class OCLContext implements OCLExecutionEnvironment {
         }
     }
 
-    public long getProperties(int index) {
+    public long getProperties() {
         long properties = 0;
-        if (Tornado.ENABLE_PROFILING) {
+        if (TornadoOptions.ENABLE_OPENCL_PROFILING) {
             properties |= OCLCommandQueueProperties.CL_QUEUE_PROFILING_ENABLE;
         }
 
-        if (Tornado.ENABLE_OOO_EXECUTION) {
+        if (TornadoOptions.ENABLE_OOO_EXECUTION) {
             properties |= OCLCommandQueueProperties.CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
         }
         return properties;
     }
 
+    @Override
     public void createCommandQueue(int index) {
-        long properties = getProperties(index);
+        long properties = getProperties();
         createCommandQueue(index, properties);
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -24,7 +24,7 @@
 package uk.ac.manchester.tornado.drivers.opencl;
 
 import static uk.ac.manchester.tornado.drivers.opencl.OCLCommandQueue.EMPTY_EVENT;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.EVENT_WINDOW;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.EVENT_WINDOW;
 
 import java.nio.ByteOrder;
 import java.util.Collections;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -25,7 +25,6 @@ package uk.ac.manchester.tornado.drivers.opencl;
 
 import static uk.ac.manchester.tornado.drivers.opencl.OCLCommandQueue.EMPTY_EVENT;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.EVENT_WINDOW;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.USE_SYNC_FLUSH;
 
 import java.nio.ByteOrder;
 import java.util.Collections;
@@ -50,6 +49,7 @@ import uk.ac.manchester.tornado.drivers.opencl.power.OCLEmptyPowerMetric;
 import uk.ac.manchester.tornado.drivers.opencl.power.OCLNvidiaPowerMetric;
 import uk.ac.manchester.tornado.drivers.opencl.runtime.OCLBufferProvider;
 import uk.ac.manchester.tornado.drivers.opencl.runtime.OCLTornadoDevice;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class OCLDeviceContext implements OCLDeviceContextInterface {
@@ -141,7 +141,7 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
     @Override
     public void sync(long executionPlanId) {
         OCLCommandQueue commandQueue = getCommandQueue(executionPlanId);
-        if (USE_SYNC_FLUSH) {
+        if (TornadoOptions.USE_SYNC_FLUSH) {
             commandQueue.flush();
         }
         commandQueue.finish();

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEvent.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEvent.java
@@ -30,7 +30,7 @@ import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLProfilingInfo.CL_
 import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLProfilingInfo.CL_PROFILING_COMMAND_QUEUED;
 import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLProfilingInfo.CL_PROFILING_COMMAND_START;
 import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLProfilingInfo.CL_PROFILING_COMMAND_SUBMIT;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.ENABLE_PROFILING;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.ENABLE_OPENCL_PROFILING;
 
 import java.nio.ByteBuffer;
 
@@ -80,7 +80,7 @@ public class OCLEvent implements Event {
     native static void clReleaseEvent(long eventId) throws OCLException;
 
     private long readEventTime(OCLProfilingInfo eventType) {
-        if (!ENABLE_PROFILING) {
+        if (!ENABLE_OPENCL_PROFILING) {
             return -1;
         }
         long time = 0;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventPool.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventPool.java
@@ -25,7 +25,6 @@ package uk.ac.manchester.tornado.drivers.opencl;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLCommandQueueProperties.CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.MAX_WAIT_EVENTS;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.CIRCULAR_EVENTS;
@@ -36,6 +35,7 @@ import java.util.BitSet;
 import java.util.List;
 
 import uk.ac.manchester.tornado.drivers.common.utils.EventDescriptor;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 /**
  * Class which holds mapping between OpenCL events and TornadoVM runtime events,
@@ -69,7 +69,7 @@ class OCLEventPool {
         this.descriptors = new EventDescriptor[eventPoolSize];
         this.eventQueues = new OCLCommandQueue[eventPoolSize];
         this.eventIndex = 0;
-        this.waitEventsBuffer = new long[MAX_WAIT_EVENTS];
+        this.waitEventsBuffer = new long[TornadoOptions.MAX_WAIT_EVENTS];
         this.internalEvent = new OCLEvent();
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventPool.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventPool.java
@@ -25,8 +25,6 @@ package uk.ac.manchester.tornado.drivers.opencl;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.drivers.opencl.enums.OCLCommandQueueProperties.CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.CIRCULAR_EVENTS;
 
 import java.util.ArrayList;
@@ -35,6 +33,7 @@ import java.util.BitSet;
 import java.util.List;
 
 import uk.ac.manchester.tornado.drivers.common.utils.EventDescriptor;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 /**
@@ -86,8 +85,8 @@ class OCLEventPool {
          * exit.
          */
         if (oclEventId == -1) {
-            fatal("invalid event: event=0x%x, description=%s, tag=0x%x\n", oclEventId, descriptorId.getNameDescription());
-            fatal("terminating application as system integrity has been compromised.");
+            TornadoLogger.fatal("invalid event: event=0x%x, description=%s, tag=0x%x\n", oclEventId, descriptorId.getNameDescription());
+            TornadoLogger.fatal("terminating application as system integrity has been compromised.");
             System.exit(-1);
         }
 
@@ -127,7 +126,7 @@ class OCLEventPool {
             if (value != -1) {
                 index++;
                 waitEventsBuffer[index] = events[value];
-                debug("[%d] 0x%x - %s\n", index, events[value], descriptors[value].getNameDescription());
+                TornadoLogger.debug("[%d] 0x%x - %s\n", index, events[value], descriptors[value].getNameDescription());
 
             }
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLScheduler.java
@@ -24,7 +24,7 @@
 package uk.ac.manchester.tornado.drivers.opencl;
 
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public class OCLScheduler {
@@ -48,7 +48,7 @@ public class OCLScheduler {
             case CL_DEVICE_TYPE_CPU:
                 return TornadoOptions.USE_BLOCK_SCHEDULER ? new OCLCPUScheduler(context) : getInstanceGPUScheduler(context);
             default:
-                Tornado.fatal("No scheduler available for device: %s", context);
+                TornadoLogger.fatal("No scheduler available for device: %s", context);
                 break;
         }
         return null;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLCodeProvider.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLCodeProvider.java
@@ -33,7 +33,7 @@ import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.SpeculationLog;
 import uk.ac.manchester.tornado.drivers.opencl.OCLTargetDescription;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class OCLCodeProvider implements CodeCacheProvider {
 
@@ -82,7 +82,7 @@ public class OCLCodeProvider implements CodeCacheProvider {
 
     @Override
     public boolean shouldDebugNonSafepoints() {
-        Tornado.warn("Debug non safe points not implemented yet.");
+        TornadoLogger.warn("Debug non safe points not implemented yet.");
         return false;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -24,9 +24,9 @@ package uk.ac.manchester.tornado.drivers.opencl.graal;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.isBoxedPrimitive;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.nio.ByteBuffer;
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -24,8 +24,6 @@ package uk.ac.manchester.tornado.drivers.opencl.graal;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.isBoxedPrimitive;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.nio.ByteBuffer;
@@ -50,6 +48,7 @@ import uk.ac.manchester.tornado.drivers.opencl.runtime.OCLTornadoDevice;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
@@ -113,13 +112,13 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
 
     public void resolveEvent(long executionPlanId, final OCLByteBuffer stack, final TaskMetaData meta, int task) {
         Event event = deviceContext.resolveEvent(executionPlanId, task);
-        debug("kernel completed: id=0x%x, method = %s, device = %s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
+        TornadoLogger.debug("kernel completed: id=0x%x, method = %s, device = %s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
         if (event != null) {
-            debug("\tstatus   : %s", event.getStatus());
+            TornadoLogger.debug("\tstatus   : %s", event.getStatus());
 
             if (meta != null && meta.enableProfiling()) {
-                debug("\texecuting: %f seconds", event.getElapsedTimeInSeconds());
-                debug("\ttotal    : %f seconds", event.getTotalTimeInSeconds());
+                TornadoLogger.debug("\texecuting: %f seconds", event.getElapsedTimeInSeconds());
+                TornadoLogger.debug("\ttotal    : %f seconds", event.getTotalTimeInSeconds());
             }
         }
     }
@@ -191,7 +190,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
 
         // local memory buffers
         if (meta != null && meta.getLocalSize() > 0) {
-            info("\tallocating %s of local memory", RuntimeUtilities.humanReadableByteCount(meta.getLocalSize(), true));
+            TornadoLogger.info("\tallocating %s of local memory", RuntimeUtilities.humanReadableByteCount(meta.getLocalSize(), true));
             kernel.setLocalRegion(index, meta.getLocalSize());
         } else {
             kernel.setArgUnused(index);
@@ -226,7 +225,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
         guarantee(kernel != null, "kernel is null");
 
         if (DEBUG) {
-            info("kernel submitted: id=0x%x, method = %s, device =%s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
+            TornadoLogger.info("kernel submitted: id=0x%x, method = %s, device =%s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
         }
 
         /*
@@ -351,7 +350,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
         checkKernelNotNull();
 
         if (DEBUG) {
-            info("kernel submitted: id=0x%x, method = %s, device =%s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
+            TornadoLogger.info("kernel submitted: id=0x%x, method = %s, device =%s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
         }
 
         setKernelArgs(oclKernelStackFrame, atomicSpace, meta);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
@@ -319,7 +319,7 @@ public class OCLBackend extends XPUBackend<OCLProviders> implements FrameMap.Ref
             asm.beginScope();
             emitVariableDefs(crb, asm, lir);
 
-            if (DEBUG_KERNEL_ARGS && (method != null && !method.getDeclaringClass().getUnqualifiedName().equalsIgnoreCase(this.getClass().getSimpleName()))) {
+            if (DEBUG_KERNEL_ARGS && !method.getDeclaringClass().getUnqualifiedName().equalsIgnoreCase(this.getClass().getSimpleName())) {
                 emitDebugKernelArgs(asm, method);
             }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
@@ -28,7 +28,6 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.drivers.common.code.CodeUtil.isHalfFloat;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG_KERNEL_ARGS;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.ENABLE_EXCEPTIONS;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEVICE_ENABLED;
 
@@ -101,6 +100,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.FPGAWorkGroupSizeNode;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.OCLTokens;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.graal.backend.XPUBackend;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
@@ -319,7 +319,7 @@ public class OCLBackend extends XPUBackend<OCLProviders> implements FrameMap.Ref
             asm.beginScope();
             emitVariableDefs(crb, asm, lir);
 
-            if (DEBUG_KERNEL_ARGS && !method.getDeclaringClass().getUnqualifiedName().equalsIgnoreCase(this.getClass().getSimpleName())) {
+            if (TornadoOptions.DEBUG_KERNEL_ARGS && !method.getDeclaringClass().getUnqualifiedName().equalsIgnoreCase(this.getClass().getSimpleName())) {
                 emitDebugKernelArgs(asm, method);
             }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
@@ -26,8 +26,6 @@ package uk.ac.manchester.tornado.drivers.opencl.graal.compiler;
 import static org.graalvm.compiler.phases.common.DeadCodeEliminationPhase.Optionality.Optional;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DUMP_COMPILED_METHODS;
 
 import java.io.File;
@@ -88,7 +86,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.backend.OCLBackend;
 import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLLIRGenerationPhase.LIRGenerationContext;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.BatchCompilationConfig;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.graal.TornadoLIRSuites;
 import uk.ac.manchester.tornado.runtime.graal.TornadoSuites;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCompilerIdentifier;
@@ -316,7 +314,7 @@ public class OCLCompiler {
 
     public static OCLCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, OCLProviders providers, OCLBackend backend,
             BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
-        Tornado.info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
+        TornadoLogger.info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
         final TornadoCompilerIdentifier id = new TornadoCompilerIdentifier("compile-kernel" + resolvedMethod.getName(), compilationId.getAndIncrement());
 
         Builder builder = new Builder(TornadoCoreRuntime.getOptions(), getDebugContext(), AllowAssumptions.YES);
@@ -364,7 +362,7 @@ public class OCLCompiler {
         final StructuredGraph kernelGraph = (StructuredGraph) sketch.getGraph().copy(getDebugContext());
         ResolvedJavaMethod resolvedMethod = kernelGraph.method();
 
-        info("Compiling sketch %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
+        TornadoLogger.info("Compiling sketch %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
 
         final TaskMetaData taskMeta = task.meta();
         final Object[] args = task.getArguments();
@@ -441,8 +439,8 @@ public class OCLCompiler {
                 try {
                     Files.createDirectories(outDir);
                 } catch (IOException e) {
-                    error("unable to create cache dir: %s", outDir.toString());
-                    error(e.getMessage());
+                    TornadoLogger.error("unable to create cache dir: %s", outDir.toString());
+                    TornadoLogger.error(e.getMessage());
                 }
             }
 
@@ -454,7 +452,7 @@ public class OCLCompiler {
                     pw.printf("%s,%s\n", m.getDeclaringClass().getName(), m.getName());
                 }
             } catch (IOException e) {
-                error("unable to dump source: ", e.getMessage());
+                TornadoLogger.error("unable to dump source: ", e.getMessage());
             }
         }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
@@ -26,9 +26,9 @@ package uk.ac.manchester.tornado.drivers.opencl.graal.compiler;
 import static org.graalvm.compiler.phases.common.DeadCodeEliminationPhase.Optionality.Optional;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DUMP_COMPILED_METHODS;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DUMP_COMPILED_METHODS;
 
 import java.io.File;
 import java.io.IOException;
@@ -314,7 +314,8 @@ public class OCLCompiler {
 
     }
 
-    public static OCLCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, OCLProviders providers, OCLBackend backend, BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
+    public static OCLCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, OCLProviders providers, OCLBackend backend,
+            BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
         Tornado.info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
         final TornadoCompilerIdentifier id = new TornadoCompilerIdentifier("compile-kernel" + resolvedMethod.getName(), compilationId.getAndIncrement());
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLVectorNodePlugin.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLVectorNodePlugin.java
@@ -42,13 +42,10 @@ public class OCLVectorNodePlugin implements NodePlugin {
         if (!ENABLE_VECTORS) {
             return false;
         }
-
         if (type.getAnnotation(Vector.class) != null) {
             return createVectorInstance(b, type);
         }
-
         return false;
-
     }
 
     private boolean createVectorInstance(GraphBuilderContext b, ResolvedJavaType type) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLVectorNodePlugin.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLVectorNodePlugin.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.graal.compiler.plugins;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.ENABLE_VECTORS;
-
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderContext;
 import org.graalvm.compiler.nodes.graphbuilderconf.NodePlugin;
 
@@ -39,9 +37,6 @@ public class OCLVectorNodePlugin implements NodePlugin {
 
     @Override
     public boolean handleNewInstance(GraphBuilderContext b, ResolvedJavaType type) {
-        if (!ENABLE_VECTORS) {
-            return false;
-        }
         if (type.getAnnotation(Vector.class) != null) {
             return createVectorInstance(b, type);
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
@@ -64,6 +64,7 @@ import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoop
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLKernelContextAccessNode;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
 
@@ -386,8 +387,8 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
         if (iterations == MAX_ITERATIONS) {
             Tornado.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
         }
-        Tornado.debug("TaskSpecialisation ran %d iterations", iterations);
-        Tornado.debug("valid graph? %s", graph.verify());
+        TornadoLogger.debug("TaskSpecialisation ran %d iterations", iterations);
+        TornadoLogger.debug("valid graph? %s", graph.verify());
         index = 0;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
@@ -63,7 +63,6 @@ import uk.ac.manchester.tornado.drivers.common.compiler.phases.analysis.TornadoV
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoopUnroller;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLKernelContextAccessNode;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
@@ -385,7 +384,7 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
         });
 
         if (iterations == MAX_ITERATIONS) {
-            Tornado.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
+            TornadoLogger.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
         }
         TornadoLogger.debug("TaskSpecialisation ran %d iterations", iterations);
         TornadoLogger.debug("valid graph? %s", graph.verify());

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
@@ -23,7 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
@@ -32,6 +31,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class FieldBuffer {
 
@@ -74,7 +74,7 @@ public class FieldBuffer {
 
     public int read(long executionPlanId, final Object ref, int[] events, boolean useDeps) {
         if (DEBUG) {
-            debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: reading with offset != 0
         return objectBuffer.read(executionPlanId, getFieldValue(ref), 0, 0, events, useDeps);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
@@ -23,10 +23,10 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
@@ -45,7 +43,7 @@ public class FieldBuffer {
 
     public int enqueueRead(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: Offset 0
         return (useDeps) ? objectBuffer.enqueueRead(executionPlanId, getFieldValue(ref), 0, (useDeps) ? events : null, useDeps) : -1;
@@ -53,7 +51,7 @@ public class FieldBuffer {
 
     public List<Integer> enqueueWrite(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         return (useDeps) ? objectBuffer.enqueueWrite(executionPlanId, getFieldValue(ref), 0, 0, (useDeps) ? events : null, useDeps) : null;
     }
@@ -63,7 +61,7 @@ public class FieldBuffer {
         try {
             value = field.get(container);
         } catch (IllegalArgumentException | IllegalAccessException e) {
-            warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
+            TornadoLogger.warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
         }
         return value;
     }
@@ -82,7 +80,7 @@ public class FieldBuffer {
 
     public void write(long executionPlanId, final Object ref) {
         if (DEBUG) {
-            trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         objectBuffer.write(executionPlanId, getFieldValue(ref));
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
@@ -28,7 +28,6 @@ package uk.ac.manchester.tornado.drivers.opencl.mm;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.VALIDATE_ARRAY_HEADERS;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 
@@ -262,18 +261,8 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
         if (array == null) {
             throw new TornadoRuntimeException("[ERROR] output data is NULL");
         }
-
-        if (VALIDATE_ARRAY_HEADERS) {
-            if (validateArrayHeader(executionPlanId, array)) {
-                return readArrayData(executionPlanId, toBuffer(), arrayHeaderSize + bufferOffset, bufferSize - arrayHeaderSize, array, hostOffset, (useDeps) ? events : null);
-            } else {
-                shouldNotReachHere("Array header is invalid");
-            }
-        } else {
-            final long numBytes = getSizeSubRegionSize() > 0 ? getSizeSubRegionSize() : (bufferSize - arrayHeaderSize);
-            return readArrayData(executionPlanId, toBuffer(), arrayHeaderSize + bufferOffset, numBytes, array, hostOffset, (useDeps) ? events : null);
-        }
-        return -1;
+        final long numBytes = getSizeSubRegionSize() > 0 ? getSizeSubRegionSize() : (bufferSize - arrayHeaderSize);
+        return readArrayData(executionPlanId, toBuffer(), arrayHeaderSize + bufferOffset, numBytes, array, hostOffset, (useDeps) ? events : null);
     }
 
     protected abstract int readArrayData(long executionPlanId, long bufferId, long offset, long bytes, T value, long hostOffset, int[] waitEvents);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
@@ -28,8 +28,6 @@ package uk.ac.manchester.tornado.drivers.opencl.mm;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -41,6 +39,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public abstract class OCLArrayWrapper<T> implements XPUBuffer {
@@ -103,8 +102,8 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            info("allocated: %s", toString());
+            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            TornadoLogger.info("allocated: %s", toString());
         }
 
     }
@@ -118,8 +117,9 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            info("deallocated: %s", toString());
+            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset,
+                    arrayHeaderSize);
+            TornadoLogger.info("deallocated: %s", toString());
         }
     }
 
@@ -308,7 +308,7 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
         final int numElements = header.getInt(arrayLengthOffset);
         final boolean valid = numElements == Array.getLength(array);
         if (!valid) {
-            fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
+            TornadoLogger.fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
             header.dump(8);
         }
         return valid;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
@@ -41,7 +41,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public abstract class OCLArrayWrapper<T> implements XPUBuffer {
 
@@ -102,7 +102,7 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
 
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
             info("allocated: %s", toString());
         }
@@ -117,7 +117,7 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
             info("deallocated: %s", toString());
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLByteBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLByteBuffer.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 /**
  * A buffer for inspecting data within an OpenCL device. It is not backed by any
@@ -291,6 +291,6 @@ public class OCLByteBuffer {
     }
 
     public void zeroMemory() {
-        Tornado.warn("zero memory unimplemented");
+        TornadoLogger.warn("zero memory unimplemented");
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
@@ -22,8 +22,6 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
-
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +36,7 @@ import uk.ac.manchester.tornado.api.types.images.TornadoImagesInterface;
 import uk.ac.manchester.tornado.api.types.matrix.TornadoMatrixInterface;
 import uk.ac.manchester.tornado.api.types.volumes.TornadoVolumesInterface;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.exceptions.TornadoUnsupportedError;
 
@@ -192,7 +191,7 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
         }
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("allocated: %s", toString());
+            TornadoLogger.info("allocated: %s", toString());
         }
     }
 
@@ -204,7 +203,7 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("deallocated: %s", toString());
+            TornadoLogger.info("deallocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
@@ -38,7 +38,7 @@ import uk.ac.manchester.tornado.api.types.images.TornadoImagesInterface;
 import uk.ac.manchester.tornado.api.types.matrix.TornadoMatrixInterface;
 import uk.ac.manchester.tornado.api.types.volumes.TornadoVolumesInterface;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.exceptions.TornadoUnsupportedError;
 
 public class OCLMemorySegmentWrapper implements XPUBuffer {
@@ -191,7 +191,7 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
             throw new TornadoMemoryException(STR."[ERROR] Bytes Allocated <= 0: \{bufferSize}");
         }
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("allocated: %s", toString());
         }
     }
@@ -203,7 +203,7 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("deallocated: %s", toString());
         }
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMultiDimArrayWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMultiDimArrayWrapper.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
-
 import java.lang.reflect.Array;
 import java.util.function.Function;
 
@@ -32,6 +30,7 @@ import jdk.vm.ci.meta.JavaKind;
 import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class OCLMultiDimArrayWrapper<T, E> extends OCLArrayWrapper<T> {
 
@@ -83,7 +82,7 @@ public class OCLMultiDimArrayWrapper<T, E> extends OCLArrayWrapper<T> {
                 addresses[i] = wrappers[i].toBuffer();
             }
         } catch (TornadoOutOfMemoryException | TornadoMemoryException e) {
-            fatal("OOM: multi-dim array: %s", e.getMessage());
+            TornadoLogger.fatal("OOM: multi-dim array: %s", e.getMessage());
             System.exit(-1);
         }
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
@@ -49,7 +49,6 @@ import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.utils.TornadoUtils;
 
@@ -95,7 +94,7 @@ public class OCLVectorWrapper implements XPUBuffer {
 
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
         }
@@ -109,7 +108,7 @@ public class OCLVectorWrapper implements XPUBuffer {
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
@@ -24,7 +24,6 @@
 package uk.ac.manchester.tornado.drivers.opencl.mm;
 
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 import static uk.ac.manchester.tornado.runtime.graal.TornadoLIRGenerator.warn;
 
 import java.lang.reflect.Array;
@@ -49,6 +48,7 @@ import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.utils.TornadoUtils;
 
@@ -95,7 +95,7 @@ public class OCLVectorWrapper implements XPUBuffer {
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
+            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
         }
     }
@@ -109,7 +109,7 @@ public class OCLVectorWrapper implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
+            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
         }
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
@@ -29,7 +29,6 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
@@ -56,6 +55,7 @@ import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.drivers.common.mm.PrimitiveSerialiser;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.utils.TornadoUtils;
 
 public class OCLXPUBuffer implements XPUBuffer {
@@ -165,7 +165,7 @@ public class OCLXPUBuffer implements XPUBuffer {
     @Override
     public void allocate(Object reference, long batchSize) throws TornadoOutOfMemoryException, TornadoMemoryException {
         if (DEBUG) {
-            debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
+            TornadoLogger.debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
         }
 
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(size());
@@ -173,7 +173,7 @@ public class OCLXPUBuffer implements XPUBuffer {
         setBuffer(new XPUBufferWrapper(bufferId, bufferOffset));
 
         if (DEBUG) {
-            debug("object: object=0x%x @ bufferId 0x%x", reference.hashCode(), bufferId);
+            TornadoLogger.debug("object: object=0x%x @ bufferId 0x%x", reference.hashCode(), bufferId);
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
@@ -29,8 +29,6 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
@@ -92,7 +90,7 @@ public class OCLXPUBuffer implements XPUBuffer {
             final Class<?> type = reflectedField.getType();
 
             if (DEBUG) {
-                trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
+                TornadoLogger.trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
             }
 
             XPUBuffer wrappedField = null;
@@ -113,7 +111,7 @@ public class OCLXPUBuffer implements XPUBuffer {
                 } else if (type == byte[].class) {
                     wrappedField = new OCLByteArrayWrapper((byte[]) objectFromField, device, 0);
                 } else {
-                    warn("cannot wrap field: array type=%s", type.getName());
+                    TornadoLogger.warn("cannot wrap field: array type=%s", type.getName());
                 }
             } else if (type == FloatArray.class) {
                 Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
@@ -265,7 +263,7 @@ public class OCLXPUBuffer implements XPUBuffer {
                 HotSpotResolvedJavaField field = fields[i];
                 Field f = getField(objectType, field.getName());
                 if (DEBUG) {
-                    trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    TornadoLogger.trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
 
                 buffer.position(field.getOffset());
@@ -285,7 +283,7 @@ public class OCLXPUBuffer implements XPUBuffer {
                 Field f = getField(objectType, field.getName());
                 f.setAccessible(true);
                 if (DEBUG) {
-                    trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    TornadoLogger.trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
                 readFieldFromBuffer(i, f, object);
             }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
@@ -29,10 +29,10 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
@@ -47,7 +47,6 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
-import uk.ac.manchester.tornado.api.types.arrays.CharArray;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/power/OCLNvidiaPowerMetric.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/power/OCLNvidiaPowerMetric.java
@@ -26,7 +26,7 @@ package uk.ac.manchester.tornado.drivers.opencl.power;
 import uk.ac.manchester.tornado.drivers.common.power.PowerMetric;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.drivers.opencl.exceptions.OCLException;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class OCLNvidiaPowerMetric implements PowerMetric {
     private final OCLDeviceContext deviceContext;
@@ -47,7 +47,7 @@ public class OCLNvidiaPowerMetric implements PowerMetric {
         try {
             clNvmlInit();
         } catch (OCLException e) {
-            error(e.getMessage());
+            TornadoLogger.error(e.getMessage());
         }
     }
 
@@ -56,7 +56,7 @@ public class OCLNvidiaPowerMetric implements PowerMetric {
         try {
             clNvmlDeviceGetHandleByIndex(this.deviceContext.getDevice().getIndex(), device);
         } catch (OCLException e) {
-            error(e.getMessage());
+            TornadoLogger.error(e.getMessage());
         }
     }
 
@@ -65,7 +65,7 @@ public class OCLNvidiaPowerMetric implements PowerMetric {
         try {
             clNvmlDeviceGetPowerUsage(device, powerUsage);
         } catch (OCLException e) {
-            error(e.getMessage());
+            TornadoLogger.error(e.getMessage());
         }
     }
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXEventPool.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXEventPool.java
@@ -24,7 +24,6 @@
 package uk.ac.manchester.tornado.drivers.ptx;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.CIRCULAR_EVENTS;
 
 import java.util.ArrayList;
@@ -34,6 +33,7 @@ import java.util.List;
 
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.drivers.common.utils.EventDescriptor;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class PTXEventPool {
 
@@ -58,8 +58,8 @@ public class PTXEventPool {
         guarantee(!retain.get(currentEvent), "overwriting retained event");
 
         if (eventWrapper == null) {
-            fatal("invalid event: description=%s\n", descriptorId.getNameDescription());
-            fatal("terminating application as system integrity has been compromised.");
+            TornadoLogger.fatal("invalid event: description=%s\n", descriptorId.getNameDescription());
+            TornadoLogger.fatal("terminating application as system integrity has been compromised.");
             throw new TornadoBailoutRuntimeException("[ERROR] NULL event received from the CUDA driver !");
         }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -25,8 +25,8 @@ package uk.ac.manchester.tornado.drivers.ptx;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.FULL_DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.FULL_DEBUG;
 
 import java.util.Arrays;
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
@@ -24,8 +24,8 @@
 package uk.ac.manchester.tornado.drivers.ptx;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.FULL_DEBUG;
 
 import java.util.Arrays;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
@@ -24,13 +24,13 @@
 package uk.ac.manchester.tornado.drivers.ptx;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.FULL_DEBUG;
 
 import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class PTXScheduler {
@@ -73,8 +73,8 @@ public class PTXScheduler {
                 defaultBlocks[i] = calculateBlockSize(calculateEffectiveMaxWorkItemSize(dimension, maxBlockThreads), globalWork[i]);
             }
         } catch (Exception e) {
-            warn("[CUDA-PTX] Failed to calculate blocks for " + javaName);
-            warn("[CUDA-PTX] Falling back to blocks: " + Arrays.toString(defaultBlocks));
+            TornadoLogger.warn("[CUDA-PTX] Failed to calculate blocks for " + javaName);
+            TornadoLogger.warn("[CUDA-PTX] Falling back to blocks: " + Arrays.toString(defaultBlocks));
             if (DEBUG || FULL_DEBUG) {
                 e.printStackTrace();
             }
@@ -121,8 +121,8 @@ public class PTXScheduler {
                 defaultGrids[i] = Math.max(Math.min(workSize / blockDimension[i], (int) maxGridSizes[i]), 1);
             }
         } catch (Exception e) {
-            warn("[CUDA-PTX] Failed to calculate grids for " + javaName);
-            warn("[CUDA-PTX] Falling back to grid: " + Arrays.toString(defaultGrids));
+            TornadoLogger.warn("[CUDA-PTX] Failed to calculate grids for " + javaName);
+            TornadoLogger.warn("[CUDA-PTX] Falling back to grid: " + Arrays.toString(defaultGrids));
             if (DEBUG || FULL_DEBUG) {
                 e.printStackTrace();
             }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
@@ -23,7 +23,7 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.EVENT_WINDOW;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.EVENT_WINDOW;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
@@ -24,16 +24,6 @@
 
 package uk.ac.manchester.tornado.drivers.ptx.graal.compiler;
 
-import static org.graalvm.compiler.phases.common.DeadCodeEliminationPhase.Optionality.Optional;
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
-import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernelName;
-import static uk.ac.manchester.tornado.drivers.ptx.graal.compiler.PTXLIRGenerationPhase.LIRGenerationContext;
-import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
-import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getTornadoRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
-import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DUMP_COMPILED_METHODS;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -77,14 +67,17 @@ import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.meta.Assumptions;
 import jdk.vm.ci.meta.ProfilingInfo;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
+import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
+import uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXProviders;
 import uk.ac.manchester.tornado.drivers.ptx.graal.PTXSuitesProvider;
 import uk.ac.manchester.tornado.drivers.ptx.graal.backend.PTXBackend;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PrintfNode;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.BatchCompilationConfig;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graal.TornadoLIRSuites;
 import uk.ac.manchester.tornado.runtime.graal.TornadoSuites;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCompilerIdentifier;
@@ -110,7 +103,8 @@ public class PTXCompiler {
 
     private static PTXCompilationResult compile(PTXCompilationRequest r) {
         assert !r.graph.isFrozen();
-        try (DebugContext.Scope s0 = getDebugContext().scope("GraalCompiler", r.graph, r.providers.getCodeCache()); DebugCloseable a = CompilerTimer.start(getDebugContext())) {
+        try (DebugContext.Scope s0 = TornadoCoreRuntime.getDebugContext().scope("GraalCompiler", r.graph, r.providers.getCodeCache());
+                DebugCloseable a = CompilerTimer.start(TornadoCoreRuntime.getDebugContext())) {
             emitFrontEnd(r);
             boolean isParallel = false;
             if (r.meta != null && r.meta.isParallel()) {
@@ -118,28 +112,28 @@ public class PTXCompiler {
             }
             emitBackEnd(r, isParallel);
         } catch (Throwable e) {
-            throw getDebugContext().handle(e);
+            throw TornadoCoreRuntime.getDebugContext().handle(e);
         }
 
         return r.compilationResult;
     }
 
     private static void emitBackEnd(PTXCompilationRequest r, boolean isParallel) {
-        try (DebugContext.Scope s = getDebugContext().scope("PTXBackend", r.graph.getLastSchedule()); DebugCloseable a = BackEnd.start(getDebugContext())) {
+        try (DebugContext.Scope s = TornadoCoreRuntime.getDebugContext().scope("PTXBackend", r.graph.getLastSchedule()); DebugCloseable a = BackEnd.start(TornadoCoreRuntime.getDebugContext())) {
             LIRGenerationResult lirGen = emitLIR(r);
-            try (DebugContext.Scope s2 = getDebugContext().scope("PTXCodeGen", lirGen, lirGen.getLIR())) {
+            try (DebugContext.Scope s2 = TornadoCoreRuntime.getDebugContext().scope("PTXCodeGen", lirGen, lirGen.getLIR())) {
                 r.compilationResult.setHasUnsafeAccess(r.graph.hasUnsafeAccess());
                 emitCode(r, lirGen, isParallel);
             } catch (Throwable e) {
-                throw getDebugContext().handle(e);
+                throw TornadoCoreRuntime.getDebugContext().handle(e);
             }
         } catch (Throwable e) {
-            throw getDebugContext().handle(e);
+            throw TornadoCoreRuntime.getDebugContext().handle(e);
         }
     }
 
     private static void emitCode(PTXCompilationRequest r, LIRGenerationResult lirGenRes, boolean isParallel) {
-        try (DebugCloseable a = EmitCode.start(getDebugContext())) {
+        try (DebugCloseable a = EmitCode.start(TornadoCoreRuntime.getDebugContext())) {
             FrameMap frameMap = lirGenRes.getFrameMap();
             final PTXCompilationResultBuilder crb = r.backend.newCompilationResultBuilder(lirGenRes, frameMap, r.compilationResult, r.factory, r.isKernel, isParallel, r.includePrintf, lirGenRes
                     .getLIR());
@@ -158,17 +152,17 @@ public class PTXCompiler {
             r.compilationResult.setNonInlinedMethods(crb.getNonInlinedMethods());
             crb.finish();
 
-            if (getDebugContext().isCountEnabled()) {
-                DebugContext.counter("CompilationResults").increment(getDebugContext());
-                DebugContext.counter("CodeBytesEmitted").add(getDebugContext(), r.compilationResult.getTargetCodeSize());
+            if (TornadoCoreRuntime.getDebugContext().isCountEnabled()) {
+                DebugContext.counter("CompilationResults").increment(TornadoCoreRuntime.getDebugContext());
+                DebugContext.counter("CodeBytesEmitted").add(TornadoCoreRuntime.getDebugContext(), r.compilationResult.getTargetCodeSize());
             }
 
-            getDebugContext().dump(DebugContext.BASIC_LEVEL, r.compilationResult, "After code generation");
+            TornadoCoreRuntime.getDebugContext().dump(DebugContext.BASIC_LEVEL, r.compilationResult, "After code generation");
         }
     }
 
     private static LIRGenerationResult emitLIR(PTXCompilationRequest r) {
-        try (DebugContext.Scope ds = getDebugContext().scope("EmitLIR"); DebugCloseable a = EmitLIR.start(getDebugContext())) {
+        try (DebugContext.Scope ds = TornadoCoreRuntime.getDebugContext().scope("EmitLIR"); DebugCloseable a = EmitLIR.start(TornadoCoreRuntime.getDebugContext())) {
             OptionValues options = r.graph.getOptions();
             StructuredGraph.ScheduleResult schedule = r.graph.getLastSchedule();
             HIRBlock[] blocks = schedule.getCFG().getBlocks();
@@ -177,13 +171,13 @@ public class PTXCompiler {
             assert startBlock.getPredecessorCount() == 0;
 
             LIR lir = null;
-            try (DebugContext.Scope s = getDebugContext().scope("ComputeLinearScanOrder", lir)) {
+            try (DebugContext.Scope s = TornadoCoreRuntime.getDebugContext().scope("ComputeLinearScanOrder", lir)) {
                 CodeEmissionOrder<?> blockOrder = r.backend.newBlockOrder(blocks.length, startBlock);
                 int[] linearScanOrder = LinearScanOrder.computeLinearScanOrder(blocks.length, startBlock);
                 lir = new LIR(schedule.getCFG(), linearScanOrder, r.graph.getOptions(), r.graph.getDebug());
-                getDebugContext().dump(DebugContext.INFO_LEVEL, lir, "After linear scan order");
+                TornadoCoreRuntime.getDebugContext().dump(DebugContext.INFO_LEVEL, lir, "After linear scan order");
             } catch (Throwable e) {
-                throw getDebugContext().handle(e);
+                throw TornadoCoreRuntime.getDebugContext().handle(e);
             }
             RegisterAllocationConfig registerAllocationConfig = r.backend.newRegisterAllocationConfig(null, new String[] {});
             FrameMapBuilder frameMapBuilder = r.backend.newFrameMapBuilder(null);
@@ -192,19 +186,19 @@ public class PTXCompiler {
             NodeLIRBuilderTool nodeLirGen = r.backend.newNodeLIRBuilder(r.graph, lirGen);
 
             // LIR generation
-            LIRGenerationContext context = new LIRGenerationContext(lirGen, nodeLirGen, r.graph, schedule, r.isKernel);
+            PTXLIRGenerationPhase.LIRGenerationContext context = new PTXLIRGenerationPhase.LIRGenerationContext(lirGen, nodeLirGen, r.graph, schedule, r.isKernel);
             LIR_GENERATION_PHASE.apply(r.backend.getTarget(), lirGenRes, context);
 
-            try (DebugContext.Scope s = getDebugContext().scope("LIRStages", nodeLirGen, lir)) {
-                getDebugContext().dump(DebugContext.BASIC_LEVEL, lir, "After LIR generation");
+            try (DebugContext.Scope s = TornadoCoreRuntime.getDebugContext().scope("LIRStages", nodeLirGen, lir)) {
+                TornadoCoreRuntime.getDebugContext().dump(DebugContext.BASIC_LEVEL, lir, "After LIR generation");
                 LIRGenerationResult result = emitLowLevel(r.backend.getTarget(), lirGenRes, lirGen, r.lirSuites, registerAllocationConfig);
-                getDebugContext().dump(DebugContext.BASIC_LEVEL, lir, "Before code generation");
+                TornadoCoreRuntime.getDebugContext().dump(DebugContext.BASIC_LEVEL, lir, "Before code generation");
                 return result;
             } catch (Throwable e) {
-                throw getDebugContext().handle(e);
+                throw TornadoCoreRuntime.getDebugContext().handle(e);
             }
         } catch (Throwable e) {
-            throw getDebugContext().handle(e);
+            throw TornadoCoreRuntime.getDebugContext().handle(e);
         }
     }
 
@@ -221,16 +215,17 @@ public class PTXCompiler {
      * Builds the graph and optimizes it.
      */
     private static void emitFrontEnd(PTXCompilationRequest r) {
-        try (DebugContext.Scope s = getDebugContext().scope("PTXFrontend", new DebugDumpScope("PTXFrontend")); DebugCloseable a = FrontEnd.start(getDebugContext())) {
+        try (DebugContext.Scope s = TornadoCoreRuntime.getDebugContext().scope("PTXFrontend", new DebugDumpScope("PTXFrontend"));
+                DebugCloseable a = FrontEnd.start(TornadoCoreRuntime.getDebugContext())) {
             final TornadoHighTierContext highTierContext = new TornadoHighTierContext(r.providers, r.graphBuilderSuite, r.optimisticOpts, r.installedCodeOwner, r.args, r.meta, r.isKernel,
                     r.batchCompilationConfig);
 
             if (r.buildGraph) {
                 if (isGraphEmpty(r.graph)) {
                     r.graphBuilderSuite.apply(r.graph, highTierContext);
-                    new DeadCodeEliminationPhase(Optional).apply(r.graph);
+                    new DeadCodeEliminationPhase(DeadCodeEliminationPhase.Optionality.Optional).apply(r.graph);
                 } else {
-                    getDebugContext().dump(DebugContext.INFO_LEVEL, r.graph, "initial state");
+                    TornadoCoreRuntime.getDebugContext().dump(DebugContext.INFO_LEVEL, r.graph, "initial state");
                 }
             }
             r.suites.getHighTier().apply(r.graph, highTierContext);
@@ -244,9 +239,9 @@ public class PTXCompiler {
             final TornadoLowTierContext lowTierContext = new TornadoLowTierContext(r.providers, r.backend, r.meta);
             r.suites.getLowTier().apply(r.graph, lowTierContext);
 
-            getDebugContext().dump(DebugContext.BASIC_LEVEL, r.graph.getLastSchedule(), "Final HIR schedule");
+            TornadoCoreRuntime.getDebugContext().dump(DebugContext.BASIC_LEVEL, r.graph.getLastSchedule(), "Final HIR schedule");
         } catch (Throwable e) {
-            throw getDebugContext().handle(e);
+            throw TornadoCoreRuntime.getDebugContext().handle(e);
         }
     }
 
@@ -255,10 +250,10 @@ public class PTXCompiler {
     }
 
     public synchronized static PTXCompilationResult compileSketchForDevice(Sketch sketch, CompilableTask task, PTXProviders providers, PTXBackend backend, TornadoProfiler profiler) {
-        final StructuredGraph kernelGraph = (StructuredGraph) sketch.getGraph().copy(getDebugContext());
+        final StructuredGraph kernelGraph = (StructuredGraph) sketch.getGraph().copy(TornadoCoreRuntime.getDebugContext());
         ResolvedJavaMethod resolvedMethod = kernelGraph.method();
 
-        info("Compiling sketch %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
+        TornadoLogger.info("Compiling sketch %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
 
         final TaskMetaData taskMeta = task.meta();
         final Object[] args = task.getArguments();
@@ -270,7 +265,7 @@ public class PTXCompiler {
         OptimisticOptimizations optimisticOpts = OptimisticOptimizations.ALL;
         ProfilingInfo profilingInfo = resolvedMethod.getProfilingInfo();
 
-        PTXCompilationResult kernelCompResult = new PTXCompilationResult(buildKernelName(resolvedMethod.getName(), task), taskMeta);
+        PTXCompilationResult kernelCompResult = new PTXCompilationResult(PTXCodeUtil.buildKernelName(resolvedMethod.getName(), task), taskMeta);
         CompilationResultBuilderFactory factory = CompilationResultBuilderFactory.Default;
 
         Set<ResolvedJavaMethod> methods = new HashSet<>();
@@ -299,7 +294,7 @@ public class PTXCompiler {
 
         kernelCompilationRequest.execute();
 
-        if (DUMP_COMPILED_METHODS) {
+        if (TornadoOptions.DUMP_COMPILED_METHODS) {
             methods.add(kernelGraph.method());
             methods.addAll(kernelGraph.getMethods());
             methods.addAll(Arrays.asList(kernelCompResult.getMethods()));
@@ -325,7 +320,7 @@ public class PTXCompiler {
             }
             Sketch currentSketch = TornadoSketcher.lookup(currentMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
             final PTXCompilationResult compResult = new PTXCompilationResult(currentMethod.getName(), taskMeta);
-            final StructuredGraph graph = (StructuredGraph) currentSketch.getGraph().copy(getDebugContext());
+            final StructuredGraph graph = (StructuredGraph) currentSketch.getGraph().copy(TornadoCoreRuntime.getDebugContext());
 
             // @formatter:off
             PTXCompilationRequest methodCompilationRequest = PTXCompilationRequest.PTXCompilationRequestBuilder.getInstance().withGraph(graph)
@@ -350,7 +345,7 @@ public class PTXCompiler {
             methodCompilationRequest.execute();
             workList.addAll(compResult.getNonInlinedMethods());
 
-            if (DUMP_COMPILED_METHODS) {
+            if (TornadoOptions.DUMP_COMPILED_METHODS) {
                 methods.add(graph.method());
                 methods.addAll(graph.getMethods());
             }
@@ -360,18 +355,18 @@ public class PTXCompiler {
 
         kernelCompResult.addPTXHeader(backend);
 
-        if (DUMP_COMPILED_METHODS) {
+        if (TornadoOptions.DUMP_COMPILED_METHODS) {
             final Path outDir = Paths.get("./ptx-compiled-methods");
             if (!Files.exists(outDir)) {
                 try {
                     Files.createDirectories(outDir);
                 } catch (IOException e) {
-                    error("unable to create cache dir: %s", outDir.toString());
-                    error(e.getMessage());
+                    TornadoLogger.error("unable to create cache dir: %s", outDir.toString());
+                    TornadoLogger.error(e.getMessage());
                 }
             }
 
-            guarantee(Files.isDirectory(outDir), "cache directory is not a directory: %s", outDir.toAbsolutePath().toString());
+            TornadoInternalError.guarantee(Files.isDirectory(outDir), "cache directory is not a directory: %s", outDir.toAbsolutePath().toString());
 
             File file = new File(outDir + "/" + task.getId() + "-" + resolvedMethod.getName());
             try (PrintWriter pw = new PrintWriter(file)) {
@@ -379,7 +374,7 @@ public class PTXCompiler {
                     pw.printf("%s,%s\n", m.getDeclaringClass().getName(), m.getName());
                 }
             } catch (IOException e) {
-                error("unable to dump source: ", e.getMessage());
+                TornadoLogger.error("unable to dump source: ", e.getMessage());
             }
         }
 
@@ -388,10 +383,10 @@ public class PTXCompiler {
 
     public static PTXCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, PTXProviders providers, PTXBackend backend,
             BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
-        Tornado.info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
+        TornadoLogger.info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
         final TornadoCompilerIdentifier id = new TornadoCompilerIdentifier("compile-kernel" + resolvedMethod.getName(), compilationId.getAndIncrement());
 
-        StructuredGraph.Builder builder = new StructuredGraph.Builder(getTornadoRuntime().getOptions(), getDebugContext(), StructuredGraph.AllowAssumptions.YES);
+        StructuredGraph.Builder builder = new StructuredGraph.Builder(TornadoCoreRuntime.getTornadoRuntime().getOptions(), TornadoCoreRuntime.getDebugContext(), StructuredGraph.AllowAssumptions.YES);
         builder.method(resolvedMethod);
         builder.compilationId(id);
         builder.name("compile-kernel" + resolvedMethod.getName());
@@ -435,7 +430,7 @@ public class PTXCompiler {
         while (!workList.isEmpty()) {
             final ResolvedJavaMethod currentMethod = workList.pop();
             final PTXCompilationResult compResult = new PTXCompilationResult(currentMethod.getName(), meta);
-            StructuredGraph.Builder builder1 = new StructuredGraph.Builder(TornadoCoreRuntime.getOptions(), getDebugContext(), StructuredGraph.AllowAssumptions.YES);
+            StructuredGraph.Builder builder1 = new StructuredGraph.Builder(TornadoCoreRuntime.getOptions(), TornadoCoreRuntime.getDebugContext(), StructuredGraph.AllowAssumptions.YES);
             builder1.method(resolvedMethod);
             builder1.compilationId(id);
             builder1.name("internal" + currentMethod.getName());

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
@@ -30,9 +30,9 @@ import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernel
 import static uk.ac.manchester.tornado.drivers.ptx.graal.compiler.PTXLIRGenerationPhase.LIRGenerationContext;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getTornadoRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DUMP_COMPILED_METHODS;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DUMP_COMPILED_METHODS;
 
 import java.io.File;
 import java.io.IOException;
@@ -294,8 +294,7 @@ public class PTXCompiler {
                 .isKernel(true)//
                 .buildGraph(true)//
                 .includePrintf(includePrintf)//
-                .setBatchCompilationConfig(batchCompilationConfig)
-                .withProfiler(profiler) //
+                .setBatchCompilationConfig(batchCompilationConfig).withProfiler(profiler) //
                 .build();
 
         kernelCompilationRequest.execute();
@@ -387,8 +386,8 @@ public class PTXCompiler {
         return kernelCompResult;
     }
 
-    public static PTXCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, PTXProviders providers, PTXBackend backend, BatchCompilationConfig batchCompilationConfig,
-            TornadoProfiler profiler) {
+    public static PTXCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, PTXProviders providers, PTXBackend backend,
+            BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
         Tornado.info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
         final TornadoCompilerIdentifier id = new TornadoCompilerIdentifier("compile-kernel" + resolvedMethod.getName(), compilationId.getAndIncrement());
 
@@ -497,8 +496,8 @@ public class PTXCompiler {
 
         private PTXCompilationRequest(StructuredGraph graph, ResolvedJavaMethod installedCodeOwner, Object[] args, TaskMetaData meta, Providers providers, PTXBackend backend,
                 PhaseSuite<HighTierContext> graphBuilderSuite, OptimisticOptimizations optimisticOpts, ProfilingInfo profilingInfo, TornadoSuites suites, TornadoLIRSuites lirSuites,
-                PTXCompilationResult compilationResult, CompilationResultBuilderFactory factory, boolean isKernel, boolean buildGraph, BatchCompilationConfig batchCompilationConfig, boolean includePrintf,
-                TornadoProfiler profiler) {
+                PTXCompilationResult compilationResult, CompilationResultBuilderFactory factory, boolean isKernel, boolean buildGraph, BatchCompilationConfig batchCompilationConfig,
+                boolean includePrintf, TornadoProfiler profiler) {
             this.graph = graph;
             this.installedCodeOwner = installedCodeOwner;
             this.args = args;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXVectorNodePlugin.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXVectorNodePlugin.java
@@ -21,8 +21,6 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.graal.compiler.plugins;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.ENABLE_VECTORS;
-
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderContext;
 import org.graalvm.compiler.nodes.graphbuilderconf.NodePlugin;
 
@@ -37,9 +35,6 @@ public class PTXVectorNodePlugin implements NodePlugin {
 
     @Override
     public boolean handleNewInstance(GraphBuilderContext b, ResolvedJavaType type) {
-        if (!ENABLE_VECTORS) {
-            return false;
-        }
 
         if (type.getAnnotation(Vector.class) != null) {
             return createVectorInstance(b, type);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXVectorPlugins.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXVectorPlugins.java
@@ -24,7 +24,6 @@
 package uk.ac.manchester.tornado.drivers.ptx.graal.compiler.plugins;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.ENABLE_VECTORS;
 
 import org.graalvm.compiler.core.common.type.ObjectStamp;
 import org.graalvm.compiler.core.common.type.StampPair;
@@ -94,107 +93,104 @@ import uk.ac.manchester.tornado.runtime.graal.nodes.PanamaPrivateMemoryNode;
 
 public final class PTXVectorPlugins {
 
-    public static final void registerPlugins(final Plugins ps, final InvocationPlugins plugins) {
+    public static void registerPlugins(final Plugins ps, final InvocationPlugins plugins) {
 
-        if (ENABLE_VECTORS) {
-            ps.appendNodePlugin(new NodePlugin() {
-                @Override
-                public boolean handleInvoke(GraphBuilderContext b, ResolvedJavaMethod method, ValueNode[] args) {
-                    PTXKind vectorKind = PTXKind.resolveToVectorKind(method.getDeclaringClass());
-                    if (vectorKind == PTXKind.ILLEGAL) {
-                        return false;
-                    }
-                    if (method.getName().equals("<init>")) {
-                        final VectorValueNode vector = resolveReceiver(b, vectorKind, args[0]);
-                        if (args.length > 1) {
-                            int offset = (vector == args[0]) ? 1 : 0;
-                            for (int i = offset; i < args.length; i++) {
-                                vector.setElement(i - offset, args[i]);
-                            }
-                        } else {
-                            if (vectorKind.getVectorLength() < 8) {
-                                vector.initialiseToDefaultValues(vector.graph());
-                            }
-                        }
-                        return true;
-                    }
+        ps.appendNodePlugin(new NodePlugin() {
+            @Override
+            public boolean handleInvoke(GraphBuilderContext b, ResolvedJavaMethod method, ValueNode[] args) {
+                PTXKind vectorKind = PTXKind.resolveToVectorKind(method.getDeclaringClass());
+                if (vectorKind == PTXKind.ILLEGAL) {
                     return false;
                 }
+                if (method.getName().equals("<init>")) {
+                    final VectorValueNode vector = resolveReceiver(b, vectorKind, args[0]);
+                    if (args.length > 1) {
+                        int offset = (vector == args[0]) ? 1 : 0;
+                        for (int i = offset; i < args.length; i++) {
+                            vector.setElement(i - offset, args[i]);
+                        }
+                    } else {
+                        if (vectorKind.getVectorLength() < 8) {
+                            vector.initialiseToDefaultValues(vector.graph());
+                        }
+                    }
+                    return true;
+                }
+                return false;
+            }
 
-            });
+        });
 
-            // Adding floats
-            registerVectorPlugins(ps, plugins, PTXKind.FLOAT2, FloatArray.class, float.class);
-            registerVectorPlugins(ps, plugins, PTXKind.FLOAT3, FloatArray.class, float.class);
-            registerVectorPlugins(ps, plugins, PTXKind.FLOAT4, FloatArray.class, float.class);
-            registerVectorPlugins(ps, plugins, PTXKind.FLOAT8, FloatArray.class, float.class);
-            registerVectorPlugins(ps, plugins, PTXKind.FLOAT16, FloatArray.class, float.class);
+        // Adding floats
+        registerVectorPlugins(ps, plugins, PTXKind.FLOAT2, FloatArray.class, float.class);
+        registerVectorPlugins(ps, plugins, PTXKind.FLOAT3, FloatArray.class, float.class);
+        registerVectorPlugins(ps, plugins, PTXKind.FLOAT4, FloatArray.class, float.class);
+        registerVectorPlugins(ps, plugins, PTXKind.FLOAT8, FloatArray.class, float.class);
+        registerVectorPlugins(ps, plugins, PTXKind.FLOAT16, FloatArray.class, float.class);
 
-            // Adding ints
-            registerVectorPlugins(ps, plugins, PTXKind.INT2, IntArray.class, int.class);
-            registerVectorPlugins(ps, plugins, PTXKind.INT3, IntArray.class, int.class);
-            registerVectorPlugins(ps, plugins, PTXKind.INT4, IntArray.class, int.class);
-            registerVectorPlugins(ps, plugins, PTXKind.INT8, IntArray.class, int.class);
-            registerVectorPlugins(ps, plugins, PTXKind.INT16, IntArray.class, int.class);
+        // Adding ints
+        registerVectorPlugins(ps, plugins, PTXKind.INT2, IntArray.class, int.class);
+        registerVectorPlugins(ps, plugins, PTXKind.INT3, IntArray.class, int.class);
+        registerVectorPlugins(ps, plugins, PTXKind.INT4, IntArray.class, int.class);
+        registerVectorPlugins(ps, plugins, PTXKind.INT8, IntArray.class, int.class);
+        registerVectorPlugins(ps, plugins, PTXKind.INT16, IntArray.class, int.class);
 
-            // Adding shorts
-            registerVectorPlugins(ps, plugins, PTXKind.SHORT2, ShortArray.class, short.class);
+        // Adding shorts
+        registerVectorPlugins(ps, plugins, PTXKind.SHORT2, ShortArray.class, short.class);
 
-            // Adding char
-            registerVectorPlugins(ps, plugins, PTXKind.CHAR3, ByteArray.class, byte.class);
-            registerVectorPlugins(ps, plugins, PTXKind.CHAR4, ByteArray.class, byte.class);
+        // Adding char
+        registerVectorPlugins(ps, plugins, PTXKind.CHAR3, ByteArray.class, byte.class);
+        registerVectorPlugins(ps, plugins, PTXKind.CHAR4, ByteArray.class, byte.class);
 
-            // Adding double
-            registerVectorPlugins(ps, plugins, PTXKind.DOUBLE2, DoubleArray.class, double.class);
-            registerVectorPlugins(ps, plugins, PTXKind.DOUBLE3, DoubleArray.class, double.class);
-            registerVectorPlugins(ps, plugins, PTXKind.DOUBLE4, DoubleArray.class, double.class);
-            registerVectorPlugins(ps, plugins, PTXKind.DOUBLE8, DoubleArray.class, double.class);
-            registerVectorPlugins(ps, plugins, PTXKind.DOUBLE16, DoubleArray.class, double.class);
+        // Adding double
+        registerVectorPlugins(ps, plugins, PTXKind.DOUBLE2, DoubleArray.class, double.class);
+        registerVectorPlugins(ps, plugins, PTXKind.DOUBLE3, DoubleArray.class, double.class);
+        registerVectorPlugins(ps, plugins, PTXKind.DOUBLE4, DoubleArray.class, double.class);
+        registerVectorPlugins(ps, plugins, PTXKind.DOUBLE8, DoubleArray.class, double.class);
+        registerVectorPlugins(ps, plugins, PTXKind.DOUBLE16, DoubleArray.class, double.class);
 
-            registerVectorPlugins(ps, plugins, PTXKind.HALF2, HalfFloat.class, short.class);
-            registerVectorPlugins(ps, plugins, PTXKind.HALF3, HalfFloat.class, short.class);
-            registerVectorPlugins(ps, plugins, PTXKind.HALF4, HalfFloat.class, short.class);
-            registerVectorPlugins(ps, plugins, PTXKind.HALF8, HalfFloat.class, short.class);
-            registerVectorPlugins(ps, plugins, PTXKind.HALF16, HalfFloat.class, short.class);
+        registerVectorPlugins(ps, plugins, PTXKind.HALF2, HalfFloat.class, short.class);
+        registerVectorPlugins(ps, plugins, PTXKind.HALF3, HalfFloat.class, short.class);
+        registerVectorPlugins(ps, plugins, PTXKind.HALF4, HalfFloat.class, short.class);
+        registerVectorPlugins(ps, plugins, PTXKind.HALF8, HalfFloat.class, short.class);
+        registerVectorPlugins(ps, plugins, PTXKind.HALF16, HalfFloat.class, short.class);
 
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORFLOAT2, FloatArray.class, Float2.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORFLOAT3, FloatArray.class, Float3.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORFLOAT4, FloatArray.class, Float4.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORFLOAT8, FloatArray.class, Float8.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORFLOAT16, FloatArray.class, Float16.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORFLOAT2, FloatArray.class, Float2.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORFLOAT3, FloatArray.class, Float3.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORFLOAT4, FloatArray.class, Float4.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORFLOAT8, FloatArray.class, Float8.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORFLOAT16, FloatArray.class, Float16.class);
 
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORINT2, IntArray.class, Int2.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORINT3, IntArray.class, Int3.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORINT4, IntArray.class, Int4.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORINT8, IntArray.class, Int8.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORINT16, IntArray.class, Int16.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORINT2, IntArray.class, Int2.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORINT3, IntArray.class, Int3.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORINT4, IntArray.class, Int4.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORINT8, IntArray.class, Int8.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORINT16, IntArray.class, Int16.class);
 
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORDOUBLE2, DoubleArray.class, Double2.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORDOUBLE3, DoubleArray.class, Double3.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORDOUBLE4, DoubleArray.class, Double4.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORDOUBLE8, DoubleArray.class, Double8.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORDOUBLE16, DoubleArray.class, Double16.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORDOUBLE2, DoubleArray.class, Double2.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORDOUBLE3, DoubleArray.class, Double3.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORDOUBLE4, DoubleArray.class, Double4.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORDOUBLE8, DoubleArray.class, Double8.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORDOUBLE16, DoubleArray.class, Double16.class);
 
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORHALF2, HalfFloatArray.class, Half2.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORHALF3, HalfFloatArray.class, Half3.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORHALF4, HalfFloatArray.class, Half4.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORHALF8, HalfFloatArray.class, Half8.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.VECTORHALF16, HalfFloatArray.class, Half16.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORHALF2, HalfFloatArray.class, Half2.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORHALF3, HalfFloatArray.class, Half3.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORHALF4, HalfFloatArray.class, Half4.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORHALF8, HalfFloatArray.class, Half8.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VECTORHALF16, HalfFloatArray.class, Half16.class);
 
-            registerVectorCollectionsPlugins(plugins, PTXKind.MATRIX2DFLOAT4, FloatArray.class, Float4.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.MATRIX3DFLOAT4, FloatArray.class, Float4.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.MATRIX4X4FLOAT, FloatArray.class, Float4.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.MATRIX2DFLOAT4, FloatArray.class, Float4.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.MATRIX3DFLOAT4, FloatArray.class, Float4.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.MATRIX4X4FLOAT, FloatArray.class, Float4.class);
 
-            registerVectorCollectionsPlugins(plugins, PTXKind.IMAGEFLOAT3, FloatArray.class, Float3.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.IMAGEFLOAT4, FloatArray.class, Float4.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.IMAGEFLOAT8, FloatArray.class, Float8.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.IMAGEFLOAT3, FloatArray.class, Float3.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.IMAGEFLOAT4, FloatArray.class, Float4.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.IMAGEFLOAT8, FloatArray.class, Float8.class);
 
-            registerVectorCollectionsPlugins(plugins, PTXKind.VOLUMESHORT2, ShortArray.class, Short2.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.VOLUMESHORT2, ShortArray.class, Short2.class);
 
-            registerVectorCollectionsPlugins(plugins, PTXKind.IMAGEBYTE3, ByteArray.class, Byte3.class);
-            registerVectorCollectionsPlugins(plugins, PTXKind.IMAGEBYTE4, ByteArray.class, Byte4.class);
-        }
-
+        registerVectorCollectionsPlugins(plugins, PTXKind.IMAGEBYTE3, ByteArray.class, Byte3.class);
+        registerVectorCollectionsPlugins(plugins, PTXKind.IMAGEBYTE4, ByteArray.class, Byte4.class);
     }
 
     private static VectorValueNode resolveReceiver(GraphBuilderContext b, PTXKind vectorKind, ValueNode thisObject) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoTaskSpecialisation.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoTaskSpecialisation.java
@@ -63,6 +63,7 @@ import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoop
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXKernelContextAccessNode;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
 
@@ -389,8 +390,8 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
         if (iterations == MAX_ITERATIONS) {
             Tornado.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
         }
-        Tornado.debug("TaskSpecialisation ran %d iterations", iterations);
-        Tornado.debug("valid graph? %s", graph.verify());
+        TornadoLogger.debug("TaskSpecialisation ran %d iterations", iterations);
+        TornadoLogger.debug("valid graph? %s", graph.verify());
         index = 0;
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoTaskSpecialisation.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoTaskSpecialisation.java
@@ -62,7 +62,6 @@ import uk.ac.manchester.tornado.drivers.common.compiler.phases.analysis.TornadoV
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoopUnroller;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXKernelContextAccessNode;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
@@ -388,7 +387,7 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
         });
 
         if (iterations == MAX_ITERATIONS) {
-            Tornado.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
+            TornadoLogger.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
         }
         TornadoLogger.debug("TaskSpecialisation ran %d iterations", iterations);
         TornadoLogger.debug("valid graph? %s", graph.verify());

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/FieldBuffer.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/FieldBuffer.java
@@ -23,7 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
@@ -35,6 +34,7 @@ import java.util.List;
 import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class FieldBuffer {
     private final Field field;
@@ -87,7 +87,7 @@ public class FieldBuffer {
 
     public int read(long executionPlanId, final Object ref, int[] events, boolean useDeps) {
         if (DEBUG) {
-            debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: reading with offset != 0
         return objectBuffer.read(executionPlanId, getFieldValue(ref), 0, 0, events, useDeps);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/FieldBuffer.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/FieldBuffer.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
@@ -56,7 +54,7 @@ public class FieldBuffer {
 
     public int enqueueRead(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: Offset 0
         int eventId = objectBuffer.enqueueRead(executionPlanId, getFieldValue(ref), 0, (useDeps) ? events : null, useDeps);
@@ -65,7 +63,7 @@ public class FieldBuffer {
 
     public List<Integer> enqueueWrite(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         List<Integer> eventsIds = objectBuffer.enqueueWrite(executionPlanId, getFieldValue(ref), 0, 0, (useDeps) ? events : null, useDeps);
         return (useDeps) ? eventsIds : Collections.emptyList();
@@ -76,7 +74,7 @@ public class FieldBuffer {
         try {
             value = field.get(container);
         } catch (IllegalArgumentException | IllegalAccessException e) {
-            warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
+            TornadoLogger.warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
         }
         return value;
     }
@@ -99,7 +97,7 @@ public class FieldBuffer {
 
     public void write(long executionPlanId, final Object ref) {
         if (DEBUG) {
-            trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         objectBuffer.write(executionPlanId, getFieldValue(ref));
     }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/FieldBuffer.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/FieldBuffer.java
@@ -23,10 +23,10 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
 import java.util.Collections;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
@@ -39,7 +39,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public abstract class PTXArrayWrapper<T> implements XPUBuffer {
 
@@ -210,7 +210,7 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
 
         this.buffer = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
             info("allocated: %s", toString());
         }
@@ -224,7 +224,7 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
         buffer = INIT_VALUE;
         bufferSize = INIT_VALUE;
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
             info("deallocated: %s", toString());
         }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
@@ -26,8 +26,6 @@ package uk.ac.manchester.tornado.drivers.ptx.mm;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -39,6 +37,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public abstract class PTXArrayWrapper<T> implements XPUBuffer {
@@ -108,7 +107,7 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
         final int numElements = header.getInt(arrayLengthOffset);
         final boolean valid = numElements == Array.getLength(array);
         if (!valid) {
-            fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
+            TornadoLogger.fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
             header.dump(8);
         }
         return valid;
@@ -211,8 +210,8 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
         this.buffer = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            info("allocated: %s", toString());
+            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            TornadoLogger.info("allocated: %s", toString());
         }
     }
 
@@ -225,8 +224,9 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            info("deallocated: %s", toString());
+            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset,
+                    arrayHeaderSize);
+            TornadoLogger.info("deallocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
@@ -26,7 +26,6 @@ package uk.ac.manchester.tornado.drivers.ptx.mm;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.VALIDATE_ARRAY_HEADERS;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 
@@ -99,17 +98,8 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
         if (array == null) {
             throw new TornadoRuntimeException("[ERROR] output data is NULL");
         }
-        if (VALIDATE_ARRAY_HEADERS) {
-            if (validateArrayHeader(executionPlanId, array)) {
-                return readArrayData(executionPlanId, toBuffer() + arrayHeaderSize, bufferSize - arrayHeaderSize, array, hostOffset, (useDeps) ? events : null);
-            } else {
-                shouldNotReachHere("Array header is invalid");
-            }
-        } else {
-            final long numBytes = getSizeSubRegionSize() > 0 ? getSizeSubRegionSize() : (bufferSize - arrayHeaderSize);
-            return readArrayData(executionPlanId, toBuffer() + arrayHeaderSize, numBytes, array, hostOffset, (useDeps) ? events : null);
-        }
-        return -1;
+        final long numBytes = getSizeSubRegionSize() > 0 ? getSizeSubRegionSize() : (bufferSize - arrayHeaderSize);
+        return readArrayData(executionPlanId, toBuffer() + arrayHeaderSize, numBytes, array, hostOffset, (useDeps) ? events : null);
     }
 
     private boolean validateArrayHeader(long executionPlanId, T array) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
@@ -37,8 +37,8 @@ import uk.ac.manchester.tornado.api.types.images.TornadoImagesInterface;
 import uk.ac.manchester.tornado.api.types.matrix.TornadoMatrixInterface;
 import uk.ac.manchester.tornado.api.types.volumes.TornadoVolumesInterface;
 import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.exceptions.TornadoUnsupportedError;
 
 public class PTXMemorySegmentWrapper implements XPUBuffer {
@@ -183,7 +183,7 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
             throw new TornadoMemoryException(STR."[ERROR] Bytes Allocated <= 0: \{bufferSize}");
         }
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             TornadoLogger.info("allocated: %s", toString());
         }
     }
@@ -195,7 +195,7 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             TornadoLogger.info("deallocated: %s", toString());
         }
     }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMultiDimArrayWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMultiDimArrayWrapper.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
-
 import java.lang.reflect.Array;
 import java.util.function.Function;
 
@@ -32,6 +30,7 @@ import jdk.vm.ci.meta.JavaKind;
 import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
 import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class PTXMultiDimArrayWrapper<T, E> extends PTXArrayWrapper<T> {
 
@@ -113,7 +112,7 @@ public class PTXMultiDimArrayWrapper<T, E> extends PTXArrayWrapper<T> {
                 addresses[i] = wrappers[i].toBuffer();
             }
         } catch (TornadoOutOfMemoryException | TornadoMemoryException e) {
-            fatal("OOM: multi-dim array: %s", e.getMessage());
+            TornadoLogger.fatal("OOM: multi-dim array: %s", e.getMessage());
             System.exit(-1);
         }
     }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
@@ -27,8 +27,6 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
@@ -89,7 +87,7 @@ public class PTXObjectWrapper implements XPUBuffer {
             final Class<?> type = reflectedField.getType();
 
             if (DEBUG) {
-                trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
+                TornadoLogger.trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
             }
 
             XPUBuffer wrappedField = null;
@@ -107,7 +105,7 @@ public class PTXObjectWrapper implements XPUBuffer {
                 } else if (type == byte[].class) {
                     wrappedField = new PTXByteArrayWrapper(deviceContext);
                 } else {
-                    warn("cannot wrap field: array type=%s", type.getName());
+                    TornadoLogger.warn("cannot wrap field: array type=%s", type.getName());
                 }
             } else if (type == FloatArray.class) {
                 Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
@@ -262,7 +260,7 @@ public class PTXObjectWrapper implements XPUBuffer {
                 HotSpotResolvedJavaField field = fields[i];
                 Field f = getField(type, field.getName());
                 if (DEBUG) {
-                    trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    TornadoLogger.trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
 
                 buffer.position(field.getOffset());
@@ -282,7 +280,7 @@ public class PTXObjectWrapper implements XPUBuffer {
                 Field f = getField(type, field.getName());
                 f.setAccessible(true);
                 if (DEBUG) {
-                    trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    TornadoLogger.trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
                 readFieldFromBuffer(i, f, object);
             }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
@@ -27,10 +27,10 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
@@ -27,7 +27,6 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
@@ -53,6 +52,7 @@ import uk.ac.manchester.tornado.api.types.arrays.LongArray;
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.utils.TornadoUtils;
 
 public class PTXObjectWrapper implements XPUBuffer {
@@ -152,13 +152,13 @@ public class PTXObjectWrapper implements XPUBuffer {
     @Override
     public void allocate(Object reference, long batchSize) {
         if (DEBUG) {
-            debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
+            TornadoLogger.debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
         }
 
         this.address = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(getObjectSize());
 
         if (DEBUG) {
-            debug("object: object=0x%x @ address 0x%x", reference.hashCode(), address);
+            TornadoLogger.debug("object: object=0x%x @ address 0x%x", reference.hashCode(), address);
         }
         for (FieldBuffer buffer : wrappedFields) {
             if (buffer != null) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
@@ -25,7 +25,6 @@ package uk.ac.manchester.tornado.drivers.ptx.mm;
 
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -296,7 +295,7 @@ public class PTXVectorWrapper implements XPUBuffer {
             } else if (type == HalfFloat[].class) {
                 return JavaKind.Object;
             } else {
-                warn("cannot wrap field: array type=%s", type.getName());
+                TornadoLogger.warn("cannot wrap field: array type=%s", type.getName());
             }
         } else if (type == FloatArray.class || type == IntArray.class || type == DoubleArray.class || type == LongArray.class || type == ShortArray.class || type == CharArray.class || type == ByteArray.class || type == HalfFloatArray.class) {
             return JavaKind.Object;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
@@ -25,7 +25,6 @@ package uk.ac.manchester.tornado.drivers.ptx.mm;
 
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 
 import java.lang.reflect.Array;
@@ -50,6 +49,7 @@ import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.utils.TornadoUtils;
 
@@ -98,8 +98,8 @@ public class PTXVectorWrapper implements XPUBuffer {
         this.buffer = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            info("allocated: %s", toString());
+            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            TornadoLogger.info("allocated: %s", toString());
         }
 
     }
@@ -113,8 +113,9 @@ public class PTXVectorWrapper implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            info("deallocated: %s", toString());
+            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset,
+                    arrayHeaderSize);
+            TornadoLogger.info("deallocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
@@ -50,7 +50,7 @@ import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.utils.TornadoUtils;
 
 public class PTXVectorWrapper implements XPUBuffer {
@@ -97,7 +97,7 @@ public class PTXVectorWrapper implements XPUBuffer {
 
         this.buffer = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
             info("allocated: %s", toString());
         }
@@ -112,7 +112,7 @@ public class PTXVectorWrapper implements XPUBuffer {
         buffer = INIT_VALUE;
         bufferSize = INIT_VALUE;
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
             info("deallocated: %s", toString());
         }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PrimitiveSerialiser.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PrimitiveSerialiser.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -23,9 +23,9 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.mm;
 
-import uk.ac.manchester.tornado.runtime.common.Tornado;
-
 import java.nio.ByteBuffer;
+
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 // FIXME <REFACTOR> Remove this class (common.mm)
 public class PrimitiveSerialiser {
@@ -52,7 +52,7 @@ public class PrimitiveSerialiser {
         } else if (value instanceof Double) {
             buffer.putDouble((double) value);
         } else {
-            Tornado.warn("unable to serialise: %s (%s)", value, value.getClass().getName());
+            TornadoLogger.warn("unable to serialise: %s (%s)", value, value.getClass().getName());
         }
 
         if (alignment != 0) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/power/PTXNvidiaPowerMetric.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/power/PTXNvidiaPowerMetric.java
@@ -25,8 +25,7 @@ package uk.ac.manchester.tornado.drivers.ptx.power;
 
 import uk.ac.manchester.tornado.drivers.common.power.PowerMetric;
 import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
-
-import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class PTXNvidiaPowerMetric implements PowerMetric {
     private final PTXDeviceContext deviceContext;
@@ -47,7 +46,7 @@ public class PTXNvidiaPowerMetric implements PowerMetric {
         try {
             ptxNvmlInit();
         } catch (RuntimeException e) {
-            error(e.getMessage());
+            TornadoLogger.error(e.getMessage());
         }
     }
 
@@ -56,7 +55,7 @@ public class PTXNvidiaPowerMetric implements PowerMetric {
         try {
             ptxNvmlDeviceGetHandleByIndex(this.deviceContext.getDevice().getDeviceIndex(), device);
         } catch (RuntimeException e) {
-            error(e.getMessage());
+            TornadoLogger.error(e.getMessage());
         }
     }
 
@@ -65,7 +64,7 @@ public class PTXNvidiaPowerMetric implements PowerMetric {
         try {
             ptxNvmlDeviceGetPowerUsage(device, powerUsage);
         } catch (RuntimeException e) {
-            error(e.getMessage());
+            TornadoLogger.error(e.getMessage());
         }
     }
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -81,7 +81,6 @@ import uk.ac.manchester.tornado.drivers.ptx.mm.PTXVectorWrapper;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
@@ -127,7 +126,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public int[] checkAtomicsForTask(SchedulableTask task) {
-        Tornado.debug("[PTX] Atomics not implemented ! Returning null");
+        TornadoLogger.debug("[PTX] Atomics not implemented ! Returning null");
         return null;
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -192,7 +192,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
             profiler.sum(ProfilerType.TOTAL_DRIVER_COMPILE_TIME, profiler.getTaskTimer(ProfilerType.TASK_COMPILE_DRIVER_TIME, taskMeta.getId()));
             return installedCode;
         } catch (Exception e) {
-            if (Tornado.DEBUG) {
+            if (TornadoOptions.DEBUG) {
                 System.err.println(e.getMessage());
             }
             TornadoLogger.fatal("unable to compile %s for device %s\n", task.getId(), getDeviceName());

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackend.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackend.java
@@ -134,7 +134,6 @@ import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.SPIRVNodeMatchRules
 import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.SPIRVReferenceMapBuilder;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.mm.SPIRVKernelStackFrame;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graal.backend.XPUBackend;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
@@ -449,18 +448,18 @@ public class SPIRVBackend extends XPUBackend<SPIRVProviders> implements FrameMap
             }
         }
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             Logger.traceCodeGen(Logger.BACKEND.SPIRV, "found %d variable, expected (%d)", variableCount.get(), expectedVariables);
         }
 
         int index = 0;
         for (SPIRVKind spirvKind : kindToVariable.keySet()) {
-            if (Tornado.FULL_DEBUG) {
+            if (TornadoOptions.FULL_DEBUG) {
                 Logger.traceCodeGen(Logger.BACKEND.SPIRV, "VARIABLES -------------- ");
                 Logger.traceCodeGen(Logger.BACKEND.SPIRV, "\tTYPE: " + spirvKind);
             }
             for (Variable var : kindToVariable.get(spirvKind)) {
-                if (Tornado.FULL_DEBUG) {
+                if (TornadoOptions.FULL_DEBUG) {
                     Logger.traceCodeGen(Logger.BACKEND.SPIRV, "\tNAME: " + var);
                 }
                 SPIRVId variable = asm.module.getNextId();

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
@@ -38,7 +38,6 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoDeviceNotFound;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVHotSpotBackendFactory;
 import uk.ac.manchester.tornado.runtime.TornadoAcceleratorBackend;
 import uk.ac.manchester.tornado.runtime.TornadoVMConfigAccess;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoSuitesProvider;
@@ -104,7 +103,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
     private SPIRVBackend checkAndInitBackend(int platformIndex, int deviceIndex) {
         SPIRVBackend backend = backends[platformIndex][deviceIndex];
         if (!backend.isInitialised()) {
-            Tornado.info("SPIRV Backend Initialization");
+            TornadoLogger.info("SPIRV Backend Initialization");
             backend.init();
         }
         return backend;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
@@ -48,7 +48,6 @@ import uk.ac.manchester.tornado.drivers.spirv.timestamps.LevelZeroTransferTimeSt
 import uk.ac.manchester.tornado.drivers.spirv.timestamps.TimeStamp;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
@@ -182,7 +181,7 @@ public abstract class SPIRVDeviceContext implements TornadoDeviceContext {
     }
 
     public void reset(long executionPlanId) {
-        spirvEventPool.put(executionPlanId, new SPIRVEventPool(Tornado.EVENT_WINDOW));
+        spirvEventPool.put(executionPlanId, new SPIRVEventPool(TornadoOptions.EVENT_WINDOW));
         codeCache.reset();
         wasReset = true;
     }
@@ -326,7 +325,7 @@ public abstract class SPIRVDeviceContext implements TornadoDeviceContext {
 
     private SPIRVEventPool getEventPool(long executionPlanId) {
         if (!spirvEventPool.containsKey(executionPlanId)) {
-            SPIRVEventPool eventPool = new SPIRVEventPool(Tornado.EVENT_WINDOW);
+            SPIRVEventPool eventPool = new SPIRVEventPool(TornadoOptions.EVENT_WINDOW);
             spirvEventPool.put(executionPlanId, eventPool);
         }
         return spirvEventPool.get(executionPlanId);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVEventPool.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVEventPool.java
@@ -24,8 +24,8 @@
 package uk.ac.manchester.tornado.drivers.spirv;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.EVENT_WINDOW;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.CIRCULAR_EVENTS;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.EVENT_WINDOW;
 
 import java.util.BitSet;
 import java.util.HashMap;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
@@ -52,7 +52,7 @@ import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeModuleFormat;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeModuleHandle;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeResult;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.utils.LevelZeroUtils;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
@@ -91,7 +91,7 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
         }
         long timeStamp = System.nanoTime();
         String file = STR."\{spirvTempDirectory}/\{timeStamp}-\{id}\{entryPoint}.spv";
-        if (Tornado.DEBUG) {
+        if (TornadoOptions.DEBUG) {
             System.out.println(STR."SPIRV-File : \{file}");
         }
         writeBufferToFile(buffer, file);
@@ -164,7 +164,7 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
 
         ZeKernelDescriptor kernelDesc = new ZeKernelDescriptor();
         ZeKernelHandle kernel = new ZeKernelHandle();
-        if (Tornado.DEBUG) {
+        if (TornadoOptions.DEBUG) {
             Logger.traceRuntime(Logger.BACKEND.SPIRV, STR."Set SPIR-V entry point: \{entryPoint}");
         }
         kernelDesc.setKernelName(entryPoint);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompiler.java
@@ -26,7 +26,7 @@ package uk.ac.manchester.tornado.drivers.spirv.graal.compiler;
 import static org.graalvm.compiler.phases.common.DeadCodeEliminationPhase.Optionality.Optional;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DUMP_COMPILED_METHODS;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DUMP_COMPILED_METHODS;
 
 import java.io.File;
 import java.io.IOException;
@@ -85,8 +85,8 @@ import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVProviders;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVSuitesProvider;
 import uk.ac.manchester.tornado.drivers.spirv.graal.asm.SPIRVAssembler;
 import uk.ac.manchester.tornado.runtime.common.BatchCompilationConfig;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graal.TornadoLIRSuites;
 import uk.ac.manchester.tornado.runtime.graal.TornadoSuites;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
@@ -361,7 +361,7 @@ public class SPIRVCompiler {
 
         kernelCompilationRequest.execute();
 
-        if (Tornado.DUMP_COMPILED_METHODS) {
+        if (TornadoOptions.DUMP_COMPILED_METHODS) {
             methods.add(kernelGraph.method());
             methods.addAll(kernelGraph.getMethods());
             Collections.addAll(methods, kernelCompilationResult.getMethods());
@@ -480,7 +480,8 @@ public class SPIRVCompiler {
 
         public SPIRVCompilationRequest(StructuredGraph graph, ResolvedJavaMethod installedCodeOwner, Object[] args, TaskMetaData meta, Providers providers, SPIRVBackend backend,
                 PhaseSuite<HighTierContext> graphBuilderSuite, OptimisticOptimizations optimisticOpts, ProfilingInfo profilingInfo, TornadoSuites suites, TornadoLIRSuites lirSuites,
-                SPIRVCompilationResult compilationResult, CompilationResultBuilderFactory factory, boolean isKernel, boolean buildGraph, BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
+                SPIRVCompilationResult compilationResult, CompilationResultBuilderFactory factory, boolean isKernel, boolean buildGraph, BatchCompilationConfig batchCompilationConfig,
+                TornadoProfiler profiler) {
             this.graph = graph;
             this.installedCodeOwner = installedCodeOwner;
             this.args = args;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVGraphBuilderPlugins.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVGraphBuilderPlugins.java
@@ -78,7 +78,6 @@ import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SPIRVFPUnaryIntrinsicN
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SPIRVIntBinaryIntrinsicNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SPIRVIntUnaryIntrinsicNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SlotsBaseAddressNode;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.directives.CompilerInternals;
 
@@ -363,7 +362,7 @@ public class SPIRVGraphBuilderPlugins {
     }
 
     private static void registerTornadoVMIntrinsicsPlugins(Plugins plugins) {
-        if (Tornado.DEBUG) {
+        if (TornadoOptions.DEBUG) {
             Logger.traceRuntime(Logger.BACKEND.SPIRV, "SPIRV Registering VM Intrinsics Plugins - pending");
         }
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVVectorNodePlugin.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVVectorNodePlugin.java
@@ -32,16 +32,11 @@ import jdk.vm.ci.meta.ResolvedJavaType;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.vector.SPIRVVectorValueNode;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 
 public class SPIRVVectorNodePlugin implements NodePlugin {
 
     @Override
     public boolean handleNewInstance(GraphBuilderContext builderContext, ResolvedJavaType type) {
-        // FIXME <REFACTOR> I think vectors should be mandatory for TornadoVM
-        if (!Tornado.ENABLE_VECTORS) {
-            return false;
-        }
         if (type.getAnnotation(Vector.class) != null) {
             return createVectorInstance(builderContext, type);
         }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoTaskSpecialization.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoTaskSpecialization.java
@@ -63,7 +63,6 @@ import uk.ac.manchester.tornado.drivers.common.compiler.phases.analysis.TornadoV
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoopUnroller;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SPIRVKernelContextAccessNode;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
@@ -385,7 +384,7 @@ public class TornadoTaskSpecialization extends BasePhase<TornadoHighTierContext>
         });
 
         if (iterations == MAX_ITERATIONS) {
-            Tornado.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
+            TornadoLogger.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
         }
         TornadoLogger.debug("TaskSpecialisation ran %d iterations", iterations);
         TornadoLogger.debug("valid graph? %s", graph.verify());

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoTaskSpecialization.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoTaskSpecialization.java
@@ -64,6 +64,7 @@ import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoop
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SPIRVKernelContextAccessNode;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
 
@@ -386,8 +387,8 @@ public class TornadoTaskSpecialization extends BasePhase<TornadoHighTierContext>
         if (iterations == MAX_ITERATIONS) {
             Tornado.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
         }
-        Tornado.debug("TaskSpecialisation ran %d iterations", iterations);
-        Tornado.debug("valid graph? %s", graph.verify());
+        TornadoLogger.debug("TaskSpecialisation ran %d iterations", iterations);
+        TornadoLogger.debug("valid graph? %s", graph.verify());
         index = 0;
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/FieldBuffer.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/FieldBuffer.java
@@ -23,7 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
@@ -32,6 +31,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 // FIXME <REFACTOR> This entire class can be common for all three backends
 public class FieldBuffer {
@@ -76,7 +76,7 @@ public class FieldBuffer {
 
     public int read(long executionPlanId, final Object ref, int[] events, boolean useDeps) {
         if (DEBUG) {
-            debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: reading with offset != 0
         return objectBuffer.read(executionPlanId, getFieldValue(ref), 0, 0, events, useDeps);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/FieldBuffer.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/FieldBuffer.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
@@ -47,7 +45,7 @@ public class FieldBuffer {
 
     public int enqueueRead(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: Offset 0
         return (useDeps) ? objectBuffer.enqueueRead(executionPlanId, getFieldValue(ref), 0, (useDeps) ? events : null, useDeps) : -1;
@@ -55,7 +53,7 @@ public class FieldBuffer {
 
     public List<Integer> enqueueWrite(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         return (useDeps) ? objectBuffer.enqueueWrite(executionPlanId, getFieldValue(ref), 0, 0, (useDeps) ? events : null, useDeps) : null;
     }
@@ -65,7 +63,7 @@ public class FieldBuffer {
         try {
             value = field.get(container);
         } catch (IllegalArgumentException | IllegalAccessException e) {
-            warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
+            TornadoLogger.warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
         }
         return value;
     }
@@ -84,7 +82,7 @@ public class FieldBuffer {
 
     public void write(long executionPlanId, final Object ref) {
         if (DEBUG) {
-            trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            TornadoLogger.trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         objectBuffer.write(executionPlanId, getFieldValue(ref));
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/FieldBuffer.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/FieldBuffer.java
@@ -23,10 +23,10 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
 import java.util.List;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
@@ -38,7 +38,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
 
@@ -255,7 +255,7 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
 
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
             info("allocated: %s", toString());
         }
@@ -270,7 +270,7 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
             info("deallocated: %s", toString());
         }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
@@ -23,9 +23,7 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv.mm;
 
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.VALIDATE_ARRAY_HEADERS;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 
@@ -149,18 +147,8 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
         if (array == null) {
             throw new TornadoRuntimeException("[ERROR] output data is NULL");
         }
-
-        if (VALIDATE_ARRAY_HEADERS) {
-            if (validateArrayHeader(executionPlanId, array)) {
-                return readArrayData(executionPlanId, toBuffer(), bufferOffset + arrayHeaderSize, bufferSize - arrayHeaderSize, array, hostOffset, (useDeps) ? events : null);
-            } else {
-                shouldNotReachHere("Array header is invalid");
-            }
-        } else {
-            final long numBytes = getSizeSubRegionSize() > 0 ? getSizeSubRegionSize() : (bufferSize - arrayHeaderSize);
-            return readArrayData(executionPlanId, toBuffer(), bufferOffset + arrayHeaderSize, numBytes, array, hostOffset, (useDeps) ? events : null);
-        }
-        return -1;
+        final long numBytes = getSizeSubRegionSize() > 0 ? getSizeSubRegionSize() : (bufferSize - arrayHeaderSize);
+        return readArrayData(executionPlanId, toBuffer(), bufferOffset + arrayHeaderSize, numBytes, array, hostOffset, (useDeps) ? events : null);
     }
 
     // FIXME <REFACTOR> <Same for all backends>

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
@@ -24,8 +24,6 @@
 package uk.ac.manchester.tornado.drivers.spirv.mm;
 
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -38,6 +36,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
@@ -135,7 +134,7 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
         final int numElements = header.getInt(arrayLengthOffset);
         final boolean valid = numElements == Array.getLength(array);
         if (!valid) {
-            fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
+            TornadoLogger.fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
             header.dump(8);
         }
         return valid;
@@ -256,8 +255,8 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            info("allocated: %s", toString());
+            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            TornadoLogger.info("allocated: %s", toString());
         }
 
     }
@@ -271,8 +270,9 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            info("deallocated: %s", toString());
+            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset,
+                    arrayHeaderSize);
+            TornadoLogger.info("deallocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
@@ -22,8 +22,6 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
-
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +36,7 @@ import uk.ac.manchester.tornado.api.types.images.TornadoImagesInterface;
 import uk.ac.manchester.tornado.api.types.matrix.TornadoMatrixInterface;
 import uk.ac.manchester.tornado.api.types.volumes.TornadoVolumesInterface;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.exceptions.TornadoUnsupportedError;
 
@@ -183,7 +182,7 @@ public class SPIRVMemorySegmentWrapper implements XPUBuffer {
         }
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("allocated: %s", toString());
+            TornadoLogger.info("allocated: %s", toString());
         }
     }
 
@@ -194,7 +193,7 @@ public class SPIRVMemorySegmentWrapper implements XPUBuffer {
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
         if (TornadoOptions.FULL_DEBUG) {
-            info("allocated: %s", toString());
+            TornadoLogger.info("allocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
@@ -38,7 +38,6 @@ import uk.ac.manchester.tornado.api.types.images.TornadoImagesInterface;
 import uk.ac.manchester.tornado.api.types.matrix.TornadoMatrixInterface;
 import uk.ac.manchester.tornado.api.types.volumes.TornadoVolumesInterface;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.exceptions.TornadoUnsupportedError;
 
@@ -183,7 +182,7 @@ public class SPIRVMemorySegmentWrapper implements XPUBuffer {
             throw new TornadoMemoryException("[ERROR] Bytes Allocated <= 0: " + bufferSize);
         }
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("allocated: %s", toString());
         }
     }
@@ -194,7 +193,7 @@ public class SPIRVMemorySegmentWrapper implements XPUBuffer {
         spirvDeviceContext.getBufferProvider().markBufferReleased(bufferId);
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("allocated: %s", toString());
         }
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMultiDimArrayWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMultiDimArrayWrapper.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv.mm;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
-
 import java.lang.reflect.Array;
 import java.util.function.Function;
 
@@ -32,6 +30,7 @@ import jdk.vm.ci.meta.JavaKind;
 import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class SPIRVMultiDimArrayWrapper<T, E> extends SPIRVArrayWrapper<T> {
 
@@ -71,7 +70,7 @@ public class SPIRVMultiDimArrayWrapper<T, E> extends SPIRVArrayWrapper<T> {
                 addresses[i] = wrappers[i].toBuffer();
             }
         } catch (TornadoOutOfMemoryException | TornadoMemoryException e) {
-            fatal("OOM: multi-dim array: %s", e.getMessage());
+            TornadoLogger.fatal("OOM: multi-dim array: %s", e.getMessage());
             throw new RuntimeException(e);
         }
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
@@ -27,7 +27,6 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
@@ -55,6 +54,7 @@ import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.drivers.common.mm.PrimitiveSerialiser;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.utils.TornadoUtils;
 
 // FIXME <REFACTOR> This class can be common for the three backends.
@@ -169,7 +169,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
     @Override
     public void allocate(Object reference, long batchSize) throws TornadoOutOfMemoryException, TornadoMemoryException {
         if (DEBUG) {
-            debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
+            TornadoLogger.debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
         }
 
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(size());
@@ -177,7 +177,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
         setBuffer(new XPUBufferWrapper(bufferId, bufferOffset));
 
         if (DEBUG) {
-            debug("object: object=0x%x @ bufferId 0x%x", reference.hashCode(), bufferId);
+            TornadoLogger.debug("object: object=0x%x @ bufferId 0x%x", reference.hashCode(), bufferId);
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
@@ -27,10 +27,10 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.DEBUG;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
@@ -27,8 +27,6 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMConfig;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getVMRuntime;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.trace;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEBUG;
 
 import java.lang.reflect.Field;
@@ -92,7 +90,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
             final Class<?> type = reflectedField.getType();
 
             if (DEBUG) {
-                trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
+                TornadoLogger.trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
             }
 
             XPUBuffer wrappedField = null;
@@ -113,7 +111,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
                 } else if (type == byte[].class) {
                     wrappedField = new SPIRVByteArrayWrapper((byte[]) objectFromField, deviceContext, 0);
                 } else {
-                    warn("cannot wrap field: array type=%s", type.getName());
+                    TornadoLogger.warn("cannot wrap field: array type=%s", type.getName());
                 }
             } else if (type == FloatArray.class) {
                 Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
@@ -269,7 +267,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
                 HotSpotResolvedJavaField field = fields[i];
                 Field f = getField(objectType, field.getName());
                 if (DEBUG) {
-                    trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    TornadoLogger.trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
 
                 buffer.position(field.getOffset());
@@ -289,7 +287,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
                 Field f = getField(objectType, field.getName());
                 f.setAccessible(true);
                 if (DEBUG) {
-                    trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    TornadoLogger.trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
                 readFieldFromBuffer(i, f, object);
             }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
@@ -24,7 +24,6 @@
 package uk.ac.manchester.tornado.drivers.spirv.mm;
 
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
@@ -351,7 +350,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
             } else if (type == HalfFloat[].class) {
                 return JavaKind.Object;
             } else {
-                warn("cannot wrap field: array type=%s", type.getName());
+                TornadoLogger.warn("cannot wrap field: array type=%s", type.getName());
             }
         } else if (type == FloatArray.class || type == IntArray.class || type == DoubleArray.class || type == LongArray.class || type == ShortArray.class || type == CharArray.class || type == ByteArray.class || type == HalfFloatArray.class) {
             return JavaKind.Object;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
@@ -49,7 +49,6 @@ import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.utils.TornadoUtils;
 
@@ -95,7 +94,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
 
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
         }
@@ -110,7 +109,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
 
-        if (Tornado.FULL_DEBUG) {
+        if (TornadoOptions.FULL_DEBUG) {
             info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
             info("deallocated: %s", toString());

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
@@ -24,7 +24,6 @@
 package uk.ac.manchester.tornado.drivers.spirv.mm;
 
 import static uk.ac.manchester.tornado.runtime.common.RuntimeUtilities.humanReadableByteCount;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.warn;
 
 import java.lang.reflect.Array;
@@ -49,6 +48,7 @@ import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.utils.TornadoUtils;
 
@@ -95,7 +95,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
+            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
         }
 
@@ -110,9 +110,9 @@ public class SPIRVVectorWrapper implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
+            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
-            info("deallocated: %s", toString());
+            TornadoLogger.info("deallocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/timestamps/LevelZeroKernelTimeStamp.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/timestamps/LevelZeroKernelTimeStamp.java
@@ -41,7 +41,7 @@ import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeEventScopeFlags;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeHostMemAllocDescriptor;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeKernelTimeStampResult;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.utils.LevelZeroUtils;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class LevelZeroKernelTimeStamp {
@@ -116,7 +116,7 @@ public class LevelZeroKernelTimeStamp {
 
         resultKernel.resolve(timeStampBuffer);
 
-        if (Tornado.DEBUG) {
+        if (TornadoOptions.DEBUG) {
             resultKernel.printTimers();
         }
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
@@ -55,7 +55,6 @@ import uk.ac.manchester.tornado.api.TornadoBackend;
 import uk.ac.manchester.tornado.api.TornadoRuntimeInterface;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBackendNotFound;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.enums.TornadoBackends;
@@ -158,7 +157,7 @@ public final class TornadoCoreRuntime implements TornadoRuntimeInterface {
         TornadoAcceleratorBackend[] tornadoAcceleratorBackends = new TornadoAcceleratorBackend[TornadoBackends.values().length];
         int index = 0;
         for (TornadoBackendProvider provider : providerList) {
-            if (Tornado.FULL_DEBUG) {
+            if (TornadoOptions.FULL_DEBUG) {
                 System.out.println("[INFO] TornadoVM Loading Backend: " + provider.getName());
             }
             TornadoAcceleratorBackend backend = provider.createBackend(options, vmRuntime, vmConfig);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
@@ -25,7 +25,6 @@ package uk.ac.manchester.tornado.runtime;
 
 import static org.graalvm.compiler.debug.GraalError.guarantee;
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.SHOULD_LOAD_RMI;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -160,15 +159,12 @@ public final class TornadoCoreRuntime implements TornadoRuntimeInterface {
         int index = 0;
         for (TornadoBackendProvider provider : providerList) {
             if (Tornado.FULL_DEBUG) {
-                System.out.println(STR."[INFO] Loading Backend: \{provider}");
+                System.out.println("[INFO] TornadoVM Loading Backend: " + provider.getName());
             }
-            boolean isRMI = provider.getName().equalsIgnoreCase("RMI Backend");
-            if ((!isRMI) || (isRMI && SHOULD_LOAD_RMI)) {
-                TornadoAcceleratorBackend backend = provider.createBackend(options, vmRuntime, vmConfig);
-                if (backend != null) {
-                    tornadoAcceleratorBackends[index] = backend;
-                    index++;
-                }
+            TornadoAcceleratorBackend backend = provider.createBackend(options, vmRuntime, vmConfig);
+            if (backend != null) {
+                tornadoAcceleratorBackends[index] = backend;
+                index++;
             }
         }
         backendCount = index;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -54,7 +54,7 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task8;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task9;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.domain.DomainTree;
 import uk.ac.manchester.tornado.runtime.domain.IntDomain;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
@@ -124,7 +124,7 @@ public class TaskUtils {
             m.setAccessible(true);
             return m;
         } catch (SecurityException | IllegalArgumentException | ClassNotFoundException | IllegalAccessException | InvocationTargetException e) {
-            Tornado.debug("HotSpotJDKReflection::getMethod is missing from the JDK distribution. Falling back to HotSpotResolvedJavaMethodImpl::toJava");
+            TornadoLogger.debug("HotSpotJDKReflection::getMethod is missing from the JDK distribution. Falling back to HotSpotResolvedJavaMethodImpl::toJava");
             useToJavaMethod = true;
             return callToJava(javaMethod);
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
@@ -124,7 +124,7 @@ public class BatchConfiguration {
         int totalChunks = (int) (totalSize / batchSize);
         int remainingChunkSize = (int) (totalSize % batchSize);
 
-        if (Tornado.DEBUG) {
+        if (TornadoOptions.DEBUG) {
             System.out.println(STR."Batch Size: \{batchSize}");
             System.out.println(STR."Total chunks: \{totalChunks}");
             System.out.println(STR."remainingChunkSize: \{remainingChunkSize}");

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.runtime.common;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.error;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.PRINT_SOURCE_DIRECTORY;
 
 import java.io.BufferedReader;
@@ -437,10 +435,10 @@ public final class RuntimeUtilities {
             writeStringToFile(loggingDirectory + FPGA_OUTPUT_FILENAME, standardOutput.toString(), true);
             writeStringToFile(loggingDirectory + FPGA_ERROR_FILENAME, errorOutput.toString(), true);
         } catch (IOException e) {
-            error("Unable to make a native system call.", e);
+            TornadoLogger.error("Unable to make a native system call.", e);
             throw new IOException(e);
         } catch (Throwable t) {
-            error("Unable to make a native system call.", t);
+            TornadoLogger.error("Unable to make a native system call.", t);
             throw new TornadoRuntimeException(t.getMessage());
         }
     }
@@ -449,7 +447,7 @@ public final class RuntimeUtilities {
         try (FileOutputStream fos = (append ? new FileOutputStream(file, true) : new FileOutputStream(file))) {
             fos.write(source);
         } catch (IOException e) {
-            error("unable to dump source: ", e.getMessage());
+            TornadoLogger.error("unable to dump source: ", e.getMessage());
             throw new RuntimeException("unable to dump source: " + e.getMessage());
         }
 
@@ -462,14 +460,14 @@ public final class RuntimeUtilities {
             bw.flush();
             bw.close();
         } catch (IOException e) {
-            error("unable to dump source: ", e.getMessage());
+            TornadoLogger.error("unable to dump source: ", e.getMessage());
             throw new RuntimeException("unable to dump source: " + e.getMessage());
         }
 
     }
 
     public static void writeToFile(String file, byte[] binary) {
-        info("dumping binary %s", file);
+        TornadoLogger.info("dumping binary %s", file);
         try (FileOutputStream fis = new FileOutputStream(file);) {
             fis.write(binary);
         } catch (IOException e) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -48,7 +48,6 @@ public final class Tornado implements TornadoSettingInterface {
     public static final boolean ENABLE_VECTORS = Boolean.parseBoolean(settings.getProperty("tornado.vectors.enable", "True"));
     public static final boolean TORNADO_ENABLE_BIFS = Boolean.parseBoolean(settings.getProperty("tornado.bifs.enable", "False"));
     public static final boolean DEBUG = Boolean.parseBoolean(settings.getProperty("tornado.debug", "False"));
-    public static final boolean FPGA_DUMP_LOG = Boolean.parseBoolean(settings.getProperty("tornado.fpgaDumpLog", "False"));
 
     private static final String TORNADO_SDK_VARIABLE = "TORNADO_SDK";
     public static boolean FORCE_BLOCKING_API_CALLS = false;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -47,7 +47,6 @@ public final class Tornado implements TornadoSettingInterface {
 
     public static final boolean ENABLE_VECTORS = Boolean.parseBoolean(settings.getProperty("tornado.vectors.enable", "True"));
     public static final boolean TORNADO_ENABLE_BIFS = Boolean.parseBoolean(settings.getProperty("tornado.bifs.enable", "False"));
-    public static final boolean DEBUG = Boolean.parseBoolean(settings.getProperty("tornado.debug", "False"));
 
     private static final String TORNADO_SDK_VARIABLE = "TORNADO_SDK";
     public static boolean FORCE_BLOCKING_API_CALLS = false;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -38,8 +38,6 @@ public final class Tornado implements TornadoSettingInterface {
 
     private static final Properties settings = System.getProperties();
 
-    public static final int EVENT_WINDOW = Integer.parseInt(getProperty("tornado.eventpool.size", "1024"));
-    public static final int MAX_WAIT_EVENTS = Integer.parseInt(getProperty("tornado.eventpool.maxwaitevents", "32"));
     public static final boolean DUMP_COMPILED_METHODS = Boolean.parseBoolean(getProperty("tornado.compiled.dump", "False"));
     public static final boolean ENABLE_PROFILING = Boolean.parseBoolean(settings.getProperty("tornado.profiling.enable", "True"));
     public static final boolean ENABLE_OOO_EXECUTION = Boolean.parseBoolean(settings.getProperty("tornado.ooo-execution.enable", "False"));

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -38,14 +38,6 @@ public final class Tornado implements TornadoSettingInterface {
 
     private static final Properties settings = System.getProperties();
 
-    public static final boolean DUMP_COMPILED_METHODS = Boolean.parseBoolean(getProperty("tornado.compiled.dump", "False"));
-    public static final boolean ENABLE_PROFILING = Boolean.parseBoolean(settings.getProperty("tornado.profiling.enable", "True"));
-    public static final boolean ENABLE_OOO_EXECUTION = Boolean.parseBoolean(settings.getProperty("tornado.ooo-execution.enable", "False"));
-    public static final boolean VM_USE_DEPS = Boolean.parseBoolean(Tornado.getProperty("tornado.vm.deps", "False"));
-
-    public static final boolean ENABLE_VECTORS = Boolean.parseBoolean(settings.getProperty("tornado.vectors.enable", "True"));
-    public static final boolean TORNADO_ENABLE_BIFS = Boolean.parseBoolean(settings.getProperty("tornado.bifs.enable", "False"));
-
     private static final String TORNADO_SDK_VARIABLE = "TORNADO_SDK";
     public static boolean FORCE_BLOCKING_API_CALLS = false;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -30,16 +30,14 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
-import uk.ac.manchester.tornado.api.TornadoCI;
+import uk.ac.manchester.tornado.api.TornadoSettingInterface;
 
-public final class Tornado implements TornadoCI {
+public final class Tornado implements TornadoSettingInterface {
 
     public static final TornadoLogger log = new TornadoLogger(TornadoLogger.class);
 
     private static final Properties settings = System.getProperties();
-    public static final boolean VALIDATE_ARRAY_HEADERS = Boolean.parseBoolean(settings.getProperty("tornado.opencl.array.validate", "False"));
 
-    public static final boolean MARKER_USE_BARRIER = Boolean.parseBoolean(settings.getProperty("tornado.opencl.marker.asbarrier", "False"));
     public static final boolean DEBUG_KERNEL_ARGS = Boolean.parseBoolean(settings.getProperty("tornado.debug.kernelargs", "False"));
     public static final boolean USE_SYNC_FLUSH = Boolean.parseBoolean(settings.getProperty("tornado.opencl.syncflush", "False"));
     public static final boolean USE_VM_FLUSH = Boolean.parseBoolean(settings.getProperty("tornado.opencl.vmflush", "True"));
@@ -49,7 +47,6 @@ public final class Tornado implements TornadoCI {
     public static final boolean ENABLE_PROFILING = Boolean.parseBoolean(settings.getProperty("tornado.profiling.enable", "True"));
     public static final boolean ENABLE_OOO_EXECUTION = Boolean.parseBoolean(settings.getProperty("tornado.ooo-execution.enable", "False"));
     public static final boolean VM_USE_DEPS = Boolean.parseBoolean(Tornado.getProperty("tornado.vm.deps", "False"));
-    public static final int UNROLL_FACTOR = Integer.parseInt(getProperty("tornado.unroll.factor", "2"));
 
     public static final boolean ENABLE_VECTORS = Boolean.parseBoolean(settings.getProperty("tornado.vectors.enable", "True"));
     public static final boolean TORNADO_ENABLE_BIFS = Boolean.parseBoolean(settings.getProperty("tornado.bifs.enable", "False"));

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -38,8 +38,6 @@ public final class Tornado implements TornadoSettingInterface {
 
     private static final Properties settings = System.getProperties();
 
-    public static final boolean USE_SYNC_FLUSH = Boolean.parseBoolean(settings.getProperty("tornado.opencl.syncflush", "False"));
-    public static final boolean USE_VM_FLUSH = Boolean.parseBoolean(settings.getProperty("tornado.opencl.vmflush", "True"));
     public static final int EVENT_WINDOW = Integer.parseInt(getProperty("tornado.eventpool.size", "1024"));
     public static final int MAX_WAIT_EVENTS = Integer.parseInt(getProperty("tornado.eventpool.maxwaitevents", "32"));
     public static final boolean DUMP_COMPILED_METHODS = Boolean.parseBoolean(getProperty("tornado.compiled.dump", "False"));

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -91,34 +91,6 @@ public final class Tornado implements TornadoSettingInterface {
         loadSettings(tornadoRoot + "/etc/tornado.properties");
     }
 
-    public static void debug(final String pattern, final Object... args) {
-        debug(String.format(pattern, args));
-    }
-
-    public static void error(final String msg) {
-        log.error(msg);
-    }
-
-    public static void error(final String pattern, final Object... args) {
-        error(String.format(pattern, args));
-    }
-
-    public static void fatal(final String msg) {
-        log.fatal(msg);
-    }
-
-    public static void fatal(final String pattern, final Object... args) {
-        fatal(String.format(pattern, args));
-    }
-
-    public static void info(final String msg) {
-        log.info(msg);
-    }
-
-    public static void info(final String pattern, final Object... args) {
-        info(String.format(pattern, args));
-    }
-
     public static void trace(final String msg) {
         log.trace(msg);
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, 2024, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,12 +34,9 @@ import uk.ac.manchester.tornado.api.TornadoSettingInterface;
 
 public final class Tornado implements TornadoSettingInterface {
 
-    public static final TornadoLogger log = new TornadoLogger(TornadoLogger.class);
+    private static final String TORNADO_SDK_VARIABLE = "TORNADO_SDK";
 
     private static final Properties settings = System.getProperties();
-
-    private static final String TORNADO_SDK_VARIABLE = "TORNADO_SDK";
-    public static boolean FORCE_BLOCKING_API_CALLS = false;
 
     static {
         tryLoadSettings();
@@ -57,10 +54,6 @@ public final class Tornado implements TornadoSettingInterface {
         return settings.getProperty(key, defaultValue);
     }
 
-    public static void debug(final String msg) {
-        log.debug(msg);
-    }
-
     private static void loadSettings(String filename) {
         final File localSettings = new File(filename);
         Properties loadProperties = new Properties();
@@ -68,43 +61,19 @@ public final class Tornado implements TornadoSettingInterface {
             try (FileInputStream fileInputStream = new FileInputStream(localSettings)) {
                 loadProperties.load(fileInputStream);
             } catch (IOException e) {
-                warn("Unable to load settings from %s", localSettings.getAbsolutePath());
+                TornadoLogger.warn("Unable to load settings from %s", localSettings.getAbsolutePath());
             }
         }
-        /*
-         * merge local and system properties, note that command line arguments override
-         * saved properties
-         */
         Set<String> localKeys = loadProperties.stringPropertyNames();
         Set<String> systemKeys = settings.stringPropertyNames();
         Set<String> diff = new HashSet<>(localKeys);
         diff.removeAll(systemKeys);
-
-        for (String key : diff) {
-            settings.setProperty(key, loadProperties.getProperty(key));
-        }
-        FORCE_BLOCKING_API_CALLS = Boolean.parseBoolean(settings.getProperty("tornado.opencl.blocking", "False"));
+        diff.forEach(key -> settings.setProperty(key, loadProperties.getProperty(key)));
     }
 
     private static void tryLoadSettings() {
         final String tornadoRoot = System.getenv(TORNADO_SDK_VARIABLE);
         loadSettings(tornadoRoot + "/etc/tornado.properties");
-    }
-
-    public static void trace(final String msg) {
-        log.trace(msg);
-    }
-
-    public static void trace(final String pattern, final Object... args) {
-        trace(String.format(pattern, args));
-    }
-
-    public static void warn(final String msg) {
-        log.warn(msg);
-    }
-
-    public static void warn(final String pattern, final Object... args) {
-        warn(String.format(pattern, args));
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -38,7 +38,6 @@ public final class Tornado implements TornadoSettingInterface {
 
     private static final Properties settings = System.getProperties();
 
-    public static final boolean DEBUG_KERNEL_ARGS = Boolean.parseBoolean(settings.getProperty("tornado.debug.kernelargs", "False"));
     public static final boolean USE_SYNC_FLUSH = Boolean.parseBoolean(settings.getProperty("tornado.opencl.syncflush", "False"));
     public static final boolean USE_VM_FLUSH = Boolean.parseBoolean(settings.getProperty("tornado.opencl.vmflush", "True"));
     public static final int EVENT_WINDOW = Integer.parseInt(getProperty("tornado.eventpool.size", "1024"));

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -53,7 +53,6 @@ public final class Tornado implements TornadoSettingInterface {
     public static final boolean DEBUG = Boolean.parseBoolean(settings.getProperty("tornado.debug", "False"));
     public static final boolean FPGA_DUMP_LOG = Boolean.parseBoolean(settings.getProperty("tornado.fpgaDumpLog", "False"));
 
-    public static final boolean FULL_DEBUG = Boolean.parseBoolean(settings.getProperty("tornado.fullDebug", "False"));
     private static final String TORNADO_SDK_VARIABLE = "TORNADO_SDK";
     public static boolean FORCE_BLOCKING_API_CALLS = false;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -54,7 +54,6 @@ public final class Tornado implements TornadoSettingInterface {
     public static final boolean FPGA_DUMP_LOG = Boolean.parseBoolean(settings.getProperty("tornado.fpgaDumpLog", "False"));
 
     public static final boolean FULL_DEBUG = Boolean.parseBoolean(settings.getProperty("tornado.fullDebug", "False"));
-    public static final boolean SHOULD_LOAD_RMI = Boolean.parseBoolean(settings.getProperty("tornado.rmi.enable", "false"));
     private static final String TORNADO_SDK_VARIABLE = "TORNADO_SDK";
     public static boolean FORCE_BLOCKING_API_CALLS = false;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoLogger.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoLogger.java
@@ -30,7 +30,7 @@ public class TornadoLogger {
 
     private static Logger logger;
 
-    static boolean isLogOptionEnabled = Tornado.DEBUG || TornadoOptions.FULL_DEBUG;
+    static boolean isLogOptionEnabled = TornadoOptions.DEBUG || TornadoOptions.FULL_DEBUG;
 
     public TornadoLogger(Class<?> clazz) {
         logger = Logger.getLogger(clazz == null ? this.getClass().getName() : clazz.getName());

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoLogger.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoLogger.java
@@ -93,11 +93,19 @@ public class TornadoLogger {
         }
     }
 
+    public static void trace(final String pattern, final Object... args) {
+        trace(String.format(pattern, args));
+    }
+
     public static void warn(final String msg) {
         if (isLogOptionEnabled) {
             logger.setLevel(Level.WARNING);
             logger.warning(msg);
         }
+    }
+
+    public static void warn(final String msg, final Object... args) {
+        trace(String.format(msg, args));
     }
 
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoLogger.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoLogger.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -30,7 +30,7 @@ public class TornadoLogger {
 
     private static Logger logger;
 
-    static boolean isLogOptionEnabled = Tornado.DEBUG || Tornado.FULL_DEBUG;
+    static boolean isLogOptionEnabled = Tornado.DEBUG || TornadoOptions.FULL_DEBUG;
 
     public TornadoLogger(Class<?> clazz) {
         logger = Logger.getLogger(clazz == null ? this.getClass().getName() : clazz.getName());

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -338,6 +338,16 @@ public class TornadoOptions {
     public static final boolean DEBUG_KERNEL_ARGS = getBooleanValue("tornado.debug.kernelargs", FALSE);
 
     /**
+     * Use flush in OpenCL to sync all pending commands from the command queue. Disabled by default.
+     */
+    public static final boolean USE_SYNC_FLUSH = getBooleanValue("tornado.opencl.syncflush", FALSE);
+
+    /**
+     * Run VM Flush when TornadoVM finishes the execution of the TornadoVM interpreter.
+     */
+    public static final boolean USE_VM_FLUSH = getBooleanValue("tornado.vmflush", TRUE);
+
+    /**
      * Option for enabling partial loop unrolling. The unroll factor can be
      * configured to take any integer value of power of 2 and less than 32.
      *

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -323,6 +323,11 @@ public class TornadoOptions {
     }
 
     /**
+     * Set Loop unrolling factor for the FPGA compilation. Default is set to 2.
+     */
+    public static final int UNROLL_FACTOR = Integer.parseInt(getProperty("tornado.unroll.factor", "2"));
+
+    /**
      * Option for enabling partial loop unrolling. The unroll factor can be
      * configured to take any integer value of power of 2 and less than 32.
      *

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -267,7 +267,7 @@ public class TornadoOptions {
      * Option to run concurrently on multiple device in single or multi-backend
      * configuration. False by default.
      */
-    public static final boolean CONCURRENT_INTERPRETERS = Boolean.parseBoolean(System.getProperty("tornado.concurrent.devices", "False"));
+    public static final boolean CONCURRENT_INTERPRETERS = Boolean.parseBoolean(System.getProperty("tornado.concurrent.devices", FALSE));
 
     /**
      * Panama Object Header in TornadoVM.
@@ -330,7 +330,12 @@ public class TornadoOptions {
     /**
      * Enable Full Debug Mode. Disabled by default.
      */
-    public static final boolean FULL_DEBUG = getBooleanValue("tornado.fullDebug", "False");
+    public static final boolean FULL_DEBUG = getBooleanValue("tornado.fullDebug", FALSE);
+
+    /**
+     * Enable debugging of the kernel parameters. Disable by default.
+     */
+    public static final boolean DEBUG_KERNEL_ARGS = getBooleanValue("tornado.debug.kernelargs", FALSE);
 
     /**
      * Option for enabling partial loop unrolling. The unroll factor can be

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -328,6 +328,11 @@ public class TornadoOptions {
     public static final int UNROLL_FACTOR = Integer.parseInt(getProperty("tornado.unroll.factor", "2"));
 
     /**
+     * Enable basic debug information. Disabled by default.
+     */
+    public static final boolean DEBUG = getBooleanValue("tornado.debug", FALSE);
+
+    /**
      * Enable Full Debug Mode. Disabled by default.
      */
     public static final boolean FULL_DEBUG = getBooleanValue("tornado.fullDebug", FALSE);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -353,6 +353,16 @@ public class TornadoOptions {
     public static final boolean USE_VM_FLUSH = getBooleanValue("tornado.vmflush", TRUE);
 
     /**
+     * Define the maximum number of events to wait for in the OpenCL Event Pool. Default is 64.
+     */
+    public static final int MAX_WAIT_EVENTS = getIntValue("tornado.eventpool.maxwaitevents", "64");
+
+    /**
+     * Define the event windows for the Internal Event Pool. Default is 1024.
+     */
+    public static final int EVENT_WINDOW = getIntValue("tornado.eventpool.size", "1024");
+
+    /**
      * Option for enabling partial loop unrolling. The unroll factor can be
      * configured to take any integer value of power of 2 and less than 32.
      *

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -363,6 +363,31 @@ public class TornadoOptions {
     public static final int EVENT_WINDOW = getIntValue("tornado.eventpool.size", "1024");
 
     /**
+     * Enable BIFS Math operations. Disabled by default.
+     */
+    public static final boolean TORNADO_ENABLE_BIFS = getBooleanValue("tornado.bifs.enable", FALSE);
+
+    /**
+     * Enable VM Dependency Path. Disabled by default. This option is only for testing.
+     */
+    public static final boolean VM_USE_DEPS = getBooleanValue("tornado.vm.deps", FALSE);
+
+    /**
+     * Enable OpenCL Profiling. Enabled by default.
+     */
+    public static final boolean ENABLE_OPENCL_PROFILING = getBooleanValue("tornado.opencl.profiling.enable", TRUE);
+
+    /**
+     * Enable to dump the generated methods to a file for debugging purposes. Disabled by default.
+     */
+    public static final boolean DUMP_COMPILED_METHODS = getBooleanValue("tornado.compiled.dump", FALSE);
+
+    /**
+     * Enable out-of-order execution. False by default.
+     */
+    public static final boolean ENABLE_OOO_EXECUTION = getBooleanValue("tornado.ooo-execution.enable", FALSE);
+
+    /**
      * Option for enabling partial loop unrolling. The unroll factor can be
      * configured to take any integer value of power of 2 and less than 32.
      *

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -328,6 +328,11 @@ public class TornadoOptions {
     public static final int UNROLL_FACTOR = Integer.parseInt(getProperty("tornado.unroll.factor", "2"));
 
     /**
+     * Enable Full Debug Mode. Disabled by default.
+     */
+    public static final boolean FULL_DEBUG = getBooleanValue("tornado.fullDebug", "False");
+
+    /**
      * Option for enabling partial loop unrolling. The unroll factor can be
      * configured to take any integer value of power of 2 and less than 32.
      *

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoDataflowAnalysis.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoDataflowAnalysis.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.runtime.graal.phases.sketcher;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.debug;
-
 import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.Optional;
@@ -60,6 +58,7 @@ import org.graalvm.compiler.phases.BasePhase;
 import jdk.vm.ci.meta.Constant;
 import jdk.vm.ci.meta.MetaAccessProvider;
 import uk.ac.manchester.tornado.api.common.Access;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelRangeNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.ParallelStrideNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.StoreAtomicIndexedNode;
@@ -80,7 +79,7 @@ public class TornadoDataflowAnalysis extends BasePhase<TornadoSketchTierContext>
             if (param != null && param.stamp(NodeView.DEFAULT) instanceof ObjectStamp) {
                 accesses[i] = processUsages(param, context.getMetaAccess());
             }
-            debug("access: parameter %d -> %s\n", i, accesses[i]);
+            TornadoLogger.debug("access: parameter %d -> %s\n", i, accesses[i]);
         }
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.runtime.graph;
 
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
-
 import java.lang.reflect.Array;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -57,6 +55,7 @@ import uk.ac.manchester.tornado.api.types.vectors.TornadoVectorsInterface;
 import uk.ac.manchester.tornado.api.types.volumes.TornadoVolumesInterface;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
@@ -326,7 +325,7 @@ public class TornadoExecutionContext {
 
         setDevice(accelerator);
 
-        info("assigning %s to %s", id, target.getDeviceName());
+        TornadoLogger.info("assigning %s to %s", id, target.getDeviceName());
 
         taskToDeviceMapTable[index] = accelerator;
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
@@ -28,7 +28,7 @@ import java.util.BitSet;
 
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.runtime.common.BatchConfiguration;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graph.nodes.AbstractNode;
 import uk.ac.manchester.tornado.runtime.graph.nodes.ContextOpNode;
@@ -61,7 +61,7 @@ public class TornadoVMGraphCompiler {
 
         intermediateTornadoGraph.analyzeDependencies();
 
-        Tornado.debug("Compiling bytecodes...");
+        TornadoLogger.debug("Compiling bytecodes...");
 
         for (int i = 0; i < tornadoVMBytecodeResults.length; i++) {
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -24,8 +24,8 @@
 package uk.ac.manchester.tornado.runtime.interpreter;
 
 import static uk.ac.manchester.tornado.api.enums.TornadoExecutionStatus.COMPLETE;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.VM_USE_DEPS;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEVICE_ENABLED;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VM_USE_DEPS;
 
 import java.util.Arrays;
 import java.util.BitSet;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -52,7 +52,6 @@ import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
@@ -766,7 +765,7 @@ public class TornadoVMInterpreter {
             resetEventIndexes(eventList);
             return lastEvent;
         } catch (Exception e) {
-            if (Tornado.DEBUG) {
+            if (TornadoOptions.DEBUG) {
                 e.printStackTrace();
             }
             throw new TornadoBailoutRuntimeException("Bailout from LAUNCH Bytecode: \nReason: " + e.toString(), e);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -24,7 +24,6 @@
 package uk.ac.manchester.tornado.runtime.interpreter;
 
 import static uk.ac.manchester.tornado.api.enums.TornadoExecutionStatus.COMPLETE;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.ENABLE_PROFILING;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.VM_USE_DEPS;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEVICE_ENABLED;
 
@@ -200,7 +199,7 @@ public class TornadoVMInterpreter {
     }
 
     public void dumpEvents() {
-        if (!ENABLE_PROFILING || !executionContext.meta().shouldDumpEvents()) {
+        if (!TornadoOptions.TORNADO_PROFILER || !executionContext.meta().shouldDumpEvents()) {
             TornadoLogger.info("profiling and/or event dumping is not enabled");
             return;
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -25,7 +25,6 @@ package uk.ac.manchester.tornado.runtime.interpreter;
 
 import static uk.ac.manchester.tornado.api.enums.TornadoExecutionStatus.COMPLETE;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.ENABLE_PROFILING;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.USE_VM_FLUSH;
 import static uk.ac.manchester.tornado.runtime.common.Tornado.VM_USE_DEPS;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEVICE_ENABLED;
 
@@ -366,7 +365,7 @@ public class TornadoVMInterpreter {
                 barrier = deviceForInterpreter.resolveEvent(executionContext.getExecutionPlanId(), event);
             }
 
-            if (USE_VM_FLUSH) {
+            if (TornadoOptions.USE_VM_FLUSH) {
                 deviceForInterpreter.flush(executionContext.getExecutionPlanId());
             }
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
@@ -30,8 +30,6 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guara
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getDebugContext;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getOptions;
 import static uk.ac.manchester.tornado.runtime.TornadoCoreRuntime.getTornadoExecutor;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.fatal;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.info;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -67,6 +65,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.OCLTokens;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCompilerIdentifier;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoSketchTier;
@@ -110,7 +109,7 @@ public class TornadoSketcher {
             }
             guarantee(sketch != null, "No sketch available for %d:%d %s", driverIndex, deviceIndex, resolvedMethod.getName());
         } catch (InterruptedException | ExecutionException e) {
-            fatal("Failed to retrieve sketch for %d:%d %s ", driverIndex, deviceIndex, resolvedMethod.getName());
+            TornadoLogger.fatal("Failed to retrieve sketch for %d:%d %s ", driverIndex, deviceIndex, resolvedMethod.getName());
             if (TornadoOptions.DEBUG) {
                 e.printStackTrace();
             }
@@ -137,7 +136,7 @@ public class TornadoSketcher {
 
     private static Sketch buildSketch(ResolvedJavaMethod resolvedMethod, Providers providers, PhaseSuite<HighTierContext> graphBuilderSuite, TornadoSketchTier sketchTier, int backendIndex,
             int deviceIndex) {
-        info("Building sketch of %s", resolvedMethod.getName());
+        TornadoLogger.info("Building sketch of %s", resolvedMethod.getName());
         TornadoCompilerIdentifier id = new TornadoCompilerIdentifier("sketch-" + resolvedMethod.getName(), sketchId.getAndIncrement());
         Builder builder = new Builder(getOptions(), getDebugContext(), AllowAssumptions.YES);
         builder.method(resolvedMethod);
@@ -183,7 +182,7 @@ public class TornadoSketcher {
             return new Sketch(graph.copy(TornadoCoreRuntime.getDebugContext()), methodAccesses, highTierContext.getBatchWriteThreadIndex());
 
         } catch (Throwable e) {
-            fatal("unable to build sketch for method: %s (%s)", resolvedMethod.getName(), e.getMessage());
+            TornadoLogger.fatal("unable to build sketch for method: %s (%s)", resolvedMethod.getName(), e.getMessage());
             if (TornadoOptions.DEBUG) {
                 e.printStackTrace();
             }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
@@ -67,7 +67,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.OCLTokens;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoCompilerIdentifier;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoSketchTier;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoSketchTierContext;
@@ -111,7 +111,7 @@ public class TornadoSketcher {
             guarantee(sketch != null, "No sketch available for %d:%d %s", driverIndex, deviceIndex, resolvedMethod.getName());
         } catch (InterruptedException | ExecutionException e) {
             fatal("Failed to retrieve sketch for %d:%d %s ", driverIndex, deviceIndex, resolvedMethod.getName());
-            if (Tornado.DEBUG) {
+            if (TornadoOptions.DEBUG) {
                 e.printStackTrace();
             }
             final Throwable cause = e.getCause();
@@ -184,7 +184,7 @@ public class TornadoSketcher {
 
         } catch (Throwable e) {
             fatal("unable to build sketch for method: %s (%s)", resolvedMethod.getName(), e.getMessage());
-            if (Tornado.DEBUG) {
+            if (TornadoOptions.DEBUG) {
                 e.printStackTrace();
             }
             throw new TornadoBailoutRuntimeException(STR."Unable to build sketch for method: \{resolvedMethod.getName()}(\{e.getMessage()})");

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -904,7 +904,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     @Override
     public void waitOn() {
-        if (Tornado.VM_USE_DEPS && event != null) {
+        if (TornadoOptions.VM_USE_DEPS && event != null) {
             event.waitOn();
         } else {
             for (TornadoXPUDevice tornadoXPUDevice : executionContext.getDevices()) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -105,7 +105,7 @@ import uk.ac.manchester.tornado.runtime.analyzer.ReduceCodeAnalysis;
 import uk.ac.manchester.tornado.runtime.analyzer.TaskUtils;
 import uk.ac.manchester.tornado.runtime.common.BatchConfiguration;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.Tornado;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.TornadoVMClient;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
@@ -962,7 +962,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     public void transferToHost(final int mode, Object... objects) {
         for (Object functionParameter : objects) {
             if (functionParameter == null) {
-                Tornado.warn("null object passed into streamIn() in schedule %s", executionContext.getId());
+                TornadoLogger.warn("null object passed into streamIn() in schedule %s", executionContext.getId());
                 continue;
             }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -796,7 +796,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         }
 
         if (compile) {
-            if (Tornado.DEBUG) {
+            if (TornadoOptions.DEBUG) {
                 System.out.println("[DEBUG] JIT compilation for the FPGA");
             }
             compileTaskToOpenCL();
@@ -830,7 +830,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     private void dumpDeoptimisationReason(TornadoBailoutRuntimeException e) {
-        if (!Tornado.DEBUG) {
+        if (!TornadoOptions.DEBUG) {
             System.err.println(STR."\{RED}[Bailout] Running the sequential implementation. Enable --debug to see the reason.\{RESET}");
         }else
 
@@ -863,7 +863,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             if (TornadoOptions.RECOVER_BAILOUT) {
                 deoptimiseToSequentialJava(e);
             } else {
-                if (Tornado.DEBUG) {
+                if (TornadoOptions.DEBUG) {
                     e.printStackTrace();
                 }
                 throw new TornadoBailoutRuntimeException(STR."Bailout is disabled. \nReason: \{e.getMessage()}");
@@ -1536,7 +1536,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             for (int i = 0; i < threads.length; i++) {
                 isAlive = threads[i].isAlive();
                 if (!isAlive) {
-                    if (Tornado.DEBUG) {
+                    if (TornadoOptions.DEBUG) {
                         System.out.println(STR."SELECTED Thread-Device: \{threads[i].getName()} ");
                     }
                     winner = i;
@@ -1578,7 +1578,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             final long start = timer.time();
             runAllTasksJavaSequential();
             final long endSequentialCode = timer.time();
-            if (Tornado.DEBUG) {
+            if (TornadoOptions.DEBUG) {
                 System.out.println(STR."Seq finished: \{Thread.currentThread().getName()}");
             }
 
@@ -1602,7 +1602,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 for (TaskPackage taskPackage : taskPackages) {
                     String taskID = taskPackage.getId();
                     TornadoRuntime.setProperty(STR."\{newTaskScheduleName}.\{taskID}.device", STR."0:\{taskScheduleNumber}");
-                    if (Tornado.DEBUG) {
+                    if (TornadoOptions.DEBUG) {
                         System.out.println(STR."SET DEVICE: \{newTaskScheduleName}.\{taskID}.device=0:\{taskScheduleNumber}");
                     }
                     task.addTask(taskPackage);
@@ -1683,7 +1683,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         if ((policy == Policy.PERFORMANCE || policy == Policy.END_2_END) && (masterThreadID == Thread.currentThread().getId())) {
             int deviceWinnerIndex = synchronizeWithPolicy(policy, totalTimers);
             policyTimeTable.put(policy, deviceWinnerIndex);
-            if (Tornado.DEBUG) {
+            if (TornadoOptions.DEBUG) {
                 System.out.println(getListDevices());
                 System.out.println(STR."BEST Position: #\{deviceWinnerIndex} \{Arrays.toString(totalTimers)}");
             }
@@ -1714,7 +1714,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         for (TaskPackage taskPackage : taskPackages) {
             TornadoRuntime.setProperty(STR."\{this.getTaskGraphName()}.\{taskPackage.getId()}.device", STR."0:\{deviceWinnerIndex}");
         }
-        if (Tornado.DEBUG) {
+        if (TornadoOptions.DEBUG) {
             System.out.println(STR."Running in parallel device: \{deviceWinnerIndex}");
         }
         TaskGraph task = taskGraphIndex.get(deviceWinnerIndex);
@@ -1828,7 +1828,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 }
 
                 TornadoRuntime.setProperty(STR."\{newTaskScheduleName}.\{taskID}.device", "0:" + taskNumber);
-                if (Tornado.DEBUG) {
+                if (TornadoOptions.DEBUG) {
                     System.out.println(STR."SET DEVICE: \{newTaskScheduleName}.\{taskID}.device=0:\{taskNumber}");
                 }
                 task.addTask(taskPackage);
@@ -1941,7 +1941,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
             updateHistoryTables(policy, deviceWinnerIndex);
 
-            if (Tornado.DEBUG) {
+            if (TornadoOptions.DEBUG) {
                 System.out.println(getListDevices());
                 System.out.println(STR."BEST Position: #\{deviceWinnerIndex} \{Arrays.toString(totalTimers)}");
             }
@@ -1995,7 +1995,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     private TornadoTaskGraphInterface scheduleDynamicReconfigurationSequential(Policy policy) {
 
         if (policy == Policy.LATENCY) {
-            if (Tornado.DEBUG) {
+            if (TornadoOptions.DEBUG) {
                 System.out.println("[WARNING]: LATENCY policy using the DRMode.SERIAL is not allowed. Changing to PERFORMANCE mode");
             }
             policy = Policy.PERFORMANCE;
@@ -2170,7 +2170,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             addInner(index, type, method, meta, id, parameters);
         } catch (TornadoBailoutRuntimeException e) {
             this.bailout = true;
-            if (!Tornado.DEBUG) {
+            if (!TornadoOptions.DEBUG) {
                 System.out.println(WARNING_DEOPT_MESSAGE);
             }
             throw e;
@@ -2198,7 +2198,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             addInner(type, method, meta, id, parameters);
         } catch (TornadoBailoutRuntimeException e) {
             this.bailout = true;
-            if (!Tornado.DEBUG) {
+            if (!TornadoOptions.DEBUG) {
                 System.out.println(WARNING_DEOPT_MESSAGE);
             }
             throw e; // Rethrow the same exception

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
@@ -24,7 +24,7 @@
 package uk.ac.manchester.tornado.runtime.tasks.meta;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.guarantee;
-import static uk.ac.manchester.tornado.runtime.common.Tornado.EVENT_WINDOW;
+import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.EVENT_WINDOW;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;


### PR DESCRIPTION
### Description

All options are moved to the `TornadoOptions` class and the debugger is moved to the `TornadoLogger`. 

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make BACKEND=opencl,spirv,ptx
make tests
```
