### PR TITLE
Update Jenkinsfile regarding the execution of SPIR-V with the OpenCL and Intel LevelZero runtimes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,16 +168,16 @@ void buildAndTest(String JDK, String tornadoProfile) {
     stage("SPIR-V (OpenCL Runtime): Unit Tests") {
         timeout(time: 12, unit: 'MINUTES') {
             sh 'tornado --devices'
-            sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:0"'
-            sh 'tornado-test -V  -J" -Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:0 -Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03'
+            sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:0 -Dtornado.spirv.dispatcher=opencl"'
+            sh 'tornado-test -V  -J" -Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:0 -Dtornado.spirv.dispatcher=opencl -Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03'
             sh 'test-native.sh'
         }
     }
     stage("SPIR-V (LevelZero Runtime): Unit Tests") {
             timeout(time: 12, unit: 'MINUTES') {
                 sh 'tornado --devices'
-                sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:1"'
-                sh 'tornado-test -V  -J" -Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:1 -Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03'
+                sh 'tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:1 -Dtornado.spirv.dispatcher=levelzero"'
+                sh 'tornado-test -V  -J" -Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:1 -Dtornado.spirv.dispatcher=levelzero -Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03'
                 sh 'test-native.sh'
             }
         }


### PR DESCRIPTION
----------------------------------------------------------------------------

#### Description

This PR adds the new flag `-Dtornado.spirv.dispatcher` to select the runtime for running SPIR-V generated code, we have to add this option in our Jenkinsfile

#### Problem description

As it was getting the "OpenCL" runtime was being selected even if the Level Zero device was explicitly added. The device id are taken from the Jenkins pipeline: 
```bash
Number of Tornado drivers: 3
[2024-06-17T15:38:47.423Z] Driver: SPIR-V
[2024-06-17T15:38:47.423Z]   Total number of SPIR-V devices  : 2
[2024-06-17T15:38:47.423Z]   Tornado device=0:0  (DEFAULT)
[2024-06-17T15:38:47.423Z] 	SPIRV -- SPIRV OCL - Intel(R) UHD Graphics 630
[2024-06-17T15:38:47.423Z] 		Global Memory Size: 58.5 GB
[2024-06-17T15:38:47.423Z] 		Local Memory Size: 64.0 KB
[2024-06-17T15:38:47.423Z] 		Workgroup Dimensions: 3
[2024-06-17T15:38:47.423Z] 		Total Number of Block Threads: [256]
[2024-06-17T15:38:47.423Z] 		Max WorkGroup Configuration: [256, 256, 256]
[2024-06-17T15:38:47.423Z] 		Device OpenCL C version: OpenCL C 1.2
[2024-06-17T15:38:47.423Z] 
[2024-06-17T15:38:47.423Z]   Tornado device=0:1
[2024-06-17T15:38:47.423Z] 	SPIRV -- SPIRV LevelZero - Intel(R) UHD Graphics 630
[2024-06-17T15:38:47.423Z] 		Global Memory Size: 58.5 GB
[2024-06-17T15:38:47.423Z] 		Local Memory Size: 64.0 KB
[2024-06-17T15:38:47.423Z] 		Workgroup Dimensions: 3
[2024-06-17T15:38:47.423Z] 		Total Number of Block Threads: [256]
[2024-06-17T15:38:47.423Z] 		Max WorkGroup Configuration: [256, 256, 256]
[2024-06-17T15:38:47.423Z] 		Device OpenCL C version:  (LEVEL ZERO) 1.3
```

```bash
tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=0:0
[2024-06-17T15:38:49.836Z] Task info: s0.t0
[2024-06-17T15:38:49.836Z] 	Backend           : SPIRV
[2024-06-17T15:38:49.836Z] 	Device            : SPIRV OCL - Intel(R) UHD Graphics 630 GPU
[2024-06-17T15:38:49.836Z] 	Dims              : 1
[2024-06-17T15:38:49.836Z] 	Global work offset: [0]
[2024-06-17T15:38:49.836Z] 	Global work size  : [131072]
[2024-06-17T15:38:49.836Z] 	Local  work size  : [256, 1, 1]
[2024-06-17T15:38:49.836Z] 	Number of workgroups  : [512]
```

But when the second device `0:1` is selected it takes again the OpenCL runtime:

```bash
[2024-06-17T15:44:31.893Z] Task info: s0.t0
[2024-06-17T15:44:31.893Z] 	Backend           : SPIRV
[2024-06-17T15:44:31.893Z] 	Device            : SPIRV OCL - Intel(R) UHD Graphics 630 GPU
[2024-06-17T15:44:31.893Z] 	Dims              : 1
[2024-06-17T15:44:31.893Z] 	Global work offset: [0]
[2024-06-17T15:44:31.893Z] 	Global work size  : [131072]
[2024-06-17T15:44:31.893Z] 	Local  work size  : [256, 1, 1]
[2024-06-17T15:44:31.893Z] 	Number of workgroups  : [512]
```

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

To reproduce please try the same instructions as Jenkins:
```bash
make BACKEND=ptx,opencl,spirv
tornado-test --verbose -J"-Dtornado.ptx.priority=100 -Dtornado.unittests.device=1:1 -Dtornado.spirv.dispatcher=levelzero -Dtornado.device.memory=1MB"
``` 

----------------------------------------------------------------------------
