### PR TITLE
CPU Virtual tests removed, since the scheduler between CPU/GPU is the same

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -134,30 +134,21 @@ __TEST_THE_WORLD__ = [
 
     ## Tests for Virtual Devices
     TestEntry(testName="uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceKernel",
-              testMethods=["testVirtualDeviceKernelGPU"],
+              testMethods=["testVirtualDeviceKernel"],
               testParameters=[
                   "-Dtornado.device.desc=" + os.environ["TORNADO_SDK"] + "/examples/virtual-device-GPU.json",
-                  "-Dtornado.print.kernel=True", "-Dtornado.virtual.device=True",
-                  "-Dtornado.print.kernel.dir=" + os.environ["TORNADO_SDK"] + "/virtualKernelOut.out"]),
-    TestEntry(testName="uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceKernel",
-              testMethods=["testVirtualDeviceKernelCPU"],
-              testParameters=[
-                  "-Dtornado.device.desc=" + os.environ["TORNADO_SDK"] + "/examples/virtual-device-CPU.json",
-                  "-Dtornado.print.kernel=True", "-Dtornado.virtual.device=True",
+                  "-Dtornado.print.kernel=True",
+                  "-Dtornado.virtual.device=True",
                   "-Dtornado.print.kernel.dir=" + os.environ["TORNADO_SDK"] + "/virtualKernelOut.out"]),
     TestEntry(testName="uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceFeatureExtraction",
-              testMethods=["testVirtualDeviceFeaturesGPU"],
+              testMethods=["testVirtualDeviceFeatures"],
               testParameters=[
                   "-Dtornado.device.desc=" + os.environ["TORNADO_SDK"] + "/examples/virtual-device-GPU.json",
-                  "-Dtornado.virtual.device=True", "-Dtornado.feature.extraction=True",
-                  "-Dtornado.features.dump.dir=" + os.environ["TORNADO_SDK"] + "/virtualFeaturesOut.out"]),
-    TestEntry(testName="uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceFeatureExtraction",
-              testMethods=["testVirtualDeviceFeaturesCPU"],
-              testParameters=[
-                  "-Dtornado.device.desc=" + os.environ["TORNADO_SDK"] + "/examples/virtual-device-CPU.json",
-                  "-Dtornado.virtual.device=True", "-Dtornado.feature.extraction=True",
+                  "-Dtornado.virtual.device=True",
+                  "-Dtornado.feature.extraction=True",
                   "-Dtornado.features.dump.dir=" + os.environ["TORNADO_SDK"] + "/virtualFeaturesOut.out"]),
 
+    ## Tests for Multi-Thread and Memory
     TestEntry(testName="uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans",
               testParameters=["-Dtornado.device.memory=4GB"]),
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceFeatureExtraction.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceFeatureExtraction.java
@@ -125,19 +125,11 @@ public class TestVirtualDeviceFeatureExtraction extends TornadoTestBase {
     }
 
     @Test
-    public void testVirtualDeviceFeaturesGPU() throws TornadoExecutionPlanException {
+    public void testVirtualDeviceFeatures() throws TornadoExecutionPlanException {
         assertNotBackend(TornadoVMBackendType.PTX);
         assertNotBackend(TornadoVMBackendType.SPIRV);
 
         testVirtuaLDeviceFeatureExtraction("virtualDeviceFeaturesGPU.json");
-    }
-
-    @Test
-    public void testVirtualDeviceFeaturesCPU() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.PTX);
-        assertNotBackend(TornadoVMBackendType.SPIRV);
-
-        testVirtuaLDeviceFeatureExtraction("virtualDeviceFeaturesCPU.json");
     }
 
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceKernel.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceKernel.java
@@ -82,7 +82,6 @@ public class TestVirtualDeviceKernel extends TornadoTestBase {
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
             executionPlan.execute();
         }
-        ;
 
         String tornadoSDK = System.getenv("TORNADO_SDK");
         String filePath = tornadoSDK + "/examples/generated/virtualDevice/" + expectedCodeFile;
@@ -95,7 +94,6 @@ public class TestVirtualDeviceKernel extends TornadoTestBase {
             generatedKernel = Files.readAllBytes(fileLog.toPath());
             expectedKernel = Files.readAllBytes(expectedKernelFile.toPath());
         } catch (IOException e) {
-            e.printStackTrace();
             Assert.fail();
         }
 
@@ -104,19 +102,9 @@ public class TestVirtualDeviceKernel extends TornadoTestBase {
     }
 
     @Test
-    public void testVirtualDeviceKernelGPU() throws TornadoExecutionPlanException {
+    public void testVirtualDeviceKernel() throws TornadoExecutionPlanException {
         assertNotBackend(TornadoVMBackendType.PTX);
         assertNotBackend(TornadoVMBackendType.SPIRV);
-
         testVirtualDeviceKernel("virtualDeviceKernelGPU.cl");
     }
-
-    @Test
-    public void testVirtualDeviceKernelCPU() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.PTX);
-        assertNotBackend(TornadoVMBackendType.SPIRV);
-
-        testVirtualDeviceKernel("virtualDeviceKernelCPU.cl");
-    }
-
 }


### PR DESCRIPTION
#### Description

The CPU Virtual Tests were failing due to the thread -scheduler changes. Since the CPU scheduler now uses the Generic GPU scheduler, there is no distinction between them in regards with the Virtual Tests. This PR fixes this. 

#### Problem description

Virtual Tests for CPU giving wrong results because the scheduler used is the Generic GPU scheduler. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado -ea  --jvm "-Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.verbose=True  -Dtornado.device.desc=${TORNADO_SDK}/examples/virtual-device-GPU.json -Dtornado.print.kernel=True -Dtornado.virtual.device=True -Dtornado.print.kernel.dir=${TORNADO_SDK}/virtualKernelOut.out"  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  --params "uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceKernel#testVirtualDeviceKernel"
```

```bash
tornado -ea  --jvm "-Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.verbose=True  -Dtornado.device.desc=${TORNADO_SDK}/examples/virtual-device-GPU.json -Dtornado.virtual.device=True -Dtornado.feature.extraction=True -Dtornado.features.dump.dir=${TORNADO_SDK}/virtualFeaturesOut.out"  -m  tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner  --params "uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceFeatureExtraction#testVirtualDeviceFeatures"
```

