### PR TITLE
Vector types for Float<With> with Int<Width> supported at the API-level

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float16.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float16.java
@@ -68,6 +68,22 @@ public final class Float16 implements TornadoVectorsInterface<FloatBuffer> {
         return result;
     }
 
+    public static Float16 add(Int16 a, Float16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) + b.get(i));
+        }
+        return result;
+    }
+
+    public static Float16 add(Float16 a, Int16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) + b.get(i));
+        }
+        return result;
+    }
+
     public static Float16 add(Float16 a, float b) {
         final Float16 result = new Float16();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
@@ -77,6 +93,22 @@ public final class Float16 implements TornadoVectorsInterface<FloatBuffer> {
     }
 
     public static Float16 sub(Float16 a, Float16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) - b.get(i));
+        }
+        return result;
+    }
+
+    public static Float16 sub(Int16 a, Float16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) - b.get(i));
+        }
+        return result;
+    }
+
+    public static Float16 sub(Float16 a, Int16 b) {
         final Float16 result = new Float16();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
             result.set(i, a.get(i) - b.get(i));
@@ -100,6 +132,22 @@ public final class Float16 implements TornadoVectorsInterface<FloatBuffer> {
         return result;
     }
 
+    public static Float16 div(Int16 a, Float16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) / b.get(i));
+        }
+        return result;
+    }
+
+    public static Float16 div(Float16 a, Int16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) / b.get(i));
+        }
+        return result;
+    }
+
     public static Float16 div(Float16 a, float value) {
         final Float16 result = new Float16();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
@@ -109,6 +157,22 @@ public final class Float16 implements TornadoVectorsInterface<FloatBuffer> {
     }
 
     public static Float16 mult(Float16 a, Float16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) * b.get(i));
+        }
+        return result;
+    }
+
+    public static Float16 mult(Int16 a, Float16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) * b.get(i));
+        }
+        return result;
+    }
+
+    public static Float16 mult(Float16 a, Int16 b) {
         final Float16 result = new Float16();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
             result.set(i, a.get(i) * b.get(i));
@@ -132,6 +196,22 @@ public final class Float16 implements TornadoVectorsInterface<FloatBuffer> {
         return result;
     }
 
+    public static Float16 min(Int16 a, Float16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, Math.min(a.get(i), b.get(i)));
+        }
+        return result;
+    }
+
+    public static Float16 min(Float16 a, Int16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, Math.min(a.get(i), b.get(i)));
+        }
+        return result;
+    }
+
     public static float min(Float16 value) {
         float result = Float.MAX_VALUE;
         for (int i = 0; i < NUM_ELEMENTS; i++) {
@@ -141,6 +221,22 @@ public final class Float16 implements TornadoVectorsInterface<FloatBuffer> {
     }
 
     public static Float16 max(Float16 a, Float16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, Math.max(a.get(i), b.get(i)));
+        }
+        return result;
+    }
+
+    public static Float16 max(Int16 a, Float16 b) {
+        final Float16 result = new Float16();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, Math.max(a.get(i), b.get(i)));
+        }
+        return result;
+    }
+
+    public static Float16 max(Float16 a, Int16 b) {
         final Float16 result = new Float16();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
             result.set(i, Math.max(a.get(i), b.get(i)));

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float2.java
@@ -57,7 +57,23 @@ public final class Float2 implements TornadoVectorsInterface<FloatBuffer> {
         return new Float2(a.getX() + b.getX(), a.getY() + b.getY());
     }
 
+    public static Float2 add(Float2 a, Int2 b) {
+        return new Float2(a.getX() + b.getX(), a.getY() + b.getY());
+    }
+
+    public static Float2 add(Int2 a, Float2 b) {
+        return new Float2(a.getX() + b.getX(), a.getY() + b.getY());
+    }
+
     public static Float2 sub(Float2 a, Float2 b) {
+        return new Float2(a.getX() - b.getX(), a.getY() - b.getY());
+    }
+
+    public static Float2 sub(Int2 a, Float2 b) {
+        return new Float2(a.getX() - b.getX(), a.getY() - b.getY());
+    }
+
+    public static Float2 sub(Float2 a, Int2 b) {
         return new Float2(a.getX() - b.getX(), a.getY() - b.getY());
     }
 
@@ -65,7 +81,23 @@ public final class Float2 implements TornadoVectorsInterface<FloatBuffer> {
         return new Float2(a.getX() / b.getX(), a.getY() / b.getY());
     }
 
+    public static Float2 div(Int2 a, Float2 b) {
+        return new Float2(a.getX() / b.getX(), a.getY() / b.getY());
+    }
+
+    public static Float2 div(Float2 a, Int2 b) {
+        return new Float2(a.getX() / b.getX(), a.getY() / b.getY());
+    }
+
     public static Float2 mult(Float2 a, Float2 b) {
+        return new Float2(a.getX() * b.getX(), a.getY() * b.getY());
+    }
+
+    public static Float2 mult(Int2 a, Float2 b) {
+        return new Float2(a.getX() * b.getX(), a.getY() * b.getY());
+    }
+
+    public static Float2 mult(Float2 a, Int2 b) {
         return new Float2(a.getX() * b.getX(), a.getY() * b.getY());
     }
 
@@ -73,7 +105,23 @@ public final class Float2 implements TornadoVectorsInterface<FloatBuffer> {
         return new Float2(Math.min(a.getX(), b.getX()), Math.min(a.getY(), b.getY()));
     }
 
+    public static Float2 min(Int2 a, Float2 b) {
+        return new Float2(Math.min(a.getX(), b.getX()), Math.min(a.getY(), b.getY()));
+    }
+
+    public static Float2 min(Float2 a, Int2 b) {
+        return new Float2(Math.min(a.getX(), b.getX()), Math.min(a.getY(), b.getY()));
+    }
+
     public static Float2 max(Float2 a, Float2 b) {
+        return new Float2(Math.max(a.getX(), b.getX()), Math.max(a.getY(), b.getY()));
+    }
+
+    public static Float2 max(Int2 a, Float2 b) {
+        return new Float2(Math.max(a.getX(), b.getX()), Math.max(a.getY(), b.getY()));
+    }
+
+    public static Float2 max(Float2 a, Int2 b) {
         return new Float2(Math.max(a.getX(), b.getX()), Math.max(a.getY(), b.getY()));
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float3.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float3.java
@@ -53,13 +53,16 @@ public final class Float3 implements TornadoVectorsInterface<FloatBuffer> {
         setZ(z);
     }
 
-    /**
-     * * Operations on Float3 vectors.
-     */
-    /*
-     * vector = op( vector, vector )
-     */
+    // vector = op (vector, vector)
     public static Float3 add(Float3 a, Float3 b) {
+        return new Float3(a.getX() + b.getX(), a.getY() + b.getY(), a.getZ() + b.getZ());
+    }
+
+    public static Float3 add(Int3 a, Float3 b) {
+        return new Float3(a.getX() + b.getX(), a.getY() + b.getY(), a.getZ() + b.getZ());
+    }
+
+    public static Float3 add(Float3 a, Int3 b) {
         return new Float3(a.getX() + b.getX(), a.getY() + b.getY(), a.getZ() + b.getZ());
     }
 
@@ -67,7 +70,23 @@ public final class Float3 implements TornadoVectorsInterface<FloatBuffer> {
         return new Float3(a.getX() - b.getX(), a.getY() - b.getY(), a.getZ() - b.getZ());
     }
 
+    public static Float3 sub(Int3 a, Float3 b) {
+        return new Float3(a.getX() - b.getX(), a.getY() - b.getY(), a.getZ() - b.getZ());
+    }
+
+    public static Float3 sub(Float3 a, Int3 b) {
+        return new Float3(a.getX() - b.getX(), a.getY() - b.getY(), a.getZ() - b.getZ());
+    }
+
     public static Float3 div(Float3 a, Float3 b) {
+        return new Float3(a.getX() / b.getX(), a.getY() / b.getY(), a.getZ() / b.getZ());
+    }
+
+    public static Float3 div(Int3 a, Float3 b) {
+        return new Float3(a.getX() / b.getX(), a.getY() / b.getY(), a.getZ() / b.getZ());
+    }
+
+    public static Float3 div(Float3 a, Int3 b) {
         return new Float3(a.getX() / b.getX(), a.getY() / b.getY(), a.getZ() / b.getZ());
     }
 
@@ -75,7 +94,23 @@ public final class Float3 implements TornadoVectorsInterface<FloatBuffer> {
         return new Float3(a.getX() * b.getX(), a.getY() * b.getY(), a.getZ() * b.getZ());
     }
 
+    public static Float3 mult(Int3 a, Float3 b) {
+        return new Float3(a.getX() * b.getX(), a.getY() * b.getY(), a.getZ() * b.getZ());
+    }
+
+    public static Float3 mult(Float3 a, Int3 b) {
+        return new Float3(a.getX() * b.getX(), a.getY() * b.getY(), a.getZ() * b.getZ());
+    }
+
     public static Float3 min(Float3 a, Float3 b) {
+        return new Float3(Math.min(a.getX(), b.getX()), Math.min(a.getY(), b.getY()), Math.min(a.getZ(), b.getZ()));
+    }
+
+    public static Float3 min(Int3 a, Float3 b) {
+        return new Float3(Math.min(a.getX(), b.getX()), Math.min(a.getY(), b.getY()), Math.min(a.getZ(), b.getZ()));
+    }
+
+    public static Float3 min(Float3 a, Int3 b) {
         return new Float3(Math.min(a.getX(), b.getX()), Math.min(a.getY(), b.getY()), Math.min(a.getZ(), b.getZ()));
     }
 
@@ -83,13 +118,19 @@ public final class Float3 implements TornadoVectorsInterface<FloatBuffer> {
         return new Float3(Math.max(a.getX(), b.getX()), Math.max(a.getY(), b.getY()), Math.max(a.getZ(), b.getZ()));
     }
 
+    public static Float3 max(Int3 a, Float3 b) {
+        return new Float3(Math.max(a.getX(), b.getX()), Math.max(a.getY(), b.getY()), Math.max(a.getZ(), b.getZ()));
+    }
+
+    public static Float3 max(Float3 a, Int3 b) {
+        return new Float3(Math.max(a.getX(), b.getX()), Math.max(a.getY(), b.getY()), Math.max(a.getZ(), b.getZ()));
+    }
+
     public static Float3 cross(Float3 a, Float3 b) {
         return new Float3(a.getY() * b.getZ() - a.getZ() * b.getY(), a.getZ() * b.getX() - a.getX() * b.getZ(), a.getX() * b.getY() - a.getY() * b.getX());
     }
 
-    /*
-     * vector = op (vector, scalar)
-     */
+    // vector = op (vector, scalar)
     public static Float3 add(Float3 a, float b) {
         return new Float3(a.getX() + b, a.getY() + b, a.getZ() + b);
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float4.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float4.java
@@ -59,7 +59,23 @@ public final class Float4 implements TornadoVectorsInterface<FloatBuffer> {
         return new Float4(a.getX() + b.getX(), a.getY() + b.getY(), a.getZ() + b.getZ(), a.getW() + b.getW());
     }
 
+    public static Float4 add(Int4 a, Float4 b) {
+        return new Float4(a.getX() + b.getX(), a.getY() + b.getY(), a.getZ() + b.getZ(), a.getW() + b.getW());
+    }
+
+    public static Float4 add(Float4 a, Int4 b) {
+        return new Float4(a.getX() + b.getX(), a.getY() + b.getY(), a.getZ() + b.getZ(), a.getW() + b.getW());
+    }
+
     public static Float4 sub(Float4 a, Float4 b) {
+        return new Float4(a.getX() - b.getX(), a.getY() - b.getY(), a.getZ() - b.getZ(), a.getW() - b.getW());
+    }
+
+    public static Float4 sub(Int4 a, Float4 b) {
+        return new Float4(a.getX() - b.getX(), a.getY() - b.getY(), a.getZ() - b.getZ(), a.getW() - b.getW());
+    }
+
+    public static Float4 sub(Float4 a, Int4 b) {
         return new Float4(a.getX() - b.getX(), a.getY() - b.getY(), a.getZ() - b.getZ(), a.getW() - b.getW());
     }
 
@@ -67,11 +83,35 @@ public final class Float4 implements TornadoVectorsInterface<FloatBuffer> {
         return new Float4(a.getX() / b.getX(), a.getY() / b.getY(), a.getZ() / b.getZ(), a.getW() / b.getW());
     }
 
+    public static Float4 div(Int4 a, Float4 b) {
+        return new Float4(a.getX() / b.getX(), a.getY() / b.getY(), a.getZ() / b.getZ(), a.getW() / b.getW());
+    }
+
+    public static Float4 div(Float4 a, Int4 b) {
+        return new Float4(a.getX() / b.getX(), a.getY() / b.getY(), a.getZ() / b.getZ(), a.getW() / b.getW());
+    }
+
     public static Float4 mult(Float4 a, Float4 b) {
         return new Float4(a.getX() * b.getX(), a.getY() * b.getY(), a.getZ() * b.getZ(), a.getW() * b.getW());
     }
 
+    public static Float4 mult(Int4 a, Float4 b) {
+        return new Float4(a.getX() * b.getX(), a.getY() * b.getY(), a.getZ() * b.getZ(), a.getW() * b.getW());
+    }
+
+    public static Float4 mult(Float4 a, Int4 b) {
+        return new Float4(a.getX() * b.getX(), a.getY() * b.getY(), a.getZ() * b.getZ(), a.getW() * b.getW());
+    }
+
     public static Float4 min(Float4 a, Float4 b) {
+        return new Float4(Math.min(a.getX(), b.getX()), Math.min(a.getY(), b.getY()), Math.min(a.getZ(), b.getZ()), Math.min(a.getW(), b.getW()));
+    }
+
+    public static Float4 min(Int4 a, Float4 b) {
+        return new Float4(Math.min(a.getX(), b.getX()), Math.min(a.getY(), b.getY()), Math.min(a.getZ(), b.getZ()), Math.min(a.getW(), b.getW()));
+    }
+
+    public static Float4 min(Float4 a, Int4 b) {
         return new Float4(Math.min(a.getX(), b.getX()), Math.min(a.getY(), b.getY()), Math.min(a.getZ(), b.getZ()), Math.min(a.getW(), b.getW()));
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Float8.java
@@ -58,10 +58,23 @@ public final class Float8 implements TornadoVectorsInterface<FloatBuffer> {
         setS7(s7);
     }
 
-    /**
-     * * Operations on Float8 vectors.
-     */
     public static Float8 add(Float8 a, Float8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) + b.get(i));
+        }
+        return result;
+    }
+
+    public static Float8 add(Int8 a, Float8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) + b.get(i));
+        }
+        return result;
+    }
+
+    public static Float8 add(Float8 a, Int8 b) {
         final Float8 result = new Float8();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
             result.set(i, a.get(i) + b.get(i));
@@ -85,6 +98,22 @@ public final class Float8 implements TornadoVectorsInterface<FloatBuffer> {
         return result;
     }
 
+    public static Float8 sub(Int8 a, Float8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) - b.get(i));
+        }
+        return result;
+    }
+
+    public static Float8 sub(Float8 a, Int8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) - b.get(i));
+        }
+        return result;
+    }
+
     public static Float8 sub(Float8 a, float b) {
         final Float8 result = new Float8();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
@@ -94,6 +123,22 @@ public final class Float8 implements TornadoVectorsInterface<FloatBuffer> {
     }
 
     public static Float8 div(Float8 a, Float8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) / b.get(i));
+        }
+        return result;
+    }
+
+    public static Float8 div(Int8 a, Float8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) / b.get(i));
+        }
+        return result;
+    }
+
+    public static Float8 div(Float8 a, Int8 b) {
         final Float8 result = new Float8();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
             result.set(i, a.get(i) / b.get(i));
@@ -117,6 +162,22 @@ public final class Float8 implements TornadoVectorsInterface<FloatBuffer> {
         return result;
     }
 
+    public static Float8 mult(Int8 a, Float8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) * b.get(i));
+        }
+        return result;
+    }
+
+    public static Float8 mult(Float8 a, Int8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, a.get(i) * b.get(i));
+        }
+        return result;
+    }
+
     public static Float8 mult(Float8 a, float value) {
         final Float8 result = new Float8();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
@@ -133,6 +194,22 @@ public final class Float8 implements TornadoVectorsInterface<FloatBuffer> {
         return result;
     }
 
+    public static Float8 min(Int8 a, Float8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, Math.min(a.get(i), b.get(i)));
+        }
+        return result;
+    }
+
+    public static Float8 min(Float8 a, Int8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, Math.min(a.get(i), b.get(i)));
+        }
+        return result;
+    }
+
     public static float min(Float8 value) {
         float result = Float.MAX_VALUE;
         for (int i = 0; i < NUM_ELEMENTS; i++) {
@@ -142,6 +219,22 @@ public final class Float8 implements TornadoVectorsInterface<FloatBuffer> {
     }
 
     public static Float8 max(Float8 a, Float8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, Math.max(a.get(i), b.get(i)));
+        }
+        return result;
+    }
+
+    public static Float8 max(Int8 a, Float8 b) {
+        final Float8 result = new Float8();
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            result.set(i, Math.max(a.get(i), b.get(i)));
+        }
+        return result;
+    }
+
+    public static Float8 max(Float8 a, Int8 b) {
         final Float8 result = new Float8();
         for (int i = 0; i < NUM_ELEMENTS; i++) {
             result.set(i, Math.max(a.get(i), b.get(i)));

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
@@ -1071,9 +1071,10 @@ public class TestFloats extends TornadoTestBase {
         VectorFloat2 output = new VectorFloat2(size);
         VectorFloat2 seq = new VectorFloat2(size);
 
-        for (int x = 0; x < b.getLength(); x++) {
-            a.set(x, new Float2(x, x));
-            b.set(x, new Int2(1, 2));
+        Random r = new Random();
+        for (int i = 0; i < b.getLength(); i++) {
+            a.set(i, new Float2(r.nextFloat(), r.nextFloat()));
+            b.set(i, new Int2(r.nextInt(), r.nextInt()));
         }
 
         TaskGraph graph = new TaskGraph("s0") //
@@ -1102,9 +1103,10 @@ public class TestFloats extends TornadoTestBase {
         VectorFloat4 output = new VectorFloat4(size);
         VectorFloat4 seq = new VectorFloat4(size);
 
-        for (int x = 0; x < b.getLength(); x++) {
-            a.set(x, new Float4(x, x, x, x));
-            b.set(x, new Int4(0, 1, 2, 3));
+        Random r = new Random();
+        for (int i = 0; i < b.getLength(); i++) {
+            a.set(i, new Float4(r.nextFloat(), r.nextFloat(), r.nextFloat(), r.nextFloat()));
+            b.set(i, new Int4(r.nextInt(), r.nextInt(), r.nextInt(), r.nextInt()));
         }
 
         TaskGraph graph = new TaskGraph("s0") //
@@ -1135,9 +1137,26 @@ public class TestFloats extends TornadoTestBase {
         VectorFloat8 output = new VectorFloat8(size);
         VectorFloat8 seq = new VectorFloat8(size);
 
-        for (int x = 0; x < b.getLength(); x++) {
-            a.set(x, new Float8(x, x, x, x, x, x, x, x));
-            b.set(x, new Int8(0, 1, 2, 3, 3, 2, 1, 0));
+        Random r = new Random();
+        for (int i = 0; i < b.getLength(); i++) {
+            // This is very ugly to initialize, and we should have a lambda or a set
+            // of methods to facilitate initialization (e.g., via an array)
+            a.set(i, new Float8(r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat()));
+            b.set(i, new Int8(r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt()));
         }
 
         TaskGraph graph = new TaskGraph("s0") //
@@ -1167,9 +1186,43 @@ public class TestFloats extends TornadoTestBase {
         VectorFloat16 output = new VectorFloat16(size);
         VectorFloat16 seq = new VectorFloat16(size);
 
-        for (int x = 0; x < b.getLength(); x++) {
-            a.set(x, new Float16(x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x));
-            b.set(x, new Int16(0, 1, 2, 3, 3, 2, 1, 0, 0, 1, 2, 3, 3, 2, 1, 0));
+        Random r = new Random();
+        for (int i = 0; i < b.getLength(); i++) {
+            // This is very ugly to initialize, and we should have a lambda or a set
+            // of methods to facilitate initialization (e.g., via an array)
+            a.set(i, new Float16(r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat(), //
+                    r.nextFloat()));
+
+            b.set(i, new Int16(r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt(), //
+                    r.nextInt()));
         }
 
         TaskGraph graph = new TaskGraph("s0") //

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
@@ -29,6 +29,7 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat16;
@@ -36,11 +37,19 @@ import uk.ac.manchester.tornado.api.types.collections.VectorFloat2;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat3;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat8;
+import uk.ac.manchester.tornado.api.types.collections.VectorInt16;
+import uk.ac.manchester.tornado.api.types.collections.VectorInt2;
+import uk.ac.manchester.tornado.api.types.collections.VectorInt4;
+import uk.ac.manchester.tornado.api.types.collections.VectorInt8;
 import uk.ac.manchester.tornado.api.types.vectors.Float16;
 import uk.ac.manchester.tornado.api.types.vectors.Float2;
 import uk.ac.manchester.tornado.api.types.vectors.Float3;
 import uk.ac.manchester.tornado.api.types.vectors.Float4;
 import uk.ac.manchester.tornado.api.types.vectors.Float8;
+import uk.ac.manchester.tornado.api.types.vectors.Int16;
+import uk.ac.manchester.tornado.api.types.vectors.Int2;
+import uk.ac.manchester.tornado.api.types.vectors.Int4;
+import uk.ac.manchester.tornado.api.types.vectors.Int8;
 import uk.ac.manchester.tornado.unittests.common.TornadoNotSupported;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
@@ -287,6 +296,41 @@ public class TestFloats extends TornadoTestBase {
             float2.setX(value.get(i).getS0() + value.get(i).getS1());
             float2.setY(value.get(i).getS1());
             output.set(i, float2);
+        }
+    }
+
+    private static void vectorComputationMixedTypes(VectorFloat2 a, VectorInt2 b, VectorFloat2 output) {
+        for (@Parallel int i = 0; i < output.getLength(); i++) {
+            Float2 result = Float2.mult(a.get(i), b.get(i));
+            output.set(i, result);
+        }
+    }
+
+    private static void vectorComputationMixedTypes(VectorFloat4 a, VectorInt4 b, VectorFloat4 output) {
+        for (@Parallel int i = 0; i < output.getLength(); i++) {
+            Float4 result = Float4.mult(a.get(i), b.get(i));
+            output.set(i, result);
+        }
+    }
+
+    private static void vectorComputationMixedTypes(VectorFloat8 a, VectorInt8 b, VectorFloat8 output) {
+        for (@Parallel int i = 0; i < output.getLength(); i++) {
+            Float8 result = Float8.mult(a.get(i), b.get(i));
+            output.set(i, result);
+        }
+    }
+
+    private static void vectorComputationMixedTypes(VectorFloat16 a, VectorInt16 b, VectorFloat16 output) {
+        for (@Parallel int i = 0; i < output.getLength(); i++) {
+            Float16 result = Float16.mult(a.get(i), b.get(i));
+            output.set(i, result);
+        }
+    }
+
+    private static void vectorComputationMixedTypes(VectorFloat4 a, VectorFloat4 b, VectorFloat4 output) {
+        for (@Parallel int i = 0; i < output.getLength(); i++) {
+            Float4 result = Float4.mult(a.get(i), b.get(i));
+            output.set(i, result);
         }
     }
 
@@ -983,6 +1027,167 @@ public class TestFloats extends TornadoTestBase {
         VectorFloat4 buffer = new VectorFloat4(size);
         for (int x = 0; x < size; x++) {
             buffer.set(x, new Float4(x, x, x, x));
+        }
+    }
+
+    @Test
+    public void testVectorFloat4Float4() throws TornadoExecutionPlanException {
+        int size = 8192;
+        VectorFloat4 a = new VectorFloat4(size);
+        VectorFloat4 b = new VectorFloat4(size);
+        VectorFloat4 output = new VectorFloat4(size);
+        VectorFloat4 seq = new VectorFloat4(size);
+
+        for (int x = 0; x < b.getLength(); x++) {
+            a.set(x, new Float4(x, x, x, x));
+            b.set(x, new Float4(0, 1, 2, 3));
+        }
+
+        TaskGraph graph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("t0", TestFloats::vectorComputationMixedTypes, a, b, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = graph.snapshot();
+
+        vectorComputationMixedTypes(a, b, seq);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+            for (int i = 0; i < size; i++) {
+                assertEquals(seq.get(i).getX(), output.get(i).getX(), DELTA);
+                assertEquals(seq.get(i).getY(), output.get(i).getY(), DELTA);
+                assertEquals(seq.get(i).getZ(), output.get(i).getZ(), DELTA);
+                assertEquals(seq.get(i).getW(), output.get(i).getW(), DELTA);
+            }
+        }
+    }
+
+    @Test
+    public void testVectorFloat2Int2() throws TornadoExecutionPlanException {
+        int size = 8192;
+        VectorFloat2 a = new VectorFloat2(size);
+        VectorInt2 b = new VectorInt2(size);
+        VectorFloat2 output = new VectorFloat2(size);
+        VectorFloat2 seq = new VectorFloat2(size);
+
+        for (int x = 0; x < b.getLength(); x++) {
+            a.set(x, new Float2(x, x));
+            b.set(x, new Int2(1, 2));
+        }
+
+        TaskGraph graph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("t0", TestFloats::vectorComputationMixedTypes, a, b, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = graph.snapshot();
+
+        vectorComputationMixedTypes(a, b, seq);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+            for (int i = 0; i < size; i++) {
+                assertEquals(seq.get(i).getX(), output.get(i).getX(), DELTA);
+                assertEquals(seq.get(i).getY(), output.get(i).getY(), DELTA);
+            }
+        }
+    }
+
+    @Test
+    public void testVectorFloat4Int4() throws TornadoExecutionPlanException {
+        int size = 8192;
+        VectorFloat4 a = new VectorFloat4(size);
+        VectorInt4 b = new VectorInt4(size);
+        VectorFloat4 output = new VectorFloat4(size);
+        VectorFloat4 seq = new VectorFloat4(size);
+
+        for (int x = 0; x < b.getLength(); x++) {
+            a.set(x, new Float4(x, x, x, x));
+            b.set(x, new Int4(0, 1, 2, 3));
+        }
+
+        TaskGraph graph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("t0", TestFloats::vectorComputationMixedTypes, a, b, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = graph.snapshot();
+
+        vectorComputationMixedTypes(a, b, seq);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+            for (int i = 0; i < size; i++) {
+                assertEquals(seq.get(i).getX(), output.get(i).getX(), DELTA);
+                assertEquals(seq.get(i).getY(), output.get(i).getY(), DELTA);
+                assertEquals(seq.get(i).getZ(), output.get(i).getZ(), DELTA);
+                assertEquals(seq.get(i).getW(), output.get(i).getW(), DELTA);
+            }
+        }
+    }
+
+    @Test
+    public void testVectorFloat8Int8() throws TornadoExecutionPlanException {
+        int size = 8192;
+        VectorFloat8 a = new VectorFloat8(size);
+        VectorInt8 b = new VectorInt8(size);
+        VectorFloat8 output = new VectorFloat8(size);
+        VectorFloat8 seq = new VectorFloat8(size);
+
+        for (int x = 0; x < b.getLength(); x++) {
+            a.set(x, new Float8(x, x, x, x, x, x, x, x));
+            b.set(x, new Int8(0, 1, 2, 3, 3, 2, 1, 0));
+        }
+
+        TaskGraph graph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("t0", TestFloats::vectorComputationMixedTypes, a, b, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = graph.snapshot();
+
+        vectorComputationMixedTypes(a, b, seq);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+            for (int i = 0; i < size; i++) {
+                for (int k = 0; k < 8; k++) {
+                    assertEquals(seq.get(i).get(k), output.get(i).get(k), DELTA);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testVectorFloat16Int16() throws TornadoExecutionPlanException {
+        int size = 8192;
+        VectorFloat16 a = new VectorFloat16(size);
+        VectorInt16 b = new VectorInt16(size);
+        VectorFloat16 output = new VectorFloat16(size);
+        VectorFloat16 seq = new VectorFloat16(size);
+
+        for (int x = 0; x < b.getLength(); x++) {
+            a.set(x, new Float16(x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x));
+            b.set(x, new Int16(0, 1, 2, 3, 3, 2, 1, 0, 0, 1, 2, 3, 3, 2, 1, 0));
+        }
+
+        TaskGraph graph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("t0", TestFloats::vectorComputationMixedTypes, a, b, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = graph.snapshot();
+
+        vectorComputationMixedTypes(a, b, seq);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+            for (int i = 0; i < size; i++) {
+                for (int k = 0; k < 16; k++) {
+                    assertEquals(seq.get(i).get(k), output.get(i).get(k), DELTA);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
#### Description

This PR adds Float<Size> vector operations to be operate with Int<Size> vector types.
Due to OpenCL/SPIR-V restrictions, the actual operation in native code can't be done using explicit vector types. But still it is possible to operate by accessing the individual fields of the vector.

#### Problem description

Example could not use vector operations because of mismatch types. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Compile and run for all backends:

```bash
tornado-test --printKernel -V uk.ac.manchester.tornado.unittests.vectortypes.TestFloats
```
