### PR TITLE
[release] TornadoVM 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Developers can choose which backends to install and run.
 
 For a quick introduction please read the following [FAQ](https://tornadovm.readthedocs.io/en/latest/).
 
-**Latest Release:** TornadoVM 1.0.4 - 30/04/2024 :
+**Latest Release:** TornadoVM 1.0.5 - 28/05/2024 :
 See [CHANGELOG](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html).
 
 ----------------------
@@ -260,12 +260,12 @@ You can import the TornadoVM API by setting this the following dependency in the
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
 </dependency>
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-matrices</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
 </dependency>
 </dependencies>
 ```

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -33,7 +33,7 @@ import wget
 import installer_config as config
 
 __DIRECTORY_DEPENDENCIES__ = os.path.join("etc", "dependencies")
-__VERSION__ = "v1.0.4"
+__VERSION__ = "v1.0.5"
 
 __SUPPORTED_JDKS__ = [
     config.__JDK21__,

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -5,6 +5,52 @@ TornadoVM Changelog
 
 This file summarizes the new features and major changes for each *TornadoVM* version.
 
+TornadoVM 1.0.5
+----------------
+26th May 2024
+
+Improvements
+~~~~~~~~~~~~~~~~~~
+
+- `#402 <https://github.com/beehive-lab/TornadoVM/pull/402>`_: Support for TornadoNativeArrays from FFI buffers.
+- `#403 <https://github.com/beehive-lab/TornadoVM/pull/403>`_: Clean-up and refactoring for the code analysis of the loop-interchange.
+- `#405 <https://github.com/beehive-lab/TornadoVM/pull/405>`_: Disable Loop-Interchange for CPU offloading..
+- `#407 <https://github.com/beehive-lab/TornadoVM/pull/407>`_: Debugging OpenCL Kernels builds improved. 
+- `#410 <https://github.com/beehive-lab/TornadoVM/pull/410>`_: CPU block scheduler disabled by default and option to switch between different thread-schedulers added.
+- `#418 <https://github.com/beehive-lab/TornadoVM/pull/418>`_: TornadoOptions and TornadoLogger improved.
+- `#423 <https://github.com/beehive-lab/TornadoVM/pull/423>`_: MxM using ns instead of ms to report performance.
+- `#425 <https://github.com/beehive-lab/TornadoVM/pull/425>`_: Vector types for ``Float<Width>`` and ``Int<Width>`` supported.
+- `#429 <https://github.com/beehive-lab/TornadoVM/pull/429>`_: Documentation of the installation process updated and improved.
+- `#432 <https://github.com/beehive-lab/TornadoVM/pull/432>`_: Support for SPIR-V code generation and dispatcher using the TornadoVM OpenCL runtime.
+
+
+Compatibility
+~~~~~~~~~~~~~~~~~~
+
+- `#409 <https://github.com/beehive-lab/TornadoVM/pull/409>`_: Guidelines to build the documentation. 
+- `#411 <https://github.com/beehive-lab/TornadoVM/pull/411>`_: Windows installer improved.
+- `#412 <https://github.com/beehive-lab/TornadoVM/pull/412>`_: Python installer improved to check download all Python dependencies before the main installer.
+- `#413 <https://github.com/beehive-lab/TornadoVM/pull/413>`_: Improved documentation for installing all configurations of backends and OS. 
+- `#424 <https://github.com/beehive-lab/TornadoVM/pull/424>`_: Use Generic GPU Scheduler for some older NVIDIA Drivers for the OpenCL runtime.
+- `#430 <https://github.com/beehive-lab/TornadoVM/pull/430>`_: Improved the installer by checking  that the TornadoVM environment is loaded upfront.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~
+
+- `#400 <https://github.com/beehive-lab/TornadoVM/pull/400>`_: Fix batch computation when the global thread indexes are used to compute the outputs.
+- `#414 <https://github.com/beehive-lab/TornadoVM/pull/414>`_: Recover Test-Field unit-tests using Panama types.
+- `#415 <https://github.com/beehive-lab/TornadoVM/pull/415>`_: Check style errors fixed.
+- `#416 <https://github.com/beehive-lab/TornadoVM/pull/416>`_: FPGA execution with multiple tasks in a task-graph fixed. 
+- `#417 <https://github.com/beehive-lab/TornadoVM/pull/417>`_: Lazy-copy out fixed for Java fields.
+- `#420 <https://github.com/beehive-lab/TornadoVM/pull/420>`_: Fix Mandelbrot example.
+- `#421 <https://github.com/beehive-lab/TornadoVM/pull/421>`_: OpenCL 2D thread-scheduler fixed for NVIDIA GPUs.
+- `#422 <https://github.com/beehive-lab/TornadoVM/pull/422>`_: Compilation for NVIDIA Jetson Nano fixed.
+- `#426 <https://github.com/beehive-lab/TornadoVM/pull/426>`_: Fix Logger for all backends.
+- `#428 <https://github.com/beehive-lab/TornadoVM/pull/428>`_: Math cos/sin operations supported for vector types.
+- `#431 <https://github.com/beehive-lab/TornadoVM/pull/431>`_: Jenkins files fixed. 
+
+
+
 TornadoVM 1.0.4
 ----------------
 30th April 2024

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -509,13 +509,13 @@ To use the TornadoVM API in your projects, you can checkout our maven repository
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>1.0.4</version>
+         <version>1.0.5</version>
       </dependency>
 
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>1.0.4</version>
+         <version>1.0.5</version>
       </dependency>
    </dependencies>
 
@@ -526,6 +526,7 @@ Notice that, for running with TornadoVM, you will need either the docker images 
 Versions available
 ========================
 
+* 1.0.5
 * 1.0.4
 * 1.0.3
 * 1.0.2

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>tornado</groupId>
     <artifactId>tornado</artifactId>
-    <version>1.0.5-dev</version>
+    <version>1.0.5</version>
     <packaging>pom</packaging>
     <name>tornado</name>
     <url>https://github.com/beehive-lab/tornadovm</url>

--- a/tornado-annotation/pom.xml
+++ b/tornado-annotation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
 
     <artifactId>tornado-annotation</artifactId>

--- a/tornado-api/pom.xml
+++ b/tornado-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
 
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.5-dev</version>
+    <version>1.0.5</version>
 
     <name>tornado-api</name>
     <url>https://tornadovm.org</url>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-assembly</artifactId>
     <packaging>pom</packaging>

--- a/tornado-benchmarks/pom.xml
+++ b/tornado-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
 
     <artifactId>tornado-benchmarks</artifactId>

--- a/tornado-drivers/drivers-common/pom.xml
+++ b/tornado-drivers/drivers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tornado-drivers/opencl-jni/pom.xml
+++ b/tornado-drivers/opencl-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-drivers-opencl-jni</artifactId>
     <name>tornado-drivers-opencl-jni</name>

--- a/tornado-drivers/opencl/pom.xml
+++ b/tornado-drivers/opencl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-drivers-opencl</artifactId>
     <name>tornado-drivers-opencl</name>

--- a/tornado-drivers/pom.xml
+++ b/tornado-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-drivers</artifactId>
     <name>tornado-drivers</name>

--- a/tornado-drivers/ptx-jni/pom.xml
+++ b/tornado-drivers/ptx-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-drivers-ptx-jni</artifactId>
     <name>tornado-drivers-ptx-jni</name>

--- a/tornado-drivers/ptx/pom.xml
+++ b/tornado-drivers/ptx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tornado-drivers</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-drivers-ptx</artifactId>
     <name>tornado-drivers-ptx</name>

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-drivers-spirv</artifactId>
     <name>tornado-drivers-spirv</name>

--- a/tornado-examples/pom.xml
+++ b/tornado-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-examples</artifactId>
     <name>tornado-examples</name>

--- a/tornado-matrices/pom.xml
+++ b/tornado-matrices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-matrices</artifactId>
     <name>tornado-matrices</name>

--- a/tornado-runtime/pom.xml
+++ b/tornado-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-runtime</artifactId>
     <name>tornado-runtime</name>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.5-dev</version>
+        <version>1.0.5</version>
     </parent>
     <artifactId>tornado-unittests</artifactId>
     <name>tornado-unittests</name>


### PR DESCRIPTION
Improvements
=============

- #402: Support for TornadoNativeArrays from FFI buffers.
- #403: Clean-up and refactoring for the code analysis of the loop-interchange.
- #405: Disable Loop-Interchange for CPU offloading..
- #407: Debugging OpenCL Kernels builds improved. 
- #410: CPU block scheduler disabled by default and option to switch between different thread-schedulers added.
- #418: TornadoOptions and TornadoLogger improved.
- #423: MxM using ns instead of ms to report performance.
- #425: Vector types for ``Float<Width>`` and ``Int<Width>`` supported.
- #429: Documentation of the installation process updated and improved.
- #432: Support for SPIR-V code generation and dispatcher using the TornadoVM OpenCL runtime.


Compatibility
=============

- #409: Guidelines to build the documentation. 
- #411: Windows installer improved.
- #412: Python installer improved to check download all Python dependencies before the main installer.
- #413: Improved documentation for installing all configurations of backends and OS. 
- #424: Use Generic GPU Scheduler for some older NVIDIA Drivers for the OpenCL runtime.
- #430: Improved the installer by checking  that the TornadoVM environment is loaded upfront.


Bug Fixes
=============

- #400: Fix batch computation when the global thread indexes are used to compute the outputs.
- #414: Recover Test-Field unit-tests using Panama types.
- #415: Check style errors fixed.
- #416: FPGA execution with multiple tasks in a task-graph fixed. 
- #417: Lazy-copy out fixed for Java fields.
- #420: Fix Mandelbrot example.
- #421: OpenCL 2D thread-scheduler fixed for NVIDIA GPUs.
- #422: Compilation for NVIDIA Jetson Nano fixed.
- #426: Fix Logger for all backends.
- #428: Math cos/sin operations supported for vector types.
- #431: Jenkins files fixed. 


## How to test?

```bash
$ make 
$ tornado --version

version=1.0.5
branch=release/1.0.5
commit=152fcbf

Backends installed: 
	 - opencl

$ make tests
```