### PR TITLE
TornadoMath double version of trigonometric functions added

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/math/TornadoMath.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/math/TornadoMath.java
@@ -40,19 +40,19 @@ import uk.ac.manchester.tornado.api.types.vectors.Float8;
 public class TornadoMath {
 
     public static float min(float a, float b) {
-        return (a > b) ? b : a;
+        return Math.min(a, b);
     }
 
     public static double min(double a, double b) {
-        return (a > b) ? b : a;
+        return Math.min(a, b);
     }
 
     public static long min(long a, long b) {
-        return (a > b) ? b : a;
+        return Math.min(a, b);
     }
 
     public static int min(int a, int b) {
-        return (a > b) ? b : a;
+        return Math.min(a, b);
     }
 
     public static short min(short a, short b) {
@@ -64,19 +64,19 @@ public class TornadoMath {
     }
 
     public static double max(double a, double b) {
-        return (a > b) ? a : b;
+        return Math.max(a, b);
     }
 
     public static float max(float a, float b) {
-        return (a > b) ? a : b;
+        return Math.max(a, b);
     }
 
     public static long max(long a, long b) {
-        return (a > b) ? a : b;
+        return Math.max(a, b);
     }
 
     public static int max(int a, int b) {
-        return (a > b) ? a : b;
+        return Math.max(a, b);
     }
 
     public static short max(short a, short b) {
@@ -384,13 +384,24 @@ public class TornadoMath {
         return (float) Math.atan(value);
     }
 
+    public static double atan(double value) {
+        return Math.atan(value);
+    }
+
     public static float tan(float value) {
         return (float) Math.tan(value);
+    }
 
+    public static double tan(double value) {
+        return Math.tan(value);
     }
 
     public static float tanh(float value) {
         return (float) Math.tanh(value);
+    }
+
+    public static double tanh(double value) {
+        return Math.tanh(value);
     }
 
     public static float floatPI() {
@@ -411,6 +422,10 @@ public class TornadoMath {
 
     public static float atan2(float a, float b) {
         return (float) Math.atan2(a, b);
+    }
+
+    public static double atan2(double a, double b) {
+        return Math.atan2(a, b);
     }
 
     public static float acos(float a) {
@@ -463,6 +478,10 @@ public class TornadoMath {
 
     public static float toRadians(float angdeg) {
         return (float) Math.toRadians(angdeg);
+    }
+
+    public static double toRadians(double angdeg) {
+        return Math.toRadians(angdeg);
     }
 
     public static float sinpi(float angle) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
@@ -130,7 +130,19 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         }
     }
 
+    public static void testTornadoAtan(DoubleArray a) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            a.set(i, TornadoMath.atan(a.get(i)));
+        }
+    }
+
     public static void testTornadoAtan2(FloatArray a, FloatArray b) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            a.set(i, TornadoMath.atan2(a.get(i), b.get(i)));
+        }
+    }
+
+    public static void testTornadoAtan2(DoubleArray a, DoubleArray b) {
         for (@Parallel int i = 0; i < a.getSize(); i++) {
             a.set(i, TornadoMath.atan2(a.get(i), b.get(i)));
         }
@@ -142,7 +154,19 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         }
     }
 
+    public static void testTornadoTan(DoubleArray a) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            a.set(i, TornadoMath.tan(a.get(i)));
+        }
+    }
+
     public static void testTornadoTanh(FloatArray a) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            a.set(i, TornadoMath.tanh(a.get(i)));
+        }
+    }
+
+    public static void testTornadoTanh(DoubleArray a) {
         for (@Parallel int i = 0; i < a.getSize(); i++) {
             a.set(i, TornadoMath.tanh(a.get(i)));
         }
@@ -216,6 +240,12 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         }
     }
 
+    public static void testTornadoRadians(DoubleArray a) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            a.set(i, TornadoMath.toRadians(a.get(i)));
+        }
+    }
+
     @Test
     public void testTornadoMathCos() throws TornadoExecutionPlanException {
         final int size = 128;
@@ -281,7 +311,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         DoubleArray seq = new DoubleArray(size);
 
         IntStream.range(0, size).parallel().forEach(i -> {
-            data.set(i, (float) Math.random());
+            data.set(i, Math.random());
             seq.set(i, data.get(i));
         });
 
@@ -298,7 +328,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         testTornadoCosPIDouble(seq);
 
         for (int i = 0; i < size; i++) {
-            assertEquals(data.get(i), seq.get(i), 0.01f);
+            assertEquals(data.get(i), seq.get(i), 0.01);
         }
 
     }
@@ -444,7 +474,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         testTornadoSignum(seq);
 
         for (int i = 0; i < size; i++) {
-            assertEquals(data.get(i), seq.get(i), 0.01f);
+            assertEquals(data.get(i), seq.get(i), 0.01);
         }
 
     }
@@ -538,6 +568,36 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         for (int i = 0; i < size; i++) {
             assertEquals(data.get(i), seq.get(i), 0.01f);
         }
+    }
+
+    @Test
+    public void testTornadoMathAtanDouble() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.PTX);
+
+        final int size = 128;
+        DoubleArray data = new DoubleArray(size);
+        DoubleArray seq = new DoubleArray(size);
+
+        IntStream.range(0, size).parallel().forEach(i -> {
+            data.set(i, (float) Math.random());
+            seq.set(i, data.get(i));
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, data) //
+                .task("t0", TestTornadoMathCollection::testTornadoAtan, data) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        testTornadoAtan(seq);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(data.get(i), seq.get(i), 0.01);
+        }
 
     }
 
@@ -567,6 +627,34 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         for (int i = 0; i < size; i++) {
             assertEquals(data.get(i), seq.get(i), 0.01f);
         }
+    }
+
+    @Test
+    public void testTornadoMathTanDouble() throws TornadoExecutionPlanException {
+        final int size = 128;
+        DoubleArray data = new DoubleArray(size);
+        DoubleArray seq = new DoubleArray(size);
+
+        IntStream.range(0, size).parallel().forEach(i -> {
+            data.set(i, Math.random());
+            seq.set(i, data.get(i));
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, data) //
+                .task("t0", TestTornadoMathCollection::testTornadoTan, data) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        testTornadoTan(seq);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(data.get(i), seq.get(i), 0.01);
+        }
 
     }
 
@@ -595,6 +683,35 @@ public class TestTornadoMathCollection extends TornadoTestBase {
 
         for (int i = 0; i < size; i++) {
             assertEquals(data.get(i), seq.get(i), 0.01f);
+        }
+
+    }
+
+    @Test
+    public void testTornadoMathTanhDouble() throws TornadoExecutionPlanException {
+        final int size = 128;
+        DoubleArray data = new DoubleArray(size);
+        DoubleArray seq = new DoubleArray(size);
+
+        IntStream.range(0, size).parallel().forEach(i -> {
+            data.set(i, Math.random());
+            seq.set(i, data.get(i));
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, data) //
+                .task("t0", TestTornadoMathCollection::testTornadoTanh, data) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        testTornadoTanh(seq);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(data.get(i), seq.get(i), 0.01);
         }
 
     }
@@ -690,7 +807,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         DoubleArray seq = new DoubleArray(size);
 
         IntStream.range(0, size).parallel().forEach(i -> {
-            data.set(i, (float) Math.random());
+            data.set(i, Math.random());
             seq.set(i, data.get(i));
         });
 
@@ -706,7 +823,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         testTornadoExp(seq);
 
         for (int i = 0; i < size; i++) {
-            assertEquals(data.get(i), seq.get(i), 0.01f);
+            assertEquals(data.get(i), seq.get(i), 0.01);
         }
 
     }
@@ -832,7 +949,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         DoubleArray seq = new DoubleArray(size);
 
         IntStream.range(0, size).parallel().forEach(i -> {
-            data.set(i, (float) Math.random());
+            data.set(i, Math.random());
             seq.set(i, data.get(i));
         });
 
@@ -848,7 +965,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         testTornadoLog(seq);
 
         for (int i = 0; i < size; i++) {
-            assertEquals(data.get(i), seq.get(i), 0.01f);
+            assertEquals(data.get(i), seq.get(i), 0.01);
         }
 
     }
@@ -998,6 +1115,35 @@ public class TestTornadoMathCollection extends TornadoTestBase {
     }
 
     @Test
+    public void testTornadoMathRadiansDouble() throws TornadoExecutionPlanException {
+        final int size = 128;
+        DoubleArray data = new DoubleArray(size);
+        DoubleArray seq = new DoubleArray(size);
+
+        IntStream.range(0, size).parallel().forEach(i -> {
+            data.set(i, Math.random());
+            seq.set(i, data.get(i));
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, data) //
+                .task("t0", TestTornadoMathCollection::testTornadoRadians, data) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        testTornadoRadians(seq);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(data.get(i), seq.get(i), 0.01);
+        }
+
+    }
+
+    @Test
     public void testMathATan2() throws TornadoExecutionPlanException {
         assertNotBackend(TornadoVMBackendType.PTX);
 
@@ -1028,6 +1174,40 @@ public class TestTornadoMathCollection extends TornadoTestBase {
 
         for (int i = 0; i < size; i++) {
             assertEquals(a.get(i), seqA.get(i), 0.01f);
+        }
+    }
+
+    @Test
+    public void testMathATan2Double() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.PTX);
+
+        final int size = 128;
+        DoubleArray a = new DoubleArray(size);
+        DoubleArray b = new DoubleArray(size);
+        DoubleArray seqA = new DoubleArray(size);
+        DoubleArray seqB = new DoubleArray(size);
+
+        IntStream.range(0, size).parallel().forEach(i -> {
+            a.set(i, Math.random());
+            b.set(i, Math.random());
+            seqA.set(i, a.get(i));
+            seqB.set(i, b.get(i));
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, b) //
+                .task("t0", TestTornadoMathCollection::testTornadoAtan2, a, b) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        testTornadoAtan2(seqA, seqB);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(a.get(i), seqA.get(i), 0.01);
         }
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
@@ -579,7 +579,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         DoubleArray seq = new DoubleArray(size);
 
         IntStream.range(0, size).parallel().forEach(i -> {
-            data.set(i, (float) Math.random());
+            data.set(i, Math.random());
             seq.set(i, data.get(i));
         });
 


### PR DESCRIPTION
#### Description

Some of the `FP64` version of the trigonometric functions within the `TornadoMath` class were missing.  Related issue #481 

#### Problem description

n/ a,.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-test -V -pk --fast uk.ac.manchester.tornado.unittests.math.TestTornadoMathCollection
```
