### PR TITLE
[fix][rt] support for query multiple SPIR-V supported versions

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
@@ -452,9 +452,9 @@ public class OCLDevice implements OCLTargetDevice {
             // We query the device properties and the current device does not support
             // OpenCL 1.2 or higher. 
             return false;
-        } else if (spirvVersion >= SPIRV_SUPPPORTED) {
+        } else if (spirvVersion > 0) {
             // We query the device properties and the device supports at least SPIR-V 1.2.
-            return spirvVersion >= 1.2;
+            return spirvVersion >= SPIRV_SUPPPORTED;
         } else {
             // Query the device properties and parse the version
             queryOpenCLAPI(OCLDeviceInfo.CL_DEVICE_IL_VERSION.getValue());

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
@@ -75,7 +75,11 @@ public class OCLDevice implements OCLTargetDevice {
     private OCLLocalMemType localMemoryType;
     private int deviceVendorID;
     private OCLDeviceContextInterface deviceContext;
-    private float spirvVersion = -1;
+    private float spirvVersion = SPIRV_VERSION_INIT;
+
+    private static final int SPIRV_VERSION_INIT = -1;
+    private static final int SPIRV_NOT_SUPPORTED = -2;
+    private static final float SPIRV_SUPPPORTED = 1.2f;
 
     public OCLDevice(int index, long id) {
         this.index = index;
@@ -444,9 +448,15 @@ public class OCLDevice implements OCLTargetDevice {
 
     @Override
     public boolean isSPIRVSupported() {
-        if (spirvVersion != -1) {
+        if (spirvVersion == SPIRV_NOT_SUPPORTED) {
+            // We query the device properties and the current device does not support
+            // OpenCL 1.2 or higher. 
+            return false;
+        } else if (spirvVersion >= SPIRV_SUPPPORTED) {
+            // We query the device properties and the device supports at least SPIR-V 1.2.
             return spirvVersion >= 1.2;
         } else {
+            // Query the device properties and parse the version
             queryOpenCLAPI(OCLDeviceInfo.CL_DEVICE_IL_VERSION.getValue());
             String versionQuery = new String(buffer.array(), StandardCharsets.US_ASCII);
             if (versionQuery.isEmpty()) {
@@ -467,6 +477,7 @@ public class OCLDevice implements OCLTargetDevice {
             }
             // if all versions have been visited and none of them is >= 1.2
             // then, we return false;
+            spirvVersion = SPIRV_NOT_SUPPORTED;
             return false;
         }
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
@@ -449,15 +449,24 @@ public class OCLDevice implements OCLTargetDevice {
         } else {
             queryOpenCLAPI(OCLDeviceInfo.CL_DEVICE_IL_VERSION.getValue());
             String versionQuery = new String(buffer.array(), StandardCharsets.US_ASCII);
-            String[] version = versionQuery.split("_");
-            if (version.length > 1) {
-                try {
-                    spirvVersion = Float.parseFloat(version[1]);
-                    return spirvVersion >= 1.2;
-                } catch (NumberFormatException e) {
-                    return false;
+            if (versionQuery.isEmpty()) {
+                return false;
+            }
+            String[] spirvVersions = versionQuery.trim().split(" ");
+            // We iterate through all supported versions and check there
+            // is support for SPIR-V >= 1.2
+            for (String version : spirvVersions) {
+                if (!version.isEmpty()) {
+                    String v = version.split("_")[1];
+                    try {
+                        spirvVersion = Float.parseFloat(v);
+                        return spirvVersion >= 1.2;
+                    } catch (NumberFormatException e) {
+                    }
                 }
             }
+            // if all versions have been visited and none of them is >= 1.2
+            // then, we return false;
             return false;
         }
     }


### PR DESCRIPTION
#### Description

This PR expands the SPIR-V support checker for OpenCL devices with multiple versions supported. 

#### Problem description

If the OpenCL device to use contains as description multiple OpenCL devices, using the OpenCL `CL_DEVICE_IL_VERSION`, then the correct version was not detected. This PR fixes that. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [X] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make BACKEND=spirv
$ tornado --devices
```
