### PR TITLE
[test] Update whitelist for PTX backend

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -167,6 +167,7 @@ __TORNADO_TESTS_WHITE_LIST__ = [
     ## PTX Backend does not support mathTahn
     "uk.ac.manchester.tornado.unittests.math.TestMath#testMathTanh",
     "uk.ac.manchester.tornado.unittests.math.TestTornadoMathCollection#testTornadoMathTanh",
+    "uk.ac.manchester.tornado.unittests.math.TestTornadoMathCollection#testTornadoMathTanhDouble",
 
     ## Virtual devices are only available for OpenCL.
     "uk.ac.manchester.tornado.unittests.virtual.TestVirtualDeviceKernel#testVirtualDeviceKernelGPU",


### PR DESCRIPTION
This PR updates the whitelist to include a unit-test that fails in PTX due to driver's issue. The unit-test is passing on other systems, so I suggest including it in the white list of tests to avoid blocking the Jenkins pipeline.