### PR TITLE
[feat] Query Memory Consumption and expanded profiler with memory consumption

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -204,4 +204,8 @@ public class ImmutableTaskGraph {
     public long getTotalBytesTransferred() {
         return taskGraph.getTotalBytesTransferred();
     }
+
+    public long getTotalDeviceMemoryUsage() {
+        return taskGraph.getTotalDeviceMemoryUsage();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -208,4 +208,8 @@ public class ImmutableTaskGraph {
     public long getTotalDeviceMemoryUsage() {
         return taskGraph.getTotalDeviceMemoryUsage();
     }
+
+    public long getCurrentMemoryUsage() {
+        return taskGraph.getCurrentMemoryUsage();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -113,6 +113,14 @@ public class ImmutableTaskGraph {
         return taskGraph.getDeviceKernelTime();
     }
 
+    long getTotalBytesCopyIn() {
+        return taskGraph.getTotalBytesCopyIn();
+    }
+
+    long getTotalBytesCopyOut() {
+        return taskGraph.getTotalBytesCopyOut();
+    }
+
     String getProfileLog() {
         return taskGraph.getProfileLog();
     }
@@ -191,5 +199,9 @@ public class ImmutableTaskGraph {
 
     void withGridScheduler(GridScheduler gridScheduler) {
         taskGraph.withGridScheduler(gridScheduler);
+    }
+
+    public long getTotalBytesTransferred() {
+        return taskGraph.getTotalBytesTransferred();
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -201,15 +201,15 @@ public class ImmutableTaskGraph {
         taskGraph.withGridScheduler(gridScheduler);
     }
 
-    public long getTotalBytesTransferred() {
+    long getTotalBytesTransferred() {
         return taskGraph.getTotalBytesTransferred();
     }
 
-    public long getTotalDeviceMemoryUsage() {
+    long getTotalDeviceMemoryUsage() {
         return taskGraph.getTotalDeviceMemoryUsage();
     }
 
-    public long getCurrentMemoryUsage() {
-        return taskGraph.getCurrentMemoryUsage();
+    long getCurrentDeviceMemoryUsage() {
+        return taskGraph.getCurrentDeviceMemoryUsage();
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -922,15 +922,15 @@ public class TaskGraph implements TaskGraphInterface {
         taskGraphImpl.withGridScheduler(gridScheduler);
     }
 
-    public long getTotalBytesTransferred() {
+    long getTotalBytesTransferred() {
         return taskGraphImpl.getTotalBytesTransferred();
     }
 
-    public long getTotalDeviceMemoryUsage() {
+    long getTotalDeviceMemoryUsage() {
         return taskGraphImpl.getTotalDeviceMemoryUsage();
     }
 
-    public long getCurrentMemoryUsage() {
-        return taskGraphImpl.getCurrentMemoryUsage();
+    long getCurrentDeviceMemoryUsage() {
+        return taskGraphImpl.getCurrentDeviceMemoryUsage();
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -929,4 +929,8 @@ public class TaskGraph implements TaskGraphInterface {
     public long getTotalDeviceMemoryUsage() {
         return taskGraphImpl.getTotalDeviceMemoryUsage();
     }
+
+    public long getCurrentMemoryUsage() {
+        return taskGraphImpl.getCurrentMemoryUsage();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -925,4 +925,8 @@ public class TaskGraph implements TaskGraphInterface {
     public long getTotalBytesTransferred() {
         return taskGraphImpl.getTotalBytesTransferred();
     }
+
+    public long getTotalDeviceMemoryUsage() {
+        return taskGraphImpl.getTotalDeviceMemoryUsage();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -870,6 +870,14 @@ public class TaskGraph implements TaskGraphInterface {
         return taskGraphImpl.getDeviceKernelTime();
     }
 
+    long getTotalBytesCopyIn() {
+        return taskGraphImpl.getTotalBytesCopyIn();
+    }
+
+    long getTotalBytesCopyOut() {
+        return taskGraphImpl.getTotalBytesCopyOut();
+    }
+
     protected String getProfileLog() {
         return taskGraphImpl.getProfileLog();
     }
@@ -914,4 +922,7 @@ public class TaskGraph implements TaskGraphInterface {
         taskGraphImpl.withGridScheduler(gridScheduler);
     }
 
+    public long getTotalBytesTransferred() {
+        return taskGraphImpl.getTotalBytesTransferred();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -399,8 +399,8 @@ public class TornadoExecutionPlan implements AutoCloseable {
      * @return long
      *     Number of bytes used.
      */
-    public long getCurrentMemoryUsage() {
-        return tornadoExecutor.getCurrentMemoryUsage();
+    public long getCurrentDeviceMemoryUsage() {
+        return tornadoExecutor.getCurrentDeviceMemoryUsage();
     }
 
     static class TornadoExecutor {
@@ -585,16 +585,16 @@ public class TornadoExecutionPlan implements AutoCloseable {
             immutableTaskGraphList.forEach(ImmutableTaskGraph::withoutPrintKernel);
         }
 
-        public long getTotalBytesTransferred() {
+        long getTotalBytesTransferred() {
             return immutableTaskGraphList.stream().mapToLong(ImmutableTaskGraph::getTotalBytesTransferred).sum();
         }
 
-        public long getTotalDeviceMemoryUsage() {
+        long getTotalDeviceMemoryUsage() {
             return immutableTaskGraphList.stream().mapToLong(ImmutableTaskGraph::getTotalDeviceMemoryUsage).sum();
         }
 
-        public long getCurrentMemoryUsage() {
-            return immutableTaskGraphList.stream().mapToLong(ImmutableTaskGraph::getCurrentMemoryUsage).sum();
+        long getCurrentDeviceMemoryUsage() {
+            return immutableTaskGraphList.stream().mapToLong(ImmutableTaskGraph::getCurrentDeviceMemoryUsage).sum();
         }
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -578,5 +578,9 @@ public class TornadoExecutionPlan implements AutoCloseable {
         public long getTotalBytesTransferred() {
             return immutableTaskGraphList.stream().mapToLong(ImmutableTaskGraph::getTotalBytesTransferred).sum();
         }
+
+        public long getTotalDeviceMemoryUsage() {
+            return immutableTaskGraphList.stream().mapToLong(ImmutableTaskGraph::getTotalDeviceMemoryUsage).sum();
+        }
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -514,6 +514,14 @@ public class TornadoExecutionPlan implements AutoCloseable {
             return immutableTaskGraphList.stream().map(ImmutableTaskGraph::getDeviceKernelTime).mapToLong(Long::longValue).sum();
         }
 
+        long getTotalBytesCopyIn() {
+            return immutableTaskGraphList.stream().map(ImmutableTaskGraph::getTotalBytesCopyIn).mapToLong(Long::longValue).sum();
+        }
+
+        long getTotalBytesCopyOut() {
+            return immutableTaskGraphList.stream().map(ImmutableTaskGraph::getTotalBytesCopyOut).mapToLong(Long::longValue).sum();
+        }
+
         String getProfileLog() {
             return immutableTaskGraphList.stream().map(ImmutableTaskGraph::getProfileLog).collect(Collectors.joining());
         }
@@ -565,6 +573,10 @@ public class TornadoExecutionPlan implements AutoCloseable {
 
         void withoutPrintKernel() {
             immutableTaskGraphList.forEach(ImmutableTaskGraph::withoutPrintKernel);
+        }
+
+        public long getTotalBytesTransferred() {
+            return immutableTaskGraphList.stream().mapToLong(ImmutableTaskGraph::getTotalBytesTransferred).sum();
         }
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -393,6 +393,16 @@ public class TornadoExecutionPlan implements AutoCloseable {
         tornadoExecutor.freeDeviceMemory();
     }
 
+    /**
+     * It returns the current memory usage on the device in bytes.
+     * 
+     * @return long
+     *     Number of bytes used.
+     */
+    public long getCurrentMemoryUsage() {
+        return tornadoExecutor.getCurrentMemoryUsage();
+    }
+
     static class TornadoExecutor {
 
         private final List<ImmutableTaskGraph> immutableTaskGraphList;
@@ -581,6 +591,10 @@ public class TornadoExecutionPlan implements AutoCloseable {
 
         public long getTotalDeviceMemoryUsage() {
             return immutableTaskGraphList.stream().mapToLong(ImmutableTaskGraph::getTotalDeviceMemoryUsage).sum();
+        }
+
+        public long getCurrentMemoryUsage() {
+            return immutableTaskGraphList.stream().mapToLong(ImmutableTaskGraph::getCurrentMemoryUsage).sum();
         }
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
@@ -168,6 +168,16 @@ public class TornadoProfilerResult implements ProfileInterface {
         return executor.getProfileLog();
     }
 
+    @Override
+    public long getTotalBytesCopyIn() {
+        return executor.getTotalBytesCopyIn();
+    }
+
+    @Override
+    public long getTotalBytesCopyOut() {
+        return executor.getTotalBytesCopyOut();
+    }
+
     TornadoExecutor getExecutor() {
         return executor;
     }
@@ -179,4 +189,15 @@ public class TornadoProfilerResult implements ProfileInterface {
     public void dumpProfiles() {
         getExecutor().dumpProfiles();
     }
+
+    /**
+     * Return the total number of bytes allocated on the target accelerators.
+     * 
+     * @return long
+     */
+    @Override
+    public long getTotalBytesTransferred() {
+        return executor.getTotalBytesTransferred();
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
@@ -191,15 +191,22 @@ public class TornadoProfilerResult implements ProfileInterface {
     }
 
     /**
-     * Return the total number of bytes allocated on the target accelerators.
+     * Return the total number of bytes transferred to/from the target accelerators.
      * 
      * @return long
+     *     Number of bytes
      */
     @Override
     public long getTotalBytesTransferred() {
         return executor.getTotalBytesTransferred();
     }
 
+    /**
+     * Return the total number of bytes allocated on the target device.
+     * 
+     * @return long
+     *     Number of bytes.
+     */
     @Override
     public long getTotalDeviceMemoryUsage() {
         return executor.getTotalDeviceMemoryUsage();

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
@@ -40,9 +40,10 @@ import uk.ac.manchester.tornado.api.profiler.ProfileInterface;
  * @since TornadoVM-0.15
  */
 public class TornadoProfilerResult implements ProfileInterface {
-    private TornadoExecutor executor;
 
-    public TornadoProfilerResult(TornadoExecutor executor) {
+    private final TornadoExecutor executor;
+
+    TornadoProfilerResult(TornadoExecutor executor) {
         this.executor = executor;
     }
 
@@ -168,11 +169,25 @@ public class TornadoProfilerResult implements ProfileInterface {
         return executor.getProfileLog();
     }
 
+    /**
+     * Returns the total number of bytes that were transferred to the hardware
+     * accelerator (host to device) for the current execution of the execution plan.
+     * 
+     * @return long
+     *     Number of bytes
+     */
     @Override
     public long getTotalBytesCopyIn() {
         return executor.getTotalBytesCopyIn();
     }
 
+    /**
+     * Returns the total number of bytes that were transferred to the host
+     * (device to host) for the current execution of the execution plan.
+     *
+     * @return long
+     *     Number of bytes
+     */
     @Override
     public long getTotalBytesCopyOut() {
         return executor.getTotalBytesCopyOut();

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
@@ -19,7 +19,7 @@ package uk.ac.manchester.tornado.api;
 
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan.TornadoExecutor;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
-import uk.ac.manchester.tornado.api.profiler.ProfileInterface;
+import uk.ac.manchester.tornado.api.profiler.ProfilerInterface;
 
 /**
  * Object that stores all information related to profiling an executor. To be
@@ -39,7 +39,7 @@ import uk.ac.manchester.tornado.api.profiler.ProfileInterface;
  *
  * @since TornadoVM-0.15
  */
-public class TornadoProfilerResult implements ProfileInterface {
+public class TornadoProfilerResult implements ProfilerInterface {
 
     private final TornadoExecutor executor;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
@@ -200,4 +200,9 @@ public class TornadoProfilerResult implements ProfileInterface {
         return executor.getTotalBytesTransferred();
     }
 
+    @Override
+    public long getTotalDeviceMemoryUsage() {
+        return executor.getTotalDeviceMemoryUsage();
+    }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -121,5 +121,5 @@ public interface TornadoTaskGraphInterface extends ProfileInterface {
 
     void withGridScheduler(GridScheduler gridScheduler);
 
-    long getCurrentMemoryUsage();
+    long getCurrentDeviceMemoryUsage();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -120,4 +120,5 @@ public interface TornadoTaskGraphInterface extends ProfileInterface {
     void withoutPrintKernel();
 
     void withGridScheduler(GridScheduler gridScheduler);
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -121,4 +121,5 @@ public interface TornadoTaskGraphInterface extends ProfileInterface {
 
     void withGridScheduler(GridScheduler gridScheduler);
 
+    long getCurrentMemoryUsage();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -26,10 +26,10 @@ import uk.ac.manchester.tornado.api.common.TaskPackage;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
 import uk.ac.manchester.tornado.api.memory.TaskMetaDataInterface;
-import uk.ac.manchester.tornado.api.profiler.ProfileInterface;
+import uk.ac.manchester.tornado.api.profiler.ProfilerInterface;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
 
-public interface TornadoTaskGraphInterface extends ProfileInterface {
+public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     SchedulableTask getTask(String taskNameID);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
@@ -43,11 +43,11 @@ public interface TornadoDevice {
      *     {@link DeviceBufferState}
      * @return an event ID
      */
-    int allocate(Object object, long batchSize, DeviceBufferState state);
+    long allocate(Object object, long batchSize, DeviceBufferState state);
 
-    int allocateObjects(Object[] objects, long batchSize, DeviceBufferState[] states);
+    long allocateObjects(Object[] objects, long batchSize, DeviceBufferState[] states);
 
-    int deallocate(DeviceBufferState state);
+    long deallocate(DeviceBufferState state);
 
     /**
      * It allocates and copy in the content of the object to the target device.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/XPUBuffer.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/XPUBuffer.java
@@ -60,7 +60,7 @@ public interface XPUBuffer {
 
     long getSizeSubRegionSize();
 
-    void deallocate();
+    long deallocate();
 
     default int[] getIntBuffer() {
         return null;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/profiler/ProfileInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/profiler/ProfileInterface.java
@@ -41,4 +41,9 @@ public interface ProfileInterface {
 
     String getProfileLog();
 
+    long getTotalBytesCopyIn();
+
+    long getTotalBytesCopyOut();
+
+    long getTotalBytesTransferred();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/profiler/ProfileInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/profiler/ProfileInterface.java
@@ -46,4 +46,6 @@ public interface ProfileInterface {
     long getTotalBytesCopyOut();
 
     long getTotalBytesTransferred();
+
+    long getTotalDeviceMemoryUsage();
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/profiler/ProfilerInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/profiler/ProfilerInterface.java
@@ -17,7 +17,7 @@
  */
 package uk.ac.manchester.tornado.api.profiler;
 
-public interface ProfileInterface {
+public interface ProfilerInterface {
 
     long getTotalTime();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/profiler/ProfilerType.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/profiler/ProfilerType.java
@@ -33,6 +33,7 @@ public enum ProfilerType {
     COPY_OUT_SIZE_BYTES_SYNC("CopyOut-Size-Sync-(Bytes)"),
     DEVICE_ID("Device-ID"),
     DEVICE("Device"),
+    ALLOCATION_BYTES("Allocation"),
     TOTAL_COPY_IN_SIZE_BYTES("CopyIn-Size-(Bytes)"),
     TOTAL_COPY_OUT_SIZE_BYTES("CopyOut-Size-(Bytes)"),
     TASK_COMPILE_DRIVER_TIME("Task-Compile-Driver"),

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/profiler/TornadoProfiler.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/profiler/TornadoProfiler.java
@@ -39,6 +39,8 @@ public interface TornadoProfiler {
 
     long getTimer(ProfilerType type);
 
+    long getSize(ProfilerType type);
+
     long getTaskTimer(ProfilerType type, String taskName);
 
     void setTimer(ProfilerType type, long time);

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -124,6 +124,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.tensors.TestTensorTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.tensors.TestTensorAPIWithOnnx"),
+    TestEntry("uk.ac.manchester.tornado.unittests.memory.TestStressDeviceMemory"),
 
     ## Test for function calls - We force not to inline methods
     TestEntry(testName="uk.ac.manchester.tornado.unittests.tasks.TestMultipleFunctions",

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -124,7 +124,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.tensors.TestTensorTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.tensors.TestTensorAPIWithOnnx"),
-    TestEntry("uk.ac.manchester.tornado.unittests.memory.TestStressDeviceMemory"),
+    TestEntry("uk.ac.manchester.tornado.unittests.memory.MemoryConsumptionTest"),
 
     ## Test for function calls - We force not to inline methods
     TestEntry(testName="uk.ac.manchester.tornado.unittests.tasks.TestMultipleFunctions",

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/TornadoBufferProvider.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/TornadoBufferProvider.java
@@ -73,7 +73,7 @@ public abstract class TornadoBufferProvider {
         // Attempts to free buffers of given size.
         long remainingSize = size;
         while (!freeBuffers.isEmpty() && remainingSize > 0) {
-            BufferContainer bufferInfo = freeBuffers.remove(0);
+            BufferContainer bufferInfo = freeBuffers.removeFirst();
             TornadoInternalError.guarantee(!usedBuffers.contains(bufferInfo), "This buffer should not be used");
             remainingSize -= bufferInfo.size;
             currentMemoryAvailable += bufferInfo.size;
@@ -81,14 +81,17 @@ public abstract class TornadoBufferProvider {
         }
     }
 
-    public synchronized void deallocate() {
+    public synchronized long deallocate() {
         // Attempts to free buffers of given size.
+        long spaceDeallocated = 0;
         while (!freeBuffers.isEmpty()) {
             BufferContainer bufferInfo = freeBuffers.removeFirst();
             TornadoInternalError.guarantee(!usedBuffers.contains(bufferInfo), "This buffer should not be used");
             currentMemoryAvailable += bufferInfo.size;
+            spaceDeallocated += bufferInfo.size;
             releaseBuffer(bufferInfo.buffer);
         }
+        return spaceDeallocated;
     }
 
     private synchronized BufferContainer markBufferUsed(int freeBufferIndex) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OpenCL.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OpenCL.java
@@ -185,7 +185,7 @@ public class OpenCL {
 
         // Create call wrapper
         final int numArgs = parameters.length;
-        KernelStackFrame callWrapper = tornadoDevice.createKernelStackFrame(numArgs);
+        KernelStackFrame callWrapper = tornadoDevice.createKernelStackFrame(executionContextId, numArgs);
         callWrapper.reset();
 
         // Fill header of call callWrapper with empty values

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/AtomicsBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/AtomicsBuffer.java
@@ -125,8 +125,8 @@ public class AtomicsBuffer implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLArrayWrapper.java
@@ -125,8 +125,8 @@ public abstract class OCLArrayWrapper<T> implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemoryManager.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemoryManager.java
@@ -69,7 +69,7 @@ public class OCLMemoryManager implements TornadoMemoryProvider {
      * Allocate regions on the device.
      */
     public void allocateDeviceMemoryRegions() {
-        this.constantPointer = createBuffer(OCLMemFlags.CL_MEM_READ_ONLY | OCLMemFlags.CL_MEM_ALLOC_HOST_PTR, 4).getBuffer();
+        this.constantPointer = createBuffer(4, OCLMemFlags.CL_MEM_READ_ONLY | OCLMemFlags.CL_MEM_ALLOC_HOST_PTR).getBuffer();
         allocateAtomicRegion();
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemoryManager.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemoryManager.java
@@ -53,12 +53,13 @@ public class OCLMemoryManager implements TornadoMemoryProvider {
         return DEVICE_AVAILABLE_MEMORY;
     }
 
-    public OCLKernelStackFrame createKernelStackFrame(long threadId, final int numberOfArguments) {
-        if (!oclKernelStackFrame.containsKey(threadId)) {
+    public OCLKernelStackFrame createKernelStackFrame(long executionPlanId, final int numberOfArguments) {
+        if (!oclKernelStackFrame.containsKey(executionPlanId)) {
+            // Create one stack frame per execution plan ID 
             long kernelStackFramePtr = deviceContext.getPlatformContext().createBuffer(OCLMemFlags.CL_MEM_READ_ONLY, RESERVED_SLOTS * Long.BYTES).getBuffer();
-            oclKernelStackFrame.put(threadId, new OCLKernelStackFrame(kernelStackFramePtr, numberOfArguments, deviceContext));
+            oclKernelStackFrame.put(executionPlanId, new OCLKernelStackFrame(kernelStackFramePtr, numberOfArguments, deviceContext));
         }
-        return oclKernelStackFrame.get(threadId);
+        return oclKernelStackFrame.get(executionPlanId);
     }
 
     public XPUBuffer createAtomicsBuffer(final int[] array) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
@@ -209,8 +209,8 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
@@ -358,7 +358,7 @@ public class OCLVectorWrapper implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLXPUBuffer.java
@@ -458,7 +458,7 @@ public class OCLXPUBuffer implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -225,8 +225,8 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public KernelStackFrame createKernelStackFrame(int numArgs) {
-        return getDeviceContext().getMemoryManager().createKernelStackFrame(Thread.currentThread().threadId(), numArgs);
+    public KernelStackFrame createKernelStackFrame(long executionPlanId, int numArgs) {
+        return getDeviceContext().getMemoryManager().createKernelStackFrame(executionPlanId, numArgs);
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -615,17 +615,17 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public synchronized long deallocate(DeviceBufferState deviceBufferState) {
-        long memoryRegionDellocated = 0;
+        long deallocatedSpace = 0;
         if (deviceBufferState.isLockedBuffer()) {
-            return memoryRegionDellocated;
+            return deallocatedSpace;
         }
         deviceBufferState.getXPUBuffer().markAsFreeBuffer();
         if (!TornadoOptions.isReusedBuffersEnabled()) {
-            memoryRegionDellocated = deviceBufferState.getXPUBuffer().deallocate();
+            deallocatedSpace = deviceBufferState.getXPUBuffer().deallocate();
         }
         deviceBufferState.setContents(false);
         deviceBufferState.setXPUBuffer(null);
-        return memoryRegionDellocated;
+        return deallocatedSpace;
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLJITCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLJITCompiler.java
@@ -130,15 +130,15 @@ public class TestOpenCLJITCompiler {
 
         tornadoDevice.allocateObjects(new Object[] { a, b, c }, 0, new DeviceBufferState[] { objectStateA, objectStateB, objectStateC });
 
-        long contextID = 0;
+        long executionPlanId = 0;
 
         // Copy-IN A
-        tornadoDevice.ensurePresent(contextID, a, objectStateA, null, 0, 0);
+        tornadoDevice.ensurePresent(executionPlanId, a, objectStateA, null, 0, 0);
         // Copy-IN B
-        tornadoDevice.ensurePresent(contextID, b, objectStateB, null, 0, 0);
+        tornadoDevice.ensurePresent(executionPlanId, b, objectStateB, null, 0, 0);
 
         // Create call wrapper
-        KernelStackFrame callWrapper = tornadoDevice.createKernelStackFrame(3);
+        KernelStackFrame callWrapper = tornadoDevice.createKernelStackFrame(executionPlanId, 3);
 
         // Fill header of call callWrapper with empty values
         callWrapper.setKernelContext(new HashMap<>());
@@ -148,10 +148,10 @@ public class TestOpenCLJITCompiler {
         callWrapper.addCallArgument(objectStateC.getXPUBuffer().toBuffer(), true);
 
         // Run the code
-        openCLCode.launchWithoutDependencies(contextID, callWrapper, null, taskMeta, 0);
+        openCLCode.launchWithoutDependencies(executionPlanId, callWrapper, null, taskMeta, 0);
 
         // Obtain the result
-        tornadoDevice.streamOutBlocking(contextID, c, 0, objectStateC, null);
+        tornadoDevice.streamOutBlocking(executionPlanId, c, 0, objectStateC, null);
     }
 
     public void test() {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -280,19 +280,19 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public int allocate(Object object, long batchSize, DeviceBufferState state) {
+    public long allocate(Object object, long batchSize, DeviceBufferState state) {
         unimplemented();
         return -1;
     }
 
     @Override
-    public synchronized int allocateObjects(Object[] objects, long batchSize, DeviceBufferState[] states) {
+    public synchronized long allocateObjects(Object[] objects, long batchSize, DeviceBufferState[] states) {
         unimplemented();
         return -1;
     }
 
     @Override
-    public synchronized int deallocate(DeviceBufferState state) {
+    public synchronized long deallocate(DeviceBufferState state) {
         unimplemented();
         return -1;
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -172,7 +172,7 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public KernelStackFrame createKernelStackFrame(int numArgs) {
+    public KernelStackFrame createKernelStackFrame(long executionPlanId, int numArgs) {
         return null;
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
@@ -118,7 +118,7 @@ public class PTX {
 
         // Create call wrapper
         final int numArgs = parameters.length;
-        KernelStackFrame callWrapper = tornadoDevice.createKernelStackFrame(numArgs);
+        KernelStackFrame callWrapper = tornadoDevice.createKernelStackFrame(executionPlanId, numArgs);
         callWrapper.reset();
 
         // Fill header of call callWrapper with empty values

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXArrayWrapper.java
@@ -232,8 +232,8 @@ public abstract class PTXArrayWrapper<T> implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 
     private long sizeOf(final T array) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
@@ -205,8 +205,8 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 
     @Override

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXObjectWrapper.java
@@ -446,8 +446,8 @@ public class PTXObjectWrapper implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
@@ -120,8 +120,8 @@ public class PTXVectorWrapper implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 
     @Override

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -117,8 +117,8 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public KernelStackFrame createKernelStackFrame(int numArgs) {
-        return getDeviceContext().getMemoryManager().createCallWrapper(Thread.currentThread().threadId(), numArgs);
+    public KernelStackFrame createKernelStackFrame(long executionPlanId, int numArgs) {
+        return getDeviceContext().getMemoryManager().createCallWrapper(executionPlanId, numArgs);
     }
 
     @Override

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -318,18 +318,18 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public synchronized long deallocate(DeviceBufferState deviceBufferState) {
-        long spaceDeallocated = 0;
+        long deallocatedSpace = 0;
         if (deviceBufferState.isLockedBuffer()) {
-            return spaceDeallocated;
+            return deallocatedSpace;
         }
 
         deviceBufferState.getXPUBuffer().markAsFreeBuffer();
         if (!TornadoOptions.isReusedBuffersEnabled()) {
-            spaceDeallocated = deviceBufferState.getXPUBuffer().deallocate();
+            deallocatedSpace = deviceBufferState.getXPUBuffer().deallocate();
         }
         deviceBufferState.setContents(false);
         deviceBufferState.setXPUBuffer(null);
-        return spaceDeallocated;
+        return deallocatedSpace;
     }
 
     private XPUBuffer createArrayWrapper(Class<?> type, PTXDeviceContext deviceContext, long batchSize) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXJITCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXJITCompiler.java
@@ -136,7 +136,7 @@ public class TestPTXJITCompiler {
         tornadoDevice.ensurePresent(executionPlanId, b, objectStateB, null, 0, 0);
 
         // Create call wrapper
-        KernelStackFrame callWrapper = tornadoDevice.createKernelStackFrame(3);
+        KernelStackFrame callWrapper = tornadoDevice.createKernelStackFrame(executionPlanId, 3);
 
         callWrapper.setKernelContext(new HashMap<>());
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVArrayWrapper.java
@@ -293,8 +293,8 @@ public abstract class SPIRVArrayWrapper<T> implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
@@ -214,7 +214,7 @@ public class SPIRVMemorySegmentWrapper implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        spirvDeviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return spirvDeviceContext.getBufferProvider().deallocate();
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVObjectWrapper.java
@@ -461,7 +461,7 @@ public class SPIRVObjectWrapper implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
@@ -118,8 +118,8 @@ public class SPIRVVectorWrapper implements XPUBuffer {
     }
 
     @Override
-    public void deallocate() {
-        deviceContext.getBufferProvider().deallocate();
+    public long deallocate() {
+        return deviceContext.getBufferProvider().deallocate();
     }
 
     @Override

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -121,8 +121,8 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public KernelStackFrame createKernelStackFrame(int numArgs) {
-        return getDeviceContext().getMemoryManager().createKernelStackFrame(Thread.currentThread().threadId(), numArgs);
+    public KernelStackFrame createKernelStackFrame(long executionPlanId, int numArgs) {
+        return getDeviceContext().getMemoryManager().createKernelStackFrame(executionPlanId, numArgs);
     }
 
     @Override
@@ -137,7 +137,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
         } else if (task instanceof PrebuiltTask) {
             return compilePreBuiltTask((PrebuiltTask) task);
         } else {
-            throw new RuntimeException("SchedulableTask task not supported");
+            throw new RuntimeException("SchedulableTask type is not supported: " + task.getClass());
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -372,18 +372,18 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public synchronized long deallocate(DeviceBufferState deviceBufferState) {
-        long spaceDeallocated = 0;
+        long deallocatedSpace = 0;
         if (deviceBufferState.isLockedBuffer()) {
-            return spaceDeallocated;
+            return deallocatedSpace;
         }
 
         deviceBufferState.getXPUBuffer().markAsFreeBuffer();
         if (!TornadoOptions.isReusedBuffersEnabled()) {
-            spaceDeallocated = deviceBufferState.getXPUBuffer().deallocate();
+            deallocatedSpace = deviceBufferState.getXPUBuffer().deallocate();
         }
         deviceBufferState.setContents(false);
         deviceBufferState.setXPUBuffer(null);
-        return spaceDeallocated;
+        return deallocatedSpace;
     }
 
     /**

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVJITCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVJITCompiler.java
@@ -137,7 +137,7 @@ public class TestSPIRVJITCompiler {
         spirvTornadoDevice.ensurePresent(executionPlanId, b, objectStateB, null, 0, 0);
 
         // Create call stack wrapper for SPIR-V with 3 arguments
-        KernelStackFrame stackFrame = spirvTornadoDevice.createKernelStackFrame(3);
+        KernelStackFrame stackFrame = spirvTornadoDevice.createKernelStackFrame(executionPlanId, 3);
         stackFrame.setKernelContext(new HashMap<>());
 
         // Add kernel arguments to the SPIR-V Stack Frame

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
@@ -140,17 +140,17 @@ public class JVMMapping implements TornadoXPUDevice {
     }
 
     @Override
-    public int allocate(Object object, long batchSize, DeviceBufferState state) {
+    public long allocate(Object object, long batchSize, DeviceBufferState state) {
         return -1;
     }
 
     @Override
-    public synchronized int allocateObjects(Object[] objects, long batchSize, DeviceBufferState[] states) {
+    public synchronized long allocateObjects(Object[] objects, long batchSize, DeviceBufferState[] states) {
         return -1;
     }
 
     @Override
-    public synchronized int deallocate(DeviceBufferState state) {
+    public synchronized long deallocate(DeviceBufferState state) {
         return 0;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
@@ -23,9 +23,10 @@
  */
 package uk.ac.manchester.tornado.runtime;
 
-import jdk.vm.ci.meta.ResolvedJavaMethod;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
 import uk.ac.manchester.tornado.api.TornadoTargetDevice;
 import uk.ac.manchester.tornado.api.common.Event;
@@ -124,7 +125,7 @@ public class JVMMapping implements TornadoXPUDevice {
     }
 
     @Override
-    public KernelStackFrame createKernelStackFrame(int numArgs) {
+    public KernelStackFrame createKernelStackFrame(long executionPlanId, int numArgs) {
         return null;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoXPUDevice.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoXPUDevice.java
@@ -46,7 +46,7 @@ public interface TornadoXPUDevice extends TornadoDevice {
      *     The number of arguments for the kernel call wrapper.
      * @return The created {@link KernelStackFrame} object.
      */
-    KernelStackFrame createKernelStackFrame(int numArgs);
+    KernelStackFrame createKernelStackFrame(long executionId, int numArgs);
 
     /**
      * It creates or reuses an atomic buffer for the specified integer array.
@@ -173,6 +173,7 @@ public interface TornadoXPUDevice extends TornadoDevice {
 
     /**
      * It returns from the sketch of a task whether the loop index is written in the output buffer.
+     * 
      * @param task
      * @return
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -90,6 +90,7 @@ public class TornadoExecutionContext {
     private boolean isPrintKernel;
 
     private long executionPlanId;  // This is set at runtime. Thus, no need to clone this value.
+    private long currentMemoryUsage;
 
     public TornadoExecutionContext(String id) {
         name = id;
@@ -107,8 +108,10 @@ public class TornadoExecutionContext {
         batchSize = INIT_VALUE;
         executionPlanMemoryLimit = INIT_VALUE;
         lastDevices = new HashSet<>();
+        currentMemoryUsage = 0;
         this.profiler = null;
         this.isDataDependencyDetected = isDataDependencyInTaskGraph();
+
     }
 
     public KernelStackFrame[] getKernelStackFrame() {
@@ -675,5 +678,13 @@ public class TornadoExecutionContext {
 
     public void setExecutionPlanId(long executionPlanId) {
         this.executionPlanId = executionPlanId;
+    }
+
+    public long getCurrentMemoryUsage() {
+        return currentMemoryUsage;
+    }
+
+    public void setCurrentMemoryUsage(long currentMemoryUsage) {
+        this.currentMemoryUsage = currentMemoryUsage;
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -90,7 +90,7 @@ public class TornadoExecutionContext {
     private boolean isPrintKernel;
 
     private long executionPlanId;  // This is set at runtime. Thus, no need to clone this value.
-    private long currentMemoryUsage;
+    private long currentDeviceMemoryUsage;
 
     public TornadoExecutionContext(String id) {
         name = id;
@@ -108,7 +108,7 @@ public class TornadoExecutionContext {
         batchSize = INIT_VALUE;
         executionPlanMemoryLimit = INIT_VALUE;
         lastDevices = new HashSet<>();
-        currentMemoryUsage = 0;
+        currentDeviceMemoryUsage = 0;
         this.profiler = null;
         this.isDataDependencyDetected = isDataDependencyInTaskGraph();
 
@@ -680,11 +680,11 @@ public class TornadoExecutionContext {
         this.executionPlanId = executionPlanId;
     }
 
-    public long getCurrentMemoryUsage() {
-        return currentMemoryUsage;
+    public long getCurrentDeviceMemoryUsage() {
+        return currentDeviceMemoryUsage;
     }
 
-    public void setCurrentMemoryUsage(long currentMemoryUsage) {
-        this.currentMemoryUsage = currentMemoryUsage;
+    public void setCurrentDeviceMemoryUsage(long currentDeviceMemoryUsage) {
+        this.currentDeviceMemoryUsage = currentDeviceMemoryUsage;
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -827,7 +827,7 @@ public class TornadoVMInterpreter {
             logger.debug("Recompiling task on device " + device);
         }
         if (kernelStackFrame[index] == null || redeployOnDevice) {
-            kernelStackFrame[index] = device.createKernelStackFrame(numArgs);
+            kernelStackFrame[index] = device.createKernelStackFrame(executionContext.getExecutionPlanId(), numArgs);
         }
         return kernelStackFrame[index];
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -410,7 +410,15 @@ public class TornadoVMInterpreter {
             }
         }
 
-        return deviceForInterpreter.allocateObjects(objects, sizeBatch, objectStates);
+        int status =  deviceForInterpreter.allocateObjects(objects, sizeBatch, objectStates);
+
+        if (TornadoOptions.isProfilerEnabled()) {
+            // Register allocations in the profiler
+            for (XPUDeviceBufferState objectState : objectStates) {
+                timeProfiler.addValueToMetric(ProfilerType.ALLOCATION_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
+            }
+        }
+        return status;
     }
 
     private int executeDeAlloc(StringBuilder tornadoVMBytecodeList, final int objectIndex) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -412,7 +412,7 @@ public class TornadoVMInterpreter {
 
         long allocationsTotalSize =  deviceForInterpreter.allocateObjects(objects, sizeBatch, objectStates);
 
-        executionContext.setCurrentMemoryUsage(allocationsTotalSize);
+        executionContext.setCurrentDeviceMemoryUsage(allocationsTotalSize);
 
         if (TornadoOptions.isProfilerEnabled()) {
             // Register allocations in the profiler
@@ -437,7 +437,7 @@ public class TornadoVMInterpreter {
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
         long spaceDeallocated =  deviceForInterpreter.deallocate(objectState);
         // Update current device area use 
-        executionContext.setCurrentMemoryUsage(executionContext.getCurrentMemoryUsage() - spaceDeallocated);
+        executionContext.setCurrentDeviceMemoryUsage(executionContext.getCurrentDeviceMemoryUsage() - spaceDeallocated);
         return -1;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/profiler/EmptyProfiler.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/profiler/EmptyProfiler.java
@@ -77,6 +77,11 @@ public class EmptyProfiler implements TornadoProfiler {
     }
 
     @Override
+    public long getSize(ProfilerType type) {
+        return 0;
+    }
+
+    @Override
     public synchronized long getTaskTimer(ProfilerType type, String taskName) {
         return 0;
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -201,8 +201,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     private long executionPlanId;
     private boolean bailout;
 
-    private long totalDeviceMemoryUsed;
-
     /**
      * Task Schedule implementation that uses GPU/FPGA and multicore backends. This constructor must be public. It is invoked using the reflection API.
      *
@@ -224,7 +222,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         streamInObjects = new ArrayList<>();
         inputModesObjects = new ArrayList<>();
         outputModeObjects = new ArrayList<>();
-        totalDeviceMemoryUsed = 0;
     }
 
     static void performStreamInObject(TaskGraph task, Object inputObject, final int dataTransferMode) {
@@ -485,6 +482,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     public void withGridScheduler(GridScheduler gridScheduler) {
         this.gridScheduler = gridScheduler;
         checkGridSchedulerNames();
+    }
+
+    @Override
+    public long getCurrentMemoryUsage() {
+        return executionContext.getCurrentMemoryUsage();
     }
 
     @Override
@@ -2311,7 +2313,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         return getProfilerValue(TOTAL_KERNEL_TIME);
     }
 
-    private long __getProfilerValueFromReduceTaskGraph(ProfilerType profilerType) {
+    private long getProfilerValueFromReduceTaskGraph(ProfilerType profilerType) {
         return switch (profilerType) {
             case TOTAL_KERNEL_TIME -> reduceTaskGraph.getExecutionResult().getProfilerResult().getDeviceKernelTime();
             case TOTAL_DISPATCH_KERNEL_TIME -> reduceTaskGraph.getExecutionResult().getProfilerResult().getKernelDispatchTime();
@@ -2347,7 +2349,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     private long getProfilerValue(ProfilerType profilerType) {
         if (reduceTaskGraph != null) {
-            return __getProfilerValueFromReduceTaskGraph(profilerType);
+            return getProfilerValueFromReduceTaskGraph(profilerType);
         } else {
             return __getProfilerValue(profilerType);
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -23,6 +23,7 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks;
 
+import static uk.ac.manchester.tornado.api.profiler.ProfilerType.ALLOCATION_BYTES;
 import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_COPY_IN_SIZE_BYTES;
 import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES;
 import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_KERNEL_TIME;
@@ -489,6 +490,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     @Override
     public long getTotalBytesTransferred() {
         return getProfilerValue(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES) + getProfilerValue(TOTAL_COPY_OUT_SIZE_BYTES);
+    }
+
+    @Override
+    public long getTotalDeviceMemoryUsage() {
+        return getProfilerValue(ALLOCATION_BYTES);
     }
 
     @Override
@@ -2317,6 +2323,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             case TOTAL_TASK_GRAPH_TIME -> reduceTaskGraph.getExecutionResult().getProfilerResult().getTotalTime();
             case TOTAL_COPY_IN_SIZE_BYTES -> reduceTaskGraph.getExecutionResult().getProfilerResult().getTotalBytesCopyIn();
             case TOTAL_COPY_OUT_SIZE_BYTES -> reduceTaskGraph.getExecutionResult().getProfilerResult().getTotalBytesCopyOut();
+            case ALLOCATION_BYTES -> reduceTaskGraph.getExecutionResult().getProfilerResult().getTotalDeviceMemoryUsage();
             default -> 0L;
         };
     }
@@ -2333,6 +2340,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             case TOTAL_TASK_GRAPH_TIME -> timeProfiler.getTimer(ProfilerType.TOTAL_TASK_GRAPH_TIME);
             case TOTAL_COPY_IN_SIZE_BYTES -> timeProfiler.getSize(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES);
             case TOTAL_COPY_OUT_SIZE_BYTES -> timeProfiler.getSize(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES);
+            case ALLOCATION_BYTES -> timeProfiler.getSize(ProfilerType.ALLOCATION_BYTES);
             default -> 0L;
         };
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -485,8 +485,8 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
-    public long getCurrentMemoryUsage() {
-        return executionContext.getCurrentMemoryUsage();
+    public long getCurrentDeviceMemoryUsage() {
+        return executionContext.getCurrentDeviceMemoryUsage();
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -23,6 +23,8 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks;
 
+import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_COPY_IN_SIZE_BYTES;
+import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES;
 import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_KERNEL_TIME;
 
 import java.io.IOException;
@@ -198,6 +200,8 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     private long executionPlanId;
     private boolean bailout;
 
+    private long totalDeviceMemoryUsed;
+
     /**
      * Task Schedule implementation that uses GPU/FPGA and multicore backends. This constructor must be public. It is invoked using the reflection API.
      *
@@ -219,6 +223,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         streamInObjects = new ArrayList<>();
         inputModesObjects = new ArrayList<>();
         outputModeObjects = new ArrayList<>();
+        totalDeviceMemoryUsed = 0;
     }
 
     static void performStreamInObject(TaskGraph task, Object inputObject, final int dataTransferMode) {
@@ -479,6 +484,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     public void withGridScheduler(GridScheduler gridScheduler) {
         this.gridScheduler = gridScheduler;
         checkGridSchedulerNames();
+    }
+
+    @Override
+    public long getTotalBytesTransferred() {
+        return getProfilerValue(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES) + getProfilerValue(TOTAL_COPY_OUT_SIZE_BYTES);
     }
 
     @Override
@@ -2247,55 +2257,55 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     @Override
     public long getTotalTime() {
-        return getProfilerTimer(ProfilerType.TOTAL_TASK_GRAPH_TIME);
+        return getProfilerValue(ProfilerType.TOTAL_TASK_GRAPH_TIME);
     }
 
     @Override
     public long getCompileTime() {
-        return getProfilerTimer(ProfilerType.TOTAL_GRAAL_COMPILE_TIME) + getProfilerTimer(ProfilerType.TOTAL_DRIVER_COMPILE_TIME);
+        return getProfilerValue(ProfilerType.TOTAL_GRAAL_COMPILE_TIME) + getProfilerValue(ProfilerType.TOTAL_DRIVER_COMPILE_TIME);
     }
 
     @Override
     public long getTornadoCompilerTime() {
-        return getProfilerTimer(ProfilerType.TOTAL_GRAAL_COMPILE_TIME);
+        return getProfilerValue(ProfilerType.TOTAL_GRAAL_COMPILE_TIME);
     }
 
     @Override
     public long getDriverInstallTime() {
-        return getProfilerTimer(ProfilerType.TOTAL_DRIVER_COMPILE_TIME);
+        return getProfilerValue(ProfilerType.TOTAL_DRIVER_COMPILE_TIME);
     }
 
     @Override
     public long getDataTransfersTime() {
-        return getProfilerTimer(ProfilerType.COPY_IN_TIME) + getProfilerTimer(ProfilerType.COPY_OUT_TIME);
+        return getProfilerValue(ProfilerType.COPY_IN_TIME) + getProfilerValue(ProfilerType.COPY_OUT_TIME);
     }
 
     @Override
     public long getDeviceWriteTime() {
-        return getProfilerTimer(ProfilerType.COPY_IN_TIME);
+        return getProfilerValue(ProfilerType.COPY_IN_TIME);
     }
 
     @Override
     public long getDeviceReadTime() {
-        return getProfilerTimer(ProfilerType.COPY_OUT_TIME);
+        return getProfilerValue(ProfilerType.COPY_OUT_TIME);
     }
 
     @Override
     public long getDataTransferDispatchTime() {
-        return getProfilerTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
+        return getProfilerValue(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
     }
 
     @Override
     public long getKernelDispatchTime() {
-        return getProfilerTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME);
+        return getProfilerValue(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME);
     }
 
     @Override
     public long getDeviceKernelTime() {
-        return getProfilerTimer(TOTAL_KERNEL_TIME);
+        return getProfilerValue(TOTAL_KERNEL_TIME);
     }
 
-    private long __getTimerFromReduceTaskGraph(ProfilerType profilerType) {
+    private long __getProfilerValueFromReduceTaskGraph(ProfilerType profilerType) {
         return switch (profilerType) {
             case TOTAL_KERNEL_TIME -> reduceTaskGraph.getExecutionResult().getProfilerResult().getDeviceKernelTime();
             case TOTAL_DISPATCH_KERNEL_TIME -> reduceTaskGraph.getExecutionResult().getProfilerResult().getKernelDispatchTime();
@@ -2305,11 +2315,13 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             case TOTAL_DRIVER_COMPILE_TIME -> reduceTaskGraph.getExecutionResult().getProfilerResult().getDriverInstallTime();
             case TOTAL_GRAAL_COMPILE_TIME -> reduceTaskGraph.getExecutionResult().getProfilerResult().getTornadoCompilerTime();
             case TOTAL_TASK_GRAPH_TIME -> reduceTaskGraph.getExecutionResult().getProfilerResult().getTotalTime();
+            case TOTAL_COPY_IN_SIZE_BYTES -> reduceTaskGraph.getExecutionResult().getProfilerResult().getTotalBytesCopyIn();
+            case TOTAL_COPY_OUT_SIZE_BYTES -> reduceTaskGraph.getExecutionResult().getProfilerResult().getTotalBytesCopyOut();
             default -> 0L;
         };
     }
 
-    private long __getProfilerTime(ProfilerType profilerType) {
+    private long __getProfilerValue(ProfilerType profilerType) {
         return switch (profilerType) {
             case TOTAL_KERNEL_TIME -> timeProfiler.getTimer(TOTAL_KERNEL_TIME);
             case TOTAL_DISPATCH_KERNEL_TIME -> timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME);
@@ -2319,21 +2331,33 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             case TOTAL_DRIVER_COMPILE_TIME -> timeProfiler.getTimer(ProfilerType.TOTAL_DRIVER_COMPILE_TIME);
             case TOTAL_GRAAL_COMPILE_TIME -> timeProfiler.getTimer(ProfilerType.TOTAL_GRAAL_COMPILE_TIME);
             case TOTAL_TASK_GRAPH_TIME -> timeProfiler.getTimer(ProfilerType.TOTAL_TASK_GRAPH_TIME);
-            default -> 0;
+            case TOTAL_COPY_IN_SIZE_BYTES -> timeProfiler.getSize(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES);
+            case TOTAL_COPY_OUT_SIZE_BYTES -> timeProfiler.getSize(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES);
+            default -> 0L;
         };
     }
 
-    private long getProfilerTimer(ProfilerType profilerType) {
+    private long getProfilerValue(ProfilerType profilerType) {
         if (reduceTaskGraph != null) {
-            return __getTimerFromReduceTaskGraph(profilerType);
+            return __getProfilerValueFromReduceTaskGraph(profilerType);
         } else {
-            return __getProfilerTime(profilerType);
+            return __getProfilerValue(profilerType);
         }
     }
 
     @Override
     public String getProfileLog() {
         return bufferLogProfiler.toString();
+    }
+
+    @Override
+    public long getTotalBytesCopyIn() {
+        return getProfilerValue(TOTAL_COPY_IN_SIZE_BYTES);
+    }
+
+    @Override
+    public long getTotalBytesCopyOut() {
+        return getProfilerValue(TOTAL_COPY_OUT_SIZE_BYTES);
     }
 
     boolean isProfilerEnabled() {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/MemoryConsumptionTest.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/MemoryConsumptionTest.java
@@ -89,7 +89,7 @@ public class MemoryConsumptionTest extends TestMemoryCommon {
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
             executionPlan.withProfiler(ProfilerMode.SILENT).execute();
-            long currentMemoryUsageInBytes = executionPlan.getCurrentMemoryUsage();
+            long currentMemoryUsageInBytes = executionPlan.getCurrentDeviceMemoryUsage();
             final long sizeAllocated = a.getNumBytesOfSegmentWithHeader() * 3;
             assertEquals(sizeAllocated, currentMemoryUsageInBytes);
         }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/MemoryConsumptionTest.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/MemoryConsumptionTest.java
@@ -50,17 +50,10 @@ public class MemoryConsumptionTest extends TestMemoryCommon {
             TornadoExecutionResult executionResult = executionPlan.execute();
             long totalMemoryUsedInBytes = executionResult.getProfilerResult().getTotalBytesTransferred();
 
-            System.out.println(totalMemoryUsedInBytes);
+            long copyInBytes = executionResult.getProfilerResult().getTotalBytesCopyIn();
+            long copyOutBytes = executionResult.getProfilerResult().getTotalBytesCopyOut();
 
-            executionResult = executionPlan.execute();
-
-            totalMemoryUsedInBytes = executionResult.getProfilerResult().getTotalBytesTransferred();
-
-            System.out.println(totalMemoryUsedInBytes);
-
-            for (int i = 0; i < c.getSize(); i++) {
-                assertEquals(a.get(i) + b.get(i) + value, c.get(i), 0.001);
-            }
+            assertEquals(copyInBytes + copyOutBytes, totalMemoryUsedInBytes);
         }
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/MemoryConsumptionTest.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/MemoryConsumptionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.memory;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+
+/**
+ * How to test?
+ *
+ * <code>
+ * tornado-test --enableProfiler console -V uk.ac.manchester.tornado.unittests.memory.MemoryConsumptionTest
+ * </code>
+ */
+public class MemoryConsumptionTest extends TestMemoryCommon {
+
+    @Test
+    public void testMemoryConsumption() throws TornadoExecutionPlanException {
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestMemoryLimit::add, a, b, c, value) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            TornadoExecutionResult executionResult = executionPlan.execute();
+            long totalMemoryUsedInBytes = executionResult.getProfilerResult().getTotalBytesTransferred();
+
+            System.out.println(totalMemoryUsedInBytes);
+
+            executionResult = executionPlan.execute();
+
+            totalMemoryUsedInBytes = executionResult.getProfilerResult().getTotalBytesTransferred();
+
+            System.out.println(totalMemoryUsedInBytes);
+
+            for (int i = 0; i < c.getSize(); i++) {
+                assertEquals(a.get(i) + b.get(i) + value, c.get(i), 0.001);
+            }
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/MemoryConsumptionTest.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/MemoryConsumptionTest.java
@@ -26,6 +26,7 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoExecutionResult;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.ProfilerMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 
 /**
@@ -33,7 +34,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
  *
  * <p>
  * <code>
- * tornado-test --enableProfiler console -V uk.ac.manchester.tornado.unittests.memory.MemoryConsumptionTest
+ * tornado-test -V uk.ac.manchester.tornado.unittests.memory.MemoryConsumptionTest
  * </code>
  * </p>
  */
@@ -49,7 +50,7 @@ public class MemoryConsumptionTest extends TestMemoryCommon {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            TornadoExecutionResult executionResult = executionPlan.execute();
+            TornadoExecutionResult executionResult = executionPlan.withProfiler(ProfilerMode.SILENT).execute();
             long totalBytesTransferred = executionResult.getProfilerResult().getTotalBytesTransferred();
             long copyInBytes = executionResult.getProfilerResult().getTotalBytesCopyIn();
             long copyOutBytes = executionResult.getProfilerResult().getTotalBytesCopyOut();
@@ -67,7 +68,7 @@ public class MemoryConsumptionTest extends TestMemoryCommon {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            TornadoExecutionResult executionResult = executionPlan.execute();
+            TornadoExecutionResult executionResult = executionPlan.withProfiler(ProfilerMode.SILENT).execute();
             long totalMemoryUsedInBytes = executionResult.getProfilerResult().getTotalDeviceMemoryUsage();
 
             // 3 Arrays
@@ -87,7 +88,7 @@ public class MemoryConsumptionTest extends TestMemoryCommon {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.execute();
+            executionPlan.withProfiler(ProfilerMode.SILENT).execute();
             long currentMemoryUsageInBytes = executionPlan.getCurrentMemoryUsage();
             final long sizeAllocated = a.getNumBytesOfSegmentWithHeader() * 3;
             assertEquals(sizeAllocated, currentMemoryUsageInBytes);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/TestMemoryCommon.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/TestMemoryCommon.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.memory;
+
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+public class TestMemoryCommon extends TornadoTestBase {
+
+    /**
+     * Set the number of elements to select ~300MB per array.
+     */
+    static final int NUM_ELEMENTS = 78643200;   // 314MB for an array of Integers
+    static IntArray a = new IntArray(NUM_ELEMENTS);
+    static IntArray b = new IntArray(NUM_ELEMENTS);
+    static IntArray c = new IntArray(NUM_ELEMENTS);
+
+    static int value = 10000000;
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/TestMemoryLimit.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/memory/TestMemoryLimit.java
@@ -30,7 +30,6 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.unittests.TestHello;
-import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
  * How to test?
@@ -41,17 +40,7 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * </code>
  * </p>
  */
-public class TestMemoryLimit extends TornadoTestBase {
-
-    /**
-     * Set the number of elements to select ~300MB per array.
-     */
-    private static final int NUM_ELEMENTS = 78643200;   // 314MB for an array of Integers
-    private static IntArray a = new IntArray(NUM_ELEMENTS);
-    private static IntArray b = new IntArray(NUM_ELEMENTS);
-    private static IntArray c = new IntArray(NUM_ELEMENTS);
-
-    private static int value = 10000000;
+public class TestMemoryLimit extends TestMemoryCommon {
 
     @BeforeClass
     public static void setUpBeforeClass() {


### PR DESCRIPTION
#### Description

This PR expands the profiler and the TornadoVM Execution Plan API to obtain the current memory consumption per task-graph, total number of bytes transferred to the device back and forth per execution plan, and the total memory usage.  This feature is requested from the GAIA project. 


a) `getTotalBytesTransferred`

This expands the profiler to obtain the total number of bytes transferred in every execution plan launch. The number of bytes transferred depends on READ_ONLY, WRITE_ONLY and READ_WRITE data buffers. 

```java
 try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
            TornadoExecutionResult executionResult = executionPlan.execute();
            long totalBytesTransferred = executionResult.getProfilerResult().getTotalBytesTransferred();
            long copyInBytes = executionResult.getProfilerResult().getTotalBytesCopyIn();
            long copyOutBytes = executionResult.getProfilerResult().getTotalBytesCopyOut();
            assertEquals(copyInBytes + copyOutBytes, totalBytesTransferred);
        }
```

b)  `getTotalDeviceMemoryUsage` 

The total device memory usage registers all allocations needed to run an execution plan. This value can be queried using the TornadoVM profiler. 

```java
try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
            TornadoExecutionResult executionResult = executionPlan.execute();
            long totalMemoryUsedInBytes = executionResult.getProfilerResult().getTotalDeviceMemoryUsage();

            // 3 Arrays
            final long sizeAllocated = a.getNumBytesOfSegmentWithHeader() * 3;
            assertEquals(sizeAllocated, totalMemoryUsedInBytes);

        }
```

c) `getCurrentMemoryUsage`

Value to query at the execution plan level, to obtain the actual memory usage at any point during execution. 

```java
try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
            executionPlan.execute();
            long currentMemoryUsageInBytes = executionPlan.getCurrentMemoryUsage();
            final long sizeAllocated = a.getNumBytesOfSegmentWithHeader() * 3;
            assertEquals(sizeAllocated, currentMemoryUsageInBytes);
        }
```

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make BACKEND=opencl
tornado-test --enableProfiler console -V uk.ac.manchester.tornado.unittests.memory.MemoryConsumptionTest

make BACKEND=ptx
tornado-test --enableProfiler console -V uk.ac.manchester.tornado.unittests.memory.MemoryConsumptionTest

make BACKEND=spirv
tornado-test --enableProfiler console -V uk.ac.manchester.tornado.unittests.memory.MemoryConsumptionTest
```
