### PR TITLE
Math operations for cos/sin with vector types supported

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/math/TornadoMath.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/math/TornadoMath.java
@@ -31,7 +31,11 @@ import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix4x4Float;
 import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.vectors.Float16;
+import uk.ac.manchester.tornado.api.types.vectors.Float2;
 import uk.ac.manchester.tornado.api.types.vectors.Float3;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
+import uk.ac.manchester.tornado.api.types.vectors.Float8;
 
 public class TornadoMath {
 
@@ -161,6 +165,54 @@ public class TornadoMath {
 
     public static double fract(double f) {
         return f - floor(f);
+    }
+
+    public static Float2 cos(Float2 f) {
+        return new Float2(TornadoMath.cos(f.getX()), TornadoMath.cos(f.getY()));
+    }
+
+    public static Float4 cos(Float4 f) {
+        return new Float4(TornadoMath.cos(f.getX()), TornadoMath.cos(f.getY()), TornadoMath.cos(f.getZ()), TornadoMath.cos(f.getW()));
+    }
+
+    public static Float8 cos(Float8 f) {
+        Float8 result = new Float8();
+        for (int i = 0; i < f.size(); i++) {
+            result.set(i, TornadoMath.cos(f.get(i)));
+        }
+        return result;
+    }
+
+    public static Float16 cos(Float16 f) {
+        Float16 result = new Float16();
+        for (int i = 0; i < f.size(); i++) {
+            result.set(i, TornadoMath.cos(f.get(i)));
+        }
+        return result;
+    }
+
+    public static Float2 sin(Float2 f) {
+        return new Float2(TornadoMath.sin(f.getX()), TornadoMath.sin(f.getY()));
+    }
+
+    public static Float4 sin(Float4 f) {
+        return new Float4(TornadoMath.sin(f.getX()), TornadoMath.sin(f.getY()), TornadoMath.sin(f.getZ()), TornadoMath.sin(f.getW()));
+    }
+
+    public static Float8 sin(Float8 f) {
+        Float8 result = new Float8();
+        for (int i = 0; i < f.size(); i++) {
+            result.set(i, TornadoMath.sin(f.get(i)));
+        }
+        return result;
+    }
+
+    public static Float16 sin(Float16 f) {
+        Float16 result = new Float16();
+        for (int i = 0; i < f.size(); i++) {
+            result.set(i, TornadoMath.sin(f.get(i)));
+        }
+        return result;
     }
 
     public static boolean isEqual(float[] a, float[] b) {

--- a/tornado-examples/src/main/java/module-info.java
+++ b/tornado-examples/src/main/java/module-info.java
@@ -19,6 +19,7 @@ open module tornado.examples {
     requires transitive java.desktop;
     requires transitive tornado.api;
     requires org.graalvm.polyglot;
+    requires jdk.incubator.vector;
 
     exports uk.ac.manchester.tornado.examples;
     exports uk.ac.manchester.tornado.examples.arrays;


### PR DESCRIPTION
#### Description

This PR adds vector math operations for the `cos` and `sin` math functions. In addition, it expands the DFT example with the Vector API and applies a fix for the vector computation of the DFT. 

#### Problem description

Fixes for the DFT application.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make
$ make tests
$  tornado --printKernel --enableProfiler console -m tornado.examples/uk.ac.manchester.tornado.examples.vectors.DFTVector vector8
```

