### PR TITLE
Typo benchmark fixed

### DIFF
--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/BenchmarkRunner.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/BenchmarkRunner.java
@@ -198,7 +198,7 @@ public abstract class BenchmarkRunner {
             case "blackscholes" -> new uk.ac.manchester.tornado.benchmarks.blackscholes.Benchmark();
             case "blurfilter" -> new uk.ac.manchester.tornado.benchmarks.blurFilter.Benchmark();
             case "convolvearray" -> new uk.ac.manchester.tornado.benchmarks.convolvearray.Benchmark();
-            case "convolveirray" -> new uk.ac.manchester.tornado.benchmarks.convolveimage.Benchmark();
+            case "convolveimage" -> new uk.ac.manchester.tornado.benchmarks.convolveimage.Benchmark();
             case "dft" -> new uk.ac.manchester.tornado.benchmarks.dft.Benchmark();
             case "dgemm" -> new uk.ac.manchester.tornado.benchmarks.dgemm.Benchmark();
             case "dotimage" -> new uk.ac.manchester.tornado.benchmarks.dotimage.Benchmark();


### PR DESCRIPTION
#### Description

List of benchmarks had one benchmark misspelled. 

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-benchmarks.py
```