### PR TITLE
Update Jenkins to run SPIRV unit-tests for OpenCL and LevelZero runtimes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,7 +165,7 @@ void buildAndTest(String JDK, String tornadoProfile) {
             }
         )
     }
-    stage("SPIR-V: Unit Tests") {
+    stage("SPIR-V (OpenCL Runtime): Unit Tests") {
         timeout(time: 12, unit: 'MINUTES') {
             sh 'tornado --devices'
             sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:0"'
@@ -173,6 +173,14 @@ void buildAndTest(String JDK, String tornadoProfile) {
             sh 'test-native.sh'
         }
     }
+    stage("SPIR-V (LevelZero Runtime): Unit Tests") {
+            timeout(time: 12, unit: 'MINUTES') {
+                sh 'tornado --devices'
+                sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:1"'
+                sh 'tornado-test -V  -J" -Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:1 -Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03'
+                sh 'test-native.sh'
+            }
+        }
     stage('Benchmarks') {
         timeout(time: 15, unit: 'MINUTES') {
             sh 'python3 tornado-assembly/src/bin/tornado-benchmarks.py --printBenchmarks '

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,7 @@ void buildAndTest(String JDK, String tornadoProfile) {
     echo "Tornado profile " + tornadoProfile
     echo "-------------------------"
     stage('Build with ' + JDK) {
-        sh "make ${tornadoProfile} BACKEND=ptx,opencl"
+        sh "make ${tornadoProfile} BACKEND=ptx,opencl,spirv"
     }
     stage('PTX: Unit Tests') {
         timeout(time: 12, unit: 'MINUTES') {
@@ -150,20 +150,28 @@ void buildAndTest(String JDK, String tornadoProfile) {
             "OpenCL and GPU: Nvidia Quadro GP100" : {
                 timeout(time: 12, unit: 'MINUTES') {
                     sh 'tornado --devices'
-                    sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:1"'
-                    sh 'tornado-test -V  -J" -Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:1 -Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03'
+                    sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=2:0"'
+                    sh 'tornado-test -V  -J" -Dtornado.ptx.priority=100 -Dtornado.unittests.device=2:0 -Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03'
                     sh 'test-native.sh'
                 }
             },
             "OpenCL and Integrated GPU: Intel(R) UHD Graphics 630" : {
                 timeout(time: 12, unit: 'MINUTES') {
                     sh 'tornado --devices'
-                    sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:0"'
-                    sh 'tornado-test -V  -J" -Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:0 -Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03'
+                    sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=2:1"'
+                    sh 'tornado-test -V  -J" -Dtornado.ptx.priority=100 -Dtornado.unittests.device=2:1 -Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03'
                     sh 'test-native.sh'
                 }
             }
         )
+    }
+    stage("SPIR-V: Unit Tests") {
+        timeout(time: 12, unit: 'MINUTES') {
+            sh 'tornado --devices'
+            sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:0"'
+            sh 'tornado-test -V  -J" -Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:0 -Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03'
+            sh 'test-native.sh'
+        }
     }
     stage('Benchmarks') {
         timeout(time: 15, unit: 'MINUTES') {


### PR DESCRIPTION
#### Description

An update in the Jenkinsfile to build TornadoVM for all backends.
I also added two new stages for SPIR-V (1. with OpenCL runtime, 2. with Level Zero runtime) and fixed the index for the tornado devices because they were not matching with the title of their stage.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No


----------------------------------------------------------------------------
