### PR TITLE
[feat] SPIR-V binary stored in tmp directory per username

### DIFF
--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVCodeCache.java
@@ -25,6 +25,7 @@ package uk.ac.manchester.tornado.drivers.spirv;
 
 import java.io.FileOutputStream;
 import java.nio.ByteBuffer;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.ConcurrentHashMap;
@@ -77,6 +78,13 @@ public abstract class SPIRVCodeCache {
         if (!pathToSPIRVBin.toFile().exists()) {
             throw new RuntimeException("Binary File does not exist");
         }
+    }
+
+    protected String createSPIRVTempDirectoryName() {
+        String tempDirectory = System.getProperty("java.io.tmpdir");
+        String user = System.getProperty("user.name");
+        String pathSeparator = FileSystems.getDefault().getSeparator();
+        return tempDirectory + pathSeparator + user + pathSeparator + "tornadoVM-spirv";
     }
 
     public abstract SPIRVInstalledCode installSPIRVBinary(TaskMetaData meta, String id, String entryPoint, String pathToFile);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVCodeCache.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2021-2022 APT Group, Department of Computer Science,
+ * Copyright (c) 2021-2022, 2024, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -24,13 +24,18 @@
 package uk.ac.manchester.tornado.drivers.spirv;
 
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.ConcurrentHashMap;
 
+import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVInstalledCode;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public abstract class SPIRVCodeCache {
@@ -59,7 +64,7 @@ public abstract class SPIRVCodeCache {
     }
 
     public SPIRVInstalledCode getInstalledCode(String id, String entryPoint) {
-        return cache.get(STR."\{id}-\{entryPoint}");
+        return cache.get(id + "-" + entryPoint);
     }
 
     protected void writeBufferToFile(ByteBuffer buffer, String filepath) {
@@ -87,8 +92,30 @@ public abstract class SPIRVCodeCache {
         return tempDirectory + pathSeparator + user + pathSeparator + "tornadoVM-spirv";
     }
 
+    public SPIRVInstalledCode installSPIRVBinary(TaskMetaData meta, String id, String entryPoint, byte[] binary) {
+        if (binary == null || binary.length == 0) {
+            throw new RuntimeException("[ERROR] SPIR-V Binary Module is Empty");
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(binary.length);
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        buffer.put(binary);
+        String spirvTempDirectory = createSPIRVTempDirectoryName();
+        Path path = Paths.get(spirvTempDirectory);
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new TornadoBailoutRuntimeException("Error - Exception when creating the temp directory for SPIR-V");
+        }
+        long timeStamp = System.nanoTime();
+        String pathSeparator = FileSystems.getDefault().getSeparator();
+        String spirvFile = spirvTempDirectory + pathSeparator + timeStamp + "-" + id + entryPoint + ".spv";
+        if (TornadoOptions.DEBUG) {
+            System.out.println("SPIR-V Binary File: " + spirvFile);
+        }
+
+        writeBufferToFile(buffer, spirvFile);
+        return installSPIRVBinary(meta, id, entryPoint, spirvFile);
+    }
+
     public abstract SPIRVInstalledCode installSPIRVBinary(TaskMetaData meta, String id, String entryPoint, String pathToFile);
-
-    public abstract SPIRVInstalledCode installSPIRVBinary(TaskMetaData meta, String id, String entryPoint, byte[] binary);
-
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
@@ -24,12 +24,6 @@
 package uk.ac.manchester.tornado.drivers.spirv;
 
 import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import uk.ac.manchester.beehivespirvtoolkit.lib.SPIRVTool;
 import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.Disassembler;
@@ -58,30 +52,6 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
 
     public SPIRVLevelZeroCodeCache(SPIRVDeviceContext deviceContext) {
         super(deviceContext);
-    }
-
-    @Override
-    public SPIRVInstalledCode installSPIRVBinary(TaskMetaData meta, String id, String entryPoint, byte[] code) {
-        if (code == null || code.length == 0) {
-            throw new RuntimeException("[ERROR] Binary SPIR-V Module is Empty");
-        }
-        ByteBuffer buffer = ByteBuffer.allocate(code.length);
-        buffer.order(ByteOrder.LITTLE_ENDIAN);
-        buffer.put(code);
-        String spirvTempDirectory = createSPIRVTempDirectoryName();
-        Path path = Paths.get(spirvTempDirectory);
-        try {
-            Files.createDirectories(path);
-        } catch (IOException e) {
-            throw new TornadoBailoutRuntimeException("Error - Exception when creating the temp directory for SPIR-V");
-        }
-        long timeStamp = System.nanoTime();
-        String file = STR."\{spirvTempDirectory}/\{timeStamp}-\{id}\{entryPoint}.spv";
-        if (TornadoOptions.DEBUG) {
-            System.out.println(STR."SPIRV-File : \{file}");
-        }
-        writeBufferToFile(buffer, file);
-        return installSPIRVBinary(meta, id, entryPoint, file);
     }
 
     @Override

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
@@ -68,8 +68,7 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
         ByteBuffer buffer = ByteBuffer.allocate(code.length);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
         buffer.put(code);
-        String tempDirectory = System.getProperty("java.io.tmpdir");
-        String spirvTempDirectory = STR."\{tempDirectory}/tornadoVM-spirv";
+        String spirvTempDirectory = createSPIRVTempDirectoryName();
         Path path = Paths.get(spirvTempDirectory);
         try {
             Files.createDirectories(path);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
@@ -27,11 +27,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import uk.ac.manchester.beehivespirvtoolkit.lib.SPIRVTool;
 import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.Disassembler;
@@ -44,38 +39,12 @@ import uk.ac.manchester.tornado.drivers.opencl.OCLTargetDevice;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVInstalledCode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVOCLInstalledCode;
 import uk.ac.manchester.tornado.drivers.spirv.ocl.SPIRVOCLNativeDispatcher;
-import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class SPIRVOCLCodeCache extends SPIRVCodeCache {
 
     public SPIRVOCLCodeCache(SPIRVDeviceContext deviceContext) {
         super(deviceContext);
-    }
-
-    @Override
-    public SPIRVInstalledCode installSPIRVBinary(TaskMetaData meta, String id, String entryPoint, byte[] binary) {
-        if (binary == null || binary.length == 0) {
-            throw new RuntimeException("[ERROR] Binary SPIR-V Module is Empty");
-        }
-        ByteBuffer buffer = ByteBuffer.allocate(binary.length);
-        buffer.order(ByteOrder.LITTLE_ENDIAN);
-        buffer.put(binary);
-        String spirvTempDirectory = createSPIRVTempDirectoryName();
-        Path path = Paths.get(spirvTempDirectory);
-        try {
-            Files.createDirectories(path);
-        } catch (IOException e) {
-            throw new TornadoBailoutRuntimeException("Error - Exception when creating the temp directory for SPIR-V");
-        }
-        long timeStamp = System.nanoTime();
-        String file = STR."\{spirvTempDirectory}/\{timeStamp}-\{id}\{entryPoint}.spv";if(TornadoOptions.DEBUG)
-    {
-            System.out.println(STR."SPIRV-File : \{file}");
-        }
-
-    writeBufferToFile(buffer, file);
-        return installSPIRVBinary(meta, id, entryPoint, file);
     }
 
     private byte[] readFile(String spirvFile) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
@@ -61,8 +61,7 @@ public class SPIRVOCLCodeCache extends SPIRVCodeCache {
         ByteBuffer buffer = ByteBuffer.allocate(binary.length);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
         buffer.put(binary);
-        String tempDirectory = System.getProperty("java.io.tmpdir");
-        String spirvTempDirectory = STR."\{tempDirectory}/tornadoVM-spirv";
+        String spirvTempDirectory = createSPIRVTempDirectoryName();
         Path path = Paths.get(spirvTempDirectory);
         try {
             Files.createDirectories(path);


### PR DESCRIPTION
#### Description

This PR improves the handling of the SPIR-V binary by storing the intermediate binary in a temp directory per user. 
This can avoid some issues when running TornadoVM in a Compute/HPC cluster by multiple users. 

#### Problem description

Directory permission issues due to sharing the same folder in some systems (e.g., Linux).

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make BACKEND=spirv

tornado-test --jvm="-Dtornado.spirv.dispatcher=levelzero" -V --debug uk.ac.manchester.tornado.unittests.foundation.TestFloats

tornado-test --jvm="-Dtornado.spirv.dispatcher=opencl" -V --debug uk.ac.manchester.tornado.unittests.foundation.TestFloats
```
