### PR TITLE
[fix] Refactored name of test that is in the white listed group

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -181,7 +181,7 @@ __TORNADO_TESTS_WHITE_LIST__ = [
     ## Precision errors
     "uk.ac.manchester.tornado.unittests.compute.ComputeTests#testNBodyBigNoWorker",
     "uk.ac.manchester.tornado.unittests.compute.ComputeTests#testEuler",
-    "uk.ac.manchester.tornado.unittests.codegen.CodeGen#test02",
+    "uk.ac.manchester.tornado.unittests.codegen.CodeGenTest#test02",
     "uk.ac.manchester.tornado.unittests.reductions.TestReductionsFloats#testComputePi",
     "uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext#mxm1DKernelContext",
     "uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext#mxm2DKernelContext01",


### PR DESCRIPTION
This PR makes a small fix regarding a test that had been renamed in previous PR from `CodeGen` to `CodeGenTest`. This line was not updated and Jenkins started failing for SPIR-V tests due to precision errors.

No production code has changed.