### PR TITLE
[installer] check TORNADO_SDK upfront 

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -377,8 +377,24 @@ def parse_args():
     return args
 
 
+def check_tornadoSDK():
+    """
+    Check if TORNADO_SDK env variable is loaded. It exits the compilation if it is not
+    declared. 
+    """
+    print("Checking TORNADO_SDK env variable ................ ",  end='')
+    try:
+        os.environ['TORNADO_SDK']
+        print("[OK]")
+    except:
+        print("[ERROR] \n\t TORNADO_SDK env variable not defined\n\n \t Suggestion (Linux and OSx): run `source setvars.sh`\n \n \t Suggestion (Windows): run `setvars.cmd`\n"),
+        sys.exit(-1)
+
+
 def main():
     args = parse_args()
+
+    check_tornadoSDK()
 
     graal_jars_status = should_handle_graal_jars(args.jdk)
 


### PR DESCRIPTION
#### Description

It checks for the `TORNADO_SDK` env variable upfront instead of compiling the whole TornadoVM and getting the error at the end, forcing to recompile the whole project. 

#### Problem description

If the `TORNADO_SDK`  was not defined, TornadoVM only emits the error when maven finishes the Java build. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make
$ bin/compile --jdk jdk21 --backend opencl
Checking TORNADO_SDK env variable ................ [ERROR] 
	 TORNADO_SDK env variable not defined

 	 Suggestion (Linux and OSx): run `source setvars.sh`
 
 	 Suggestion (Windows): run `setvars.cmd`

$ source setvars.sh
$ make 

ource setvars.sh 
 juan   feat/install/checker … 3  ~  tornadovm  TornadoVM  make
bin/compile --jdk jdk21 --backend opencl
Checking TORNADO_SDK env variable ................ [OK]
mvn -Popencl-backend,ptx-backend,spirv-backend clean
...
```

