### PR TITLE
Add URL for JDK Temurin Windows

### DIFF
--- a/bin/installer_config.py
+++ b/bin/installer_config.py
@@ -163,7 +163,7 @@ JDK = {
             __ARM__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.1_12.tar.gz",
         },
         __WINDOWS__: {
-            __X86_64__: None,
+            __X86_64__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_x64_windows_hotspot_21.0.3_9.zip",
             __ARM__: None,
         },
     },


### PR DESCRIPTION
#### Description

Related issue #471. This PR adds the Temurin url for Windows.  I can't access to a Windows machine right now. 
@stratika , when you get the time, give it a try. 

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows      >>>> To be tested

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

[UPDATED INSTRUCTIONS]

```bash
python -m venv .venv
.venv\Scripts\activate.bat
.\bin\windowsMicrosoftStudioTools2022.cmd
python .\bin\tornadovm-installer --jdk temurin-jdk-21 --backend=opencl,ptx
tornado-test -V
```
