### PR TITLE
[hotfix] TornadoVM installer script fixed to build with GraalVM JDK 21

### DIFF
--- a/bin/installer_config.py
+++ b/bin/installer_config.py
@@ -27,7 +27,7 @@ __APPLE__ = "darwin"
 __WINDOWS__ = "windows"
 
 __JDK21__ = "jdk21"
-__GRAALVM21__ = "graalvm-jdk-21"
+__GRAALVM21__ = "graal-jdk-21"
 __MANDREL21__ = "mandrel-jdk-21"
 __CORRETTO21__ = "corretto-jdk-21"
 __MICROSOFT21__ = "microsoft-jdk-21"


### PR DESCRIPTION
#### Description

It seems that the tornadovm-installer script was configured in the past with a problematic name for graalvm jdk21. I tried to install it now and I got the following message:

```bash
JDK not supported. Please install with one of the JDKs from the supported list
	jdk21
	graalvm-jdk-21
	corretto-jdk-21
	microsoft-jdk-21
	mandrel-jdk-21
	zulu-jdk-21
	temurin-jdk-21
	sapmachine-jdk-21
```

The problem is that in our documentation and in the help message printed by the script we use `graal-jdk-21` as a valid name. 

As a result, I reverted the name in order to restore the installation.

#### Problem description

If the patch provides a fix for a bug, please describe what was the issue and how to reproduce the issue.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Try to install with the installer:

```bash
./bin/tornadovm-installer --jdk graal-jdk-21  --backend opencl
```

----------------------------------------------------------------------------
