### PR TITLE
Fix recompilation when batch processing is not triggered

### DIFF
--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/AddJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/AddJava.java
@@ -64,7 +64,7 @@ public class AddJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         GraphicsKernels.addImage(a, b, c);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/AddTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/AddTornado.java
@@ -102,8 +102,6 @@ public class AddTornado extends BenchmarkDriver {
         final ImageFloat4 result = new ImageFloat4(numElementsX, numElementsY);
 
         runBenchmark(device);
-        executionResult.transferToHost(c);
-        executionPlan.clearProfiles();
 
         GraphicsKernels.addImage(a, b, result);
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/AddTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/AddTornado.java
@@ -23,7 +23,6 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat4;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.api.types.vectors.Float4;
@@ -92,7 +91,7 @@ public class AddTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device) //
                 .execute();
     }
@@ -102,7 +101,7 @@ public class AddTornado extends BenchmarkDriver {
 
         final ImageFloat4 result = new ImageFloat4(numElementsX, numElementsY);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionResult.transferToHost(c);
         executionPlan.clearProfiles();
 
@@ -121,11 +120,4 @@ public class AddTornado extends BenchmarkDriver {
         return Float.compare(maxULP, MAX_ULP) <= 0;
     }
 
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("benchmark.device"));
-        }
-    }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/BlackScholesJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/BlackScholesJava.java
@@ -53,7 +53,7 @@ public class BlackScholesJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         blackscholes(randArray, call, put);
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/BlackScholesTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/BlackScholesTornado.java
@@ -111,7 +111,7 @@ public class BlackScholesTornado extends BenchmarkDriver {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.execute();
+            executionPlan.withDevice(device).execute();
         } catch (TornadoExecutionPlanException e) {
             e.printStackTrace();
             throw new TornadoRuntimeException(e);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/BlackScholesTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/BlackScholesTornado.java
@@ -20,10 +20,14 @@ package uk.ac.manchester.tornado.benchmarks.blackscholes;
 import static uk.ac.manchester.tornado.api.math.TornadoMath.abs;
 import static uk.ac.manchester.tornado.benchmarks.ComputeKernels.blackscholes;
 
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 import uk.ac.manchester.tornado.benchmarks.ComputeKernels;
@@ -62,25 +66,27 @@ public class BlackScholesTornado extends BenchmarkDriver {
                 .transferToDevice(DataTransferMode.EVERY_EXECUTION, randArray) //
                 .task("t0", ComputeKernels::blackscholes, randArray, put, call) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, put, call);
-
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
     }
 
     @Override
     public void tearDown() {
-        executionResult.getProfilerResult().dumpProfiles();
+        if (executionResult != null) {
+            executionResult.getProfilerResult().dumpProfiles();
+        }
         randArray = null;
         call = null;
         put = null;
-        executionPlan.resetDevice();
+        if (executionPlan != null) {
+            executionPlan.resetDevice();
+        }
         super.tearDown();
     }
 
     @Override
     public boolean validate(TornadoDevice device) {
-        FloatArray randArrayTor;
+        FloatArray randArraySeq;
         FloatArray callTor;
         FloatArray putTor;
         FloatArray calSeq;
@@ -89,28 +95,31 @@ public class BlackScholesTornado extends BenchmarkDriver {
 
         val = true;
 
-        randArrayTor = new FloatArray(size);
+        randArraySeq = new FloatArray(size);
         callTor = new FloatArray(size);
         putTor = new FloatArray(size);
         calSeq = new FloatArray(size);
         putSeq = new FloatArray(size);
 
         for (int i = 0; i < size; i++) {
-            randArrayTor.set(i, (float) Math.random());
+            randArraySeq.set(i, randArray.get(i));
         }
 
-        taskGraph = new TaskGraph("benchmark");
-        taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, randArrayTor);
-        taskGraph.task("t0", ComputeKernels::blackscholes, randArrayTor, putTor, callTor);
+        TaskGraph taskGraph = new TaskGraph("benchmark");
+        taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, randArraySeq);
+        taskGraph.task("t0", ComputeKernels::blackscholes, randArraySeq, putTor, callTor);
 
-        immutableTaskGraph = taskGraph.snapshot();
-        executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionResult = executionPlan.withWarmUp().execute();
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            TornadoExecutionResult executionResult = executionPlan.withWarmUp().execute();
+            executionResult.transferToHost(putTor, callTor);
+            executionPlan.clearProfiles();
+        } catch (TornadoExecutionPlanException e) {
+            e.printStackTrace();
+            throw new TornadoRuntimeException(e);
+        }
 
-        executionResult.transferToHost(putTor, callTor);
-        executionPlan.clearProfiles();
-
-        blackscholes(randArrayTor, putSeq, calSeq);
+        blackscholes(randArraySeq, putSeq, calSeq);
 
         for (int i = 0; i < size; i++) {
             if (abs(putTor.get(i) - putSeq.get(i)) > 0.01) {
@@ -127,7 +136,7 @@ public class BlackScholesTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device) //
                 .execute();
     }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/BlurFilterJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/BlurFilterJava.java
@@ -18,13 +18,13 @@
 
 package uk.ac.manchester.tornado.benchmarks.blurFilter;
 
+import java.util.Random;
+
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 import uk.ac.manchester.tornado.benchmarks.ComputeKernels;
-
-import java.util.Random;
 
 public class BlurFilterJava extends BenchmarkDriver {
 
@@ -85,7 +85,7 @@ public class BlurFilterJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         ComputeKernels.channelConvolution(redChannel, redFilter, size, size, filter, FILTER_WIDTH);
         ComputeKernels.channelConvolution(greenChannel, greenFilter, size, size, filter, FILTER_WIDTH);
         ComputeKernels.channelConvolution(blueChannel, blueFilter, size, size, filter, FILTER_WIDTH);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/BlurFilterTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/BlurFilterTornado.java
@@ -159,7 +159,7 @@ public class BlurFilterTornado extends BenchmarkDriver {
 
         ImmutableTaskGraph immutableTaskGraph1 = parallelFilter.snapshot();
         TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph1);
-        executor.withDefaultScheduler().execute();
+        executor.withDevice(device).withDefaultScheduler().execute();
 
         // Sequential
         ComputeKernels.channelConvolution(redChannel, redFilterSeq, size, size, filter, FILTER_WIDTH);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/BlurFilterTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/BlurFilterTornado.java
@@ -185,7 +185,7 @@ public class BlurFilterTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/ConvolveImageArrayJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/ConvolveImageArrayJava.java
@@ -62,7 +62,7 @@ public class ConvolveImageArrayJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         convolveImageArray(input, filter, output, imageSizeX, imageSizeY, filterSize, filterSize);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/ConvolveImageArrayTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/ConvolveImageArrayTornado.java
@@ -24,7 +24,6 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
@@ -86,7 +85,7 @@ public class ConvolveImageArrayTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -95,7 +94,7 @@ public class ConvolveImageArrayTornado extends BenchmarkDriver {
 
         final FloatArray result = new FloatArray(imageSizeX * imageSizeY);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionResult.transferToHost(output);
         executionPlan.clearProfiles();
 
@@ -112,11 +111,4 @@ public class ConvolveImageArrayTornado extends BenchmarkDriver {
         return Float.compare(maxULP, MAX_ULP) <= 0;
     }
 
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("s0.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("s0.device"));
-        }
-    }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/ConvolveImageArrayTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/ConvolveImageArrayTornado.java
@@ -95,8 +95,6 @@ public class ConvolveImageArrayTornado extends BenchmarkDriver {
         final FloatArray result = new FloatArray(imageSizeX * imageSizeY);
 
         runBenchmark(device);
-        executionResult.transferToHost(output);
-        executionPlan.clearProfiles();
 
         GraphicsKernels.convolveImageArray(input, filter, result, imageSizeX, imageSizeY, filterSize, filterSize);
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageJava.java
@@ -61,7 +61,7 @@ public class ConvolveImageJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         convolveImage(input, filter, output);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageStreams.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageStreams.java
@@ -61,7 +61,7 @@ public class ConvolveImageStreams extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         convolveImageStreams(input, filter, output);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageTornado.java
@@ -24,7 +24,6 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
@@ -88,7 +87,7 @@ public class ConvolveImageTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -97,7 +96,7 @@ public class ConvolveImageTornado extends BenchmarkDriver {
 
         final ImageFloat result = new ImageFloat(imageSizeX, imageSizeY);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
 
         executionResult.transferToHost(output);
         executionPlan.clearProfiles();
@@ -115,14 +114,6 @@ public class ConvolveImageTornado extends BenchmarkDriver {
             }
         }
         return Float.compare(maxULP, MAX_ULP) <= 0;
-    }
-
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("benchmark.device"));
-        }
     }
 
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageTornado.java
@@ -98,9 +98,6 @@ public class ConvolveImageTornado extends BenchmarkDriver {
 
         runBenchmark(device);
 
-        executionResult.transferToHost(output);
-        executionPlan.clearProfiles();
-
         GraphicsKernels.convolveImage(input, filter, result);
 
         float maxULP = 0f;

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTJava.java
@@ -60,7 +60,7 @@ public class DFTJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         ComputeKernels.computeDFT(inReal, inImag, outReal, outImag);
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTTornado.java
@@ -82,9 +82,9 @@ public class DFTTornado extends BenchmarkDriver {
                 .withWarmUp() //
                 .execute();
 
-        executionResult.transferToHost(outReal, outImag);
-
         ComputeKernels.computeDFT(inReal, inImag, outRealTor, outImagTor);
+
+        executionPlan.clearProfiles();
 
         for (int i = 0; i < size; i++) {
             if (abs(outImagTor.get(i) - outImag.get(i)) > 0.01) {

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTTornado.java
@@ -54,8 +54,8 @@ public class DFTTornado extends BenchmarkDriver {
         outReal = new FloatArray(size);
         outImag = new FloatArray(size);
         for (int i = 0; i < size; i++) {
-            inReal.set(i, (1 /  (i + 2)));
-            inImag.set(i, (1 /  (i + 2)));
+            inReal.set(i, (1 / (i + 2)));
+            inImag.set(i, (1 / (i + 2)));
         }
     }
 
@@ -112,7 +112,7 @@ public class DFTTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/DgemmJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/DgemmJava.java
@@ -67,7 +67,7 @@ public class DgemmJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         dgemm(m, n, m, a, b, c);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/DgemmTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/DgemmTornado.java
@@ -120,7 +120,7 @@ public class DgemmTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -129,21 +129,13 @@ public class DgemmTornado extends BenchmarkDriver {
 
         final DoubleArray result = new DoubleArray(m * n);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionPlan.clearProfiles();
 
         dgemm(m, n, m, a, b, result);
 
         final double ulp = TornadoMath.findULPDistance(c, result);
         return ulp < MAX_ULP;
-    }
-
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("benchmark.device"));
-        }
     }
 
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/DotJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/DotJava.java
@@ -21,10 +21,10 @@ import static uk.ac.manchester.tornado.benchmarks.GraphicsKernels.dotImage;
 
 import java.util.Random;
 
-import uk.ac.manchester.tornado.api.types.vectors.Float3;
+import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat3;
-import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.types.vectors.Float3;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 
 public class DotJava extends BenchmarkDriver {
@@ -66,7 +66,7 @@ public class DotJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         dotImage(a, b, c);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/DotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/DotTornado.java
@@ -96,9 +96,7 @@ public class DotTornado extends BenchmarkDriver {
     public boolean validate(TornadoDevice device) {
 
         final ImageFloat result = new ImageFloat(numElementsX, numElementsX);
-
         runBenchmark(device);
-        executionResult.transferToHost(c);
         executionPlan.clearProfiles();
 
         GraphicsKernels.dotImage(a, b, result);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/DotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/DotTornado.java
@@ -25,7 +25,6 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat3;
 import uk.ac.manchester.tornado.api.types.vectors.Float3;
@@ -89,7 +88,7 @@ public class DotTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -98,7 +97,7 @@ public class DotTornado extends BenchmarkDriver {
 
         final ImageFloat result = new ImageFloat(numElementsX, numElementsX);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionResult.transferToHost(c);
         executionPlan.clearProfiles();
 
@@ -117,11 +116,4 @@ public class DotTornado extends BenchmarkDriver {
         return Float.compare(maxULP, MAX_ULP) <= 0;
     }
 
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("benchmark.device"));
-        }
-    }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/DotJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/DotJava.java
@@ -21,10 +21,10 @@ import static uk.ac.manchester.tornado.benchmarks.GraphicsKernels.dotVector;
 
 import java.util.Random;
 
-import uk.ac.manchester.tornado.api.types.vectors.Float3;
-import uk.ac.manchester.tornado.api.types.collections.VectorFloat3;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat3;
+import uk.ac.manchester.tornado.api.types.vectors.Float3;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 
 public class DotJava extends BenchmarkDriver {
@@ -62,7 +62,7 @@ public class DotJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         dotVector(a, b, c);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/DotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/DotTornado.java
@@ -25,7 +25,6 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat3;
 import uk.ac.manchester.tornado.api.types.vectors.Float3;
@@ -89,7 +88,7 @@ public class DotTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -98,7 +97,7 @@ public class DotTornado extends BenchmarkDriver {
 
         final FloatArray result = new FloatArray(numElements);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionPlan.clearProfiles();
 
         GraphicsKernels.dotVector(a, b, result);
@@ -107,11 +106,4 @@ public class DotTornado extends BenchmarkDriver {
         return Float.compare(ulp, MAX_ULP) <= 0;
     }
 
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("benchmark.device"));
-        }
-    }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/EulerJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/EulerJava.java
@@ -61,7 +61,7 @@ public class EulerJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         ComputeKernels.euler(size, input, outputA, outputB, outputC, outputD, outputE);
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/EulerTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/EulerTornado.java
@@ -105,7 +105,7 @@ public class EulerTornado extends BenchmarkDriver {
                 .task("s0", ComputeKernels::euler, size, input, outputA, outputB, outputC, outputD, outputE) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, outputA, outputB, outputC, outputD, outputE);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        ImmutableTaskGraph immutableTaskGraph = graph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
         executionPlan.withDevice(device).execute();
     }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/EulerTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/EulerTornado.java
@@ -150,7 +150,7 @@ public class EulerTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/HilbertJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/HilbertJava.java
@@ -43,7 +43,7 @@ public class HilbertJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         ComputeKernels.hilbertComputation(hilbertMatrix, size, size);
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/HilbertTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/HilbertTornado.java
@@ -90,7 +90,7 @@ public class HilbertTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JuliaSetJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JuliaSetJava.java
@@ -58,7 +58,7 @@ public class JuliaSetJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         GraphicsKernels.juliaSetTornado(size, hue, brightness);
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JuliaSetTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JuliaSetTornado.java
@@ -74,7 +74,7 @@ public class JuliaSetTornado extends BenchmarkDriver {
         final FloatArray hueSeq = new FloatArray(size * size);
         final FloatArray brightnessSeq = new FloatArray(size * size);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionPlan.clearProfiles();
 
         GraphicsKernels.juliaSetTornado(size, hueSeq, brightnessSeq);
@@ -100,7 +100,7 @@ public class JuliaSetTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/MandelbrotJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/MandelbrotJava.java
@@ -42,7 +42,7 @@ public class MandelbrotJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         ComputeKernels.mandelbrot(size, result);
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/MandelbrotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/MandelbrotTornado.java
@@ -66,7 +66,7 @@ public class MandelbrotTornado extends BenchmarkDriver {
         boolean val = true;
         ShortArray result = new ShortArray(size * size);
 
-        executionResult.transferToHost(output);
+        executionPlan.withDevice(device).execute();
         executionPlan.clearProfiles();
 
         ComputeKernels.mandelbrot(size, result);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/MandelbrotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/MandelbrotTornado.java
@@ -84,7 +84,7 @@ public class MandelbrotTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/MonteCarloJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/MonteCarloJava.java
@@ -45,7 +45,7 @@ public class MonteCarloJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         monteCarlo(seq, size);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/MonteCarloTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/MonteCarloTornado.java
@@ -23,7 +23,6 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 import uk.ac.manchester.tornado.benchmarks.ComputeKernels;
@@ -66,7 +65,7 @@ public class MonteCarloTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -95,11 +94,4 @@ public class MonteCarloTornado extends BenchmarkDriver {
         return isCorrect;
     }
 
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("benchmark.device"));
-        }
-    }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/MonteCarloTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/MonteCarloTornado.java
@@ -77,11 +77,7 @@ public class MonteCarloTornado extends BenchmarkDriver {
         result = new FloatArray(size);
 
         ComputeKernels.monteCarlo(result, size);
-        executionPlan.withDevice(device).withWarmUp();
-        for (int i = 0; i < 3; i++) {
-            executionPlan.execute();
-        }
-        executionResult.transferToHost(output);
+        executionPlan.withDevice(device).execute();
         executionPlan.clearProfiles();
 
         for (int i = 0; i < size; i++) {

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyJava.java
@@ -73,7 +73,7 @@ public class NBodyJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         nBody(numBodies, posSeq, velSeq, delT, espSqr);
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyTornado.java
@@ -158,7 +158,7 @@ public class NBodyTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyTornado.java
@@ -20,6 +20,7 @@ package uk.ac.manchester.tornado.benchmarks.nbody;
 import static uk.ac.manchester.tornado.api.math.TornadoMath.abs;
 import static uk.ac.manchester.tornado.benchmarks.ComputeKernels.nBody;
 
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoExecutionResult;
@@ -126,12 +127,12 @@ public class NBodyTornado extends BenchmarkDriver {
             velSeq.set(i, auxVelocityZero.get(i));
             velSeqSeq.set(i, auxVelocityZero.get(i));
         }
-        taskGraph = new TaskGraph("benchmark");
+        TaskGraph taskGraph = new TaskGraph("benchmark");
         taskGraph.task("t0", ComputeKernels::nBody, numBodies, posSeq, velSeq, delT, espSqr);
         taskGraph.transferToHost(DataTransferMode.UNDER_DEMAND, posSeq, velSeq);
 
-        immutableTaskGraph = taskGraph.snapshot();
-        executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
         executionPlan.withWarmUp();
 
         TornadoExecutionResult executionResult = executionPlan.withWarmUp() //

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/RenderTrackJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/RenderTrackJava.java
@@ -17,14 +17,14 @@
  */
 package uk.ac.manchester.tornado.benchmarks.renderTrack;
 
-import uk.ac.manchester.tornado.api.types.vectors.Float3;
+import java.util.Random;
+
+import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.types.images.ImageByte3;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat3;
-import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.types.vectors.Float3;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 import uk.ac.manchester.tornado.benchmarks.ComputeKernels;
-
-import java.util.Random;
 
 public class RenderTrackJava extends BenchmarkDriver {
 
@@ -56,7 +56,7 @@ public class RenderTrackJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         ComputeKernels.renderTrack(output, input);
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/RenderTrackTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/RenderTrackTornado.java
@@ -108,7 +108,7 @@ public class RenderTrackTornado extends BenchmarkDriver {
                 .task("t0", ComputeKernels::renderTrack, outputTornado, inputValidation) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, outputTornado);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        ImmutableTaskGraph immutableTaskGraph = s0.snapshot();
         TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph);
         executor.withDevice(device).execute();
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/RenderTrackTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/RenderTrackTornado.java
@@ -116,7 +116,7 @@ public class RenderTrackTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateJava.java
@@ -19,10 +19,10 @@ package uk.ac.manchester.tornado.benchmarks.rotateimage;
 
 import static uk.ac.manchester.tornado.benchmarks.GraphicsKernels.rotateImage;
 
-import uk.ac.manchester.tornado.api.types.vectors.Float3;
+import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat3;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix4x4Float;
-import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.types.vectors.Float3;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 
 public class RotateJava extends BenchmarkDriver {
@@ -63,7 +63,7 @@ public class RotateJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         rotateImage(output, m, input);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateStreams.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateStreams.java
@@ -19,10 +19,10 @@ package uk.ac.manchester.tornado.benchmarks.rotateimage;
 
 import static uk.ac.manchester.tornado.benchmarks.GraphicsKernels.rotateImageStreams;
 
-import uk.ac.manchester.tornado.api.types.vectors.Float3;
+import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat3;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix4x4Float;
-import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.types.vectors.Float3;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 
 public class RotateStreams extends BenchmarkDriver {
@@ -66,7 +66,7 @@ public class RotateStreams extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         rotateImageStreams(output, m, input);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateTornado.java
@@ -24,7 +24,6 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat3;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix4x4Float;
 import uk.ac.manchester.tornado.api.types.vectors.Float3;
@@ -91,7 +90,7 @@ public class RotateTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -100,7 +99,7 @@ public class RotateTornado extends BenchmarkDriver {
 
         final ImageFloat3 result = new ImageFloat3(numElementsX, numElementsY);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionResult.transferToHost(output);
         executionPlan.clearProfiles();
 
@@ -117,14 +116,6 @@ public class RotateTornado extends BenchmarkDriver {
             }
         }
         return Float.compare(maxULP, MAX_ULP) <= 0;
-    }
-
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("benchmark.device"));
-        }
     }
 
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateTornado.java
@@ -100,7 +100,6 @@ public class RotateTornado extends BenchmarkDriver {
         final ImageFloat3 result = new ImageFloat3(numElementsX, numElementsY);
 
         runBenchmark(device);
-        executionResult.transferToHost(output);
         executionPlan.clearProfiles();
 
         rotateImage(result, m, input);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/RotateJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/RotateJava.java
@@ -19,10 +19,10 @@ package uk.ac.manchester.tornado.benchmarks.rotatevector;
 
 import static uk.ac.manchester.tornado.benchmarks.GraphicsKernels.rotateVector;
 
-import uk.ac.manchester.tornado.api.types.vectors.Float3;
-import uk.ac.manchester.tornado.api.types.matrix.Matrix4x4Float;
-import uk.ac.manchester.tornado.api.types.collections.VectorFloat3;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat3;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix4x4Float;
+import uk.ac.manchester.tornado.api.types.vectors.Float3;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 
 public class RotateJava extends BenchmarkDriver {
@@ -62,7 +62,7 @@ public class RotateJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         rotateVector(output, m, input);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/RotateTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/RotateTornado.java
@@ -24,7 +24,6 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat3;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix4x4Float;
 import uk.ac.manchester.tornado.api.types.vectors.Float3;
@@ -85,7 +84,7 @@ public class RotateTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -94,7 +93,7 @@ public class RotateTornado extends BenchmarkDriver {
 
         final VectorFloat3 result = new VectorFloat3(numElements);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionResult.transferToHost(output);
         executionPlan.clearProfiles();
 
@@ -110,13 +109,5 @@ public class RotateTornado extends BenchmarkDriver {
         }
 
         return Float.compare(maxULP, MAX_ULP) <= 0;
-    }
-
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("benchmark.device"));
-        }
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/RotateTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/RotateTornado.java
@@ -94,7 +94,6 @@ public class RotateTornado extends BenchmarkDriver {
         final VectorFloat3 result = new VectorFloat3(numElements);
 
         runBenchmark(device);
-        executionResult.transferToHost(output);
         executionPlan.clearProfiles();
 
         rotateVector(result, m, input);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/SaxpyJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/SaxpyJava.java
@@ -55,7 +55,7 @@ public class SaxpyJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         saxpy(alpha, x, y);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/SaxpyTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/SaxpyTornado.java
@@ -90,7 +90,6 @@ public class SaxpyTornado extends BenchmarkDriver {
         final FloatArray result = new FloatArray(numElements);
 
         runBenchmark(device);
-        executionResult.transferToHost(y);
         executionPlan.clearProfiles();
 
         saxpy(alpha, x, result);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/SaxpyTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/SaxpyTornado.java
@@ -24,7 +24,6 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.benchmarks.BenchmarkDriver;
 import uk.ac.manchester.tornado.benchmarks.LinearAlgebraArrays;
@@ -81,7 +80,7 @@ public class SaxpyTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -90,7 +89,7 @@ public class SaxpyTornado extends BenchmarkDriver {
 
         final FloatArray result = new FloatArray(numElements);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionResult.transferToHost(y);
         executionPlan.clearProfiles();
 
@@ -100,11 +99,4 @@ public class SaxpyTornado extends BenchmarkDriver {
         return ulp < MAX_ULP;
     }
 
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("benchmark.device"));
-        }
-    }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmJava.java
@@ -67,7 +67,7 @@ public class SgemmJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         sgemm(m, n, m, a, b, c);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmTornado.java
@@ -135,7 +135,7 @@ public class SgemmTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         if (grid != null) {
             executionPlan.withGridScheduler(grid);
         }
@@ -148,7 +148,7 @@ public class SgemmTornado extends BenchmarkDriver {
         final FloatArray result = new FloatArray(m * n);
         boolean val = true;
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionResult.transferToHost(c);
 
         executionPlan.clearProfiles();
@@ -165,14 +165,6 @@ public class SgemmTornado extends BenchmarkDriver {
         }
         System.out.printf("Number validation: " + val + "\n");
         return val;
-    }
-
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", TornadoRuntime.getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", TornadoRuntime.getProperty("benchmark.device"));
-        }
     }
 
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmTornado.java
@@ -149,10 +149,7 @@ public class SgemmTornado extends BenchmarkDriver {
         boolean val = true;
 
         runBenchmark(device);
-        executionResult.transferToHost(c);
-
         executionPlan.clearProfiles();
-
         sgemm(m, n, m, a, b, result);
 
         for (int i = 0; i < n; i++) {

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/SgemvJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/SgemvJava.java
@@ -66,7 +66,7 @@ public class SgemvJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         sgemv(m, n, a, x, y);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/SgemvTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/SgemvTornado.java
@@ -100,7 +100,6 @@ public class SgemvTornado extends BenchmarkDriver {
         final FloatArray result = new FloatArray(n);
 
         runBenchmark(device);
-        executionResult.transferToHost(y);
         executionPlan.clearProfiles();
 
         sgemv(m, n, a, x, result);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/SgemvTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/SgemvTornado.java
@@ -90,7 +90,7 @@ public class SgemvTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -99,7 +99,7 @@ public class SgemvTornado extends BenchmarkDriver {
 
         final FloatArray result = new FloatArray(n);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionResult.transferToHost(y);
         executionPlan.clearProfiles();
 
@@ -107,14 +107,6 @@ public class SgemvTornado extends BenchmarkDriver {
 
         final float ulp = findULPDistance(y, result);
         return ulp < MAX_ULP;
-    }
-
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", getProperty("benchmark.device"));
-        }
     }
 
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/SpmvJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/SpmvJava.java
@@ -50,7 +50,7 @@ public class SpmvJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         spmv(matrix.vals, matrix.cols, matrix.rows, v, matrix.size, y);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/SpmvTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/SpmvTornado.java
@@ -77,7 +77,7 @@ public class SpmvTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -86,7 +86,7 @@ public class SpmvTornado extends BenchmarkDriver {
 
         final FloatArray ref = new FloatArray(matrix.size);
 
-        benchmarkMethod(device);
+        runBenchmark(device);
         executionPlan.clearProfiles();
 
         spmv(matrix.vals, matrix.cols, matrix.rows, v, matrix.size, ref);
@@ -94,13 +94,5 @@ public class SpmvTornado extends BenchmarkDriver {
         final float ulp = findULPDistance(y, ref);
         System.out.printf("ulp is %f\n", ulp);
         return ulp < MAX_ULP;
-    }
-
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", getProperty("benchmark.device"));
-        }
     }
 }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/StencilJava.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/StencilJava.java
@@ -66,7 +66,7 @@ public class StencilJava extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         stencil3d(n, sz, a0, a1, FAC);
         copy(sz, a0, a1);
     }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/StencilTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/StencilTornado.java
@@ -102,10 +102,7 @@ public class StencilTornado extends BenchmarkDriver {
         final FloatArray b1 = new FloatArray(ainit.getSize());
 
         copy(sz, ainit, b0);
-        for (int i = 0; i < iterations; i++) {
-            runBenchmark(device);
-        }
-        barrier();
+        runBenchmark(device);
         executionPlan.clearProfiles();
 
         for (int i = 0; i < iterations; i++) {

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/StencilTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/StencilTornado.java
@@ -91,7 +91,7 @@ public class StencilTornado extends BenchmarkDriver {
     }
 
     @Override
-    public void benchmarkMethod(TornadoDevice device) {
+    public void runBenchmark(TornadoDevice device) {
         executionResult = executionPlan.withDevice(device).execute();
     }
 
@@ -103,7 +103,7 @@ public class StencilTornado extends BenchmarkDriver {
 
         copy(sz, ainit, b0);
         for (int i = 0; i < iterations; i++) {
-            benchmarkMethod(device);
+            runBenchmark(device);
         }
         barrier();
         executionPlan.clearProfiles();
@@ -122,11 +122,4 @@ public class StencilTornado extends BenchmarkDriver {
         executionResult.transferToHost(a0);
     }
 
-    public void printSummary() {
-        if (isValid()) {
-            System.out.printf("id=%s, elapsed=%f, per iteration=%f\n", getProperty("benchmark.device"), getElapsed(), getElapsedPerIteration());
-        } else {
-            System.out.printf("id=%s produced invalid result\n", getProperty("benchmark.device"));
-        }
-    }
 }


### PR DESCRIPTION
#### Description

This patch provides a fix to avoid continuous recompilation of execution plans that do not use batch processing. 
TornadoVM was set to recompile every time, but we only need to recompile under certain conditions only when using batch processing, or when changing the device. 

Side note: We need the benchmarking suite for the AERO project. 

#### Problem description

The issue was that the benchmark suite, and therefore, user code, can trigger recompilation over and over again due to a condition for batch processing. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ tornado --enableProfiler console -m tornado.benchmarks/uk.ac.manchester.tornado.benchmarks.BenchmarkRunner blackscholes

$ tornado-test -V uk.ac.manchester.tornado.unittests.batches.TestBatches

Test: class uk.ac.manchester.tornado.unittests.batches.TestBatches
	Running test: testSameInputSizeAndTypeRestriction ................  [PASS] 
	Running test: test100MBSmall             ................  [PASS] 
	Running test: test100MBSmallLazy         ................  [PASS] 
	Running test: test100MB                  ................  [PASS] 
	Running test: test100MBLazy              ................  [PASS] 
	Running test: test300MB                  ................  [PASS] 
	Running test: test300MBLazy              ................  [PASS] 
	Running test: test512MB                  ................  [PASS] 
	Running test: test512MBLazy              ................  [PASS] 
	Running test: test50MB                   ................  [PASS] 
	Running test: test50MBInteger            ................  [PASS] 
	Running test: test50MBShort              ................  [PASS] 
	Running test: test50MBDouble             ................  [PASS] 
	Running test: test50MBLong               ................  [PASS] 
	Running test: testSameInputSizeAndTypeRestrictionJavaArrays ................  [PASS] 
	Running test: testSameInputTypeRestriction ................  [PASS] 
	Running test: testSameInputTypeRestrictionJavaArrays ................  [PASS] 
	Running test: testSameInputSize          ................  [PASS] 
	Running test: testSameInputSizeJavaArrays ................  [PASS] 
	Running test: testSameInputSizeJavaToTornado ................  [PASS] 
	Running test: testSameInputSizeTornadoToJava ................  [PASS] 
	Running test: testSameInputSizeAndTypeJavaToTornado ................  [PASS] 
	Running test: testSameInputSizeAndTypeTornadoToJava ................  [PASS] 
	Running test: testBatchNotEven           ................  [PASS] 
	Running test: testBatchNotEven2          ................  [PASS] 
	Running test: testBatchNotEven2Lazy      ................  [PASS] 
	Running test: testBatchThreadIndex       ................  [PASS] 
Test ran: 27, Failed: 0, Unsupported: 0

```
