### PR TITLE
[feat][api] Prebuilt API redesign and simplification

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/AccessorParameters.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/AccessorParameters.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api;
+
+import uk.ac.manchester.tornado.api.common.Access;
+
+/**
+ * Definition of accessor for the Prebuilt-Task API.
+ * It defines for all input parameter to the task, the accessor of each object.*
+ */
+public class AccessorParameters {
+
+    private final PairAccessor[] accessors;
+
+    public AccessorParameters(int numParameters) {
+        accessors = new PairAccessor[numParameters];
+    }
+
+    public void set(int index, Object object, Access access) {
+        accessors[index] = new PairAccessor(object, access);
+    }
+
+    public int numAccessors() {
+        return accessors.length;
+    }
+
+    public PairAccessor getAccessor(int index) {
+        return accessors[index];
+    }
+
+    public record PairAccessor(Object object, Access access) {
+    }
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -603,29 +603,21 @@ public class TaskGraph implements TaskGraphInterface {
     }
 
     /**
-     * Add a pre-built OpenCL task into a task-schedule.
      *
      * @param id
-     *     Task-Id
+     *     String that represents the task-id.
      * @param entryPoint
-     *     Name of the method to be executed on the target device
+     *     Name of the kernel to be launched on the target device.
      * @param filename
-     *     Input file with the source kernel
-     * @param args
-     *     Arguments to the kernel
-     * @param accesses
-     *     Accesses ({@link uk.ac.manchester.tornado.api.common.Access} for
-     *     each input parameter to the method
-     * @param device
-     *     Device to be executed
-     * @param dimensions
-     *     Select number of dimensions of the kernel (1D, 2D or 3D)
+     *     String that represents the path to the native source (e.g., the OpenCL C kernel).
+     * @param accessorParameters
+     *     {@link AccessorParameters} with the type of accessor for each of the input parameters to the low-level kernel.
      * @return {@link TaskGraph}
      */
     @Override
-    public TaskGraph prebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
+    public TaskGraph prebuiltTask(String id, String entryPoint, String filename, AccessorParameters accessorParameters) {
         checkTaskName(id);
-        TaskPackage prebuiltTask = TaskPackage.createPrebuiltTask(id, entryPoint, filename, args, accesses, device, dimensions);
+        TaskPackage prebuiltTask = TaskPackage.createPrebuiltTask(id, entryPoint, filename, accessorParameters);
         taskGraphImpl.addPrebuiltTask(prebuiltTask);
         return this;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.PrebuiltTaskPackage;
 import uk.ac.manchester.tornado.api.common.TaskPackage;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
@@ -631,22 +630,16 @@ public class TaskGraph implements TaskGraphInterface {
      *     Kernel's name of the entry point
      * @param filename
      *     Input OpenCL C Kernel
-     * @param args
-     *     Arguments to the method that the kernel represents.
-     * @param accesses
-     *     Array of access of each parameter to the kernel
-     * @param device
-     *     Device in which the OpenCL C code will be executed.
-     * @param dimensions
-     *     Select the dimension of the OpenCL kernel (1D, 2D or 3D)
+     * @param accessorParameters
+     *     {@link AccessorParameters} with the type of accessor for each of the input parameters to the low-level kernel.
      * @param atomics
      *     Atomics region.
      * @return {@link TaskGraph}
      */
     @Override
-    public TaskGraph prebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions, int[] atomics) {
+    public TaskGraph prebuiltTask(String id, String entryPoint, String filename, AccessorParameters accessorParameters, int[] atomics) {
         checkTaskName(id);
-        PrebuiltTaskPackage prebuiltTask = TaskPackage.createPrebuiltTask(id, entryPoint, filename, args, accesses, device, dimensions);
+        PrebuiltTaskPackage prebuiltTask = TaskPackage.createPrebuiltTask(id, entryPoint, filename, accessorParameters);
         prebuiltTask.withAtomics(atomics);
         taskGraphImpl.addPrebuiltTask(prebuiltTask);
         return this;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
@@ -17,9 +17,7 @@
  */
 package uk.ac.manchester.tornado.api;
 
-import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.TaskPackage;
-import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task1;
@@ -483,20 +481,12 @@ public interface TaskGraphInterface {
      *     Kernel's name of the entry point
      * @param filename
      *     Input OpenCL C Kernel
-     * @param args
-     *     Arguments to the method that the kernel represents.
-     * @param accesses
-     *     Array of access of each parameter to the kernel
-     * @param device
-     *     Device in which the OpenCL C code will be executed.
-     * @param dimensions
-     *     Select the dimension of the OpenCL kernel (1D, 2D or 3D)
      * @param atomics
      *     Atomics region.
      * @return {@link TaskGraphInterface}
      *
      */
-    TaskGraphInterface prebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions, int[] atomics);
+    TaskGraphInterface prebuiltTask(String id, String entryPoint, String filename, AccessorParameters accessorParameters, int[] atomics);
 
     /**
      * Obtains the task-schedule name that was assigned.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
@@ -472,27 +472,7 @@ public interface TaskGraphInterface {
     <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> TaskGraphInterface task(String id, Task15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> code, T1 arg1,
             T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15);
 
-    /**
-     * Add a pre-built OpenCL task into a task-schedule.
-     *
-     * @param id
-     *     Task-Id
-     * @param entryPoint
-     *     Name of the method to be executed on the target device
-     * @param filename
-     *     Input file with the source kernel
-     * @param args
-     *     Arguments to the kernel
-     * @param accesses
-     *     Accesses ({@link uk.ac.manchester.tornado.api.common.Access} for
-     *     each input parameter to the method
-     * @param device
-     *     Device to be executed
-     * @param dimensions
-     *     Select number of dimensions of the kernel (1D, 2D or 3D)
-     * @return {@link TaskGraphInterface}
-     */
-    TaskGraphInterface prebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions);
+    TaskGraphInterface prebuiltTask(String id, String entryPoint, String filename, AccessorParameters accessorParameters);
 
     /**
      * Add a pre-built OpenCL task into a task-schedule with atomics region.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/PrebuiltTaskPackage.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/PrebuiltTaskPackage.java
@@ -25,19 +25,7 @@ public class PrebuiltTaskPackage extends TaskPackage {
     private final String filename;
     private final Object[] args;
     private final Access[] accesses;
-    private final TornadoDevice device;
-    private final int[] dimensions;
     private int[] atomics;
-
-    PrebuiltTaskPackage(String id, String entryPoint, String fileName, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
-        super(id, null);
-        this.entryPoint = entryPoint;
-        this.filename = fileName;
-        this.args = args;
-        this.accesses = accesses;
-        this.device = device;
-        this.dimensions = dimensions;
-    }
 
     PrebuiltTaskPackage(String id, String entryPoint, String fileName, AccessorParameters accessorParameters) {
         super(id, null);
@@ -51,8 +39,6 @@ public class PrebuiltTaskPackage extends TaskPackage {
         for (int i = 0; i < accessorParameters.numAccessors(); i++) {
             this.accesses[i] = accessorParameters.getAccessor(i).access();
         }
-        this.device = null;
-        this.dimensions = null;
     }
 
     public PrebuiltTaskPackage withAtomics(int[] atomics) {
@@ -74,14 +60,6 @@ public class PrebuiltTaskPackage extends TaskPackage {
 
     public Access[] getAccesses() {
         return accesses;
-    }
-
-    public TornadoDevice getDevice() {
-        return device;
-    }
-
-    public int[] getDimensions() {
-        return dimensions;
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/PrebuiltTaskPackage.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/PrebuiltTaskPackage.java
@@ -17,6 +17,8 @@
  */
 package uk.ac.manchester.tornado.api.common;
 
+import uk.ac.manchester.tornado.api.AccessorParameters;
+
 public class PrebuiltTaskPackage extends TaskPackage {
 
     private final String entryPoint;
@@ -27,7 +29,7 @@ public class PrebuiltTaskPackage extends TaskPackage {
     private final int[] dimensions;
     private int[] atomics;
 
-    public PrebuiltTaskPackage(String id, String entryPoint, String fileName, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
+    PrebuiltTaskPackage(String id, String entryPoint, String fileName, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
         super(id, null);
         this.entryPoint = entryPoint;
         this.filename = fileName;
@@ -35,6 +37,22 @@ public class PrebuiltTaskPackage extends TaskPackage {
         this.accesses = accesses;
         this.device = device;
         this.dimensions = dimensions;
+    }
+
+    PrebuiltTaskPackage(String id, String entryPoint, String fileName, AccessorParameters accessorParameters) {
+        super(id, null);
+        this.entryPoint = entryPoint;
+        this.filename = fileName;
+        this.args = new Object[accessorParameters.numAccessors()];
+        for (int i = 0; i < accessorParameters.numAccessors(); i++) {
+            this.args[i] = accessorParameters.getAccessor(i).object();
+        }
+        this.accesses = new Access[accessorParameters.numAccessors()];
+        for (int i = 0; i < accessorParameters.numAccessors(); i++) {
+            this.accesses[i] = accessorParameters.getAccessor(i).access();
+        }
+        this.device = null;
+        this.dimensions = null;
     }
 
     public PrebuiltTaskPackage withAtomics(int[] atomics) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TaskPackage.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TaskPackage.java
@@ -220,10 +220,6 @@ public class TaskPackage {
         return new TaskPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
     }
 
-    public static PrebuiltTaskPackage createPrebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
-        return new PrebuiltTaskPackage(id, entryPoint, filename, args, accesses, device, dimensions);
-    }
-
     public static PrebuiltTaskPackage createPrebuiltTask(String id, String entryPoint, String filename, AccessorParameters accessorParameters) {
         return new PrebuiltTaskPackage(id, entryPoint, filename, accessorParameters);
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TaskPackage.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TaskPackage.java
@@ -17,6 +17,7 @@
  */
 package uk.ac.manchester.tornado.api.common;
 
+import uk.ac.manchester.tornado.api.AccessorParameters;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task1;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task10;
@@ -221,6 +222,10 @@ public class TaskPackage {
 
     public static PrebuiltTaskPackage createPrebuiltTask(String id, String entryPoint, String filename, Object[] args, Access[] accesses, TornadoDevice device, int[] dimensions) {
         return new PrebuiltTaskPackage(id, entryPoint, filename, args, accesses, device, dimensions);
+    }
+
+    public static PrebuiltTaskPackage createPrebuiltTask(String id, String entryPoint, String filename, AccessorParameters accessorParameters) {
+        return new PrebuiltTaskPackage(id, entryPoint, filename, accessorParameters);
     }
 
     public String getId() {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddIntPrebuilt.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddIntPrebuilt.java
@@ -87,14 +87,8 @@ public class ArrayAddIntPrebuilt {
             executor.withDevice(device) //
                     .withGridScheduler(gridScheduler) //
                     .execute();
-
         } catch (TornadoExecutionPlanException e) {
             e.printStackTrace();
         }
-
-        System.out.println("a: " + a);
-        System.out.println("b: " + b);
-        System.out.println("c: " + c);
     }
-
 }

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddIntPrebuilt.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddIntPrebuilt.java
@@ -18,20 +18,28 @@
 
 package uk.ac.manchester.tornado.examples.arrays;
 
-import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.AccessorParameters;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 
 /**
- * Example using the Prebuilt API of TornadoVM. <code>
- * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.arrays.ArrayAddIntPrebuilt
+ * Example using the Prebuilt API of TornadoVM.
+ *
+ * <p>
+ * <code>
+ * $ tornado -m tornado.examples/uk.ac.manchester.tornado.examples.arrays.ArrayAddIntPrebuilt
  * </code>
+ * </p>
  */
 public class ArrayAddIntPrebuilt {
 
@@ -62,18 +70,27 @@ public class ArrayAddIntPrebuilt {
         String filePath = tornadoSDK + "/examples/generated/";
         filePath += device.getPlatformName().contains("PTX") ? "add.ptx" : "add.cl";
 
+        AccessorParameters accessorParameters = new AccessorParameters(3);
+        accessorParameters.set(0, a, Access.READ_ONLY);
+        accessorParameters.set(1, b, Access.READ_ONLY);
+        accessorParameters.set(2, c, Access.WRITE_ONLY);
+
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
-                .prebuiltTask("t0", "add", filePath, //
-                        new Object[] { a, b, c }, //
-                        new Access[] { Access.READ_ONLY, Access.READ_ONLY, Access.WRITE_ONLY }, //
-                        device, //
-                        new int[] { numElements }) //
+                .prebuiltTask("t0", "add", filePath, accessorParameters) // 
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph);
-        executor.execute();
+        WorkerGrid workerGrid = new WorkerGrid1D(numElements);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
+
+        try (TornadoExecutionPlan executor = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executor.withDevice(device) //
+                    .withGridScheduler(gridScheduler) //
+                    .execute();
+
+        } catch (TornadoExecutionPlanException e) {
+            e.printStackTrace();
+        }
 
         System.out.println("a: " + a);
         System.out.println("b: " + b);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -312,8 +312,6 @@ public class TaskUtils {
     }
 
     public static PrebuiltTask createTask(ScheduleMetaData meta, PrebuiltTaskPackage taskPackage) {
-        //DomainTree domain = buildDomainTree(taskPackage.getDimensions());
-        DomainTree domain = null;
         PrebuiltTask prebuiltTask = new PrebuiltTask(meta, //
                 taskPackage.getId(), //
                 taskPackage.getEntryPoint(), //

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -312,15 +312,14 @@ public class TaskUtils {
     }
 
     public static PrebuiltTask createTask(ScheduleMetaData meta, PrebuiltTaskPackage taskPackage) {
-        DomainTree domain = buildDomainTree(taskPackage.getDimensions());
+        //DomainTree domain = buildDomainTree(taskPackage.getDimensions());
+        DomainTree domain = null;
         PrebuiltTask prebuiltTask = new PrebuiltTask(meta, //
                 taskPackage.getId(), //
                 taskPackage.getEntryPoint(), //
                 taskPackage.getFilename(), //
                 taskPackage.getArgs(),  //
-                taskPackage.getAccesses(), //
-                taskPackage.getDevice(), //
-                domain);
+                taskPackage.getAccesses());
         if (taskPackage.getAtomics() != null) {
             prebuiltTask.withAtomics(taskPackage.getAtomics());
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -83,7 +83,7 @@ public class TornadoVMInterpreter {
     private final KernelStackFrame[] kernelStackFrame;
     private final int[][] events;
     private final int[] eventsIndexes;
-    private final TornadoXPUDevice deviceForInterpreter;
+    private final TornadoXPUDevice interpreterDevice;
     private final TornadoInstalledCode[] installedCodes;
 
     private final List<Object> constants;
@@ -119,7 +119,7 @@ public class TornadoVMInterpreter {
         this.bytecodeResult = bytecodeResult;
 
         assert device != null;
-        this.deviceForInterpreter = device;
+        this.interpreterDevice = device;
 
         useDependencies = VM_USE_DEPS;
         totalTime = 0;
@@ -133,7 +133,7 @@ public class TornadoVMInterpreter {
         events = new int[this.bytecodeResult.getInt()][MAX_EVENTS];
         eventsIndexes = new int[events.length];
 
-        localTaskList = executionContext.getTasksForDevice(deviceForInterpreter.getDeviceContext(), deviceForInterpreter.getDriverIndex());
+        localTaskList = executionContext.getTasksForDevice(interpreterDevice.getDeviceContext(), interpreterDevice.getDriverIndex());
 
         installedCodes = new TornadoInstalledCode[localTaskList.size()];
 
@@ -176,10 +176,10 @@ public class TornadoVMInterpreter {
         while (op != TornadoVMBytecodes.BEGIN.value()) {
             TornadoInternalError.guarantee(op == TornadoVMBytecodes.CONTEXT.value(), "invalid code: 0x%x", op);
             final int deviceIndex = bytecodeResult.getInt();
-            assert deviceIndex == deviceForInterpreter.getDeviceContext().getDeviceIndex();
-            logger.debug("loading context %s", deviceForInterpreter.toString());
+            assert deviceIndex == interpreterDevice.getDeviceContext().getDeviceIndex();
+            logger.debug("loading context %s", interpreterDevice.toString());
             final long t0 = System.nanoTime();
-            deviceForInterpreter.ensureLoaded(executionContext.getExecutionPlanId());
+            interpreterDevice.ensureLoaded(executionContext.getExecutionPlanId());
             final long t1 = System.nanoTime();
             logger.debug("loaded in %.9f s", (t1 - t0) * 1e-9);
             op = bytecodeResult.get();
@@ -206,7 +206,7 @@ public class TornadoVMInterpreter {
             return;
         }
 
-        deviceForInterpreter.dumpEvents(executionContext.getExecutionPlanId());
+        interpreterDevice.dumpEvents(executionContext.getExecutionPlanId());
     }
 
     public void dumpProfiles() {
@@ -246,7 +246,7 @@ public class TornadoVMInterpreter {
 
     private Event execute(boolean isWarmup) {
         isWarmup = isWarmup || VIRTUAL_DEVICE_ENABLED;
-        deviceForInterpreter.enableThreadSharing();
+        interpreterDevice.enableThreadSharing();
 
         if (isMemoryLimitEnabled() && executionContext.doesExceedExecutionPlanLimit()) {
             throw new TornadoMemoryException(STR."OutofMemoryException due to executionPlan.withMemoryLimit of \{executionContext.getExecutionPlanMemoryLimit()}");
@@ -259,7 +259,7 @@ public class TornadoVMInterpreter {
         StringBuilder tornadoVMBytecodeList = null;
         if (TornadoOptions.PRINT_BYTECODES) {
             tornadoVMBytecodeList = new StringBuilder();
-            tornadoVMBytecodeList.append(InterpreterUtilities.debugHighLightHelper("Interpreter instance running bytecodes for: ")).append(deviceForInterpreter).append(InterpreterUtilities
+            tornadoVMBytecodeList.append(InterpreterUtilities.debugHighLightHelper("Interpreter instance running bytecodes for: ")).append(interpreterDevice).append(InterpreterUtilities
                     .debugHighLightHelper(" Running in thread: ")).append(Thread.currentThread().getName()).append("\n");
         }
 
@@ -361,12 +361,12 @@ public class TornadoVMInterpreter {
         Event barrier = EMPTY_EVENT;
         if (!isWarmup) {
             if (useDependencies) {
-                final int event = deviceForInterpreter.enqueueMarker(executionContext.getExecutionPlanId());
-                barrier = deviceForInterpreter.resolveEvent(executionContext.getExecutionPlanId(), event);
+                final int event = interpreterDevice.enqueueMarker(executionContext.getExecutionPlanId());
+                barrier = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), event);
             }
 
             if (TornadoOptions.USE_VM_FLUSH) {
-                deviceForInterpreter.flush(executionContext.getExecutionPlanId());
+                interpreterDevice.flush(executionContext.getExecutionPlanId());
             }
         }
 
@@ -404,13 +404,13 @@ public class TornadoVMInterpreter {
             objectStates[i] = resolveObjectState(args[i]);
 
             if (TornadoOptions.PRINT_BYTECODES) {
-                String verbose = String.format(STR."bc: \{InterpreterUtilities.debugHighLightBC("ALLOC")}%s on %s, size=%d", objects[i], InterpreterUtilities.debugDeviceBC(deviceForInterpreter),
+                String verbose = String.format(STR."bc: \{InterpreterUtilities.debugHighLightBC("ALLOC")}%s on %s, size=%d", objects[i], InterpreterUtilities.debugDeviceBC(interpreterDevice),
                         sizeBatch);
                 tornadoVMBytecodeList.append(verbose).append("\n");
             }
         }
 
-        long allocationsTotalSize =  deviceForInterpreter.allocateObjects(objects, sizeBatch, objectStates);
+        long allocationsTotalSize =  interpreterDevice.allocateObjects(objects, sizeBatch, objectStates);
 
         executionContext.setCurrentDeviceMemoryUsage(allocationsTotalSize);
 
@@ -429,13 +429,13 @@ public class TornadoVMInterpreter {
 
         if (TornadoOptions.PRINT_BYTECODES && isNotObjectAtomic(object)) {
             String verbose = String.format(STR."bc: \{InterpreterUtilities.debugHighLightBC("DEALLOC")}[0x%x] %s on %s", object.hashCode(), object, InterpreterUtilities.debugDeviceBC(
-                    deviceForInterpreter));
+                    interpreterDevice));
             tornadoVMBytecodeList.append(verbose).append("\n");
 
         }
 
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
-        long spaceDeallocated =  deviceForInterpreter.deallocate(objectState);
+        long spaceDeallocated =  interpreterDevice.deallocate(objectState);
         // Update current device area use 
         executionContext.setCurrentDeviceMemoryUsage(executionContext.getCurrentDeviceMemoryUsage() - spaceDeallocated);
         return -1;
@@ -453,19 +453,19 @@ public class TornadoVMInterpreter {
         // We need to stream-in when using batches, because the whole data is not copied
         List<Integer> allEvents;
         if (sizeBatch > 0) {
-            allEvents = deviceForInterpreter.streamIn(executionContext.getExecutionPlanId(), object, sizeBatch, offset, objectState, waitList);
+            allEvents = interpreterDevice.streamIn(executionContext.getExecutionPlanId(), object, sizeBatch, offset, objectState, waitList);
         } else {
-            allEvents = deviceForInterpreter.ensurePresent(executionContext.getExecutionPlanId(), object, objectState, waitList, sizeBatch, offset);
+            allEvents = interpreterDevice.ensurePresent(executionContext.getExecutionPlanId(), object, objectState, waitList, sizeBatch, offset);
         }
         resetEventIndexes(eventList);
 
         if (TornadoOptions.PRINT_BYTECODES && isNotObjectAtomic(object)) {
-            DebugInterpreter.logTransferToDeviceOnce(allEvents, object, deviceForInterpreter, sizeBatch, offset, eventList, tornadoVMBytecodeList);
+            DebugInterpreter.logTransferToDeviceOnce(allEvents, object, interpreterDevice, sizeBatch, offset, eventList, tornadoVMBytecodeList);
         }
 
         if (TornadoOptions.isProfilerEnabled() && allEvents != null) {
             for (Integer e : allEvents) {
-                Event event = deviceForInterpreter.resolveEvent(executionContext.getExecutionPlanId(), e);
+                Event event = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), e);
                 event.waitForEvents(executionContext.getExecutionPlanId());
                 long copyInTimer = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
                 copyInTimer += event.getElapsedTime();
@@ -488,17 +488,17 @@ public class TornadoVMInterpreter {
         }
 
         if (TornadoOptions.PRINT_BYTECODES && isNotObjectAtomic(object)) {
-            DebugInterpreter.logTransferToDeviceAlways(object, deviceForInterpreter, sizeBatch, offset, eventList, tornadoVMBytecodeList);
+            DebugInterpreter.logTransferToDeviceAlways(object, interpreterDevice, sizeBatch, offset, eventList, tornadoVMBytecodeList);
         }
 
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
-        List<Integer> allEvents = deviceForInterpreter.streamIn(executionContext.getExecutionPlanId(), object, sizeBatch, offset, objectState, waitList);
+        List<Integer> allEvents = interpreterDevice.streamIn(executionContext.getExecutionPlanId(), object, sizeBatch, offset, objectState, waitList);
 
         resetEventIndexes(eventList);
 
         if (TornadoOptions.isProfilerEnabled() && allEvents != null) {
             for (Integer e : allEvents) {
-                Event event = deviceForInterpreter.resolveEvent(executionContext.getExecutionPlanId(), e);
+                Event event = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), e);
                 event.waitForEvents(executionContext.getExecutionPlanId());
                 long copyInTimer = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
                 copyInTimer += event.getElapsedTime();
@@ -522,18 +522,18 @@ public class TornadoVMInterpreter {
 
         if (TornadoOptions.PRINT_BYTECODES) {
             String verbose = String.format("bc: " + InterpreterUtilities.debugHighLightBC("TRANSFER_DEVICE_TO_HOST_ALWAYS") + "[0x%x] %s on %s, size=%d, offset=%d [event list=%d]", object.hashCode(),
-                    object, InterpreterUtilities.debugDeviceBC(deviceForInterpreter), sizeBatch, offset, eventList);
+                    object, InterpreterUtilities.debugDeviceBC(interpreterDevice), sizeBatch, offset, eventList);
             tornadoVMBytecodeList.append(verbose).append("\n");
 
         }
 
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
-        int readEvent = deviceForInterpreter.streamOutBlocking(executionContext.getExecutionPlanId(), object, offset, objectState, waitList);
+        int readEvent = interpreterDevice.streamOutBlocking(executionContext.getExecutionPlanId(), object, offset, objectState, waitList);
 
         resetEventIndexes(eventList);
 
         if (TornadoOptions.isProfilerEnabled() && readEvent != -1) {
-            Event event = deviceForInterpreter.resolveEvent(executionContext.getExecutionPlanId(), readEvent);
+            Event event = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), readEvent);
             event.waitForEvents(executionContext.getExecutionPlanId());
             long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
             value += event.getElapsedTime();
@@ -558,17 +558,17 @@ public class TornadoVMInterpreter {
 
         if (TornadoOptions.PRINT_BYTECODES) {
             String verbose = String.format("bc: " + InterpreterUtilities.debugHighLightBC("TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING") + " [0x%x] %s on %s, size=%d, offset=%d [event list=%d]", object
-                    .hashCode(), object, InterpreterUtilities.debugDeviceBC(deviceForInterpreter), sizeBatch, offset, eventList);
+                    .hashCode(), object, InterpreterUtilities.debugDeviceBC(interpreterDevice), sizeBatch, offset, eventList);
             tornadoVMBytecodeList.append(verbose).append("\n");
 
         }
 
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
 
-        final int readEvent = deviceForInterpreter.streamOutBlocking(executionContext.getExecutionPlanId(), object, offset, objectState, waitList);
+        final int readEvent = interpreterDevice.streamOutBlocking(executionContext.getExecutionPlanId(), object, offset, objectState, waitList);
 
         if (TornadoOptions.isProfilerEnabled() && readEvent != -1) {
-            Event event = deviceForInterpreter.resolveEvent(executionContext.getExecutionPlanId(), readEvent);
+            Event event = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), readEvent);
             event.waitForEvents(executionContext.getExecutionPlanId());
             long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
             value += event.getElapsedTime();
@@ -609,13 +609,13 @@ public class TornadoVMInterpreter {
 
     private XPUExecutionFrame compileTaskFromBytecodeToBinary(final int callWrapperIndex, final int numArgs, final int eventList, final int taskIndex, final long batchThreads) {
 
-        if (deviceForInterpreter.getDeviceContext().wasReset() && finishedWarmup) {
-            throw new TornadoFailureException("[ERROR] reset() was called after warmup() on device: " + deviceForInterpreter + "!");
+        if (interpreterDevice.getDeviceContext().wasReset() && finishedWarmup) {
+            throw new TornadoFailureException("[ERROR] reset() was called after warmup() on device: " + interpreterDevice + "!");
         }
 
         boolean redeployOnDevice = executionContext.redeployOnDevice();
 
-        final KernelStackFrame callWrapper = resolveCallWrapper(callWrapperIndex, numArgs, kernelStackFrame, deviceForInterpreter, redeployOnDevice);
+        final KernelStackFrame callWrapper = resolveCallWrapper(callWrapperIndex, numArgs, kernelStackFrame, interpreterDevice, redeployOnDevice);
 
         final int[] waitList = (useDependencies && eventList != -1) ? events[eventList] : null;
         final SchedulableTask task = tasks.get(taskIndex);
@@ -623,7 +623,7 @@ public class TornadoVMInterpreter {
         TaskMetaDataInterface meta = task.meta();
         meta.setPrintKernelFlag(executionContext.meta().isPrintKernelEnabled());
 
-        boolean indexInWrite = deviceForInterpreter.loopIndexInWrite(task);
+        boolean indexInWrite = interpreterDevice.loopIndexInWrite(task);
         // Check if a different batch size was used for the same kernel or
         // if the loop index is written in the output buffer, and we are not in the first batch.
         // If any is true, then the kernel needs to be recompiled.
@@ -649,7 +649,7 @@ public class TornadoVMInterpreter {
         }
 
         if (shouldCompile(installedCodes[globalToLocalTaskIndex(taskIndex)])) {
-            task.mapTo(deviceForInterpreter);
+            task.mapTo(interpreterDevice);
             try {
                 task.attachProfiler(timeProfiler);
                 if (taskIndex == (tasks.size() - 1)) {
@@ -659,7 +659,7 @@ public class TornadoVMInterpreter {
                     task.forceCompilation();
                 }
 
-                installedCodes[globalToLocalTaskIndex(taskIndex)] = deviceForInterpreter.installCode(task);
+                installedCodes[globalToLocalTaskIndex(taskIndex)] = interpreterDevice.installCode(task);
                 profilerUpdateForPreCompiledTask(task);
                 // After the compilation has been completed, increment
                 // the batch number of the task and update it.
@@ -695,7 +695,7 @@ public class TornadoVMInterpreter {
         if (installedCodes[globalToLocalTaskIndex(taskIndex)] == null) {
             // After warming-up, it is possible to get a null pointer in the task-cache due
             // to lazy compilation for FPGAs. In tha case, we check again the code cache.
-            installedCodes[globalToLocalTaskIndex(taskIndex)] = deviceForInterpreter.getCodeFromCache(task);
+            installedCodes[globalToLocalTaskIndex(taskIndex)] = interpreterDevice.getCodeFromCache(task);
         }
 
         final TornadoInstalledCode installedCode = installedCodes[globalToLocalTaskIndex(taskIndex)];
@@ -706,7 +706,7 @@ public class TornadoVMInterpreter {
 
         int[] atomicsArray;
 
-        atomicsArray = (task instanceof PrebuiltTask prebuiltTask) ? prebuiltTask.getAtomics() : deviceForInterpreter.checkAtomicsForTask(task);
+        atomicsArray = (task instanceof PrebuiltTask prebuiltTask) ? prebuiltTask.getAtomics() : interpreterDevice.checkAtomicsForTask(task);
 
         HashMap<Integer, Integer> threadDeploy = new HashMap<>();
         if (gridScheduler != null && gridScheduler.get(task.getId()) != null) {
@@ -738,13 +738,13 @@ public class TornadoVMInterpreter {
                 }
 
                 final DataObjectState globalState = resolveGlobalObjectState(argIndex);
-                final XPUDeviceBufferState objectState = globalState.getDeviceBufferState(deviceForInterpreter);
+                final XPUDeviceBufferState objectState = globalState.getDeviceBufferState(interpreterDevice);
 
-                if (!isObjectInAtomicRegion(objectState, deviceForInterpreter, task)) {
+                if (!isObjectInAtomicRegion(objectState, interpreterDevice, task)) {
                     // Add a reference (arrays, vector types, panama regions)
                     stackFrame.addCallArgument(objectState.getXPUBuffer().toBuffer(), true);
                 } else {
-                    atomicsArray = deviceForInterpreter.updateAtomicRegionAndObjectState(task, atomicsArray, i, objects.get(argIndex), objectState);
+                    atomicsArray = interpreterDevice.updateAtomicRegionAndObjectState(task, atomicsArray, i, objects.get(argIndex), objectState);
                 }
             } else {
                 TornadoInternalError.shouldNotReachHere();
@@ -752,11 +752,11 @@ public class TornadoVMInterpreter {
         }
 
         if (atomicsArray != null) {
-            bufferAtomics = deviceForInterpreter.createOrReuseAtomicsBuffer(atomicsArray);
+            bufferAtomics = interpreterDevice.createOrReuseAtomicsBuffer(atomicsArray);
             List<Integer> allEvents = bufferAtomics.enqueueWrite(executionContext.getExecutionPlanId(), null, 0, 0, null, false);
             if (TornadoOptions.isProfilerEnabled()) {
                 for (Integer e : allEvents) {
-                    Event event = deviceForInterpreter.resolveEvent(executionContext.getExecutionPlanId(), e);
+                    Event event = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), e);
                     event.waitForEvents(executionContext.getExecutionPlanId());
                     long value = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
                     value += event.getElapsedTime();
@@ -765,14 +765,14 @@ public class TornadoVMInterpreter {
             }
             if (TornadoOptions.PRINT_BYTECODES) {
                 String verbose = String.format("bc: " + InterpreterUtilities.debugHighLightBC("STREAM_IN") + "  ATOMIC [0x%x] %s on %s, size=%d, offset=%d [event list=%d]", bufferAtomics.hashCode(),
-                        bufferAtomics, deviceForInterpreter, 0, 0, eventList);
+                        bufferAtomics, interpreterDevice, 0, 0, eventList);
                 tornadoVMBytecodeList.append(verbose).append("\n");
 
             }
         }
 
         if (TornadoOptions.PRINT_BYTECODES) {
-            String verbose = String.format("bc: " + InterpreterUtilities.debugHighLightBC("LAUNCH") + " %s on %s, size=%d, offset=%d [event list=%d]", task.getFullName(), deviceForInterpreter,
+            String verbose = String.format("bc: " + InterpreterUtilities.debugHighLightBC("LAUNCH") + " %s on %s, size=%d, offset=%d [event list=%d]", task.getFullName(), interpreterDevice,
                     batchThreads, offset, eventList);
             tornadoVMBytecodeList.append(verbose).append("\n");
         }
@@ -822,7 +822,7 @@ public class TornadoVMInterpreter {
             tornadoVMBytecodeList.append(String.format("bc: " + InterpreterUtilities.debugHighLightBC("BARRIER") + " event-list %d%n", eventList));
         }
 
-        int lastEvent = deviceForInterpreter.enqueueMarker(executionContext.getExecutionPlanId(), waitList);
+        int lastEvent = interpreterDevice.enqueueMarker(executionContext.getExecutionPlanId(), waitList);
 
         resetEventIndexes(eventList);
         return lastEvent;
@@ -836,7 +836,7 @@ public class TornadoVMInterpreter {
     }
 
     private XPUDeviceBufferState resolveObjectState(int index) {
-        return dataObjectStates[index].getDeviceBufferState(deviceForInterpreter);
+        return dataObjectStates[index].getDeviceBufferState(interpreterDevice);
     }
 
     private boolean isObjectKernelContext(Object object) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
@@ -70,6 +70,18 @@ public class PrebuiltTask implements SchedulableTask {
 
     }
 
+    public PrebuiltTask(ScheduleMetaData scheduleMeta, String id, String entryPoint, String filename, Object[] args, Access[] access) {
+        this.entryPoint = entryPoint;
+        this.filename = filename;
+        this.args = args;
+        this.argumentsAccess = access;
+        meta = new TaskMetaData(scheduleMeta, id, access.length);
+        for (int i = 0; i < access.length; i++) {
+            meta.getArgumentsAccess()[i] = access[i];
+        }
+
+    }
+
     public PrebuiltTask withAtomics(int[] atomics) {
         this.atomics = atomics;
         return this;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/atomics/TestAtomics.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/atomics/TestAtomics.java
@@ -28,11 +28,15 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
+import uk.ac.manchester.tornado.api.AccessorParameters;
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoExecutionResult;
 import uk.ac.manchester.tornado.api.TornadoVMIntrinsics;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
@@ -277,20 +281,24 @@ public class TestAtomics extends TornadoTestBase {
         TornadoDevice defaultDevice = TornadoRuntimeProvider.getTornadoRuntime().getBackend(0).getDevice(deviceNumber);
         String tornadoSDK = System.getenv("TORNADO_SDK");
 
+        AccessorParameters accessorParameters = new AccessorParameters(2);
+        accessorParameters.set(0, a, Access.WRITE_ONLY);
+        accessorParameters.set(1, b, Access.WRITE_ONLY);
+
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .prebuiltTask("t0", //
                         "add", //
                         tornadoSDK + "/examples/generated/atomics.cl", //
-                        new Object[] { a, b }, //
-                        new Access[] { Access.WRITE_ONLY, Access.WRITE_ONLY }, //
-                        defaultDevice, //
-                        new int[] { 32 }, //
-                        new int[] { 155 } // Atomics - Initial Value
-                )//
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a);
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.execute();
+                        accessorParameters, //
+                        new int[] { 155 }   // Array for AtomicsInteger - Initial int value
+                ).transferToHost(DataTransferMode.EVERY_EXECUTION, a);
+
+        WorkerGrid workerGrid = new WorkerGrid1D(32);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.withGridScheduler(gridScheduler) //
+                    .withDevice(defaultDevice) //
+                    .execute();
         }
 
         boolean repeated = isValueRepeated(a);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/PrebuiltTest.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/PrebuiltTest.java
@@ -24,6 +24,7 @@ import java.util.stream.IntStream;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import uk.ac.manchester.tornado.api.AccessorParameters;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.KernelContext;
@@ -88,20 +89,31 @@ public class PrebuiltTest extends TornadoTestBase {
                 throw new TornadoRuntimeException("Backend not supported");
         }
 
+        // Define accessors for each parameter
+        AccessorParameters accessorParameters = new AccessorParameters(3);
+        accessorParameters.set(0, a, Access.READ_ONLY);
+        accessorParameters.set(1, b, Access.READ_ONLY);
+        accessorParameters.set(2, c, Access.WRITE_ONLY);
+
+        // Define the Task-Graph
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
-                .prebuiltTask("t0", //
-                        "add", //
-                        FILE_PATH, //
-                        new Object[] { a, b, c }, //
-                        new Access[] { Access.READ_ONLY, Access.READ_ONLY, Access.WRITE_ONLY }, //
-                        defaultDevice, //
-                        new int[] { numElements })//
+                .prebuiltTask("t0",      //task name
+                        "add",              // name of the low-level kernel to invoke
+                        FILE_PATH,          // file name
+                        accessorParameters) // accessors
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.execute();
+        // When using the prebuilt API, we need to define the WorkerGrid, otherwise it will launch 1 thread
+        // on the target device
+        WorkerGrid workerGrid = new WorkerGrid1D(numElements);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
+
+        // Launch the application on the target device
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.withGridScheduler(gridScheduler) //
+                    .withDevice(defaultDevice) //
+                    .execute();
         }
 
         for (int i = 0; i < c.getSize(); i++) {
@@ -127,20 +139,23 @@ public class PrebuiltTest extends TornadoTestBase {
         GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
+        AccessorParameters accessorParameters = new AccessorParameters(3);
+        accessorParameters.set(0, context, Access.READ_ONLY);
+        accessorParameters.set(1, input, Access.READ_ONLY);
+        accessorParameters.set(2, reduce, Access.WRITE_ONLY);
+
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, input) //
-                .prebuiltTask("t0", //
+                .prebuiltTask("t0",         //
                         "floatReductionAddLocalMemory", //
-                        FILE_PATH, //
-                        new Object[] { context, input, reduce }, //
-                        new Access[] { Access.READ_ONLY, Access.READ_ONLY, Access.WRITE_ONLY }, //
-                        defaultDevice, //
-                        new int[] { size })//
+                        FILE_PATH,          //
+                        accessorParameters) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, reduce);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
             executionPlan.withGridScheduler(gridScheduler) //
+                    .withDevice(defaultDevice) //
                     .execute();
         }
 
@@ -155,10 +170,8 @@ public class PrebuiltTest extends TornadoTestBase {
     }
 
     /**
-     * It tests the functionality of the prebuilt03SPIRV method.
-     *
-     * <p>This test case verifies that the prebuilt03SPIRV runs correctly though a
-     * SPIR-V or OpenCL runtime if the device supports SPIRV.</p>
+     * This test case verifies that the {@link PrebuiltTest#testPrebuilt03SPIRV} runs correctly though a
+     * SPIR-V or OpenCL runtime if the device supports SPIR-V.
      *
      * <p>Expected outcome: - If the current backend type is PTX, the test should have
      * thrown unsupported exception. - The test should succeed if a SPIR-V supported
@@ -175,7 +188,7 @@ public class PrebuiltTest extends TornadoTestBase {
         final int size = 32;
         final int localSize = 32;
         int[] input = new int[size];
-        int[] reduce = new int[size / localSize];
+        int[] output = new int[size / localSize];
         IntStream.range(0, input.length).sequential().forEach(i -> input[i] = 2);
 
         WorkerGrid worker = new WorkerGrid1D(size);
@@ -183,26 +196,29 @@ public class PrebuiltTest extends TornadoTestBase {
         GridScheduler gridScheduler = new GridScheduler("a.b", worker);
         KernelContext context = new KernelContext();
 
+        AccessorParameters accessorParameters = new AccessorParameters(3);
+        accessorParameters.set(0, context, Access.READ_ONLY);
+        accessorParameters.set(1, input, Access.READ_ONLY);
+        accessorParameters.set(2, output, Access.WRITE_ONLY);
+
         TaskGraph taskGraph = new TaskGraph("a") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, input) //
                 .prebuiltTask("b", //
                         "intReductionAddGlobalMemory", //
                         FILE_PATH, //
-                        new Object[] { context, input, reduce }, //
-                        new Access[] { Access.READ_ONLY, Access.READ_ONLY, Access.WRITE_ONLY }, //
-                        defaultDevice, //
-                        new int[] { size })//
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, reduce);
+                        accessorParameters) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
             executionPlan.withGridScheduler(gridScheduler) //
+                    .withDevice(defaultDevice) //
                     .execute();
         }
 
         // Final SUM
         float finalSum = 0;
-        for (int v : reduce) {
+        for (int v : output) {
             finalSum += v;
         }
 
@@ -225,7 +241,7 @@ public class PrebuiltTest extends TornadoTestBase {
         final int size = 512;
         final int localSize = 256;
         float[] input = new float[size];
-        float[] reduce = new float[size / localSize];
+        float[] output = new float[size / localSize];
         IntStream.range(0, input.length).sequential().forEach(i -> input[i] = 1);
 
         WorkerGrid worker = new WorkerGrid1D(size);
@@ -233,26 +249,29 @@ public class PrebuiltTest extends TornadoTestBase {
         GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
         KernelContext context = new KernelContext();
 
+        AccessorParameters accessorParameters = new AccessorParameters(3);
+        accessorParameters.set(0, context, Access.READ_ONLY);
+        accessorParameters.set(1, input, Access.READ_ONLY);
+        accessorParameters.set(2, output, Access.WRITE_ONLY);
+
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, input) //
                 .prebuiltTask("t0", //
                         "floatReductionAddLocalMemory", //
                         FILE_PATH, //
-                        new Object[] { context, input, reduce }, //
-                        new Access[] { Access.READ_ONLY, Access.READ_ONLY, Access.WRITE_ONLY }, //
-                        device, //
-                        new int[] { size })//
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, reduce);
+                        accessorParameters) // 
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
             executionPlan.withGridScheduler(gridScheduler) //
+                    .withDevice(device) // 
                     .execute();
         }
 
         // Final SUM
         float finalSum = 0;
-        for (float v : reduce) {
+        for (float v : output) {
             finalSum += v;
         }
 


### PR DESCRIPTION
#### Description

Draft PR - > Proposal to simplify the prebuilt-task API. 

Since we split Task-Graph into different data structures for definition and execution, we do not need all scheduling arguments in the prebuilt task API. This PR proposes a simplification of the Prebuilt Task API for:

1) Create Accessors to define data and its own accessor to the kernel. This is similar to SYCL and oneAPI. 
2) Remove the scheduling parameters from the Prebuilt-Task Graph. This information is stored in a GridScheduler that is passed at a later stage to the execution plan. 

As an example:

```java
       // Define accessors for each parameter
        AccessorParameters accessorParameters = new AccessorParameters(3);
        accessorParameters.set(0, a, Access.READ_ONLY);
        accessorParameters.set(1, b, Access.READ_ONLY);
        accessorParameters.set(2, c, Access.WRITE_ONLY);

        // Define the Task-Graph
        TaskGraph taskGraph = new TaskGraph("s0") //
                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
                .prebuiltTask("t0",      //task name
                        "add",              // name of the low-level kernel to invoke
                        FILE_PATH,          // file name
                        accessorParameters) // accessors
                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);

        // When using the prebuilt API, we need to define the WorkerGrid, otherwise it will launch 1 thread
        // on the target device
        WorkerGrid workerGrid = new WorkerGrid1D(numElements);
        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);

        // Launch the application on the target device
        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
            executionPlan.withGridScheduler(gridScheduler) //
                    .withDevice(defaultDevice) //
                    .execute();
        }
```

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-test --debug -V uk.ac.manchester.tornado.unittests.prebuilt.PrebuiltTest

tornado-test -pk --threadInfo -V --fast uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic05_precompiled
```
