### PR TITLE
Guard Nvidia GPU scheduler for minor version to prevent incorrect thread scheduling

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLAMDScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLAMDScheduler.java
@@ -86,6 +86,10 @@ public class OCLAMDScheduler extends OCLKernelScheduler {
         }
     }
 
+    @Override
+    public void checkAndAdaptLocalWork(TaskMetaData meta) {
+    }
+
     private int calculateGroupSize(long maxBlockSize, long customBlockSize, long globalWorkSize) {
         if (maxBlockSize == globalWorkSize) {
             maxBlockSize /= 4;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLCPUScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLCPUScheduler.java
@@ -51,4 +51,8 @@ public class OCLCPUScheduler extends OCLKernelScheduler {
         meta.setLocalWorkToNull();
     }
 
+    @Override
+    public void checkAndAdaptLocalWork(TaskMetaData meta) {
+    }
+
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLFPGAScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLFPGAScheduler.java
@@ -73,6 +73,10 @@ public class OCLFPGAScheduler extends OCLKernelScheduler {
     }
 
     @Override
+    public void checkAndAdaptLocalWork(TaskMetaData meta) {
+    }
+
+    @Override
     public int launch(long executionPlanId, final OCLKernel kernel, final TaskMetaData meta, final int[] waitEvents, long batchThreads) {
         if (meta.isWorkerGridAvailable()) {
             WorkerGrid grid = meta.getWorkerGrid(meta.getId());

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLGenericGPUScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLGenericGPUScheduler.java
@@ -75,6 +75,10 @@ public class OCLGenericGPUScheduler extends OCLKernelScheduler {
         }
     }
 
+    @Override
+    public void checkAndAdaptLocalWork(TaskMetaData meta) {
+    }
+
     private int calculateGroupSize(long maxBlockSize, long globalWorkSize) {
         if (maxBlockSize == globalWorkSize) {
             maxBlockSize /= 4;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLKernelScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLKernelScheduler.java
@@ -54,6 +54,8 @@ public abstract class OCLKernelScheduler {
 
     public abstract void calculateLocalWork(final TaskMetaData meta);
 
+    public abstract void checkAndAdaptLocalWork(final TaskMetaData meta);
+
     public long[] getDefaultLocalWorkGroup() {
         return null;
     }
@@ -129,6 +131,7 @@ public abstract class OCLKernelScheduler {
             }
             if (!meta.isLocalWorkDefined()) {
                 calculateLocalWork(meta);
+                checkAndAdaptLocalWork(meta);
             }
         } else {
             checkLocalWorkGroupFitsOnDevice(meta);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
@@ -34,6 +34,7 @@ public class OCLScheduler {
     private static final String AMD_VENDOR = "Advanced Micro Devices";
     private static final String NVIDIA = "NVIDIA";
     private static final int NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER = 550;
+    private static final int NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER = 67;
 
     private static OCLKernelScheduler getInstanceGPUScheduler(final OCLDeviceContext context) {
         OCLTargetDevice device = context.getDevice();
@@ -41,7 +42,8 @@ public class OCLScheduler {
             return new OCLAMDScheduler(context);
         } else if (device.getDeviceVendor().contains(NVIDIA)) {
             int majorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[0]);
-            if (majorVersion >= NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER) {
+            int minorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[1]);
+            if (majorVersion >= NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER && minorVersion > NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER) {
                 return new OCLNVIDIAGPUScheduler(context);
             } else {
                 return new OCLGenericGPUScheduler(context);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
@@ -36,14 +36,19 @@ public class OCLScheduler {
     private static final int NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER = 550;
     private static final int NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER = 67;
 
+    private static boolean isDriverVersionCompatible(OCLTargetDevice device) {
+        int majorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[0]);
+        int minorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[1]);
+
+        return majorVersion >= NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER && minorVersion >= NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER
+    }
+
     private static OCLKernelScheduler getInstanceGPUScheduler(final OCLDeviceContext context) {
         OCLTargetDevice device = context.getDevice();
         if (device.getDeviceVendor().contains(AMD_VENDOR)) {
             return new OCLAMDScheduler(context);
         } else if (device.getDeviceVendor().contains(NVIDIA)) {
-            int majorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[0]);
-            int minorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[1]);
-            if (majorVersion >= NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER && minorVersion >= NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER) {
+            if (isDriverVersionCompatible(device)) {
                 return new OCLNVIDIAGPUScheduler(context);
             } else {
                 return new OCLGenericGPUScheduler(context);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
@@ -43,7 +43,7 @@ public class OCLScheduler {
         } else if (device.getDeviceVendor().contains(NVIDIA)) {
             int majorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[0]);
             int minorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[1]);
-            if (majorVersion >= NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER && minorVersion > NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER) {
+            if (majorVersion >= NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER && minorVersion >= NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER) {
                 return new OCLNVIDIAGPUScheduler(context);
             } else {
                 return new OCLGenericGPUScheduler(context);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
@@ -40,7 +40,7 @@ public class OCLScheduler {
         int majorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[0]);
         int minorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[1]);
 
-        return majorVersion >= NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER && minorVersion >= NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER
+        return majorVersion >= NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER && minorVersion >= NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER;
     }
 
     private static OCLKernelScheduler getInstanceGPUScheduler(final OCLDeviceContext context) {


### PR DESCRIPTION
#### Problem description

It seems that the new thread deployment strategy was introduced after the nvidia driver 550.67. So, not checking also for the minor version causes tornado-runtime to use the speciliazed nvidia scheduler and fails with:
```
[TornadoVM-OCL-JNI] ERROR : clEnqueueNDRangeKernel -> Returned: -54
```

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [x] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash 
tornado -ea  --jvm "-Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.verbose=True "  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  --params "uk.ac.manchester.tornado.unittests.loops.TestParallelDimensions"
```
----------------------------------------------------------------------------
