### PR TITLE
[release] TornadoVM v1.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Developers can choose which backends to install and run.
 
 For a quick introduction please read the following [FAQ](https://tornadovm.readthedocs.io/en/latest/).
 
-**Latest Release:** TornadoVM 1.0.5 - 28/05/2024 :
+**Latest Release:** TornadoVM 1.0.6 - 27/06/2024 :
 See [CHANGELOG](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html).
 
 ----------------------
@@ -260,12 +260,12 @@ You can import the TornadoVM API by setting this the following dependency in the
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
 </dependency>
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-matrices</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
 </dependency>
 </dependencies>
 ```

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -5,6 +5,42 @@ TornadoVM Changelog
 
 This file summarizes the new features and major changes for each *TornadoVM* version.
 
+TornadoVM 1.0.6
+----------------
+27th June 2024
+
+Improvements
+~~~~~~~~~~~~~~~~~~
+
+- `#442 <https://github.com/beehive-lab/TornadoVM/pull/442>`_: Support for multiple SPIR-V device versions (>= 1.2).
+- `#444 <https://github.com/beehive-lab/TornadoVM/pull/444>`_: Enabling automatic device memory clean-up after each run from the execution plan.
+- `#448 <https://github.com/beehive-lab/TornadoVM/pull/448>`_: API extension to query device memory consumption at the TaskGraph granularity.
+- `#451 <https://github.com/beehive-lab/TornadoVM/pull/451>`_: Option to select the default SPIR-V runtime.
+- `#455 <https://github.com/beehive-lab/TornadoVM/pull/455>`_: Refactoring the API and documentation updated.
+- `#460 <https://github.com/beehive-lab/TornadoVM/pull/460>`_: Refactoring all examples to use try-with-resources execution plans by default.
+- `#462 <https://github.com/beehive-lab/TornadoVM/pull/462>`_: Support for copy array references from private to private memory on the hardware accelerator.
+
+
+Compatibility
+~~~~~~~~~~~~~~~~~~
+
+- `#438 <https://github.com/beehive-lab/TornadoVM/pull/438>`_: No writes for intermediate files to avoid permissions issues with Jenkins.
+- `#440 <https://github.com/beehive-lab/TornadoVM/pull/440>`_: Update Jenkinsfile  for CI/CD testing.
+- `#443 <https://github.com/beehive-lab/TornadoVM/pull/443>`_: Level Zero and OpenCL runtimes for SPIR-V included in the Jenkins CI/CD.
+- `#450 <https://github.com/beehive-lab/TornadoVM/pull/450>`_: TornadoVM benchmark script improved to report dimensions and sizes.
+- `#453 <https://github.com/beehive-lab/TornadoVM/pull/453>`_: Update Jenkinsfile with regards to the runtime for SPIR-V.
+
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~
+
+- `#434 <https://github.com/beehive-lab/TornadoVM/pull/434>`_: Fix for building TornadoVM on OSx after integration with SPIR-V binaries for OpenCL.
+- `#441 <https://github.com/beehive-lab/TornadoVM/pull/441>`_: Fix PTX unit-tests.
+- `#446 <https://github.com/beehive-lab/TornadoVM/pull/446>`_: Fix NVIDIA thread-block scheduler for new GPU drivers.
+- `#447 <https://github.com/beehive-lab/TornadoVM/pull/447>`_: Fix recompilation when batch processing is not triggered.
+- `#463 <https://github.com/beehive-lab/TornadoVM/pull/463>`_: Fix unit-tests for CPU virtual devices.
+
+
 TornadoVM 1.0.5
 ----------------
 26th May 2024

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -509,13 +509,13 @@ To use the TornadoVM API in your projects, you can checkout our maven repository
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>1.0.5</version>
+         <version>1.0.6</version>
       </dependency>
 
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>1.0.5</version>
+         <version>1.0.6</version>
       </dependency>
    </dependencies>
 
@@ -526,6 +526,7 @@ Notice that, for running with TornadoVM, you will need either the docker images 
 Versions available
 ========================
 
+* 1.0.6
 * 1.0.5
 * 1.0.4
 * 1.0.3

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>tornado</groupId>
     <artifactId>tornado</artifactId>
-    <version>1.0.6-dev</version>
+    <version>1.0.6</version>
     <packaging>pom</packaging>
     <name>tornado</name>
     <url>https://github.com/beehive-lab/tornadovm</url>

--- a/tornado-annotation/pom.xml
+++ b/tornado-annotation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
 
     <artifactId>tornado-annotation</artifactId>

--- a/tornado-api/pom.xml
+++ b/tornado-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
 
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.6-dev</version>
+    <version>1.0.6</version>
 
     <name>tornado-api</name>
     <url>https://tornadovm.org</url>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-assembly</artifactId>
     <packaging>pom</packaging>

--- a/tornado-benchmarks/pom.xml
+++ b/tornado-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
 
     <artifactId>tornado-benchmarks</artifactId>

--- a/tornado-drivers/drivers-common/pom.xml
+++ b/tornado-drivers/drivers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tornado-drivers/opencl-jni/pom.xml
+++ b/tornado-drivers/opencl-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-drivers-opencl-jni</artifactId>
     <name>tornado-drivers-opencl-jni</name>

--- a/tornado-drivers/opencl/pom.xml
+++ b/tornado-drivers/opencl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-drivers-opencl</artifactId>
     <name>tornado-drivers-opencl</name>

--- a/tornado-drivers/pom.xml
+++ b/tornado-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-drivers</artifactId>
     <name>tornado-drivers</name>

--- a/tornado-drivers/ptx-jni/pom.xml
+++ b/tornado-drivers/ptx-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-drivers-ptx-jni</artifactId>
     <name>tornado-drivers-ptx-jni</name>

--- a/tornado-drivers/ptx/pom.xml
+++ b/tornado-drivers/ptx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tornado-drivers</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-drivers-ptx</artifactId>
     <name>tornado-drivers-ptx</name>

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-drivers-spirv</artifactId>
     <name>tornado-drivers-spirv</name>

--- a/tornado-examples/pom.xml
+++ b/tornado-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-examples</artifactId>
     <name>tornado-examples</name>

--- a/tornado-matrices/pom.xml
+++ b/tornado-matrices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-matrices</artifactId>
     <name>tornado-matrices</name>

--- a/tornado-runtime/pom.xml
+++ b/tornado-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-runtime</artifactId>
     <name>tornado-runtime</name>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.6-dev</version>
+        <version>1.0.6</version>
     </parent>
     <artifactId>tornado-unittests</artifactId>
     <name>tornado-unittests</name>


### PR DESCRIPTION
## Improvements

- #442: Support for multiple SPIR-V device versions (>= 1.2).
- #444: Enabling automatic device memory clean-up after each run from the execution plan.
- #448: API extension to query device memory consumption at the TaskGraph granularity.
- #451: Option to select the default SPIR-V runtime.
- #455: Refactoring the API and documentation updated.
- #460: Refactoring all examples to use try-with-resources execution plans by default.
- #462: Support for copy array references from private to private memory on the hardware accelerator.


## Compatibility

- #438: No writes for intermediate files to avoid permissions issues with Jenkins.
- #440: Update Jenkinsfile  for CI/CD testing.
- #443: Level Zero and OpenCL runtimes for SPIR-V included in the Jenkins CI/CD.
- #450: TornadoVM benchmark script improved to report dimensions and sizes.
- #453: Update Jenkinsfile with regards to the runtime for SPIR-V.


## Bug Fixes

- #434: Fix for building TornadoVM on OSx after integration with SPIR-V binaries for OpenCL.
- #441: Fix PTX unit-tests.
- #446: Fix NVIDIA thread-block scheduler for new GPU drivers.
- #447: Fix recompilation when batch processing is not triggered.
- #463: Fix unit-tests for CPU virtual devices.
