### PR TITLE
Fix logger for all backends

### DIFF
--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/analysis/TornadoShapeAnalysis.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/analysis/TornadoShapeAnalysis.java
@@ -50,6 +50,8 @@ import uk.ac.manchester.tornado.runtime.graal.phases.TornadoHighTierContext;
  */
 public class TornadoShapeAnalysis extends BasePhase<TornadoHighTierContext> {
 
+    private TornadoLogger logger = new TornadoLogger(this.getClass());
+
     private static int getIntegerValue(ValueNode value) {
         if (value instanceof ConstantNode) {
             return value.asJavaConstant().asInt();
@@ -98,15 +100,15 @@ public class TornadoShapeAnalysis extends BasePhase<TornadoHighTierContext> {
                 domainTree.set(index, new IntDomain(getIntegerValue(range.offset().value()), getIntegerValue(range.stride().value()), getIntegerValue(range.value())));
             } else {
                 valid = false;
-                TornadoLogger.info("unsupported multiple parallel loops");
+                logger.info("unsupported multiple parallel loops");
                 break;
             }
             lastIndex = index;
         }
 
         if (valid) {
-            TornadoLogger.trace("loop nest depth = %d\n", domainTree.getDepth());
-            TornadoLogger.debug("discovered parallel domain: %s\n", domainTree);
+            logger.trace("loop nest depth = %d\n", domainTree.getDepth());
+            logger.debug("discovered parallel domain: %s\n", domainTree);
             context.getMeta().setDomain(domainTree);
         }
     }

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/mm/PrimitiveSerialiser.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/mm/PrimitiveSerialiser.java
@@ -50,7 +50,7 @@ public class PrimitiveSerialiser {
             case Float floatValue -> buffer.putFloat(floatValue);
             case Long longValue -> buffer.putLong(longValue);
             case Double doubleValue -> buffer.putDouble(doubleValue);
-            case null, default -> TornadoLogger.warn("unable to serialise: %s (%s)", value, value.getClass().getName());
+            case null, default -> new TornadoLogger().warn("unable to serialise: %s (%s)", value, value.getClass().getName());
         }
 
         if (alignment != 0) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLBackendImpl.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLBackendImpl.java
@@ -53,6 +53,7 @@ import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 
 public final class OCLBackendImpl implements TornadoAcceleratorBackend {
+
     private static final List<OCLDeviceType> DEVICE_TYPE_LIST = Arrays.asList( //
             OCLDeviceType.CL_DEVICE_TYPE_GPU, //
             OCLDeviceType.CL_DEVICE_TYPE_CPU, //
@@ -61,8 +62,8 @@ public final class OCLBackendImpl implements TornadoAcceleratorBackend {
     private final OCLBackend[][] backends;
     private final List<OCLExecutionEnvironment> contexts;
     private OCLBackend[] flatBackends;
-
     private List<TornadoDevice> devices;
+    private final TornadoLogger logger;
 
     public OCLBackendImpl(final OptionValues options, final HotSpotJVMCIRuntime vmRuntime, TornadoVMConfigAccess vmConfig) {
         final int numPlatforms = OpenCL.getNumPlatforms();
@@ -73,9 +74,11 @@ public final class OCLBackendImpl implements TornadoAcceleratorBackend {
 
         backends = new OCLBackend[numPlatforms][];
         contexts = new ArrayList<>();
+        logger = new TornadoLogger(this.getClass());
         discoverDevices(options, vmRuntime, vmConfig);
         flatBackends = flattenBackends(backends);
         flatBackends = orderFlattenBackends();
+
     }
 
     private OCLBackend[] flattenBackends(OCLBackend[][] backends) {
@@ -200,21 +203,21 @@ public final class OCLBackendImpl implements TornadoAcceleratorBackend {
     private OCLBackend createOCLJITCompiler(final OptionValues options, final HotSpotJVMCIRuntime jvmciRuntime, TornadoVMConfigAccess vmConfig, final OCLExecutionEnvironment context,
             final int deviceIndex) {
         final OCLTargetDevice device = context.devices().get(deviceIndex);
-        TornadoLogger.info("Creating backend for %s", device.getDeviceName());
+        logger.info("Creating backend for %s", device.getDeviceName());
         return OCLHotSpotBackendFactory.createJITCompiler(options, jvmciRuntime, vmConfig, context, device);
     }
 
     private void installDevices(int platformIndex, TornadoPlatformInterface platform, final OptionValues options, final HotSpotJVMCIRuntime vmRuntime, TornadoVMConfigAccess vmConfig) {
-        TornadoLogger.info("OpenCL[%d]: Platform %s", platformIndex, platform.getName());
+        logger.info("OpenCL[%d]: Platform %s", platformIndex, platform.getName());
         final OCLExecutionEnvironment context = platform.createContext();
         assert context != null : "OpenCL context is null";
         contexts.add(context);
         final int numDevices = context.getNumDevices();
-        TornadoLogger.info("OpenCL[%d]: Has %d devices...", platformIndex, numDevices);
+        logger.info("OpenCL[%d]: Has %d devices...", platformIndex, numDevices);
         backends[platformIndex] = new OCLBackend[numDevices];
         for (int deviceIndex = 0; deviceIndex < numDevices; deviceIndex++) {
             final OCLTargetDevice device = context.devices().get(deviceIndex);
-            TornadoLogger.info("OpenCL[%d]: device=%s", platformIndex, device.getDeviceName());
+            logger.info("OpenCL[%d]: device=%s", platformIndex, device.getDeviceName());
             backends[platformIndex][deviceIndex] = createOCLJITCompiler(options, vmRuntime, vmConfig, context, deviceIndex);
         }
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCommandQueue.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCommandQueue.java
@@ -38,6 +38,7 @@ import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 public class OCLCommandQueue {
 
     protected static final Event EMPTY_EVENT = new EmptyEvent();
+    private TornadoLogger logger = new TornadoLogger(this.getClass());
 
     private final long commandQueuePtr;
 
@@ -145,7 +146,7 @@ public class OCLCommandQueue {
             clGetCommandQueueInfo(commandQueuePtr, CL_QUEUE_CONTEXT.getValue(), buffer.array());
             result = buffer.getLong();
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
         return result;
@@ -158,7 +159,7 @@ public class OCLCommandQueue {
             clGetCommandQueueInfo(commandQueuePtr, CL_QUEUE_DEVICE.getValue(), buffer.array());
             result = buffer.getLong();
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
         return result;
@@ -198,7 +199,7 @@ public class OCLCommandQueue {
         try {
             return clEnqueueNDRangeKernel(commandQueuePtr, kernel.getOclKernelID(), dim, (openclVersion > 100) ? globalWorkOffset : null, globalWorkSize, localWorkSize, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -208,7 +209,7 @@ public class OCLCommandQueue {
         try {
             return writeArrayToDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -218,7 +219,7 @@ public class OCLCommandQueue {
         try {
             return writeArrayToDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -228,7 +229,7 @@ public class OCLCommandQueue {
         try {
             return writeArrayToDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -238,7 +239,7 @@ public class OCLCommandQueue {
         try {
             return writeArrayToDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -248,7 +249,7 @@ public class OCLCommandQueue {
         try {
             return writeArrayToDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -258,7 +259,7 @@ public class OCLCommandQueue {
         try {
             return writeArrayToDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -268,7 +269,7 @@ public class OCLCommandQueue {
         try {
             return writeArrayToDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -278,7 +279,7 @@ public class OCLCommandQueue {
         try {
             return writeArrayToDevice(commandQueuePtr, hostPointer, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -288,7 +289,7 @@ public class OCLCommandQueue {
         try {
             return readArrayFromDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -298,7 +299,7 @@ public class OCLCommandQueue {
         try {
             return readArrayFromDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -308,7 +309,7 @@ public class OCLCommandQueue {
         try {
             return readArrayFromDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -318,7 +319,7 @@ public class OCLCommandQueue {
         try {
             return readArrayFromDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -328,7 +329,7 @@ public class OCLCommandQueue {
         try {
             return readArrayFromDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -338,7 +339,7 @@ public class OCLCommandQueue {
         try {
             return readArrayFromDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -348,7 +349,7 @@ public class OCLCommandQueue {
         try {
             return readArrayFromDevice(commandQueuePtr, array, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -358,7 +359,7 @@ public class OCLCommandQueue {
         try {
             return readArrayFromDeviceOffHeap(commandQueuePtr, hostPointer, hostOffset, blocking, offset, bytes, devicePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -367,7 +368,7 @@ public class OCLCommandQueue {
         try {
             clFinish(commandQueuePtr);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -390,7 +391,7 @@ public class OCLCommandQueue {
                 clEnqueueWaitForEvents(commandQueuePtr, events);
             }
         } catch (OCLException e) {
-            TornadoLogger.fatal(e.getMessage());
+            logger.fatal(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
         return 0;
@@ -400,7 +401,7 @@ public class OCLCommandQueue {
         try {
             return clEnqueueBarrierWithWaitList(commandQueuePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.fatal(e.getMessage());
+            logger.fatal(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }
@@ -417,7 +418,7 @@ public class OCLCommandQueue {
         try {
             return clEnqueueMarkerWithWaitList(commandQueuePtr, waitEvents);
         } catch (OCLException e) {
-            TornadoLogger.fatal(e.getMessage());
+            logger.fatal(e.getMessage());
             throw new TornadoBailoutRuntimeException(e.getMessage());
         }
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEvent.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEvent.java
@@ -52,9 +52,11 @@ public class OCLEvent implements Event {
     private final ByteBuffer buffer = ByteBuffer.allocate(8);
     private String name;
     private int status;
+    private TornadoLogger logger;
 
     OCLEvent() {
         buffer.order(OpenCL.BYTE_ORDER);
+        this.logger = new TornadoLogger(this.getClass());
     }
 
     OCLEvent(String eventNameDescription, final OCLCommandQueue queue, final int event, final long oclEventID) {
@@ -89,7 +91,7 @@ public class OCLEvent implements Event {
             clGetEventProfilingInfo(oclEventID, eventType.getValue(), buffer.array());
             time = buffer.getLong();
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
         return time;
     }
@@ -130,7 +132,7 @@ public class OCLEvent implements Event {
             clGetEventInfo(oclEventID, CL_EVENT_COMMAND_EXECUTION_STATUS.getValue(), buffer.array());
             status = buffer.getInt();
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
 
         return createOCLCommandExecutionStatus(status);
@@ -149,7 +151,7 @@ public class OCLEvent implements Event {
                 break;
             case CL_ERROR:
             case CL_UNKNOWN:
-                TornadoLogger.fatal("error on event: %s", name);
+                logger.fatal("error on event: %s", name);
         }
     }
 
@@ -159,7 +161,7 @@ public class OCLEvent implements Event {
             internalBuffer[1] = oclEventID;
             clWaitForEvents(internalBuffer);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 
@@ -226,7 +228,7 @@ public class OCLEvent implements Event {
         try {
             clReleaseEvent(oclEventID);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventPool.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventPool.java
@@ -59,6 +59,7 @@ class OCLEventPool {
     private final OCLEvent internalEvent;
     private int eventIndex;
     private int eventPoolSize;
+    private final TornadoLogger logger;
 
     protected OCLEventPool(int poolSize) {
         this.eventPoolSize = poolSize;
@@ -70,6 +71,7 @@ class OCLEventPool {
         this.eventIndex = 0;
         this.waitEventsBuffer = new long[TornadoOptions.MAX_WAIT_EVENTS];
         this.internalEvent = new OCLEvent();
+        this.logger = new TornadoLogger(this.getClass());
     }
 
     protected int registerEvent(long oclEventId, EventDescriptor descriptorId, OCLCommandQueue queue) {
@@ -85,8 +87,8 @@ class OCLEventPool {
          * exit.
          */
         if (oclEventId == -1) {
-            TornadoLogger.fatal("invalid event: event=0x%x, description=%s, tag=0x%x\n", oclEventId, descriptorId.getNameDescription());
-            TornadoLogger.fatal("terminating application as system integrity has been compromised.");
+            logger.fatal("invalid event: event=0x%x, description=%s, tag=0x%x\n", oclEventId, descriptorId.getNameDescription());
+            logger.fatal("terminating application as system integrity has been compromised.");
             System.exit(-1);
         }
 
@@ -126,7 +128,7 @@ class OCLEventPool {
             if (value != -1) {
                 index++;
                 waitEventsBuffer[index] = events[value];
-                TornadoLogger.debug("[%d] 0x%x - %s\n", index, events[value], descriptors[value].getNameDescription());
+                logger.debug("[%d] 0x%x - %s\n", index, events[value], descriptors[value].getNameDescription());
 
             }
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLKernel.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLKernel.java
@@ -39,6 +39,7 @@ public class OCLKernel {
     private final OCLDeviceContext deviceContext;
     private final ByteBuffer buffer;
     private String kernelName;
+    private final TornadoLogger logger;
 
     public OCLKernel(long id, OCLDeviceContext deviceContext) {
         this.oclKernelID = id;
@@ -46,7 +47,7 @@ public class OCLKernel {
         this.buffer = ByteBuffer.allocate(1024);
         this.buffer.order(OpenCL.BYTE_ORDER);
         this.kernelName = "unknown";
-
+        this.logger = new TornadoLogger(this.getClass());
         queryName();
 
     }
@@ -63,7 +64,7 @@ public class OCLKernel {
         try {
             clSetKernelArg(oclKernelID, index, buffer.position(), buffer.array());
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 
@@ -72,7 +73,7 @@ public class OCLKernel {
         try {
             clSetKernelArgRef(oclKernelID, index, devicePtr);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 
@@ -80,7 +81,7 @@ public class OCLKernel {
         try {
             clSetKernelArg(oclKernelID, index, 8, null);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 
@@ -96,7 +97,7 @@ public class OCLKernel {
         try {
             clSetKernelArg(oclKernelID, index, size, null);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLCodeProvider.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLCodeProvider.java
@@ -82,7 +82,7 @@ public class OCLCodeProvider implements CodeCacheProvider {
 
     @Override
     public boolean shouldDebugNonSafepoints() {
-        TornadoLogger.warn("Debug non safe points not implemented yet.");
+        new TornadoLogger().warn("Debug non safe points not implemented yet.");
         return false;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLFrameContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLFrameContext.java
@@ -32,12 +32,12 @@ public class OCLFrameContext implements FrameContext {
 
     @Override
     public void enter(CompilationResultBuilder crb) {
-        TornadoLogger.trace("FrameContext.enter()");
+        new TornadoLogger().trace("FrameContext.enter()");
     }
 
     @Override
     public void leave(CompilationResultBuilder crb) {
-        TornadoLogger.trace("FrameContext.leave()");
+        new TornadoLogger().trace("FrameContext.leave()");
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -67,6 +67,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
     private final long[] singleThreadLocalWorkSize = new long[] { 1 };
     private final boolean isSPIRVBinary;
     private boolean valid;
+    TornadoLogger logger = new TornadoLogger(this.getClass());
 
     public OCLInstalledCode(final String entryPoint, final byte[] code, final OCLDeviceContext deviceContext, final OCLProgram program, final OCLKernel kernel, boolean isSPIRVBinary) {
         super(entryPoint);
@@ -112,13 +113,13 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
 
     public void resolveEvent(long executionPlanId, final OCLByteBuffer stack, final TaskMetaData meta, int task) {
         Event event = deviceContext.resolveEvent(executionPlanId, task);
-        TornadoLogger.debug("kernel completed: id=0x%x, method = %s, device = %s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
+        logger.debug("kernel completed: id=0x%x, method = %s, device = %s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
         if (event != null) {
-            TornadoLogger.debug("\tstatus   : %s", event.getStatus());
+            logger.debug("\tstatus   : %s", event.getStatus());
 
             if (meta != null && meta.enableProfiling()) {
-                TornadoLogger.debug("\texecuting: %f seconds", event.getElapsedTimeInSeconds());
-                TornadoLogger.debug("\ttotal    : %f seconds", event.getTotalTimeInSeconds());
+                logger.debug("\texecuting: %f seconds", event.getElapsedTimeInSeconds());
+                logger.debug("\ttotal    : %f seconds", event.getTotalTimeInSeconds());
             }
         }
     }
@@ -190,7 +191,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
 
         // local memory buffers
         if (meta != null && meta.getLocalSize() > 0) {
-            TornadoLogger.info("\tallocating %s of local memory", RuntimeUtilities.humanReadableByteCount(meta.getLocalSize(), true));
+            logger.info("\tallocating %s of local memory", RuntimeUtilities.humanReadableByteCount(meta.getLocalSize(), true));
             kernel.setLocalRegion(index, meta.getLocalSize());
         } else {
             kernel.setArgUnused(index);
@@ -225,7 +226,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
         guarantee(kernel != null, "kernel is null");
 
         if (DEBUG) {
-            TornadoLogger.info("kernel submitted: id=0x%x, method = %s, device =%s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
+            logger.info("kernel submitted: id=0x%x, method = %s, device =%s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
         }
 
         /*
@@ -350,7 +351,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
         checkKernelNotNull();
 
         if (DEBUG) {
-            TornadoLogger.info("kernel submitted: id=0x%x, method = %s, device =%s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
+            logger.info("kernel submitted: id=0x%x, method = %s, device =%s", kernel.getOclKernelID(), kernel.getName(), deviceContext.getDevice().getDeviceName());
         }
 
         setKernelArgs(oclKernelStackFrame, atomicSpace, meta);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
@@ -314,7 +314,7 @@ public class OCLCompiler {
 
     public static OCLCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, OCLProviders providers, OCLBackend backend,
             BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
-        TornadoLogger.info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
+        new TornadoLogger().info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
         final TornadoCompilerIdentifier id = new TornadoCompilerIdentifier("compile-kernel" + resolvedMethod.getName(), compilationId.getAndIncrement());
 
         Builder builder = new Builder(TornadoCoreRuntime.getOptions(), getDebugContext(), AllowAssumptions.YES);
@@ -362,7 +362,7 @@ public class OCLCompiler {
         final StructuredGraph kernelGraph = (StructuredGraph) sketch.getGraph().copy(getDebugContext());
         ResolvedJavaMethod resolvedMethod = kernelGraph.method();
 
-        TornadoLogger.info("Compiling sketch %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
+        new TornadoLogger().info("Compiling sketch %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
 
         final TaskMetaData taskMeta = task.meta();
         final Object[] args = task.getArguments();
@@ -439,8 +439,9 @@ public class OCLCompiler {
                 try {
                     Files.createDirectories(outDir);
                 } catch (IOException e) {
-                    TornadoLogger.error("unable to create cache dir: %s", outDir.toString());
-                    TornadoLogger.error(e.getMessage());
+                    TornadoLogger logger = new TornadoLogger();
+                    logger.error("unable to create cache dir: %s", outDir.toString());
+                    logger.error(e.getMessage());
                 }
             }
 
@@ -452,7 +453,7 @@ public class OCLCompiler {
                     pw.printf("%s,%s\n", m.getDeclaringClass().getName(), m.getName());
                 }
             } catch (IOException e) {
-                TornadoLogger.error("unable to dump source: ", e.getMessage());
+                new TornadoLogger().error("unable to dump source: ", e.getMessage());
             }
         }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
@@ -383,11 +383,13 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
             }
         });
 
+        TornadoLogger logger = new TornadoLogger(this.getClass());
+
         if (iterations == MAX_ITERATIONS) {
-            TornadoLogger.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
+            logger.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
         }
-        TornadoLogger.debug("TaskSpecialisation ran %d iterations", iterations);
-        TornadoLogger.debug("valid graph? %s", graph.verify());
+        logger.debug("TaskSpecialisation ran %d iterations", iterations);
+        logger.debug("valid graph? %s", graph.verify());
         index = 0;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
@@ -35,15 +35,17 @@ public class FieldBuffer {
 
     private final Field field;
     private final XPUBuffer objectBuffer;
+    private final TornadoLogger logger;
 
     public FieldBuffer(final Field field, final XPUBuffer objectBuffer) {
         this.objectBuffer = objectBuffer;
         this.field = field;
+        this.logger = new TornadoLogger(this.getClass());
     }
 
     public int enqueueRead(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            TornadoLogger.trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: Offset 0
         return (useDeps) ? objectBuffer.enqueueRead(executionPlanId, getFieldValue(ref), 0, (useDeps) ? events : null, useDeps) : -1;
@@ -51,7 +53,7 @@ public class FieldBuffer {
 
     public List<Integer> enqueueWrite(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            TornadoLogger.trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         return (useDeps) ? objectBuffer.enqueueWrite(executionPlanId, getFieldValue(ref), 0, 0, (useDeps) ? events : null, useDeps) : null;
     }
@@ -61,7 +63,7 @@ public class FieldBuffer {
         try {
             value = field.get(container);
         } catch (IllegalArgumentException | IllegalAccessException e) {
-            TornadoLogger.warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
+            logger.warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
         }
         return value;
     }
@@ -72,7 +74,7 @@ public class FieldBuffer {
 
     public int read(long executionPlanId, final Object ref, int[] events, boolean useDeps) {
         if (DEBUG) {
-            TornadoLogger.debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: reading with offset != 0
         return objectBuffer.read(executionPlanId, getFieldValue(ref), 0, 0, events, useDeps);
@@ -80,7 +82,7 @@ public class FieldBuffer {
 
     public void write(long executionPlanId, final Object ref) {
         if (DEBUG) {
-            TornadoLogger.trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         objectBuffer.write(executionPlanId, getFieldValue(ref));
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
@@ -54,6 +54,7 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
     private long bufferOffset;
     private long bufferSize;
     private long setSubRegionSize;
+    private TornadoLogger logger;
 
     protected OCLArrayWrapper(final OCLDeviceContext device, final JavaKind kind, long batchSize) {
         this.deviceContext = device;
@@ -65,6 +66,7 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
 
         arrayLengthOffset = getVMConfig().arrayOopDescLengthOffset();
         arrayHeaderSize = getVMConfig().getArrayBaseOffset(kind);
+        logger = new TornadoLogger(this.getClass());
     }
 
     protected OCLArrayWrapper(final T array, final OCLDeviceContext device, final JavaKind kind, long batchSize) {
@@ -102,8 +104,8 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            TornadoLogger.info("allocated: %s", toString());
+            logger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            logger.info("allocated: %s", toString());
         }
 
     }
@@ -117,9 +119,8 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset,
-                    arrayHeaderSize);
-            TornadoLogger.info("deallocated: %s", toString());
+            logger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            logger.info("deallocated: %s", toString());
         }
     }
 
@@ -308,7 +309,7 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
         final int numElements = header.getInt(arrayLengthOffset);
         final boolean valid = numElements == Array.getLength(array);
         if (!valid) {
-            TornadoLogger.fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
+            logger.fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
             header.dump(8);
         }
         return valid;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLByteBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLByteBuffer.java
@@ -27,7 +27,6 @@ import java.nio.ByteBuffer;
 
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
-import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 /**
  * A buffer for inspecting data within an OpenCL device. It is not backed by any
@@ -290,7 +289,4 @@ public class OCLByteBuffer {
         return deviceContext.getMemoryManager().toAtomicAddress();
     }
 
-    public void zeroMemory() {
-        TornadoLogger.warn("zero memory unimplemented");
-    }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
@@ -192,7 +192,7 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
         }
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("allocated: %s", toString());
+            new TornadoLogger().info("allocated: %s", toString());
         }
     }
 
@@ -204,7 +204,7 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("deallocated: %s", toString());
+            new TornadoLogger().info("deallocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMultiDimArrayWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMultiDimArrayWrapper.java
@@ -82,7 +82,7 @@ public class OCLMultiDimArrayWrapper<T, E> extends OCLArrayWrapper<T> {
                 addresses[i] = wrappers[i].toBuffer();
             }
         } catch (TornadoOutOfMemoryException | TornadoMemoryException e) {
-            TornadoLogger.fatal("OOM: multi-dim array: %s", e.getMessage());
+            new TornadoLogger().fatal("OOM: multi-dim array: %s", e.getMessage());
             System.exit(-1);
         }
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
@@ -95,7 +95,7 @@ public class OCLVectorWrapper implements XPUBuffer {
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
+            new TornadoLogger().info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
         }
     }
@@ -109,7 +109,7 @@ public class OCLVectorWrapper implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
+            new TornadoLogger().info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
         }
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
@@ -70,10 +70,12 @@ public class OCLXPUBuffer implements XPUBuffer {
     private long bufferOffset;
     private ByteBuffer buffer;
     private long setSubRegionSize;
+    private final TornadoLogger logger;
 
     public OCLXPUBuffer(final OCLDeviceContext device, Object object) {
         this.objectType = object.getClass();
         this.deviceContext = device;
+        this.logger = new TornadoLogger(this.getClass());
 
         hubOffset = getVMConfig().hubOffset;
         fieldsOffset = getVMConfig().instanceKlassFieldsOffset();
@@ -90,7 +92,7 @@ public class OCLXPUBuffer implements XPUBuffer {
             final Class<?> type = reflectedField.getType();
 
             if (DEBUG) {
-                TornadoLogger.trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
+                logger.trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
             }
 
             XPUBuffer wrappedField = null;
@@ -111,7 +113,7 @@ public class OCLXPUBuffer implements XPUBuffer {
                 } else if (type == byte[].class) {
                     wrappedField = new OCLByteArrayWrapper((byte[]) objectFromField, device, 0);
                 } else {
-                    TornadoLogger.warn("cannot wrap field: array type=%s", type.getName());
+                    logger.warn("cannot wrap field: array type=%s", type.getName());
                 }
             } else if (type == FloatArray.class) {
                 Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
@@ -163,7 +165,7 @@ public class OCLXPUBuffer implements XPUBuffer {
     @Override
     public void allocate(Object reference, long batchSize) throws TornadoOutOfMemoryException, TornadoMemoryException {
         if (DEBUG) {
-            TornadoLogger.debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
+            logger.debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
         }
 
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(size());
@@ -171,7 +173,7 @@ public class OCLXPUBuffer implements XPUBuffer {
         setBuffer(new XPUBufferWrapper(bufferId, bufferOffset));
 
         if (DEBUG) {
-            TornadoLogger.debug("object: object=0x%x @ bufferId 0x%x", reference.hashCode(), bufferId);
+            logger.debug("object: object=0x%x @ bufferId 0x%x", reference.hashCode(), bufferId);
         }
     }
 
@@ -263,7 +265,7 @@ public class OCLXPUBuffer implements XPUBuffer {
                 HotSpotResolvedJavaField field = fields[i];
                 Field f = getField(objectType, field.getName());
                 if (DEBUG) {
-                    TornadoLogger.trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    logger.trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
 
                 buffer.position(field.getOffset());
@@ -283,7 +285,7 @@ public class OCLXPUBuffer implements XPUBuffer {
                 Field f = getField(objectType, field.getName());
                 f.setAccessible(true);
                 if (DEBUG) {
-                    TornadoLogger.trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    logger.trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
                 readFieldFromBuffer(i, f, object);
             }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/power/OCLNvidiaPowerMetric.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/power/OCLNvidiaPowerMetric.java
@@ -29,10 +29,13 @@ import uk.ac.manchester.tornado.drivers.opencl.exceptions.OCLException;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class OCLNvidiaPowerMetric implements PowerMetric {
+
     private final OCLDeviceContext deviceContext;
+    private final TornadoLogger logger;
 
     public OCLNvidiaPowerMetric(OCLDeviceContext deviceContext) {
         this.deviceContext = deviceContext;
+        this.logger = new TornadoLogger(this.getClass());
         initializePowerLibrary();
     }
 
@@ -47,7 +50,7 @@ public class OCLNvidiaPowerMetric implements PowerMetric {
         try {
             clNvmlInit();
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 
@@ -56,7 +59,7 @@ public class OCLNvidiaPowerMetric implements PowerMetric {
         try {
             clNvmlDeviceGetHandleByIndex(this.deviceContext.getDevice().getIndex(), device);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 
@@ -65,7 +68,7 @@ public class OCLNvidiaPowerMetric implements PowerMetric {
         try {
             clNvmlDeviceGetPowerUsage(device, powerUsage);
         } catch (OCLException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -299,8 +299,9 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
 
             return installedCode;
         } catch (Exception e) {
-            TornadoLogger.fatal("Unable to compile %s for device %s\n", task.getId(), getDeviceName());
-            TornadoLogger.fatal("Exception occurred when compiling %s\n", ((CompilableTask) task).getMethod().getName());
+            TornadoLogger logger = new TornadoLogger();
+            logger.fatal("Unable to compile %s for device %s\n", task.getId(), getDeviceName());
+            logger.fatal("Exception occurred when compiling %s\n", ((CompilableTask) task).getMethod().getName());
             if (TornadoOptions.RECOVER_BAILOUT) {
                 throw new TornadoBailoutRuntimeException("[Error during the Task Compilation]: " + e.getMessage());
             } else {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
@@ -60,7 +60,7 @@ public class OCLScheduler {
             case CL_DEVICE_TYPE_CPU:
                 return TornadoOptions.USE_BLOCK_SCHEDULER ? new OCLCPUScheduler(context) : getInstanceGPUScheduler(context);
             default:
-                TornadoLogger.fatal("No scheduler available for device: %s", context);
+                new TornadoLogger().fatal("No scheduler available for device: %s", context);
                 break;
         }
         return null;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLContext.java
@@ -59,7 +59,7 @@ public class VirtualOCLContext implements OCLExecutionEnvironment {
 
     @Override
     public VirtualOCLDeviceContext createDeviceContext(int index) {
-        TornadoLogger.debug("creating device context for device: %s", devices.get(index).toString());
+        new TornadoLogger().debug("creating device context for device: %s", devices.get(index).toString());
         return new VirtualOCLDeviceContext(devices.get(index), this);
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -206,9 +206,10 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
 
             return null;
         } catch (Exception e) {
-            TornadoLogger.fatal("unable to compile %s for device %s", task.getId(), getDeviceName());
-            TornadoLogger.fatal("exception occurred when compiling %s", ((CompilableTask) task).getMethod().getName());
-            TornadoLogger.fatal("exception: %s", e.toString());
+            TornadoLogger tornadoLogger = new TornadoLogger();
+            tornadoLogger.fatal("unable to compile %s for device %s", task.getId(), getDeviceName());
+            tornadoLogger.fatal("exception occurred when compiling %s", ((CompilableTask) task).getMethod().getName());
+            tornadoLogger.fatal("exception: %s", e.toString());
             throw new TornadoBailoutRuntimeException("[Error During the Task Compilation] ", e);
         }
     }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXBackendImpl.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXBackendImpl.java
@@ -48,12 +48,14 @@ public final class PTXBackendImpl implements TornadoAcceleratorBackend {
 
     private final PTXBackend[] backends;
     private List<TornadoDevice> devices;
+    private final TornadoLogger logger;
 
     public PTXBackendImpl(final OptionValues options, final HotSpotJVMCIRuntime vmRuntime, TornadoVMConfigAccess vmConfig) {
 
         int deviceCount = PTX.getPlatform().getDeviceCount();
+        logger = new TornadoLogger(this.getClass());
         backends = new PTXBackend[deviceCount];
-        TornadoLogger.info("CUDA: Has %d devices...", deviceCount);
+        logger.info("CUDA: Has %d devices...", deviceCount);
         if (deviceCount == 0) {
             throw new TornadoBailoutRuntimeException("[WARNING] No PTX devices found. Deoptimizing to sequential execution.");
         }
@@ -65,7 +67,7 @@ public final class PTXBackendImpl implements TornadoAcceleratorBackend {
 
     private void installDevice(int deviceIndex, OptionValues options, HotSpotJVMCIRuntime vmRuntime, TornadoVMConfigAccess vmConfig) {
         PTXDevice device = PTX.getPlatform().getDevice(deviceIndex);
-        TornadoLogger.info("Creating backend for %s", device.getDeviceName());
+        logger.info("Creating backend for %s", device.getDeviceName());
         backends[deviceIndex] = PTXHotSpotBackendFactory.createJITCompiler(options, vmRuntime, vmConfig, device);
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXEventPool.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXEventPool.java
@@ -58,8 +58,9 @@ public class PTXEventPool {
         guarantee(!retain.get(currentEvent), "overwriting retained event");
 
         if (eventWrapper == null) {
-            TornadoLogger.fatal("invalid event: description=%s\n", descriptorId.getNameDescription());
-            TornadoLogger.fatal("terminating application as system integrity has been compromised.");
+            TornadoLogger logger = new TornadoLogger();
+            logger.fatal("invalid event: description=%s\n", descriptorId.getNameDescription());
+            logger.fatal("terminating application as system integrity has been compromised.");
             throw new TornadoBailoutRuntimeException("[ERROR] NULL event received from the CUDA driver !");
         }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
@@ -36,9 +36,11 @@ import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 public class PTXScheduler {
 
     private final PTXDevice device;
+    private final TornadoLogger logger;
 
     public PTXScheduler(final PTXDevice device) {
         this.device = device;
+        this.logger = new TornadoLogger(this.getClass());
     }
 
     public void calculateGlobalWork(final TaskMetaData meta, long batchThreads) {
@@ -73,8 +75,8 @@ public class PTXScheduler {
                 defaultBlocks[i] = calculateBlockSize(calculateEffectiveMaxWorkItemSize(dimension, maxBlockThreads), globalWork[i]);
             }
         } catch (Exception e) {
-            TornadoLogger.warn("[CUDA-PTX] Failed to calculate blocks for " + javaName);
-            TornadoLogger.warn("[CUDA-PTX] Falling back to blocks: " + Arrays.toString(defaultBlocks));
+            logger.warn("[CUDA-PTX] Failed to calculate blocks for " + javaName);
+            logger.warn("[CUDA-PTX] Falling back to blocks: " + Arrays.toString(defaultBlocks));
             if (DEBUG || FULL_DEBUG) {
                 e.printStackTrace();
             }
@@ -121,8 +123,8 @@ public class PTXScheduler {
                 defaultGrids[i] = Math.max(Math.min(workSize / blockDimension[i], (int) maxGridSizes[i]), 1);
             }
         } catch (Exception e) {
-            TornadoLogger.warn("[CUDA-PTX] Failed to calculate grids for " + javaName);
-            TornadoLogger.warn("[CUDA-PTX] Falling back to grid: " + Arrays.toString(defaultGrids));
+            logger.warn("[CUDA-PTX] Failed to calculate grids for " + javaName);
+            logger.warn("[CUDA-PTX] Falling back to grid: " + Arrays.toString(defaultGrids));
             if (DEBUG || FULL_DEBUG) {
                 e.printStackTrace();
             }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXFrameContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXFrameContext.java
@@ -31,13 +31,13 @@ import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 public class PTXFrameContext implements FrameContext {
     @Override
     public void enter(CompilationResultBuilder crb) {
-        TornadoLogger.trace("FrameContext.enter()");
+        new TornadoLogger().trace("FrameContext.enter()");
 
     }
 
     @Override
     public void leave(CompilationResultBuilder crb) {
-        TornadoLogger.trace("FrameContext.leave()");
+        new TornadoLogger().trace("FrameContext.leave()");
     }
 
     @Override

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
@@ -92,13 +92,11 @@ import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 public class PTXCompiler {
 
     private static final AtomicInteger compilationId = new AtomicInteger();
-
     private static final TimerKey CompilerTimer = DebugContext.timer("PTXGraalCompiler");
     private static final TimerKey FrontEnd = DebugContext.timer("PTXFrontend");
     private static final TimerKey BackEnd = DebugContext.timer("PTXBackend");
     private static final TimerKey EmitLIR = DebugContext.timer("PTXEmitLIR");
     private static final TimerKey EmitCode = DebugContext.timer("PTXEmitCode");
-
     private static final PTXLIRGenerationPhase LIR_GENERATION_PHASE = new PTXLIRGenerationPhase();
 
     private static PTXCompilationResult compile(PTXCompilationRequest r) {
@@ -253,7 +251,7 @@ public class PTXCompiler {
         final StructuredGraph kernelGraph = (StructuredGraph) sketch.getGraph().copy(TornadoCoreRuntime.getDebugContext());
         ResolvedJavaMethod resolvedMethod = kernelGraph.method();
 
-        TornadoLogger.info("Compiling sketch %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
+        new TornadoLogger().info("Compiling sketch %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
 
         final TaskMetaData taskMeta = task.meta();
         final Object[] args = task.getArguments();
@@ -361,8 +359,9 @@ public class PTXCompiler {
                 try {
                     Files.createDirectories(outDir);
                 } catch (IOException e) {
-                    TornadoLogger.error("unable to create cache dir: %s", outDir.toString());
-                    TornadoLogger.error(e.getMessage());
+                    TornadoLogger logger = new TornadoLogger();
+                    logger.error("unable to create cache dir: %s", outDir.toString());
+                    logger.error(e.getMessage());
                 }
             }
 
@@ -374,7 +373,7 @@ public class PTXCompiler {
                     pw.printf("%s,%s\n", m.getDeclaringClass().getName(), m.getName());
                 }
             } catch (IOException e) {
-                TornadoLogger.error("unable to dump source: ", e.getMessage());
+                new TornadoLogger().error("unable to dump source: ", e.getMessage());
             }
         }
 
@@ -383,7 +382,7 @@ public class PTXCompiler {
 
     public static PTXCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, PTXProviders providers, PTXBackend backend,
             BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
-        TornadoLogger.info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
+        new TornadoLogger().info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
         final TornadoCompilerIdentifier id = new TornadoCompilerIdentifier("compile-kernel" + resolvedMethod.getName(), compilationId.getAndIncrement());
 
         StructuredGraph.Builder builder = new StructuredGraph.Builder(TornadoCoreRuntime.getTornadoRuntime().getOptions(), TornadoCoreRuntime.getDebugContext(), StructuredGraph.AllowAssumptions.YES);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoTaskSpecialisation.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoTaskSpecialisation.java
@@ -386,11 +386,12 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
             }
         });
 
+        TornadoLogger logger = new TornadoLogger(this.getClass());
         if (iterations == MAX_ITERATIONS) {
-            TornadoLogger.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
+            logger.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
         }
-        TornadoLogger.debug("TaskSpecialisation ran %d iterations", iterations);
-        TornadoLogger.debug("valid graph? %s", graph.verify());
+        logger.debug("TaskSpecialisation ran %d iterations", iterations);
+        logger.debug("valid graph? %s", graph.verify());
         index = 0;
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/FieldBuffer.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/FieldBuffer.java
@@ -35,13 +35,15 @@ import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class FieldBuffer {
-    private final Field field;
 
+    private final Field field;
     private final XPUBuffer objectBuffer;
+    private final TornadoLogger logger;
 
     public FieldBuffer(final Field field, final XPUBuffer objectBuffer) {
         this.objectBuffer = objectBuffer;
         this.field = field;
+        this.logger = new TornadoLogger(getClass());
     }
 
     public void allocate(final Object ref, long batchSize) throws TornadoOutOfMemoryException, TornadoMemoryException {
@@ -54,7 +56,7 @@ public class FieldBuffer {
 
     public int enqueueRead(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            TornadoLogger.trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: Offset 0
         int eventId = objectBuffer.enqueueRead(executionPlanId, getFieldValue(ref), 0, (useDeps) ? events : null, useDeps);
@@ -63,7 +65,7 @@ public class FieldBuffer {
 
     public List<Integer> enqueueWrite(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            TornadoLogger.trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         List<Integer> eventsIds = objectBuffer.enqueueWrite(executionPlanId, getFieldValue(ref), 0, 0, (useDeps) ? events : null, useDeps);
         return (useDeps) ? eventsIds : Collections.emptyList();
@@ -74,7 +76,7 @@ public class FieldBuffer {
         try {
             value = field.get(container);
         } catch (IllegalArgumentException | IllegalAccessException e) {
-            TornadoLogger.warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
+            logger.warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
         }
         return value;
     }
@@ -85,7 +87,7 @@ public class FieldBuffer {
 
     public int read(long executionPlanId, final Object ref, int[] events, boolean useDeps) {
         if (DEBUG) {
-            TornadoLogger.debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: reading with offset != 0
         return objectBuffer.read(executionPlanId, getFieldValue(ref), 0, 0, events, useDeps);
@@ -97,7 +99,7 @@ public class FieldBuffer {
 
     public void write(long executionPlanId, final Object ref) {
         if (DEBUG) {
-            TornadoLogger.trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         objectBuffer.write(executionPlanId, getFieldValue(ref));
     }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
@@ -50,6 +50,7 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
     private long bufferSize;
     private JavaKind kind;
     private long setSubRegionSize;
+    private final TornadoLogger logger;
 
     public PTXArrayWrapper(PTXDeviceContext deviceContext, JavaKind kind) {
         this.deviceContext = deviceContext;
@@ -59,6 +60,7 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
 
         arrayHeaderSize = getVMConfig().getArrayBaseOffset(kind);
         arrayLengthOffset = getVMConfig().arrayOopDescLengthOffset();
+        logger = new TornadoLogger(this.getClass());
     }
 
     @SuppressWarnings("unchecked")
@@ -107,7 +109,7 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
         final int numElements = header.getInt(arrayLengthOffset);
         final boolean valid = numElements == Array.getLength(array);
         if (!valid) {
-            TornadoLogger.fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
+            logger.fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
             header.dump(8);
         }
         return valid;
@@ -210,8 +212,8 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
         this.buffer = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            TornadoLogger.info("allocated: %s", toString());
+            logger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            logger.info("allocated: %s", toString());
         }
     }
 
@@ -224,9 +226,8 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset,
-                    arrayHeaderSize);
-            TornadoLogger.info("deallocated: %s", toString());
+            logger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            logger.info("deallocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
@@ -42,14 +42,15 @@ import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.exceptions.TornadoUnsupportedError;
 
 public class PTXMemorySegmentWrapper implements XPUBuffer {
+
     private static final int INIT_VALUE = -1;
     private final PTXDeviceContext deviceContext;
     private final long batchSize;
     private long bufferId;
     private long bufferOffset;
     private long bufferSize;
-
     private long setSubRegionSize;
+    private final TornadoLogger logger;
 
     public PTXMemorySegmentWrapper(PTXDeviceContext deviceContext, long batchSize) {
         this.deviceContext = deviceContext;
@@ -57,6 +58,7 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
         this.bufferSize = INIT_VALUE;
         this.bufferId = INIT_VALUE;
         this.bufferOffset = 0;
+        logger = new TornadoLogger(this.getClass());
     }
 
     public PTXMemorySegmentWrapper(PTXDeviceContext deviceContext, long bufferSize, long batchSize) {
@@ -65,6 +67,7 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
         this.bufferSize = bufferSize;
         this.bufferId = INIT_VALUE;
         this.bufferOffset = 0;
+        logger = new TornadoLogger(this.getClass());
     }
 
     @Override
@@ -185,7 +188,7 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
         }
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("allocated: %s", toString());
+            logger.info("allocated: %s", toString());
         }
     }
 
@@ -197,7 +200,7 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("deallocated: %s", toString());
+            logger.info("deallocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMultiDimArrayWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMultiDimArrayWrapper.java
@@ -24,6 +24,7 @@
 package uk.ac.manchester.tornado.drivers.ptx.mm;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.function.Function;
 
 import jdk.vm.ci.meta.JavaKind;
@@ -112,7 +113,7 @@ public class PTXMultiDimArrayWrapper<T, E> extends PTXArrayWrapper<T> {
                 addresses[i] = wrappers[i].toBuffer();
             }
         } catch (TornadoOutOfMemoryException | TornadoMemoryException e) {
-            TornadoLogger.fatal("OOM: multi-dim array: %s", e.getMessage());
+            new TornadoLogger().fatal("OOM: multi-dim array: %s", e.getMessage());
             System.exit(-1);
         }
     }
@@ -126,9 +127,7 @@ public class PTXMultiDimArrayWrapper<T, E> extends PTXArrayWrapper<T> {
     }
 
     private void deallocateElements() {
-        for (int i = 0; i < wrappers.length; i++) {
-            wrappers[i].deallocate();
-        }
+        Arrays.stream(wrappers).forEach(PTXArrayWrapper::deallocate);
     }
 
     private int writeElements(long executionPlanId, T values) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
@@ -66,11 +66,12 @@ public class PTXObjectWrapper implements XPUBuffer {
     private int hubOffset;
     private int fieldsOffset;
     private long subRegionSize;
+    private final TornadoLogger logger;
 
     public PTXObjectWrapper(final PTXDeviceContext device, Object object) {
         this.type = object.getClass();
         this.deviceContext = device;
-
+        this.logger = new TornadoLogger(this.getClass());
         hubOffset = getVMConfig().hubOffset;
         fieldsOffset = getVMConfig().instanceKlassFieldsOffset();
 
@@ -87,7 +88,7 @@ public class PTXObjectWrapper implements XPUBuffer {
             final Class<?> type = reflectedField.getType();
 
             if (DEBUG) {
-                TornadoLogger.trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
+                logger.trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
             }
 
             XPUBuffer wrappedField = null;
@@ -105,7 +106,7 @@ public class PTXObjectWrapper implements XPUBuffer {
                 } else if (type == byte[].class) {
                     wrappedField = new PTXByteArrayWrapper(deviceContext);
                 } else {
-                    TornadoLogger.warn("cannot wrap field: array type=%s", type.getName());
+                    logger.warn("cannot wrap field: array type=%s", type.getName());
                 }
             } else if (type == FloatArray.class) {
                 Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
@@ -150,13 +151,13 @@ public class PTXObjectWrapper implements XPUBuffer {
     @Override
     public void allocate(Object reference, long batchSize) {
         if (DEBUG) {
-            TornadoLogger.debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
+            logger.debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
         }
 
         this.address = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(getObjectSize());
 
         if (DEBUG) {
-            TornadoLogger.debug("object: object=0x%x @ address 0x%x", reference.hashCode(), address);
+            logger.debug("object: object=0x%x @ address 0x%x", reference.hashCode(), address);
         }
         for (FieldBuffer buffer : wrappedFields) {
             if (buffer != null) {
@@ -260,7 +261,7 @@ public class PTXObjectWrapper implements XPUBuffer {
                 HotSpotResolvedJavaField field = fields[i];
                 Field f = getField(type, field.getName());
                 if (DEBUG) {
-                    TornadoLogger.trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    logger.trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
 
                 buffer.position(field.getOffset());
@@ -280,7 +281,7 @@ public class PTXObjectWrapper implements XPUBuffer {
                 Field f = getField(type, field.getName());
                 f.setAccessible(true);
                 if (DEBUG) {
-                    TornadoLogger.trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    logger.trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
                 readFieldFromBuffer(i, f, object);
             }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
@@ -63,6 +63,7 @@ public class PTXVectorWrapper implements XPUBuffer {
     private long buffer;
     private long bufferSize;
     private long setSubRegionSize;
+    private final TornadoLogger logger;
 
     public PTXVectorWrapper(final PTXDeviceContext device, final Object object, long batchSize) {
         TornadoInternalError.guarantee(object instanceof PrimitiveStorage, "Expecting a PrimitiveStorage type");
@@ -74,6 +75,7 @@ public class PTXVectorWrapper implements XPUBuffer {
         this.bufferSize = sizeOf(payload);
         this.arrayLengthOffset = getVMConfig().arrayOopDescLengthOffset();
         this.arrayHeaderSize = getVMConfig().getArrayBaseOffset(kind);
+        this.logger = new TornadoLogger(this.getClass());
     }
 
     public long getBatchSize() {
@@ -97,8 +99,8 @@ public class PTXVectorWrapper implements XPUBuffer {
         this.buffer = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            TornadoLogger.info("allocated: %s", toString());
+            logger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            logger.info("allocated: %s", toString());
         }
 
     }
@@ -112,9 +114,8 @@ public class PTXVectorWrapper implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset,
-                    arrayHeaderSize);
-            TornadoLogger.info("deallocated: %s", toString());
+            logger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            logger.info("deallocated: %s", toString());
         }
     }
 
@@ -295,7 +296,7 @@ public class PTXVectorWrapper implements XPUBuffer {
             } else if (type == HalfFloat[].class) {
                 return JavaKind.Object;
             } else {
-                TornadoLogger.warn("cannot wrap field: array type=%s", type.getName());
+                logger.warn("cannot wrap field: array type=%s", type.getName());
             }
         } else if (type == FloatArray.class || type == IntArray.class || type == DoubleArray.class || type == LongArray.class || type == ShortArray.class || type == CharArray.class || type == ByteArray.class || type == HalfFloatArray.class) {
             return JavaKind.Object;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PrimitiveSerialiser.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PrimitiveSerialiser.java
@@ -41,18 +41,13 @@ public class PrimitiveSerialiser {
     }
 
     public static void put(ByteBuffer buffer, Object value, int alignment) {
-        if (value instanceof Integer) {
-            buffer.putInt((int) value);
-        } else if (value instanceof Long) {
-            buffer.putLong((long) value);
-        } else if (value instanceof Short) {
-            buffer.putShort((short) value);
-        } else if (value instanceof Float) {
-            buffer.putFloat((float) value);
-        } else if (value instanceof Double) {
-            buffer.putDouble((double) value);
-        } else {
-            TornadoLogger.warn("unable to serialise: %s (%s)", value, value.getClass().getName());
+        switch (value) {
+            case Integer i -> buffer.putInt((int) value);
+            case Long l -> buffer.putLong((long) value);
+            case Short i -> buffer.putShort((short) value);
+            case Float v -> buffer.putFloat((float) value);
+            case Double v -> buffer.putDouble((double) value);
+            case null, default -> new TornadoLogger().warn("unable to serialise: %s (%s)", value, value.getClass().getName());
         }
 
         if (alignment != 0) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/power/PTXNvidiaPowerMetric.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/power/PTXNvidiaPowerMetric.java
@@ -28,10 +28,13 @@ import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 
 public class PTXNvidiaPowerMetric implements PowerMetric {
+
     private final PTXDeviceContext deviceContext;
+    private final TornadoLogger logger;
 
     public PTXNvidiaPowerMetric(PTXDeviceContext deviceContext) {
         this.deviceContext = deviceContext;
+        this.logger = new TornadoLogger(this.getClass());
         initializePowerLibrary();
     }
 
@@ -46,7 +49,7 @@ public class PTXNvidiaPowerMetric implements PowerMetric {
         try {
             ptxNvmlInit();
         } catch (RuntimeException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 
@@ -55,7 +58,7 @@ public class PTXNvidiaPowerMetric implements PowerMetric {
         try {
             ptxNvmlDeviceGetHandleByIndex(this.deviceContext.getDevice().getDeviceIndex(), device);
         } catch (RuntimeException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 
@@ -64,7 +67,7 @@ public class PTXNvidiaPowerMetric implements PowerMetric {
         try {
             ptxNvmlDeviceGetPowerUsage(device, powerUsage);
         } catch (RuntimeException e) {
-            TornadoLogger.error(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -99,6 +99,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     private static PTXBackendImpl driver = null;
     private final PTXDevice device;
     private final int deviceIndex;
+    private final TornadoLogger logger;
 
     public PTXTornadoDevice(final int deviceIndex) {
         this.deviceIndex = deviceIndex;
@@ -107,6 +108,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
             throw new RuntimeException("TornadoVM PTX Driver not found");
         }
         device = PTX.getPlatform().getDevice(deviceIndex);
+        this.logger = new TornadoLogger(this.getClass());
     }
 
     @Override
@@ -126,7 +128,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public int[] checkAtomicsForTask(SchedulableTask task) {
-        TornadoLogger.debug("[PTX] Atomics not implemented ! Returning null");
+        logger.debug("[PTX] Atomics not implemented ! Returning null");
         return null;
     }
 
@@ -194,8 +196,8 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
             if (TornadoOptions.DEBUG) {
                 System.err.println(e.getMessage());
             }
-            TornadoLogger.fatal("unable to compile %s for device %s\n", task.getId(), getDeviceName());
-            TornadoLogger.fatal("exception occurred when compiling %s\n", ((CompilableTask) task).getMethod().getName());
+            logger.fatal("unable to compile %s for device %s\n", task.getId(), getDeviceName());
+            logger.fatal("exception occurred when compiling %s\n", ((CompilableTask) task).getMethod().getName());
             throw new TornadoBailoutRuntimeException("[Error During the Task Compilation] ", e);
         }
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
@@ -55,6 +55,8 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
      */
     private final SPIRVBackend[] flatBackends;
 
+    private final TornadoLogger logger;
+
     /**
      * Total number of devices available (include all backends platform and
      * devices).
@@ -64,13 +66,15 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
 
     public SPIRVBackendImpl(OptionValues options, HotSpotJVMCIRuntime vmRuntime, TornadoVMConfigAccess vmCon) {
         int numSPIRVPlatforms = SPIRVProxy.getNumPlatforms();
-        TornadoLogger.info("[SPIRV] Found %d platforms", numSPIRVPlatforms);
+        this.logger = new TornadoLogger(this.getClass());
+        logger.info("[SPIRV] Found %d platforms", numSPIRVPlatforms);
 
         if (numSPIRVPlatforms < 1) {
             throw new TornadoBailoutRuntimeException("[Warning] No SPIRV platforms found. Deoptimizing to sequential execution");
         }
 
         backends = new SPIRVBackend[numSPIRVPlatforms][];
+
         discoverDevices(options, vmRuntime, vmCon, numSPIRVPlatforms);
         flatBackends = new SPIRVBackend[deviceCount];
         int index = 0;
@@ -103,7 +107,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
     private SPIRVBackend checkAndInitBackend(int platformIndex, int deviceIndex) {
         SPIRVBackend backend = backends[platformIndex][deviceIndex];
         if (!backend.isInitialised()) {
-            TornadoLogger.info("SPIRV Backend Initialization");
+            logger.info("SPIRV Backend Initialization");
             backend.init();
         }
         return backend;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompiler.java
@@ -319,7 +319,7 @@ public class SPIRVCompiler {
         final StructuredGraph kernelGraph = (StructuredGraph) sketch.getGraph().copy(getDebugContext());
         ResolvedJavaMethod resolvedJavaMethod = kernelGraph.method();
 
-        TornadoLogger.info("Compiling sketch %s on %s", resolvedJavaMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
+        new TornadoLogger().info("Compiling sketch %s on %s", resolvedJavaMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
 
         final TaskMetaData taskMeta = task.meta();
         final Object[] args = task.getArguments();
@@ -439,8 +439,9 @@ public class SPIRVCompiler {
                 try {
                     Files.createDirectories(outDir);
                 } catch (IOException e) {
-                    TornadoLogger.error("unable to create cache dir: %s", outDir.toString());
-                    TornadoLogger.error(e.getMessage());
+                    TornadoLogger tornadoLogger = new TornadoLogger();
+                    tornadoLogger.error("unable to create cache dir: %s", outDir.toString());
+                    tornadoLogger.error(e.getMessage());
                 }
             }
 
@@ -452,7 +453,7 @@ public class SPIRVCompiler {
                     pw.printf("%s,%s\n", m.getDeclaringClass().getName(), m.getName());
                 }
             } catch (IOException e) {
-                TornadoLogger.error("unable to dump source: ", e.getMessage());
+                new TornadoLogger().error("unable to dump source: ", e.getMessage());
             }
         }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoTaskSpecialization.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoTaskSpecialization.java
@@ -383,11 +383,12 @@ public class TornadoTaskSpecialization extends BasePhase<TornadoHighTierContext>
             }
         });
 
+        TornadoLogger logger = new TornadoLogger(this.getClass());
         if (iterations == MAX_ITERATIONS) {
-            TornadoLogger.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
+            logger.warn("TaskSpecialisation unable to complete after %d iterations", iterations);
         }
-        TornadoLogger.debug("TaskSpecialisation ran %d iterations", iterations);
-        TornadoLogger.debug("valid graph? %s", graph.verify());
+        logger.debug("TaskSpecialisation ran %d iterations", iterations);
+        logger.debug("valid graph? %s", graph.verify());
         index = 0;
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/FieldBuffer.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/FieldBuffer.java
@@ -35,17 +35,18 @@ import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 public class FieldBuffer {
 
     private final Field field;
-
     private final XPUBuffer objectBuffer;
+    private final TornadoLogger logger;
 
     public FieldBuffer(final Field field, final XPUBuffer objectBuffer) {
         this.field = field;
         this.objectBuffer = objectBuffer;
+        this.logger = new TornadoLogger(this.getClass());
     }
 
     public int enqueueRead(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            TornadoLogger.trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.trace("fieldBuffer: enqueueRead* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: Offset 0
         return (useDeps) ? objectBuffer.enqueueRead(executionPlanId, getFieldValue(ref), 0, (useDeps) ? events : null, useDeps) : -1;
@@ -53,7 +54,7 @@ public class FieldBuffer {
 
     public List<Integer> enqueueWrite(long executionPlanId, final Object ref, final int[] events, boolean useDeps) {
         if (DEBUG) {
-            TornadoLogger.trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.trace("fieldBuffer: enqueueWrite* - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         return (useDeps) ? objectBuffer.enqueueWrite(executionPlanId, getFieldValue(ref), 0, 0, (useDeps) ? events : null, useDeps) : null;
     }
@@ -63,7 +64,7 @@ public class FieldBuffer {
         try {
             value = field.get(container);
         } catch (IllegalArgumentException | IllegalAccessException e) {
-            TornadoLogger.warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
+            logger.warn("Illegal access to field: name=%s, object=0x%x", field.getName(), container.hashCode());
         }
         return value;
     }
@@ -74,7 +75,7 @@ public class FieldBuffer {
 
     public int read(long executionPlanId, final Object ref, int[] events, boolean useDeps) {
         if (DEBUG) {
-            TornadoLogger.debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.debug("fieldBuffer: read - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         // TODO: reading with offset != 0
         return objectBuffer.read(executionPlanId, getFieldValue(ref), 0, 0, events, useDeps);
@@ -82,7 +83,7 @@ public class FieldBuffer {
 
     public void write(long executionPlanId, final Object ref) {
         if (DEBUG) {
-            TornadoLogger.trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
+            logger.trace("fieldBuffer: write - field=%s, parent=0x%x, child=0x%x", field, ref.hashCode(), getFieldValue(ref).hashCode());
         }
         objectBuffer.write(executionPlanId, getFieldValue(ref));
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
@@ -51,6 +51,7 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
     private long bufferOffset;
     private long bufferSize;
     private long setSubRegionSize;
+    private final TornadoLogger logger;
 
     public SPIRVArrayWrapper(SPIRVDeviceContext deviceContext, JavaKind javaKind, long batchSize) {
         this.deviceContext = deviceContext;
@@ -59,6 +60,7 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
         this.bufferId = INIT_VALUE;
         this.bufferSize = INIT_VALUE;
         this.bufferOffset = 0;
+        this.logger = new TornadoLogger(this.getClass());
 
         this.arrayLengthOffset = TornadoCoreRuntime.getVMConfig().arrayOopDescLengthOffset();
         this.arrayHeaderSize = TornadoCoreRuntime.getVMConfig().getArrayBaseOffset(kind);
@@ -134,7 +136,7 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
         final int numElements = header.getInt(arrayLengthOffset);
         final boolean valid = numElements == Array.getLength(array);
         if (!valid) {
-            TornadoLogger.fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
+            logger.fatal("Array: expected=%d, got=%d", Array.getLength(array), numElements);
             header.dump(8);
         }
         return valid;
@@ -255,8 +257,8 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
-            TornadoLogger.info("allocated: %s", toString());
+            logger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            logger.info("allocated: %s", toString());
         }
 
     }
@@ -270,9 +272,8 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset,
-                    arrayHeaderSize);
-            TornadoLogger.info("deallocated: %s", toString());
+            logger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), arrayLengthOffset, arrayHeaderSize);
+            logger.info("deallocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
@@ -183,7 +183,7 @@ public class SPIRVMemorySegmentWrapper implements XPUBuffer {
         }
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("allocated: %s", toString());
+            new TornadoLogger().info("allocated: %s", toString());
         }
     }
 
@@ -194,7 +194,7 @@ public class SPIRVMemorySegmentWrapper implements XPUBuffer {
         bufferId = INIT_VALUE;
         bufferSize = INIT_VALUE;
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("allocated: %s", toString());
+            new TornadoLogger().info("allocated: %s", toString());
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMultiDimArrayWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMultiDimArrayWrapper.java
@@ -70,7 +70,7 @@ public class SPIRVMultiDimArrayWrapper<T, E> extends SPIRVArrayWrapper<T> {
                 addresses[i] = wrappers[i].toBuffer();
             }
         } catch (TornadoOutOfMemoryException | TornadoMemoryException e) {
-            TornadoLogger.fatal("OOM: multi-dim array: %s", e.getMessage());
+            new TornadoLogger().fatal("OOM: multi-dim array: %s", e.getMessage());
             throw new RuntimeException(e);
         }
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
@@ -70,10 +70,12 @@ public class SPIRVObjectWrapper implements XPUBuffer {
     private long bufferOffset;
     private ByteBuffer buffer;
     private long subRegionSize;
+    private final TornadoLogger logger;
 
     public SPIRVObjectWrapper(final SPIRVDeviceContext deviceContext, Object object) {
         this.objectType = object.getClass();
         this.deviceContext = deviceContext;
+        this.logger = new TornadoLogger(this.getClass());
 
         hubOffset = getVMConfig().hubOffset;
         fieldsOffset = getVMConfig().instanceKlassFieldsOffset();
@@ -90,7 +92,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
             final Class<?> type = reflectedField.getType();
 
             if (DEBUG) {
-                TornadoLogger.trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
+                logger.trace("field: name=%s, kind=%s, offset=%d", field.getName(), type.getName(), field.getOffset());
             }
 
             XPUBuffer wrappedField = null;
@@ -111,7 +113,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
                 } else if (type == byte[].class) {
                     wrappedField = new SPIRVByteArrayWrapper((byte[]) objectFromField, deviceContext, 0);
                 } else {
-                    TornadoLogger.warn("cannot wrap field: array type=%s", type.getName());
+                    logger.warn("cannot wrap field: array type=%s", type.getName());
                 }
             } else if (type == FloatArray.class) {
                 Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
@@ -167,7 +169,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
     @Override
     public void allocate(Object reference, long batchSize) throws TornadoOutOfMemoryException, TornadoMemoryException {
         if (DEBUG) {
-            TornadoLogger.debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
+            logger.debug("object: object=0x%x, class=%s", reference.hashCode(), reference.getClass().getName());
         }
 
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(size());
@@ -175,7 +177,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
         setBuffer(new XPUBufferWrapper(bufferId, bufferOffset));
 
         if (DEBUG) {
-            TornadoLogger.debug("object: object=0x%x @ bufferId 0x%x", reference.hashCode(), bufferId);
+            logger.debug("object: object=0x%x @ bufferId 0x%x", reference.hashCode(), bufferId);
         }
     }
 
@@ -267,7 +269,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
                 HotSpotResolvedJavaField field = fields[i];
                 Field f = getField(objectType, field.getName());
                 if (DEBUG) {
-                    TornadoLogger.trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    logger.trace("writing field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
 
                 buffer.position(field.getOffset());
@@ -287,7 +289,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
                 Field f = getField(objectType, field.getName());
                 f.setAccessible(true);
                 if (DEBUG) {
-                    TornadoLogger.trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
+                    logger.trace("reading field: name=%s, offset=%d", field.getName(), field.getOffset());
                 }
                 readFieldFromBuffer(i, f, object);
             }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
@@ -61,6 +61,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
     private long bufferOffset;
     private long bufferSize;
     private long setSubRegionSize;
+    private final TornadoLogger logger;
 
     public SPIRVVectorWrapper(final SPIRVDeviceContext device, final Object object, long batchSize) {
         TornadoInternalError.guarantee(object instanceof PrimitiveStorage, STR."Expecting a PrimitiveStorage type, but found: \{object.getClass()}");
@@ -71,6 +72,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
         Object payload = TornadoUtils.getAnnotatedObjectFromField(object, Payload.class);
         this.kind = getJavaKind(payload.getClass());
         this.bufferSize = sizeOf(payload);
+        this.logger = new TornadoLogger(this.getClass());
     }
 
     public long getBatchSize() {
@@ -94,7 +96,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
+            logger.info("allocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
         }
 
@@ -109,9 +111,9 @@ public class SPIRVVectorWrapper implements XPUBuffer {
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
-            TornadoLogger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
+            logger.info("deallocated: array kind=%s, size=%s, length offset=%d, header size=%d", kind.getJavaName(), humanReadableByteCount(bufferSize, true), bufferOffset,
                     TornadoOptions.PANAMA_OBJECT_HEADER_SIZE);
-            TornadoLogger.info("deallocated: %s", toString());
+            logger.info("deallocated: %s", toString());
         }
     }
 
@@ -350,7 +352,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
             } else if (type == HalfFloat[].class) {
                 return JavaKind.Object;
             } else {
-                TornadoLogger.warn("cannot wrap field: array type=%s", type.getName());
+                logger.warn("cannot wrap field: array type=%s", type.getName());
             }
         } else if (type == FloatArray.class || type == IntArray.class || type == DoubleArray.class || type == LongArray.class || type == ShortArray.class || type == CharArray.class || type == ByteArray.class || type == HalfFloatArray.class) {
             return JavaKind.Object;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -189,8 +189,9 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
             profiler.sum(ProfilerType.TOTAL_DRIVER_COMPILE_TIME, profiler.getTaskTimer(ProfilerType.TASK_COMPILE_DRIVER_TIME, taskMeta.getId()));
             return installedCode;
         } catch (Exception e) {
-            TornadoLogger.fatal("Unable to compile %s for device %s\n", task.getId(), getDeviceName());
-            TornadoLogger.fatal("Exception occurred when compiling %s\n", task.getMethod().getName());
+            TornadoLogger logger = new TornadoLogger(this.getClass());
+            logger.fatal("Unable to compile %s for device %s\n", task.getId(), getDeviceName());
+            logger.fatal("Exception occurred when compiling %s\n", task.getMethod().getName());
             if (TornadoOptions.RECOVER_BAILOUT) {
                 throw new TornadoBailoutRuntimeException(STR."[Error During the Task Compilation]: \{e.getMessage()}");
             } else {

--- a/tornado-runtime/src/main/java/module-info.java
+++ b/tornado-runtime/src/main/java/module-info.java
@@ -2,7 +2,7 @@ import uk.ac.manchester.tornado.runtime.TornadoBackendProvider;
 
 open module tornado.runtime{requires java.logging;requires jdk.unsupported;requires org.graalvm.collections;
 
-requires transitive jdk.internal.vm.ci;requires transitive jdk.internal.vm.compiler;requires transitive tornado.api;
+requires transitive jdk.internal.vm.ci;requires transitive jdk.internal.vm.compiler;requires transitive tornado.api;requires commons.math3;
 
 exports uk.ac.manchester.tornado.runtime;exports uk.ac.manchester.tornado.runtime.analyzer;exports uk.ac.manchester.tornado.runtime.common;exports uk.ac.manchester.tornado.runtime.common.enums;exports uk.ac.manchester.tornado.runtime.common.exceptions;exports uk.ac.manchester.tornado.runtime.directives;exports uk.ac.manchester.tornado.runtime.domain;exports uk.ac.manchester.tornado.runtime.graal;exports uk.ac.manchester.tornado.runtime.graal.backend;exports uk.ac.manchester.tornado.runtime.graal.compiler;exports uk.ac.manchester.tornado.runtime.graal.nodes;exports uk.ac.manchester.tornado.runtime.graal.nodes.logic;exports uk.ac.manchester.tornado.runtime.graal.nodes.calc;exports uk.ac.manchester.tornado.runtime.graal.phases;exports uk.ac.manchester.tornado.runtime.graph;exports uk.ac.manchester.tornado.runtime.graph.nodes;exports uk.ac.manchester.tornado.runtime.profiler;exports uk.ac.manchester.tornado.runtime.sketcher;exports uk.ac.manchester.tornado.runtime.tasks;exports uk.ac.manchester.tornado.runtime.tasks.meta;exports uk.ac.manchester.tornado.runtime.utils;exports uk.ac.manchester.tornado.runtime.graal.phases.sketcher;exports uk.ac.manchester.tornado.runtime.graal.nodes.interfaces;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -124,7 +124,7 @@ public class TaskUtils {
             m.setAccessible(true);
             return m;
         } catch (SecurityException | IllegalArgumentException | ClassNotFoundException | IllegalAccessException | InvocationTargetException e) {
-            TornadoLogger.debug("HotSpotJDKReflection::getMethod is missing from the JDK distribution. Falling back to HotSpotResolvedJavaMethodImpl::toJava");
+            new TornadoLogger().debug("HotSpotJDKReflection::getMethod is missing from the JDK distribution. Falling back to HotSpotResolvedJavaMethodImpl::toJava");
             useToJavaMethod = true;
             return callToJava(javaMethod);
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
@@ -408,6 +408,8 @@ public final class RuntimeUtilities {
         StringBuilder errorOutput = new StringBuilder();
         final String lineSeparator = System.lineSeparator();
 
+        TornadoLogger logger = new TornadoLogger();
+
         try {
             Process p = Runtime.getRuntime().exec(command);
             p.waitFor();
@@ -435,10 +437,10 @@ public final class RuntimeUtilities {
             writeStringToFile(loggingDirectory + FPGA_OUTPUT_FILENAME, standardOutput.toString(), true);
             writeStringToFile(loggingDirectory + FPGA_ERROR_FILENAME, errorOutput.toString(), true);
         } catch (IOException e) {
-            TornadoLogger.error("Unable to make a native system call.", e);
+            logger.error("Unable to make a native system call.", e);
             throw new IOException(e);
         } catch (Throwable t) {
-            TornadoLogger.error("Unable to make a native system call.", t);
+            logger.error("Unable to make a native system call.", t);
             throw new TornadoRuntimeException(t.getMessage());
         }
     }
@@ -447,7 +449,7 @@ public final class RuntimeUtilities {
         try (FileOutputStream fos = (append ? new FileOutputStream(file, true) : new FileOutputStream(file))) {
             fos.write(source);
         } catch (IOException e) {
-            TornadoLogger.error("unable to dump source: ", e.getMessage());
+            new TornadoLogger().error("unable to dump source: ", e.getMessage());
             throw new RuntimeException("unable to dump source: " + e.getMessage());
         }
 
@@ -460,14 +462,14 @@ public final class RuntimeUtilities {
             bw.flush();
             bw.close();
         } catch (IOException e) {
-            TornadoLogger.error("unable to dump source: ", e.getMessage());
+            new TornadoLogger().error("unable to dump source: ", e.getMessage());
             throw new RuntimeException("unable to dump source: " + e.getMessage());
         }
 
     }
 
     public static void writeToFile(String file, byte[] binary) {
-        TornadoLogger.info("dumping binary %s", file);
+        new TornadoLogger().info("dumping binary %s", file);
         try (FileOutputStream fis = new FileOutputStream(file);) {
             fis.write(binary);
         } catch (IOException e) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/Tornado.java
@@ -61,7 +61,7 @@ public final class Tornado implements TornadoSettingInterface {
             try (FileInputStream fileInputStream = new FileInputStream(localSettings)) {
                 loadProperties.load(fileInputStream);
             } catch (IOException e) {
-                TornadoLogger.warn("Unable to load settings from %s", localSettings.getAbsolutePath());
+                new TornadoLogger().warn("Unable to load settings from %s", localSettings.getAbsolutePath());
             }
         }
         Set<String> localKeys = loadProperties.stringPropertyNames();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoLogger.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoLogger.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
 
 public class TornadoLogger {
 
-    private static Logger logger;
+    private static Logger logger = Logger.getAnonymousLogger();
 
     static boolean isLogOptionEnabled = TornadoOptions.DEBUG || TornadoOptions.FULL_DEBUG;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoLogger.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoLogger.java
@@ -28,84 +28,86 @@ import java.util.logging.Logger;
 
 public class TornadoLogger {
 
-    private static Logger logger = Logger.getAnonymousLogger();
-
-    static boolean isLogOptionEnabled = TornadoOptions.DEBUG || TornadoOptions.FULL_DEBUG;
+    private final Logger logger;
+    private final boolean isLogOptionEnabled = TornadoOptions.DEBUG || TornadoOptions.FULL_DEBUG;
 
     public TornadoLogger(Class<?> clazz) {
-        logger = Logger.getLogger(clazz == null ? this.getClass().getName() : clazz.getName());
+        if (clazz == null) {
+            logger = Logger.getAnonymousLogger();
+        } else {
+            logger = Logger.getLogger(clazz.getName());
+        }
     }
 
     public TornadoLogger() {
         this(null);
     }
 
-    public static void debug(final String msg) {
+    public void debug(final String msg) {
         if (isLogOptionEnabled) {
             logger.setLevel(Level.INFO);
             logger.info(msg);
         }
     }
 
-    public static void debug(final String pattern, final Object... args) {
+    public void debug(final String pattern, final Object... args) {
         debug(String.format(pattern, args));
     }
 
-    public static void error(final String msg) {
+    public void error(final String msg) {
         if (isLogOptionEnabled) {
             logger.setLevel(Level.SEVERE);
             logger.severe(msg);
         }
     }
 
-    public static void error(final String pattern, final Object... args) {
+    public void error(final String pattern, final Object... args) {
         if (isLogOptionEnabled) {
             error(String.format(pattern, args));
         }
     }
 
-    public static void fatal(final String msg) {
+    public void fatal(final String msg) {
         if (isLogOptionEnabled) {
             logger.setLevel(Level.SEVERE);
             logger.severe(msg);
         }
     }
 
-    public static void fatal(final String pattern, final Object... args) {
+    public void fatal(final String pattern, final Object... args) {
         fatal(String.format(pattern, args));
     }
 
-    public static void info(final String msg) {
+    public void info(final String msg) {
         if (isLogOptionEnabled) {
             logger.setLevel(Level.INFO);
             logger.info(msg);
         }
     }
 
-    public static void info(final String pattern, final Object... args) {
+    public void info(final String pattern, final Object... args) {
         info(String.format(pattern, args));
     }
 
-    public static void trace(final String msg) {
+    public void trace(final String msg) {
         if (isLogOptionEnabled) {
             logger.setLevel(Level.INFO);
             logger.info(msg);
         }
     }
 
-    public static void trace(final String pattern, final Object... args) {
+    public void trace(final String pattern, final Object... args) {
         trace(String.format(pattern, args));
     }
 
-    public static void warn(final String msg) {
+    public void warn(final String msg) {
         if (isLogOptionEnabled) {
             logger.setLevel(Level.WARNING);
             logger.warning(msg);
         }
     }
 
-    public static void warn(final String msg, final Object... args) {
+    public void warn(final String msg, final Object... args) {
         trace(String.format(msg, args));
     }
-
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/compiler/TornadoCodeGenerator.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/compiler/TornadoCodeGenerator.java
@@ -30,7 +30,7 @@ public final class TornadoCodeGenerator {
     public static final TornadoLogger log = new TornadoLogger(TornadoCodeGenerator.class);
 
     public static void debug(final String msg) {
-        TornadoLogger.debug(msg);
+        log.debug(msg);
     }
 
     public static void debug(final String pattern, final Object... args) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoDataflowAnalysis.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoDataflowAnalysis.java
@@ -79,7 +79,7 @@ public class TornadoDataflowAnalysis extends BasePhase<TornadoSketchTierContext>
             if (param != null && param.stamp(NodeView.DEFAULT) instanceof ObjectStamp) {
                 accesses[i] = processUsages(param, context.getMetaAccess());
             }
-            TornadoLogger.debug("access: parameter %d -> %s\n", i, accesses[i]);
+            new TornadoLogger().debug("access: parameter %d -> %s\n", i, accesses[i]);
         }
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -325,7 +325,7 @@ public class TornadoExecutionContext {
 
         setDevice(accelerator);
 
-        TornadoLogger.info("assigning %s to %s", id, target.getDeviceName());
+        new TornadoLogger().info("assigning %s to %s", id, target.getDeviceName());
 
         taskToDeviceMapTable[index] = accelerator;
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
@@ -90,7 +90,7 @@ public class TornadoVMBytecodeBuilder {
         } else if (node instanceof CopyInNode) {
             bitcodeASM.transferToDeviceOnce(((CopyInNode) node).getValue().getIndex(), dependencyBC, offset, batchSize);
         } else if (node instanceof AllocateNode) {
-            TornadoLogger.info("[%s]: Skipping deprecated node %s", getClass().getSimpleName(), AllocateNode.class.getSimpleName());
+            new TornadoLogger().info("[%s]: Skipping deprecated node %s", getClass().getSimpleName(), AllocateNode.class.getSimpleName());
         } else if (node instanceof CopyOutNode) {
             ObjectNode value = ((CopyOutNode) node).getValue().getValue();
             bitcodeASM.transferToHost(value.getIndex(), dependencyBC, offset, batchSize);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
@@ -61,7 +61,7 @@ public class TornadoVMGraphCompiler {
 
         intermediateTornadoGraph.analyzeDependencies();
 
-        TornadoLogger.debug("Compiling bytecodes...");
+        new TornadoLogger().debug("Compiling bytecodes...");
 
         for (int i = 0; i < tornadoVMBytecodeResults.length; i++) {
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -99,6 +99,8 @@ public class TornadoVMInterpreter {
 
     private GridScheduler gridScheduler;
 
+    private TornadoLogger logger = new TornadoLogger(this.getClass());
+
     /**
      * It constructs a new TornadoVMInterpreter object.
      *
@@ -123,7 +125,7 @@ public class TornadoVMInterpreter {
         totalTime = 0;
         invocations = 0;
 
-        TornadoLogger.debug("init an instance of a TornadoVM interpreter...");
+        logger.debug("init an instance of a TornadoVM interpreter...");
 
         this.bytecodeResult.getLong(); // Skips bytes not needed
 
@@ -140,8 +142,8 @@ public class TornadoVMInterpreter {
             eventsIndexes[i] = 0;
         }
 
-        TornadoLogger.debug("created %d kernelStackFrame", kernelStackFrame.length);
-        TornadoLogger.debug("created %d event lists", events.length);
+        logger.debug("created %d kernelStackFrame", kernelStackFrame.length);
+        logger.debug("created %d event lists", events.length);
 
         objects = executionContext.getObjects();
         dataObjectStates = new DataObjectState[objects.size()];
@@ -152,7 +154,7 @@ public class TornadoVMInterpreter {
         constants = executionContext.getConstants();
         tasks = executionContext.getTasks();
 
-        TornadoLogger.debug("interpreter for device %s is ready to go", device.toString());
+        logger.debug("interpreter for device %s is ready to go", device.toString());
 
         this.bytecodeResult.mark();
     }
@@ -175,11 +177,11 @@ public class TornadoVMInterpreter {
             TornadoInternalError.guarantee(op == TornadoVMBytecodes.CONTEXT.value(), "invalid code: 0x%x", op);
             final int deviceIndex = bytecodeResult.getInt();
             assert deviceIndex == deviceForInterpreter.getDeviceContext().getDeviceIndex();
-            TornadoLogger.debug("loading context %s", deviceForInterpreter.toString());
+            logger.debug("loading context %s", deviceForInterpreter.toString());
             final long t0 = System.nanoTime();
             deviceForInterpreter.ensureLoaded(executionContext.getExecutionPlanId());
             final long t1 = System.nanoTime();
-            TornadoLogger.debug("loaded in %.9f s", (t1 - t0) * 1e-9);
+            logger.debug("loaded in %.9f s", (t1 - t0) * 1e-9);
             op = bytecodeResult.get();
         }
     }
@@ -200,7 +202,7 @@ public class TornadoVMInterpreter {
 
     public void dumpEvents() {
         if (!TornadoOptions.TORNADO_PROFILER || !executionContext.meta().shouldDumpEvents()) {
-            TornadoLogger.info("profiling and/or event dumping is not enabled");
+            logger.info("profiling and/or event dumping is not enabled");
             return;
         }
 
@@ -209,7 +211,7 @@ public class TornadoVMInterpreter {
 
     public void dumpProfiles() {
         if (!executionContext.meta().shouldDumpProfiles()) {
-            TornadoLogger.info("profiling is not enabled");
+            logger.info("profiling is not enabled");
             return;
         }
 
@@ -376,7 +378,7 @@ public class TornadoVMInterpreter {
         }
 
         if (executionContext.meta().isDebug()) {
-            TornadoLogger.debug("bc: complete elapsed=%.9f s (%d iterations, %.9f s mean)", elapsed, invocations, (totalTime / invocations));
+            logger.debug("bc: complete elapsed=%.9f s (%d iterations, %.9f s mean)", elapsed, invocations, (totalTime / invocations));
         }
 
         bytecodeResult.reset();
@@ -797,7 +799,7 @@ public class TornadoVMInterpreter {
 
     private void throwErrorInterpreter(byte op) {
         if (executionContext.meta().isDebug()) {
-            TornadoLogger.debug("bc: invalid op 0x%x(%d)", op, op);
+            logger.debug("bc: invalid op 0x%x(%d)", op, op);
         }
         throw new TornadoRuntimeException("[ERROR] TornadoVM Bytecode not recognized");
     }
@@ -822,7 +824,7 @@ public class TornadoVMInterpreter {
 
     private KernelStackFrame resolveCallWrapper(int index, int numArgs, KernelStackFrame[] kernelStackFrame, TornadoXPUDevice device, boolean redeployOnDevice) {
         if (executionContext.meta().isDebug() && redeployOnDevice) {
-            TornadoLogger.debug("Recompiling task on device " + device);
+            logger.debug("Recompiling task on device " + device);
         }
         if (kernelStackFrame[index] == null || redeployOnDevice) {
             kernelStackFrame[index] = device.createKernelStackFrame(numArgs);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
@@ -77,6 +77,7 @@ public class TornadoSketcher {
     private static final Map<ResolvedJavaMethod, List<TornadoSketcherCacheEntry>> cache = new ConcurrentHashMap<>();
     private static final TimerKey Sketcher = DebugContext.timer("Sketcher");
     private static final OptimisticOptimizations optimisticOpts = OptimisticOptimizations.ALL;
+    private static TornadoLogger logger = new TornadoLogger();
 
     private static boolean cacheContainsSketch(ResolvedJavaMethod method, int driverIndex, int deviceIndex) {
         List<TornadoSketcherCacheEntry> entries = cache.get(method);
@@ -109,7 +110,7 @@ public class TornadoSketcher {
             }
             guarantee(sketch != null, "No sketch available for %d:%d %s", driverIndex, deviceIndex, resolvedMethod.getName());
         } catch (InterruptedException | ExecutionException e) {
-            TornadoLogger.fatal("Failed to retrieve sketch for %d:%d %s ", driverIndex, deviceIndex, resolvedMethod.getName());
+            logger.fatal("Failed to retrieve sketch for %d:%d %s ", driverIndex, deviceIndex, resolvedMethod.getName());
             if (TornadoOptions.DEBUG) {
                 e.printStackTrace();
             }
@@ -136,7 +137,7 @@ public class TornadoSketcher {
 
     private static Sketch buildSketch(ResolvedJavaMethod resolvedMethod, Providers providers, PhaseSuite<HighTierContext> graphBuilderSuite, TornadoSketchTier sketchTier, int backendIndex,
             int deviceIndex) {
-        TornadoLogger.info("Building sketch of %s", resolvedMethod.getName());
+        logger.info("Building sketch of %s", resolvedMethod.getName());
         TornadoCompilerIdentifier id = new TornadoCompilerIdentifier("sketch-" + resolvedMethod.getName(), sketchId.getAndIncrement());
         Builder builder = new Builder(getOptions(), getDebugContext(), AllowAssumptions.YES);
         builder.method(resolvedMethod);
@@ -182,7 +183,7 @@ public class TornadoSketcher {
             return new Sketch(graph.copy(TornadoCoreRuntime.getDebugContext()), methodAccesses, highTierContext.getBatchWriteThreadIndex());
 
         } catch (Throwable e) {
-            TornadoLogger.fatal("unable to build sketch for method: %s (%s)", resolvedMethod.getName(), e.getMessage());
+            logger.fatal("unable to build sketch for method: %s (%s)", resolvedMethod.getName(), e.getMessage());
             if (TornadoOptions.DEBUG) {
                 e.printStackTrace();
             }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -962,7 +962,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     public void transferToHost(final int mode, Object... objects) {
         for (Object functionParameter : objects) {
             if (functionParameter == null) {
-                TornadoLogger.warn("null object passed into streamIn() in schedule %s", executionContext.getId());
+                new TornadoLogger().warn("null object passed into streamIn() in schedule %s", executionContext.getId());
                 continue;
             }
 


### PR DESCRIPTION
#### Description

Fix logger initialization after the Tornado class refactoring. 

#### Problem description

The issue was a missing initialisation for the factory logging methods. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado --debug -ea  --jvm "-Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.verbose=True "  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  --params "uk.ac.manchester.tornado.unittests.foundation.TestIntegers"
```

