### PR TITLE
Option to select the SPIR-V Runtime Dispatcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,20 @@ tests:
 	tornado-test --ea -V -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
 	test-native.sh
 
+tests-spirv-levelzero:
+	rm -f tornado_unittests.log
+	tornado --jvm="-Dtornado.spirv.dispatcher=levelzero" uk.ac.manchester.tornado.drivers.TornadoDeviceQuery --params="verbose"
+	tornado-test --jvm="-Dtornado.spirv.dispatcher=levelzero" --ea --verbose
+	tornado-test --jvm="-Dtornado.spirv.dispatcher=levelzero"--ea -V -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
+	test-native.sh
+
+tests-spirv-opencl:
+	rm -f tornado_unittests.log
+	tornado --jvm="-Dtornado.spirv.dispatcher=opencl" uk.ac.manchester.tornado.drivers.TornadoDeviceQuery --params="verbose"
+	tornado-test --jvm="-Dtornado.spirv.dispatcher=opencl" --ea --verbose
+	tornado-test --jvm="-Dtornado.spirv.dispatcher=opencl"--ea -V -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
+	test-native.sh
+
 tests-opt:
 	tornado --devices
 	tornado-test -V --fast --ea --verbose -J"-Dtornado.spirv.loadstore=True" --printKernel

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
@@ -111,7 +111,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
     }
 
     private SPIRVBackend createSPIRVJITCompilerBackend(OptionValues options, HotSpotJVMCIRuntime vmRuntime, TornadoVMConfigAccess vmConfig, SPIRVDevice device, SPIRVContext context,
-            SPIRVRuntime spirvRuntime) {
+            SPIRVRuntimeType spirvRuntime) {
         return SPIRVHotSpotBackendFactory.createJITCompiler(options, vmRuntime, vmConfig, device, context, spirvRuntime);
     }
 
@@ -196,10 +196,10 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
         return TornadoVMBackendType.SPIRV;
     }
 
-    public SPIRVBackend getBackend(SPIRVRuntime port) {
+    public SPIRVBackend getBackend(SPIRVRuntimeType port) {
         for (SPIRVBackend[] spirvBackend : spirvBackends) {
             for (SPIRVBackend backend : spirvBackend) {
-                SPIRVRuntime spirvRuntime = backend.getDeviceContext().device.getSPIRVRuntime();
+                SPIRVRuntimeType spirvRuntime = backend.getDeviceContext().device.getSPIRVRuntime();
                 if (spirvRuntime.equals(port)) {
                     return backend;
                 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDevice.java
@@ -81,5 +81,5 @@ public abstract class SPIRVDevice implements TornadoTargetDevice {
 
     public abstract boolean isSPIRVSupported();
 
-    public abstract SPIRVRuntime getSPIRVRuntime();
+    public abstract SPIRVRuntimeType getSPIRVRuntime();
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroDevice.java
@@ -252,8 +252,8 @@ public class SPIRVLevelZeroDevice extends SPIRVDevice {
     }
 
     @Override
-    public SPIRVRuntime getSPIRVRuntime() {
-        return SPIRVRuntime.LEVEL_ZERO;
+    public SPIRVRuntimeType getSPIRVRuntime() {
+        return SPIRVRuntimeType.LEVEL_ZERO;
     }
 
     @Override

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroPlatform.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroPlatform.java
@@ -101,7 +101,7 @@ public class SPIRVLevelZeroPlatform implements SPIRVPlatform {
     }
 
     @Override
-    public SPIRVRuntime getRuntime() {
-        return SPIRVRuntime.LEVEL_ZERO;
+    public SPIRVRuntimeType getRuntime() {
+        return SPIRVRuntimeType.LEVEL_ZERO;
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLDevice.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2021-2022 APT Group, Department of Computer Science,
+ * Copyright (c) 2021-2022, 2024, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,94 +34,94 @@ public class SPIRVOCLDevice extends SPIRVDevice {
 
     // Holds a reference to the OpenCL device implementation from the OpenCL
     // backend. It reuses the JNI low level code from the OpenCL Backend.
-    private OCLTargetDevice device;
+    private final OCLTargetDevice oclDevice;
 
     public SPIRVOCLDevice(int platformIndex, int deviceIndex, OCLTargetDevice device) {
         super(platformIndex, deviceIndex);
-        this.device = device;
+        this.oclDevice = device;
     }
 
     public int deviceVersion() {
-        return device.deviceVersion();
+        return oclDevice.deviceVersion();
     }
 
     public long getId() {
-        return device.getDevicePointer();
+        return oclDevice.getDevicePointer();
     }
 
     @Override
     public boolean isDeviceDoubleFPSupported() {
-        return device.isDeviceDoubleFPSupported();
+        return oclDevice.isDeviceDoubleFPSupported();
     }
 
     @Override
     public String getDeviceExtensions() {
-        return device.getDeviceExtensions();
+        return oclDevice.getDeviceExtensions();
     }
 
     @Override
     public ByteOrder getByteOrder() {
-        return device.getByteOrder();
+        return oclDevice.getByteOrder();
     }
 
     @Override
     public String getName() {
-        return "SPIRV OCL - " + device.getDeviceName();
+        return "SPIRV OCL - " + oclDevice.getDeviceName();
     }
 
     @Override
     public OCLTargetDevice getDeviceRuntime() {
-        return device;
+        return oclDevice;
     }
 
     @Override
     public String getDeviceName() {
-        return device.getDeviceName();
+        return oclDevice.getDeviceName();
     }
 
     @Override
     public long getDeviceGlobalMemorySize() {
-        return device.getDeviceGlobalMemorySize();
+        return oclDevice.getDeviceGlobalMemorySize();
     }
 
     @Override
     public long getDeviceLocalMemorySize() {
-        return device.getDeviceLocalMemorySize();
+        return oclDevice.getDeviceLocalMemorySize();
     }
 
     @Override
     public int getDeviceMaxComputeUnits() {
-        return device.getDeviceMaxComputeUnits();
+        return oclDevice.getDeviceMaxComputeUnits();
     }
 
     @Override
     public long[] getDeviceMaxWorkItemSizes() {
-        return device.getDeviceMaxWorkItemSizes();
+        return oclDevice.getDeviceMaxWorkItemSizes();
     }
 
     @Override
     public long[] getDeviceMaxWorkGroupSize() {
-        return device.getDeviceMaxWorkGroupSize();
+        return oclDevice.getDeviceMaxWorkGroupSize();
     }
 
     @Override
     public int getMaxThreadsPerBlock() {
-        return device.getMaxThreadsPerBlock();
+        return oclDevice.getMaxThreadsPerBlock();
     }
 
     @Override
     public int getDeviceMaxClockFrequency() {
-        return device.getDeviceMaxClockFrequency();
+        return oclDevice.getDeviceMaxClockFrequency();
     }
 
     @Override
     public long getDeviceMaxConstantBufferSize() {
-        return device.getDeviceMaxConstantBufferSize();
+        return oclDevice.getDeviceMaxConstantBufferSize();
     }
 
     @Override
     public long getDeviceMaxAllocationSize() {
-        return device.getDeviceMaxAllocationSize();
+        return oclDevice.getDeviceMaxAllocationSize();
     }
 
     @Override
@@ -131,33 +131,29 @@ public class SPIRVOCLDevice extends SPIRVDevice {
 
     @Override
     public long[] getDeviceMaxWorkgroupDimensions() {
-        return device.getDeviceMaxWorkItemSizes();
+        return oclDevice.getDeviceMaxWorkItemSizes();
     }
 
     @Override
     public String getDeviceOpenCLCVersion() {
-        return device.getDeviceOpenCLCVersion();
+        return oclDevice.getDeviceOpenCLCVersion();
     }
 
     @Override
     public long getMaxAllocMemory() {
-        return device.getDeviceMaxAllocationSize();
+        return oclDevice.getDeviceMaxAllocationSize();
     }
 
     @Override
     public TornadoDeviceType getTornadoDeviceType() {
-        OCLDeviceType type = device.getDeviceType();
-        switch (type) {
-            case CL_DEVICE_TYPE_CPU:
-                return TornadoDeviceType.CPU;
-            case CL_DEVICE_TYPE_GPU:
-                return TornadoDeviceType.GPU;
-            case CL_DEVICE_TYPE_ACCELERATOR:
-                return TornadoDeviceType.FPGA;
-            case CL_DEVICE_TYPE_ALL:
-                return TornadoDeviceType.DEFAULT;
-        }
-        return null;
+        OCLDeviceType type = oclDevice.getDeviceType();
+        return switch (type) {
+            case CL_DEVICE_TYPE_CPU -> TornadoDeviceType.CPU;
+            case CL_DEVICE_TYPE_GPU -> TornadoDeviceType.GPU;
+            case CL_DEVICE_TYPE_ACCELERATOR -> TornadoDeviceType.FPGA;
+            case CL_DEVICE_TYPE_ALL -> TornadoDeviceType.DEFAULT;
+            default -> null;
+        };
     }
 
     @Override
@@ -167,12 +163,12 @@ public class SPIRVOCLDevice extends SPIRVDevice {
 
     @Override
     public boolean isSPIRVSupported() {
-        return device.isSPIRVSupported();
+        return oclDevice.isSPIRVSupported();
     }
 
     @Override
-    public SPIRVRuntime getSPIRVRuntime() {
-        return SPIRVRuntime.OPENCL;
+    public SPIRVRuntimeType getSPIRVRuntime() {
+        return SPIRVRuntimeType.OPENCL;
     }
 
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOpenCLPlatform.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOpenCLPlatform.java
@@ -76,8 +76,8 @@ public class SPIRVOpenCLPlatform implements SPIRVPlatform {
     }
 
     @Override
-    public SPIRVRuntime getRuntime() {
-        return SPIRVRuntime.OPENCL;
+    public SPIRVRuntimeType getRuntime() {
+        return SPIRVRuntimeType.OPENCL;
     }
 
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVPlatform.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVPlatform.java
@@ -33,5 +33,5 @@ public interface SPIRVPlatform {
 
     SPIRVDevice[] getDevices();
 
-    SPIRVRuntime getRuntime();
+    SPIRVRuntimeType getRuntime();
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
@@ -27,6 +27,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
+
 /**
  * Class for Calling JNI methods that can dispatch SPIR-V code.
  * code.
@@ -39,6 +42,8 @@ import java.util.stream.IntStream;
  * <p>
  */
 public class SPIRVRuntimeImpl {
+
+    private final String ERROR_PLATFORM_NOT_IMPLEMENTED = "SPIR-V Runtime Implementation not supported: " + TornadoOptions.SPIRV_DISPATCHER + " \nUse \"opencl\" or \"levelzero\"";
 
     private List<SPIRVPlatform> platforms;
     private static SPIRVRuntimeImpl instance;
@@ -56,9 +61,19 @@ public class SPIRVRuntimeImpl {
 
     private synchronized void init() {
         if (platforms == null) {
-            SPIRVDispatcher[] dispatchers = new SPIRVDispatcher[SPIRVRuntime.values().length];
-            dispatchers[SPIRVRuntime.OPENCL.ordinal()] = new SPIRVOpenCLDriver();
-            dispatchers[SPIRVRuntime.LEVEL_ZERO.ordinal()] = new SPIRVLevelZeroDriver();
+            SPIRVDispatcher[] dispatchers = new SPIRVDispatcher[SPIRVRuntimeType.values().length];
+            SPIRVLevelZeroDriver levelZeroDriver = new SPIRVLevelZeroDriver();
+            SPIRVOpenCLDriver openCLDriver = new SPIRVOpenCLDriver();
+            int index = 0;
+            if (TornadoOptions.SPIRV_DISPATCHER.equalsIgnoreCase("opencl")) {
+                dispatchers[index++] = openCLDriver;
+                dispatchers[index] = levelZeroDriver;
+            } else if (TornadoOptions.SPIRV_DISPATCHER.equalsIgnoreCase("levelzero")) {
+                dispatchers[index++] = levelZeroDriver;
+                dispatchers[index] = openCLDriver;
+            } else {
+                throw new TornadoRuntimeException(ERROR_PLATFORM_NOT_IMPLEMENTED);
+            }
 
             platforms = new ArrayList<>();
             for (SPIRVDispatcher dispatcher : dispatchers) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
@@ -62,8 +62,8 @@ public class SPIRVRuntimeImpl {
     private synchronized void init() {
         if (platforms == null) {
             SPIRVDispatcher[] dispatchers = new SPIRVDispatcher[SPIRVRuntimeType.values().length];
-            SPIRVLevelZeroDriver levelZeroDriver = new SPIRVLevelZeroDriver();
-            SPIRVOpenCLDriver openCLDriver = new SPIRVOpenCLDriver();
+            SPIRVDispatcher levelZeroDriver = new SPIRVLevelZeroDriver();
+            SPIRVDispatcher openCLDriver = new SPIRVOpenCLDriver();
             int index = 0;
             if (TornadoOptions.SPIRV_DISPATCHER.equalsIgnoreCase("opencl")) {
                 dispatchers[index++] = openCLDriver;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeType.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeType.java
@@ -23,7 +23,7 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv;
 
-public enum SPIRVRuntime {
+public enum SPIRVRuntimeType {
     OPENCL, //
     LEVEL_ZERO,
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVArchitecture.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVArchitecture.java
@@ -40,7 +40,7 @@ import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.PlatformKind;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.common.architecture.ArchitectureRegister;
-import uk.ac.manchester.tornado.drivers.spirv.SPIRVRuntime;
+import uk.ac.manchester.tornado.drivers.spirv.SPIRVRuntimeType;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.graal.meta.SPIRVMemorySpace;
 
@@ -62,7 +62,7 @@ public class SPIRVArchitecture extends Architecture {
     private static final int RETURN_ADDRESS_SIZE = 0;
     public static String BACKEND_ARCHITECTURE = "TornadoVM SPIR-V";
 
-    public SPIRVArchitecture(SPIRVKind wordKind, ByteOrder byteOrder, SPIRVRuntime runtime) {
+    public SPIRVArchitecture(SPIRVKind wordKind, ByteOrder byteOrder, SPIRVRuntimeType runtime) {
         super(BACKEND_ARCHITECTURE + "@" + runtime.name(), wordKind, byteOrder, false, null, LOAD_STORE | STORE_STORE, NATIVE_CALL_DISPLACEMENT_OFFSET, RETURN_ADDRESS_SIZE);
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVHotSpotBackendFactory.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVHotSpotBackendFactory.java
@@ -52,7 +52,7 @@ import uk.ac.manchester.tornado.drivers.spirv.SPIRVBackend;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVContext;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDevice;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
-import uk.ac.manchester.tornado.drivers.spirv.SPIRVRuntime;
+import uk.ac.manchester.tornado.drivers.spirv.SPIRVRuntimeType;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVTargetDescription;
 import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.SPIRVCompilerConfiguration;
 import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.plugins.SPIRVGraphBuilderPlugins;
@@ -79,7 +79,7 @@ public class SPIRVHotSpotBackendFactory {
     private static final SPIRVAddressLowering addressLowering = new SPIRVAddressLowering();
 
     public static SPIRVBackend createJITCompiler(OptionValues options, HotSpotJVMCIRuntime jvmciRuntime, TornadoVMConfigAccess vmConfig, SPIRVDevice device, SPIRVContext context,
-            SPIRVRuntime spirvRuntime) {
+            SPIRVRuntimeType spirvRuntime) {
         JVMCIBackend jvmci = jvmciRuntime.getHostJVMCIBackend();
         HotSpotMetaAccessProvider metaAccess = (HotSpotMetaAccessProvider) jvmci.getMetaAccess();
         HotSpotConstantReflectionProvider constantReflection = (HotSpotConstantReflectionProvider) jvmci.getConstantReflection();

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestVM.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestVM.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVBackend;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVBackendImpl;
-import uk.ac.manchester.tornado.drivers.spirv.SPIRVRuntime;
+import uk.ac.manchester.tornado.drivers.spirv.SPIRVRuntimeType;
 import uk.ac.manchester.tornado.drivers.spirv.runtime.SPIRVTornadoDevice;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
@@ -45,7 +45,7 @@ import uk.ac.manchester.tornado.runtime.tasks.DataObjectState;
  */
 public class TestVM {
 
-    public TornadoDevice invokeSPIRVBackend(SPIRVRuntime spirvRuntime) {
+    public TornadoDevice invokeSPIRVBackend(SPIRVRuntimeType spirvRuntime) {
         // Get the backend from TornadoVM
         SPIRVBackend spirvBackend = TornadoCoreRuntime.getTornadoRuntime().getBackend(SPIRVBackendImpl.class).getBackend(spirvRuntime);
         System.out.println("Query SPIR_V Runtime: " + spirvBackend);
@@ -107,7 +107,7 @@ public class TestVM {
 
     }
 
-    public void test(SPIRVRuntime runtime) {
+    public void test(SPIRVRuntimeType runtime) {
         TornadoDevice device = invokeSPIRVBackend(runtime);
         int[] a = new int[64];
         int[] b = new int[64];
@@ -124,7 +124,7 @@ public class TestVM {
 
     public static void main(String[] args) {
         System.out.print("Running Native: uk.ac.manchester.tornado.drivers.spirv.tests.TestVM");
-        new TestVM().test(SPIRVRuntime.OPENCL);
-        new TestVM().test(SPIRVRuntime.LEVEL_ZERO);
+        new TestVM().test(SPIRVRuntimeType.OPENCL);
+        new TestVM().test(SPIRVRuntimeType.LEVEL_ZERO);
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -196,9 +196,9 @@ public class TornadoOptions {
      */
     public static final boolean INLINE_DURING_BYTECODE_PARSING = getBooleanValue("tornado.compiler.bytecodeInlining", FALSE);
     /**
-     * Use Level Zero as a dispatcher for SPIRV.
+     * Use Level Zero or OpenCL as default SPIR-V Code Dispatcher and Runtime. Allowed values: "opencl", "levelzero"
      */
-    public static final boolean USE_LEVELZERO_FOR_SPIRV = getBooleanValue("tornado.spirv.levelzero", TRUE);
+    public static final String SPIRV_DISPATCHER = getProperty("tornado.spirv.dispatcher", "opencl");
     /**
      * Check I/O parameters for every task within a task-graph.
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -196,7 +196,7 @@ public class TornadoOptions {
      */
     public static final boolean INLINE_DURING_BYTECODE_PARSING = getBooleanValue("tornado.compiler.bytecodeInlining", FALSE);
     /**
-     * Use Level Zero or OpenCL as default SPIR-V Code Dispatcher and Runtime. Allowed values: "opencl", "levelzero"
+     * Use Level Zero or OpenCL as the SPIR-V Code Dispatcher and Runtime. Allowed values: "opencl", "levelzero". The default option is "opencl".
      */
     public static final String SPIRV_DISPATCHER = getProperty("tornado.spirv.dispatcher", "opencl");
     /**


### PR DESCRIPTION
#### Description

This PR adds an option in the `TornadoOptions` to select which runtime we want as default to dispatch SPIR-V code. 
By default. TornadoVM currently selects the OpenCL, but the user now can override this by using the following option:

- Use `-Dtornado.spirv.dispatcher=opencl` to select OpenCL as default.
- Use `-Dtornado.spirv.dispatcher=levelzero` to select LevelZero as default.

This is useful to pass, for example, all tests with another Runtime Dispatcher for SPIR-V. 

```bash
$ make tests-spirv-levelzero 

$ make tests-spirv-opencl
```


#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make BACKEND=spirv

tornado --jvm="-Dtornado.spirv.dispatcher=opencl" uk.ac.manchester.tornado.drivers.TornadoDeviceQuery --params="verbose"

tornado --jvm="-Dtornado.spirv.dispatcher=levelzero" uk.ac.manchester.tornado.drivers.TornadoDeviceQuery --params="verbose"

## If set a random value
tornado --jvm="-Dtornado.spirv.dispatcher=foo" uk.ac.manchester.tornado.drivers.TornadoDeviceQuery --params="verbose"

#We get an error
```

