### PR TITLE
Extension of the prebuilt API to be able to load prebuilt kernels stored in JAR files 

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -603,7 +603,8 @@ public class TaskGraph implements TaskGraphInterface {
     }
 
     /**
-     * Add a pre-built OpenCL task into a task-schedule.
+     * Add a pre-built kernel (OpenCL, PTX or SPIR-V) task into a task-graph. The access to the pre-built file is provided
+     * as a String with the name of the file (path).
      *
      * @param id
      *     Task-Id
@@ -630,8 +631,33 @@ public class TaskGraph implements TaskGraphInterface {
         return this;
     }
 
+    /**
+     * Add a pre-built kernel (OpenCL, PTX or SPIR-V) task into a task-graph. The kernel is stored in a JAR file accessible
+     * from the CLASSPATH. The access to the pre-built file is provided as a combination of the klass (Class) with the
+     * JAR File, and the name of the file that contains the prebuilt kernel.
+     *
+     * @param id
+     *     Task-Id
+     * @param entryPoint
+     *     Name of the method to be executed on the target device
+     * @param klass
+     *     Klass that can access the resource within the JAR File
+     * @param resource
+     *     Input file with the source kernel
+     * @param args
+     *     Arguments to the kernel
+     * @param accesses
+     *     Accesses ({@link uk.ac.manchester.tornado.api.common.Access} for
+     *     each input parameter to the method
+     * @param device
+     *     Device to be executed
+     * @param dimensions
+     *     Select number of dimensions of the kernel (1D, 2D or 3D)
+     * @return {@link TaskGraph}
+     */
     @Override
     public TaskGraph prebuiltTask(String id, String entryPoint, Class<?> klass, String resource, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
+        System.out.println("[Warning] This API call is experimental and it may be removed in future versions");
         checkTaskName(id);
         PrebuiltTaskPackage prebuiltTask = TaskPackage.createPrebuiltTask(id, entryPoint, resource, args, accesses, device, dimensions);
         prebuiltTask.withClass(klass);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -630,6 +630,15 @@ public class TaskGraph implements TaskGraphInterface {
         return this;
     }
 
+    @Override
+    public TaskGraph prebuiltTask(String id, String entryPoint, Class<?> klass, String resource, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
+        checkTaskName(id);
+        PrebuiltTaskPackage prebuiltTask = TaskPackage.createPrebuiltTask(id, entryPoint, resource, args, accesses, device, dimensions);
+        prebuiltTask.withClass(klass);
+        taskGraphImpl.addPrebuiltTask(prebuiltTask);
+        return this;
+    }
+
     /**
      * Add a pre-built OpenCL task into a task-schedule with atomics region.
      *
@@ -868,7 +877,7 @@ public class TaskGraph implements TaskGraphInterface {
         return taskGraphImpl.getProfileLog();
     }
 
-    public Collection<?> getOutputs() {
+    Collection<?> getOutputs() {
         return taskGraphImpl.getOutputs();
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
@@ -518,6 +518,8 @@ public interface TaskGraphInterface {
      */
     TaskGraphInterface prebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions, int[] atomics);
 
+    TaskGraph prebuiltTask(String id, String entryPoint, Class<?> klass, String resource, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions);
+
     /**
      * Obtains the task-schedule name that was assigned.
      *

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/PrebuiltTaskPackage.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/PrebuiltTaskPackage.java
@@ -26,6 +26,7 @@ public class PrebuiltTaskPackage extends TaskPackage {
     private final TornadoDevice device;
     private final int[] dimensions;
     private int[] atomics;
+    private Class<?> klass;
 
     public PrebuiltTaskPackage(String id, String entryPoint, String fileName, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
         super(id, null);
@@ -39,6 +40,11 @@ public class PrebuiltTaskPackage extends TaskPackage {
 
     public PrebuiltTaskPackage withAtomics(int[] atomics) {
         this.atomics = atomics;
+        return this;
+    }
+
+    public PrebuiltTaskPackage withClass(Class<?> klass) {
+        this.klass = klass;
         return this;
     }
 
@@ -73,5 +79,9 @@ public class PrebuiltTaskPackage extends TaskPackage {
 
     public int[] getAtomics() {
         return atomics;
+    }
+
+    public Class<?> getKlassJar() {
+        return this.klass;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/TornadoNativeArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/TornadoNativeArray.java
@@ -32,7 +32,7 @@ import uk.ac.manchester.tornado.api.types.tensors.Tensor;
  * </p>
  *
  * <p>
- * The constant {@link ARRAY_HEADER} represents the size of the header in bytes.
+ * The constant {@link TornadoNativeArray#ARRAY_HEADER} represents the size of the header in bytes.
  * </p>
  */
 public abstract sealed class TornadoNativeArray //

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -24,6 +24,7 @@
 package uk.ac.manchester.tornado.drivers.opencl.runtime;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.foreign.MemorySegment;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -53,14 +54,8 @@ import uk.ac.manchester.tornado.api.memory.TornadoMemoryProvider;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
-import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
-import uk.ac.manchester.tornado.api.types.arrays.CharArray;
-import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.arrays.LongArray;
-import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
+import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
+import uk.ac.manchester.tornado.api.types.tensors.Tensor;
 import uk.ac.manchester.tornado.drivers.common.TornadoBufferProvider;
 import uk.ac.manchester.tornado.drivers.opencl.OCLBackendImpl;
 import uk.ac.manchester.tornado.drivers.opencl.OCLCodeCache;
@@ -309,31 +304,46 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         }
     }
 
+    private byte[] getSource(PrebuiltTask prebuiltTask) {
+        byte[] source;
+        Class<?> klass = prebuiltTask.getPackageClass();
+        if (klass != null) {
+            try (InputStream inputStream = klass.getClassLoader().getResourceAsStream(prebuiltTask.getFilename())) {
+                TornadoInternalError.guarantee(inputStream != null, "file does not exist: %s", prebuiltTask.getFilename());
+                source = inputStream.readAllBytes();
+            } catch (IOException e) {
+                throw new TornadoBailoutRuntimeException("[Error] I/O Exception in readAllBytes", e);
+            }
+        } else {
+            final Path path = Paths.get(prebuiltTask.getFilename());
+            TornadoInternalError.guarantee(path.toFile().exists(), "file does not exist: %s", prebuiltTask.getFilename());
+            try {
+                source = Files.readAllBytes(path);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return source;
+    }
+
     private TornadoInstalledCode compilePreBuiltTask(SchedulableTask task) {
         final OCLDeviceContextInterface deviceContext = getDeviceContext();
-        final PrebuiltTask executable = (PrebuiltTask) task;
-        if (deviceContext.isCached(task.getId(), executable.getEntryPoint())) {
-            return deviceContext.getInstalledCode(task.getId(), executable.getEntryPoint());
+        final PrebuiltTask prebuiltTask = (PrebuiltTask) task;
+        if (deviceContext.isCached(task.getId(), prebuiltTask.getEntryPoint())) {
+            return deviceContext.getInstalledCode(task.getId(), prebuiltTask.getEntryPoint());
         }
 
-        final Path path = Paths.get(executable.getFilename());
-        TornadoInternalError.guarantee(path.toFile().exists(), "file does not exist: %s", executable.getFilename());
-        try {
-            final byte[] source = Files.readAllBytes(path);
-
-            OCLInstalledCode installedCode;
-            if (OCLBackend.isDeviceAnFPGAAccelerator(deviceContext)) {
-                // A) for FPGA
-                installedCode = deviceContext.installCode(task.getId(), executable.getEntryPoint(), source, task.meta().isPrintKernelEnabled());
-            } else {
-                // B) for CPU multi-core or GPU
-                installedCode = deviceContext.installCode(executable.meta(), task.getId(), executable.getEntryPoint(), source);
-            }
-            return installedCode;
-        } catch (IOException e) {
-            e.printStackTrace();
+        byte[] source = getSource(prebuiltTask);
+        OCLInstalledCode installedCode;
+        if (OCLBackend.isDeviceAnFPGAAccelerator(deviceContext)) {
+            // A) for FPGA
+            installedCode = deviceContext.installCode(task.getId(), prebuiltTask.getEntryPoint(), source, task.meta().isPrintKernelEnabled());
+        } else {
+            // B) for CPU multi-core or GPU
+            installedCode = deviceContext.installCode(prebuiltTask.meta(), task.getId(), prebuiltTask.getEntryPoint(), source);
         }
-        return null;
+        return installedCode;
+
     }
 
     private TornadoInstalledCode compileJavaToAccelerator(SchedulableTask task) {
@@ -535,21 +545,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
                 result = new OCLVectorWrapper(deviceContext, object, batchSize);
             } else if (object instanceof MemorySegment) {
                 result = new OCLMemorySegmentWrapper(deviceContext, batchSize);
-            } else if (object instanceof IntArray) {
-                result = new OCLMemorySegmentWrapper(deviceContext, batchSize);
-            } else if (object instanceof FloatArray) {
-                result = new OCLMemorySegmentWrapper(deviceContext, batchSize);
-            } else if (object instanceof DoubleArray) {
-                result = new OCLMemorySegmentWrapper(deviceContext, batchSize);
-            } else if (object instanceof LongArray) {
-                result = new OCLMemorySegmentWrapper(deviceContext, batchSize);
-            } else if (object instanceof ShortArray) {
-                result = new OCLMemorySegmentWrapper(deviceContext, batchSize);
-            } else if (object instanceof ByteArray) {
-                result = new OCLMemorySegmentWrapper(deviceContext, batchSize);
-            } else if (object instanceof CharArray) {
-                result = new OCLMemorySegmentWrapper(deviceContext, batchSize);
-            } else if (object instanceof HalfFloatArray) {
+            } else if (object instanceof TornadoNativeArray && !(object instanceof Tensor)) {
                 result = new OCLMemorySegmentWrapper(deviceContext, batchSize);
             } else {
                 result = new OCLXPUBuffer(deviceContext, object);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -50,14 +50,8 @@ import uk.ac.manchester.tornado.api.memory.TornadoMemoryProvider;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
-import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
-import uk.ac.manchester.tornado.api.types.arrays.CharArray;
-import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
-import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
-import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.arrays.LongArray;
-import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
+import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
+import uk.ac.manchester.tornado.api.types.tensors.Tensor;
 import uk.ac.manchester.tornado.drivers.common.TornadoBufferProvider;
 import uk.ac.manchester.tornado.drivers.ptx.PTX;
 import uk.ac.manchester.tornado.drivers.ptx.PTXBackendImpl;
@@ -202,19 +196,11 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
         }
     }
 
-    private TornadoInstalledCode compilePreBuiltTask(SchedulableTask task) {
-        final PTXDeviceContext deviceContext = getDeviceContext();
-        final PrebuiltTask prebuiltTask = (PrebuiltTask) task;
-        String functionName = buildKernelName(prebuiltTask.getEntryPoint(), prebuiltTask);
-        if (deviceContext.isCached(prebuiltTask.getEntryPoint(), prebuiltTask)) {
-            return deviceContext.getInstalledCode(functionName);
-        }
-
-        Class<?> klass = prebuiltTask.getPackageClass();
+    private byte[] getSource(PrebuiltTask prebuiltTask) {
         byte[] source;
+        Class<?> klass = prebuiltTask.getPackageClass();
         if (klass != null) {
-            try {
-                InputStream inputStream = klass.getClassLoader().getResourceAsStream(prebuiltTask.getFilename());
+            try (InputStream inputStream = klass.getClassLoader().getResourceAsStream(prebuiltTask.getFilename())) {
                 TornadoInternalError.guarantee(inputStream != null, "file does not exist: %s", prebuiltTask.getFilename());
                 source = inputStream.readAllBytes();
             } catch (IOException e) {
@@ -229,8 +215,21 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
                 throw new RuntimeException(e);
             }
         }
-        source = PTXCodeUtil.getCodeWithAttachedPTXHeader(source, getBackend());
-        return deviceContext.installCode(functionName, source, prebuiltTask.getEntryPoint(), task.meta().isPrintKernelEnabled());
+        return source;
+    }
+
+    private TornadoInstalledCode compilePreBuiltTask(SchedulableTask task) {
+        final PTXDeviceContext deviceContext = getDeviceContext();
+        final PrebuiltTask prebuiltTask = (PrebuiltTask) task;
+        String functionName = buildKernelName(prebuiltTask.getEntryPoint(), prebuiltTask);
+
+        if (deviceContext.isCached(prebuiltTask.getEntryPoint(), prebuiltTask)) {
+            return deviceContext.getInstalledCode(functionName);
+        }
+
+        byte[] source = getSource(prebuiltTask);
+        byte[] binary = PTXCodeUtil.getCodeWithAttachedPTXHeader(source, getBackend());
+        return deviceContext.installCode(functionName, binary, prebuiltTask.getEntryPoint(), task.meta().isPrintKernelEnabled());
     }
 
     @Override
@@ -241,8 +240,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     @Override
     public TornadoInstalledCode getCodeFromCache(SchedulableTask task) {
         String methodName;
-        if (task instanceof PrebuiltTask) {
-            PrebuiltTask prebuiltTask = (PrebuiltTask) task;
+        if (task instanceof PrebuiltTask prebuiltTask) {
             methodName = prebuiltTask.getEntryPoint();
         } else {
             CompilableTask compilableTask = (CompilableTask) task;
@@ -272,21 +270,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
                 result = new PTXVectorWrapper(getDeviceContext(), object, batchSize);
             } else if (object instanceof MemorySegment) {
                 result = new PTXMemorySegmentWrapper(getDeviceContext(), batchSize);
-            } else if (object instanceof IntArray) {
-                result = new PTXMemorySegmentWrapper(getDeviceContext(), batchSize);
-            } else if (object instanceof FloatArray) {
-                result = new PTXMemorySegmentWrapper(getDeviceContext(), batchSize);
-            } else if (object instanceof DoubleArray) {
-                result = new PTXMemorySegmentWrapper(getDeviceContext(), batchSize);
-            } else if (object instanceof LongArray) {
-                result = new PTXMemorySegmentWrapper(getDeviceContext(), batchSize);
-            } else if (object instanceof ShortArray) {
-                result = new PTXMemorySegmentWrapper(getDeviceContext(), batchSize);
-            } else if (object instanceof ByteArray) {
-                result = new PTXMemorySegmentWrapper(getDeviceContext(), batchSize);
-            } else if (object instanceof CharArray) {
-                result = new PTXMemorySegmentWrapper(getDeviceContext(), batchSize);
-            } else if (object instanceof HalfFloatArray) {
+            } else if (object instanceof TornadoNativeArray && !(object instanceof Tensor)) {
                 result = new PTXMemorySegmentWrapper(getDeviceContext(), batchSize);
             } else {
                 result = new PTXObjectWrapper(getDeviceContext(), object);
@@ -539,8 +523,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof PTXTornadoDevice) {
-            final PTXTornadoDevice other = (PTXTornadoDevice) obj;
+        if (obj instanceof PTXTornadoDevice other) {
             return (other.deviceIndex == deviceIndex);
         }
         return false;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -321,8 +321,13 @@ public class TaskUtils {
                 taskPackage.getAccesses(), //
                 taskPackage.getDevice(), //
                 domain);
+        // Attach atomics
         if (taskPackage.getAtomics() != null) {
             prebuiltTask.withAtomics(taskPackage.getAtomics());
+        }
+        // Attach class if in a JAR file
+        if (taskPackage.getKlassJar() != null) {
+            prebuiltTask.withKlass(taskPackage.getKlassJar());
         }
         return prebuiltTask;
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
@@ -49,6 +49,7 @@ public class PrebuiltTask implements SchedulableTask {
     private TornadoProfiler profiler;
     private boolean forceCompiler;
     private int[] atomics;
+    private Class<?> klass;
 
     public PrebuiltTask(ScheduleMetaData scheduleMeta, String id, String entryPoint, String filename, Object[] args, Access[] access, TornadoDevice device, DomainTree domain) {
         this.entryPoint = entryPoint;
@@ -72,6 +73,11 @@ public class PrebuiltTask implements SchedulableTask {
 
     public PrebuiltTask withAtomics(int[] atomics) {
         this.atomics = atomics;
+        return this;
+    }
+
+    public PrebuiltTask withKlass(Class<?> klass) {
+        this.klass = klass;
         return this;
     }
 
@@ -234,4 +240,7 @@ public class PrebuiltTask implements SchedulableTask {
         return atomics;
     }
 
+    public Class<?> getPackageClass() {
+        return this.klass;
+    }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/PrebuiltTest.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/PrebuiltTest.java
@@ -88,16 +88,19 @@ public class PrebuiltTest extends TornadoTestBase {
                 throw new TornadoRuntimeException("Backend not supported");
         }
 
+        // @formatter:off
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
-                .prebuiltTask("t0", //
-                        "add", //
-                        FILE_PATH, //
-                        new Object[] { a, b, c }, //
-                        new Access[] { Access.READ_ONLY, Access.READ_ONLY, Access.WRITE_ONLY }, //
-                        defaultDevice, //
-                        new int[] { numElements })//
+                .prebuiltTask("t0", //  task-name
+                        "add",         //   method name (entry point  in the prebuilt source, e.g., the OpenCL kernel name).
+                        FILE_PATH,     // Path to the file
+                        new Object[] { a, b, c }, //  Parameters to the function
+                        new Access[] { Access.READ_ONLY, Access.READ_ONLY, Access.WRITE_ONLY }, // Data access to the function
+                        defaultDevice, //  Device in which the application will be executed. This is at the task graph
+                                       // level because TornadoVM performs code specialization per device.
+                        new int[] { numElements }) // Number of threads to deploy
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+        // @formatter:on
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {


### PR DESCRIPTION
#### Description

Extension of the prebuilt API to be able to load prebuilt kernels stored in JAR files. 

Example:

```java
 TaskGraph taskGraph = new TaskGraph("reftg")
      .transferToDevice(DataTransferMode.EVERY_EXECUTION, problemDimensions, problemParameters, doubleTimes, doubleValues, doubleWeights,  doubleFreqs, tsIdPerFreq)
	.prebuiltTask("t1",             // task name
		"sampleKernel",         // kernel nme
                  MyJavaClass.class,   // class accessible from the JAR file that contains the resource 
		"myKernel.ptx",          // name of the kernel file
		new Object[] { problemDimensions, problemParameters, doubleTimes, doubleValues, doubleWeights,  doubleFreqs, tsIdPerFreq, doubleAmplitudes, doubleDebug }, //
		new Access[] { Access.READ_ONLY, Access.READ_ONLY, Access.READ_ONLY,Access.READ_ONLY,Access.READ_ONLY, Access.READ_ONLY, Access.READ_ONLY, Access.WRITE_ONLY, Access.WRITE_ONLY }, //
		preferredDevice, //
		new int[] { nThreads })
         .transferToHost(DataTransferMode.EVERY_EXECUTION, doubleAmplitudes, doubleDebug);
```

This API access is required by GAIA for the project AERO. We may also simplify this API in future versions, since the main purpose was for debugging, not for running production code. 

#### Problem description

If the patch provides a fix for a bug, please describe what was the issue and how to reproduce the issue.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [X] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

This change has been tested in the GAIA code base. 

```bash
make
make tests
```
