### PR TITLE
[hotfix] Avoid cycles due to the revisiting of same nodes

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoBatchFunctionAnalysis.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/sketcher/TornadoBatchFunctionAnalysis.java
@@ -33,12 +33,13 @@ import org.graalvm.compiler.nodes.memory.address.OffsetAddressNode;
 import org.graalvm.compiler.phases.BasePhase;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoSketchTierContext;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 /**
- * This phase analyses the graph to deduct if the loop index is written in the output buffer.
- * This information is necessary for batch processing, because in that case the kernel
- * will need to be recompiled to offset the value written based on the number of the batch.
+ * This phase analyses the graph to deduct if the loop index is written in the output buffer. This information is necessary for batch processing, because in that case the kernel will need to be
+ * recompiled to offset the value written based on the number of the batch.
  */
 public class TornadoBatchFunctionAnalysis extends BasePhase<TornadoSketchTierContext> {
 
@@ -51,21 +52,27 @@ public class TornadoBatchFunctionAnalysis extends BasePhase<TornadoSketchTierCon
     protected void run(StructuredGraph graph, TornadoSketchTierContext context) {
         for (ValuePhiNode phiNode : graph.getNodes().filter(ValuePhiNode.class)) {
             for (Node phiNodeUsage : phiNode.usages()) {
-                if (isIndexUsedInJavaWrite(phiNodeUsage)) {
+                Set<Node> visited = new HashSet<>();
+                if (isIndexUsedInJavaWrite(phiNodeUsage, visited)) {
                     context.setBatchWriteThreadIndex();
                 }
             }
         }
     }
 
-    private static boolean isIndexUsedInJavaWrite(Node indexUsage) {
+    private static boolean isIndexUsedInJavaWrite(Node indexUsage, Set<Node> visited) {
+        visited.add(indexUsage);
         if (indexUsage instanceof OffsetAddressNode || indexUsage instanceof FrameState || indexUsage instanceof LoadIndexedNode || indexUsage instanceof JavaReadNode) {
             return false;
         } else if (indexUsage instanceof JavaWriteNode) {
             return true;
         } else {
-            for (Node usage : indexUsage.usages()) {
-                return isIndexUsedInJavaWrite(usage);
+            for (Node node : indexUsage.usages()) {
+                if (!visited.contains(node)) {
+                    if (isIndexUsedInJavaWrite(node, visited)) {
+                        return true;
+                    }
+                }
             }
         }
         return false;


### PR DESCRIPTION
## Template to be used in the PR description (remove this part when submitted the PR)

#### Description

We identified a [bug](https://github.com/beehive-lab/TornadoVM-Ray-Tracer/issues/8) in TornadoVM-Ray-Tracer which we tried to detect the source of it, since tornado version `v1.0.4` was working.

After looking at it, we figured out that the problem was in the `TornadoBatchFunctionAnalysis.java` class. This class is used in the Sketcher to analyze the IR graph and detect if the loop index is being written in an output buffer. The problem was attributed to potential cycles that were resulting in a propagation of a null pointer that was then triggered by the TornadoVM-Ray-Tracer application.

This PR provides a fix.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

Run the unit-tests for all backends:
```java
make BACKEND=opencl
tornado-test -V --fast uk.ac.manchester.tornado.unittests.batches.TestBatches
make BACKEND=ptx
tornado-test -V --fast uk.ac.manchester.tornado.unittests.batches.TestBatches
make BACKEND=spirv
tornado-test -V --fast uk.ac.manchester.tornado.unittests.batches.TestBatches
```

Additionally, try to run the TornadoVM-Ray-Tracer for the [branch](https://github.com/stratika/TornadoVM-Path-Tracer/tree/upgrade/api/1.0.6-dev) from my fork repository. `OpenCL`  and `SPIR-V` seem to be working again, `PTX` seems to have an [error](https://github.com/beehive-lab/TornadoVM-Ray-Tracer/issues/9).
```bash
git checkout upgrade/api/1.0.6-dev
mvn clean install
tornadovm-ray-tracer
``` 
----------------------------------------------------------------------------
