### PR TITLE
Reverse usage of String Templates in preparation for JDK23

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -544,7 +544,7 @@ public class TornadoExecutionPlan implements AutoCloseable {
 
         TornadoDevice getDevice(int immutableTaskGraphIndex) {
             if (immutableTaskGraphList.size() < immutableTaskGraphIndex) {
-                throw new TornadoRuntimeException(STR."TaskGraph index #\{immutableTaskGraphIndex} does not exist in current executor");
+                throw new TornadoRuntimeException("TaskGraph index #" + immutableTaskGraphIndex + " does not exist in current executor");
             }
             return immutableTaskGraphList.get(immutableTaskGraphIndex).getDevice();
         }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/Shape.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/Shape.java
@@ -65,7 +65,7 @@ public record Shape(long... dimensions) {
 
     @Override
     public String toString() {
-        return STR."Shape{dimensions=\{Arrays.toString(dimensions)}}";
+        return "Shape{dimensions=" + Arrays.toString(dimensions) + "}";
     }
 
     /**

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLBackendImpl.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLBackendImpl.java
@@ -160,7 +160,7 @@ public final class OCLBackendImpl implements TornadoAcceleratorBackend {
         if (index < flatBackends.length) {
             return flatBackends[index].getDeviceContext().asMapping();
         } else {
-            throw new TornadoDeviceNotFound(STR."[ERROR] device required not found: \{index} - Max: \{flatBackends.length}");
+            throw new TornadoDeviceNotFound("[ERROR] device required not found: " + index + " - Max: " + flatBackends.length);
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -547,16 +547,16 @@ public class OCLCodeCache {
 
     private void dumpKernelSource(String id, String entryPoint, String log, byte[] source) {
         final Path outDir = resolveLogDirectory();
-        final String identifier = STR."\{id}-\{entryPoint}";
+        final String identifier = id + "-" + entryPoint;
         logger.error("Unable to compile task %s: check logs at %s/%s.log", identifier, outDir.toAbsolutePath(), identifier);
 
-        File file = new File(STR."\{outDir}/\{identifier}.log");
+        File file = new File(outDir + "/" + identifier + ".log");
         try (FileOutputStream fos = new FileOutputStream(file)) {
             fos.write(log.getBytes());
         } catch (IOException e) {
             logger.error("unable to write error log: ", e.getMessage());
         }
-        file = new File(STR."\{outDir}/\{identifier}\{OPENCL_SOURCE_SUFFIX}");
+        file = new File(outDir + "/" + identifier + OPENCL_SOURCE_SUFFIX);
         try (FileOutputStream fos = new FileOutputStream(file)) {
             fos.write(source);
         } catch (IOException e) {
@@ -567,13 +567,13 @@ public class OCLCodeCache {
 
     private void installCodeInCodeCache(OCLProgram program, TaskMetaData meta, String id, String entryPoint, OCLInstalledCode code) {
         
-        cache.put(STR."\{id}-\{entryPoint}", code);
+        cache.put(id + "-" + entryPoint, code);
 
         // BUG Apple does not seem to like implementing the OpenCL spec
         // properly, this causes a SIGFAULT.
         if ((OPENCL_CACHE_ENABLE || OPENCL_DUMP_BINS) && !deviceContext.getPlatformContext().getPlatform().getVendor().equalsIgnoreCase("Apple")) {
             final Path outDir = resolveCacheDirectory();
-            program.dumpBinaries(STR."\{outDir.toAbsolutePath()}/\{entryPoint}");
+            program.dumpBinaries(outDir.toAbsolutePath() + "/" + entryPoint);
         }
     }
 
@@ -662,11 +662,11 @@ public class OCLCodeCache {
             long afterLoad = (TornadoOptions.TIME_IN_NANOSECONDS) ? System.nanoTime() : System.currentTimeMillis();
 
             if (PRINT_LOAD_TIME) {
-                System.out.println(STR."Binary load time: \{afterLoad - beforeLoad}\{TornadoOptions.TIME_IN_NANOSECONDS ? " ns" : " ms"} \n");
+                System.out.println("Binary load time: " + (afterLoad - beforeLoad) + (TornadoOptions.TIME_IN_NANOSECONDS ? " ns" : " ms") + "\n");
             }
 
             if (program == null) {
-                throw new OCLException(STR."unable to load binary for \{entryPoint}");
+                throw new OCLException("unable to load binary for " + entryPoint);
             }
 
             program.build("");

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -643,13 +643,13 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
     @Override
     public boolean isCached(String id, String entryPoint) {
         entryPoint = checkKernelName(entryPoint);
-        return codeCache.isCached(STR."\{id}-\{entryPoint}");
+        return codeCache.isCached(id + "-" + entryPoint);
     }
 
     @Override
     public boolean isCached(String methodName, SchedulableTask task) {
         methodName = checkKernelName(methodName);
-        return codeCache.isCached(STR."\{task.getId()}-\{methodName}");
+        return codeCache.isCached(task.getId() + "-" + methodName);
     }
 
     public OCLInstalledCode getInstalledCode(String id, String entryPoint) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLWriteAtomicNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLWriteAtomicNode.java
@@ -101,7 +101,7 @@ public class OCLWriteAtomicNode extends AbstractWriteNode implements LIRLowerabl
         return switch (operation) {
             case ADD -> new OCLStamp(OCLKind.ATOMIC_ADD_INT);
             case MUL -> new OCLStamp(OCLKind.ATOMIC_MUL_INT);
-            default -> throw new RuntimeException(STR."Operation for reduction not supported yet: \{operation}");
+            default -> throw new RuntimeException("Operation for reduction not supported yet: " + operation);
         };
     }
 
@@ -112,7 +112,7 @@ public class OCLWriteAtomicNode extends AbstractWriteNode implements LIRLowerabl
                 oclStamp = new OCLStamp(OCLKind.ATOMIC_ADD_FLOAT);
                 break;
             default:
-                throw new RuntimeException(STR."Operation for reduction not supported yet: \{operation}");
+                throw new RuntimeException("Operation for reduction not supported yet: " + operation);
         }
         return oclStamp;
     }
@@ -127,7 +127,7 @@ public class OCLWriteAtomicNode extends AbstractWriteNode implements LIRLowerabl
                 // DUE TO UNSUPPORTED FEATURE IN INTEL OpenCL PLATFORM
                 new OCLStamp(OCLKind.ATOMIC_ADD_INT);
             case Float -> getStampFloat();
-            default -> throw new RuntimeException(STR."Data type for reduction not supported yet: \{elementKind}");
+            default -> throw new RuntimeException("Data type for reduction not supported yet: " + elementKind);
         };
 
         LIRKind writeKind = gen.getLIRGeneratorTool().getLIRKind(oclStamp);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/OCLFP16SupportPhase.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/OCLFP16SupportPhase.java
@@ -66,7 +66,7 @@ public class OCLFP16SupportPhase extends Phase {
 
         for (ReadNode readNode : graph.getNodes().filter(ReadNode.class)) {
             if (readNode.getLocationIdentity().toString().contains("VectorHalf") && !fp16Support) {
-                throw new TornadoDeviceFP16NotSupported(STR."The current OpenCL device (\{deviceContext.getDeviceName()}) does not support FP64");
+                throw new TornadoDeviceFP16NotSupported("The current OpenCL device (" + deviceContext.getDeviceName() + ") does not support FP64");
             }
         }
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/OCLFP64SupportPhase.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/OCLFP64SupportPhase.java
@@ -75,7 +75,7 @@ public class OCLFP64SupportPhase extends Phase {
     private void checkStampForFP64Support(Stamp stamp) {
         boolean isStampFP64Type = isStampFP64Type(stamp);
         if (isStampFP64Type && !deviceContext.isFP64Supported()) {
-            throw new TornadoDeviceFP64NotSupported(STR."The current OpenCL device (\{deviceContext.getDeviceName()}) does not support FP64");
+            throw new TornadoDeviceFP64NotSupported("The current OpenCL device (" + deviceContext.getDeviceName() + ") does not support FP64");
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoOpenCLIntrinsicsReplacements.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoOpenCLIntrinsicsReplacements.java
@@ -191,7 +191,7 @@ public class TornadoOpenCLIntrinsicsReplacements extends BasePhase<TornadoHighTi
             case "Class:double", "Class:uk.ac.manchester.tornado.api.types.arrays.DoubleArray":
                 return JavaKind.Double;
             default:
-                unimplemented(STR."Other types not supported yet: \{signatureNode.getValue().toValueString()}");
+                unimplemented("Other types not supported yet: " + signatureNode.getValue().toValueString());
         }
         return null;
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoTaskSpecialisation.java
@@ -345,7 +345,7 @@ public class TornadoTaskSpecialisation extends BasePhase<TornadoHighTierContext>
 
             deadCodeElimination.run(graph);
 
-            getDebugContext().dump(DebugContext.INFO_LEVEL, graph, STR."After TaskSpecialisation iteration = \{iterations}");
+            getDebugContext().dump(DebugContext.INFO_LEVEL, graph, "After TaskSpecialisation iteration = " + iterations);
 
             hasWork = (lastNodeCount != graph.getNodeCount() || graph.getNewNodes(mark).isNotEmpty() || hasPanamaArraySizeNode(graph)) && (iterations < MAX_ITERATIONS);
             lastNodeCount = graph.getNodeCount();

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
@@ -100,7 +100,7 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
             case TornadoImagesInterface<?> imagesInterface -> imagesInterface.getSegmentWithHeader();
             case TornadoMatrixInterface<?> matrixInterface -> matrixInterface.getSegmentWithHeader();
             case TornadoVolumesInterface<?> volumesInterface -> volumesInterface.getSegmentWithHeader();
-            default -> throw new TornadoMemoryException(STR."Memory Segment not supported: \{reference.getClass()}");
+            default -> throw new TornadoMemoryException("Memory Segment not supported: " + reference.getClass());
         };
     }
 
@@ -188,7 +188,7 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
         }
 
         if (bufferSize <= 0) {
-            throw new TornadoMemoryException(STR."[ERROR] Bytes Allocated <= 0: \{bufferSize}");
+            throw new TornadoMemoryException("[ERROR] Bytes Allocated <= 0: " + bufferSize);
         }
 
         if (TornadoOptions.FULL_DEBUG) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLVectorWrapper.java
@@ -64,7 +64,7 @@ public class OCLVectorWrapper implements XPUBuffer {
     private long setSubRegionSize;
 
     public OCLVectorWrapper(final OCLDeviceContext device, final Object object, long batchSize) {
-        TornadoInternalError.guarantee(object instanceof PrimitiveStorage, STR."Expecting a PrimitiveStorage type, but found: \{object.getClass()}");
+        TornadoInternalError.guarantee(object instanceof PrimitiveStorage, "Expecting a PrimitiveStorage type, but found: " + object.getClass());
         this.deviceContext = device;
         this.batchSize = batchSize;
         this.bufferId = INIT_VALUE;
@@ -89,7 +89,7 @@ public class OCLVectorWrapper implements XPUBuffer {
         }
 
         if (bufferSize <= 0) {
-            throw new TornadoMemoryException(STR."[ERROR] Bytes Allocated <= 0: \{bufferSize}");
+            throw new TornadoMemoryException("[ERROR] Bytes Allocated <= 0: " + bufferSize);
         }
 
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
@@ -167,7 +167,7 @@ public class OCLVectorWrapper implements XPUBuffer {
             if (value instanceof TornadoNativeArray nativeArray) {
                 return deviceContext.enqueueReadBuffer(executionPlanId, bufferId, offset, bytes, nativeArray.getSegmentWithHeader().address(), hostOffset, waitEvents);
             } else {
-                throw new TornadoRuntimeException(STR."Type not supported: \{value.getClass()}");
+                throw new TornadoRuntimeException("Type not supported: " + value.getClass());
             }
         } else {
             TornadoInternalError.shouldNotReachHere("Expecting an array type");
@@ -206,7 +206,7 @@ public class OCLVectorWrapper implements XPUBuffer {
             if (value instanceof TornadoNativeArray nativeArray) {
                 return deviceContext.enqueueWriteBuffer(executionPlanId, bufferId, offset, bytes, nativeArray.getSegmentWithHeader().address(), hostOffset, waitEvents);
             } else {
-                throw new TornadoRuntimeException(STR."Type not supported: \{value.getClass()}");
+                throw new TornadoRuntimeException("Type not supported: " + value.getClass());
             }
         } else {
             TornadoInternalError.shouldNotReachHere("Expecting an array type");
@@ -247,7 +247,7 @@ public class OCLVectorWrapper implements XPUBuffer {
             if (value instanceof TornadoNativeArray nativeArray) {
                 return deviceContext.readBuffer(executionPlanId, bufferId, offset, bytes, nativeArray.getSegmentWithHeader().address(), hostOffset, waitEvents);
             } else {
-                throw new TornadoRuntimeException(STR."Type not supported: \{value.getClass()}");
+                throw new TornadoRuntimeException("Type not supported: " + value.getClass());
             }
         } else {
             TornadoInternalError.shouldNotReachHere("Expecting an array type");
@@ -318,7 +318,7 @@ public class OCLVectorWrapper implements XPUBuffer {
             if (value instanceof TornadoNativeArray nativeArray) {
                 deviceContext.writeBuffer(executionPlanId, bufferId, offset, bytes, nativeArray.getSegmentWithHeader().address(), hostOffset, waitEvents);
             } else {
-                throw new TornadoRuntimeException(STR."Data type not supported: \{value.getClass()}");
+                throw new TornadoRuntimeException("Data not supported: " + value.getClass());
             }
         } else {
             TornadoInternalError.shouldNotReachHere("Expecting an array type");
@@ -347,7 +347,7 @@ public class OCLVectorWrapper implements XPUBuffer {
         } else if (type == FloatArray.class || type == IntArray.class || type == DoubleArray.class || type == LongArray.class || type == ShortArray.class || type == CharArray.class || type == ByteArray.class || type == HalfFloatArray.class) {
             return JavaKind.Object;
         } else {
-            TornadoInternalError.shouldNotReachHere(STR."The type should be an array, but found: \{type}");
+            TornadoInternalError.shouldNotReachHere("The type should be an array, but found: " + type);
         }
         return null;
     }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXBackendImpl.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXBackendImpl.java
@@ -47,8 +47,8 @@ import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoSuitesProvider;
 public final class PTXBackendImpl implements TornadoAcceleratorBackend {
 
     private final PTXBackend[] backends;
-    private List<TornadoDevice> devices;
     private final TornadoLogger logger;
+    private List<TornadoDevice> devices;
 
     public PTXBackendImpl(final OptionValues options, final HotSpotJVMCIRuntime vmRuntime, TornadoVMConfigAccess vmConfig) {
 
@@ -125,7 +125,7 @@ public final class PTXBackendImpl implements TornadoAcceleratorBackend {
         if (index < backends.length) {
             return backends[index].getDeviceContext().asMapping();
         } else {
-            throw new TornadoDeviceNotFound(STR."[ERROR]-[PTX-DRIVER] Device required not found: \{index} - Max: \{backends.length}");
+            throw new TornadoDeviceNotFound("[ERROR]-[PTX-DRIVER] Device required not found: " + index + " - Max: " + backends.length);
         }
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -65,11 +65,9 @@ public class PTXDeviceContext implements TornadoDeviceContext {
     private final PTXCodeCache codeCache;
     private final PTXScheduler scheduler;
     private final TornadoBufferProvider bufferProvider;
-    private boolean wasReset;
     private final PowerMetric powerMetric;
-
     private final Map<Long, PTXStreamTable> streamTable;
-
+    private boolean wasReset;
     private Set<Long> executionIDs;
 
     public PTXDeviceContext(PTXDevice device) {
@@ -551,7 +549,8 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         PTXStream stream = getStream(executionPlanId);
         List<PTXEvent> events = stream.getEventPool().getEvents();
 
-        final String deviceName = STR."PTX-\{device.getDeviceName()}";
+        final String deviceName = "PTX-" + device.getDeviceName();
+
         System.out.printf("Found %d events on device %s:\n", events.size(), deviceName);
         if (events.isEmpty()) {
             return;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssembler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssembler.java
@@ -579,7 +579,7 @@ public class PTXAssembler extends Assembler {
                 if (((PTXKind) x.getPlatformKind()).is64Bit()) {
                     instructionKind = PTXKind.B64;
                 }
-                asm.emit(STR.".\{instructionKind}" );
+                asm.emit("."+instructionKind );
 
                 asm.emitSymbol(TAB);
                 asm.emitValues(new Value[] { dest, x });

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
@@ -46,11 +46,11 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
     private static final int INIT_VALUE = -1;
     private final PTXDeviceContext deviceContext;
     private final long batchSize;
+    private final TornadoLogger logger;
     private long bufferId;
     private long bufferOffset;
     private long bufferSize;
     private long setSubRegionSize;
-    private final TornadoLogger logger;
 
     public PTXMemorySegmentWrapper(PTXDeviceContext deviceContext, long batchSize) {
         this.deviceContext = deviceContext;
@@ -100,7 +100,7 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
             case TornadoImagesInterface<?> imagesInterface -> imagesInterface.getSegmentWithHeader();
             case TornadoMatrixInterface<?> matrixInterface -> matrixInterface.getSegmentWithHeader();
             case TornadoVolumesInterface<?> volumesInterface -> volumesInterface.getSegmentWithHeader();
-            default -> throw new TornadoMemoryException(STR."Memory Segment not supported: \{reference.getClass()}");
+            default -> throw new TornadoMemoryException("Memory Segment not supported: " + reference.getClass());
         };
     }
 
@@ -183,7 +183,7 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
         }
 
         if (bufferSize <= 0) {
-            throw new TornadoMemoryException(STR."[ERROR] Bytes Allocated <= 0: \{bufferSize}");
+            throw new TornadoMemoryException("[ERROR] Bytes Allocated <= 0: " + bufferSize);
         }
 
         if (TornadoOptions.FULL_DEBUG) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXVectorWrapper.java
@@ -60,10 +60,10 @@ public class PTXVectorWrapper implements XPUBuffer {
     private final int arrayLengthOffset;
     private final long batchSize;
     private final JavaKind kind;
+    private final TornadoLogger logger;
     private long buffer;
     private long bufferSize;
     private long setSubRegionSize;
-    private final TornadoLogger logger;
 
     public PTXVectorWrapper(final PTXDeviceContext device, final Object object, long batchSize) {
         TornadoInternalError.guarantee(object instanceof PrimitiveStorage, "Expecting a PrimitiveStorage type");
@@ -93,7 +93,7 @@ public class PTXVectorWrapper implements XPUBuffer {
         }
 
         if (bufferSize <= 0) {
-            throw new TornadoMemoryException(STR."[ERROR] Bytes Allocated <= 0: \{bufferSize}");
+            throw new TornadoMemoryException("[ERROR] Bytes Allocated <= 0: " + bufferSize);
         }
 
         this.buffer = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
@@ -167,7 +167,7 @@ public class PTXVectorWrapper implements XPUBuffer {
             case JavaKind.Short -> deviceContext.enqueueReadBuffer(executionPlanId, address, bytes, (short[]) value, hostOffset, waitEvents);
             case JavaKind.Byte -> deviceContext.enqueueReadBuffer(executionPlanId, address, bytes, (byte[]) value, hostOffset, waitEvents);
             case JavaKind.Object -> deviceContext.enqueueReadBuffer(executionPlanId, address, bytes, ((TornadoNativeArray) value).getSegmentWithHeader().address(), hostOffset, waitEvents);
-            default -> throw new TornadoRuntimeException(STR."Type not supported: \{value.getClass()}");
+            default -> throw new TornadoRuntimeException("Type not supported: " + value.getClass());
         };
     }
 
@@ -194,7 +194,7 @@ public class PTXVectorWrapper implements XPUBuffer {
             case JavaKind.Short -> deviceContext.enqueueWriteBuffer(executionPlanId, address, bytes, (short[]) value, hostOffset, waitEvents);
             case JavaKind.Byte -> deviceContext.enqueueWriteBuffer(executionPlanId, address, bytes, (byte[]) value, hostOffset, waitEvents);
             case JavaKind.Object -> deviceContext.enqueueWriteBuffer(executionPlanId, address, bytes, ((TornadoNativeArray) value).getSegmentWithHeader().address(), hostOffset, waitEvents);
-            default -> throw new TornadoRuntimeException(STR."Type not supported: \{value.getClass()}");
+            default -> throw new TornadoRuntimeException("Type not supported: " + value.getClass());
         };
     }
 
@@ -224,7 +224,7 @@ public class PTXVectorWrapper implements XPUBuffer {
             case JavaKind.Short -> deviceContext.readBuffer(executionPlanId, address, bytes, (short[]) value, hostOffset, waitEvents);
             case JavaKind.Byte -> deviceContext.readBuffer(executionPlanId, address, bytes, (byte[]) value, hostOffset, waitEvents);
             case JavaKind.Object -> deviceContext.readBuffer(executionPlanId, address, bytes, ((TornadoNativeArray) value).getSegmentWithHeader().address(), hostOffset, waitEvents);
-            default -> throw new TornadoRuntimeException(STR."Type not supported: \{value.getClass()}");
+            default -> throw new TornadoRuntimeException("Type not supported: " + value.getClass());
         };
     }
 
@@ -280,7 +280,7 @@ public class PTXVectorWrapper implements XPUBuffer {
             case JavaKind.Short -> deviceContext.writeBuffer(executionPlanId, address, bytes, (short[]) value, hostOffset, waitEvents);
             case JavaKind.Byte -> deviceContext.writeBuffer(executionPlanId, address, bytes, (byte[]) value, hostOffset, waitEvents);
             case JavaKind.Object -> deviceContext.writeBuffer(executionPlanId, address, bytes, ((TornadoNativeArray) value).getSegmentWithHeader().address(), hostOffset, waitEvents);
-            default -> throw new TornadoRuntimeException(STR."Type not supported: \{value.getClass()}");
+            default -> throw new TornadoRuntimeException("Type not supported: " + value.getClass());
         }
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -156,7 +156,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
         return switch (task) {
             case CompilableTask _ -> compileTask(task);
             case PrebuiltTask _ -> compilePreBuiltTask(task);
-            default -> throw new TornadoInternalError(STR."task of unknown type: \{task.getClass().getSimpleName()}");
+            default -> throw new TornadoInternalError("task of unknown type: " + task.getClass().getSimpleName());
         };
     }
 
@@ -567,7 +567,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public String getDeviceName() {
-        return STR."cuda-\{device.getDeviceIndex()}";
+        return "cuda-" + device.getDeviceIndex();
     }
 
     @Override
@@ -676,7 +676,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public String toString() {
-        return STR."\{getPlatformName()} -- \{device.getDeviceName()}";
+        return getPlatformName() + " -- " + device.getDeviceName();
     }
 
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXTornadoCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXTornadoCompiler.java
@@ -91,7 +91,7 @@ public class TestPTXTornadoCompiler {
 
         String generatedSourceCode = code.getGeneratedSourceCode();
         if (meta.isPrintKernelEnabled()) {
-            System.out.println(STR."Compiled code: \{generatedSourceCode}");
+            System.out.println("Compiled code: " + generatedSourceCode);
         }
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
@@ -166,7 +166,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
         if (index < flatBackends.length) {
             return flatBackends[index].getDeviceContext().asMapping();
         } else {
-            throw new TornadoDeviceNotFound(STR."[ERROR]-[SPIRV-DRIVER] Device required not found: \{index} - Max: \{spirvBackends.length}");
+            throw new TornadoDeviceNotFound("[ERROR]-[SPIRV-DRIVER] Device required not found: " + index + " - Max: " + spirvBackends.length);
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
@@ -395,12 +395,12 @@ public abstract class SPIRVDeviceContext implements TornadoDeviceContext {
     }
 
     public boolean isCached(String id, String entryPoint) {
-        return codeCache.isCached(STR."\{id}-\{entryPoint}");
+        return codeCache.isCached(id + "-" + entryPoint);
     }
 
     @Override
     public boolean isCached(String methodName, SchedulableTask task) {
-        return codeCache.isCached(STR."\{task.getId()}-\{methodName}");
+        return codeCache.isCached(task.getId() + "-" + methodName);
     }
 
     public SPIRVInstalledCode getInstalledCode(String id, String entryPoint) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
@@ -85,7 +85,7 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
             System.out.println("SPIR-V Kernel Errors from LevelZero:");
             System.out.println(errorMessage[0]);
             System.out.println("----------------");
-            throw new TornadoBailoutRuntimeException(STR."[Build SPIR-V ERROR]\{errorMessage[0]}");
+            throw new TornadoBailoutRuntimeException("[Build SPIR-V ERROR]" + errorMessage[0]);
         }
 
         if (meta.isPrintKernelEnabled()) {
@@ -114,7 +114,7 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
         ZeKernelDescriptor kernelDesc = new ZeKernelDescriptor();
         ZeKernelHandle kernel = new ZeKernelHandle();
         if (TornadoOptions.DEBUG) {
-            Logger.traceRuntime(Logger.BACKEND.SPIRV, STR."Set SPIR-V entry point: \{entryPoint}");
+            Logger.traceRuntime(Logger.BACKEND.SPIRV, "Set SPIR-V entry point: " + entryPoint);
         }
         kernelDesc.setKernelName(entryPoint);
         result = levelZeroModule.zeKernelCreate(module.getPtrZeModuleHandle(), kernelDesc, kernel);
@@ -127,7 +127,7 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
         SPIRVInstalledCode installedCode = new SPIRVLevelZeroInstalledCode(id, spirvModule, deviceContext);
 
         // Install module in the code cache
-        cache.put(STR."\{id}-\{entryPoint}", installedCode);
+        cache.put(id + "-" + entryPoint, installedCode);
         return installedCode;
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
@@ -113,9 +113,9 @@ public class SPIRVOCLCodeCache extends SPIRVCodeCache {
 
         SPIRVOCLModule module = new SPIRVOCLModule(kernelPointer, entryPoint, pathToFile);
         final SPIRVOCLInstalledCode installedCode = new SPIRVOCLInstalledCode(entryPoint, module, deviceContext);
-        
+
         // Install code in the code cache
-        cache.put(STR."\{id}-\{entryPoint}", installedCode);
+        cache.put(id + "-" + entryPoint, installedCode);
         return installedCode;
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/asm/SPIRVAssembler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/asm/SPIRVAssembler.java
@@ -553,7 +553,7 @@ public final class SPIRVAssembler extends Assembler {
             case OP_TYPE_FLOAT_16 -> module.add(new SPIRVOpConstant(typeID, newConstantId, new SPIRVContextDependentHalfFloat(Float.floatToFloat16(Float.parseFloat(valueConstant)))));
             case OP_TYPE_FLOAT_32 -> module.add(new SPIRVOpConstant(typeID, newConstantId, new SPIRVContextDependentFloat(Float.parseFloat(valueConstant))));
             case OP_TYPE_FLOAT_64 -> module.add(new SPIRVOpConstant(typeID, newConstantId, new SPIRVContextDependentDouble(Double.parseDouble(valueConstant))));
-            default -> throw new TornadoRuntimeException(STR."Data type not supported yet: \{type}");
+            default -> throw new TornadoRuntimeException("Data type not supported yet: " + type);
         }
         return newConstantId;
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVMemorySegmentWrapper.java
@@ -101,7 +101,7 @@ public class SPIRVMemorySegmentWrapper implements XPUBuffer {
             case TornadoImagesInterface<?> imagesInterface -> imagesInterface.getSegmentWithHeader();
             case TornadoMatrixInterface<?> matrixInterface -> matrixInterface.getSegmentWithHeader();
             case TornadoVolumesInterface<?> volumesInterface -> volumesInterface.getSegmentWithHeader();
-            default -> throw new TornadoMemoryException(STR."Memory Segment not supported: \{reference.getClass()}");
+            default -> throw new TornadoMemoryException("Memory Segment not supported: " + reference.getClass());
         };
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/mm/SPIRVVectorWrapper.java
@@ -57,14 +57,14 @@ public class SPIRVVectorWrapper implements XPUBuffer {
     protected final SPIRVDeviceContext deviceContext;
     private final long batchSize;
     private final JavaKind kind;
+    private final TornadoLogger logger;
     private long bufferId;
     private long bufferOffset;
     private long bufferSize;
     private long setSubRegionSize;
-    private final TornadoLogger logger;
 
     public SPIRVVectorWrapper(final SPIRVDeviceContext device, final Object object, long batchSize) {
-        TornadoInternalError.guarantee(object instanceof PrimitiveStorage, STR."Expecting a PrimitiveStorage type, but found: \{object.getClass()}");
+        TornadoInternalError.guarantee(object instanceof PrimitiveStorage, "Expecting a PrimitiveStorage type, but found: " + object.getClass());
         this.deviceContext = device;
         this.batchSize = batchSize;
         this.bufferId = INIT_VALUE;
@@ -90,7 +90,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
         }
 
         if (bufferSize <= 0) {
-            throw new TornadoMemoryException(STR."[ERROR] Bytes Allocated <= 0: \{bufferSize}");
+            throw new TornadoMemoryException("[ERROR] Bytes Allocated <= 0: " + bufferSize);
         }
 
         this.bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize);
@@ -180,7 +180,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
             if (value instanceof TornadoNativeArray tornadoNativeArray) {
                 return deviceContext.enqueueReadBuffer(executionPlanId, bufferId, offset, bytes, tornadoNativeArray.getSegmentWithHeader().address(), hostOffset, waitEvents);
             } else {
-                throw new TornadoRuntimeException(STR."Type not supported: \{value.getClass()}");
+                throw new TornadoRuntimeException("Type not supported: " + value.getClass());
             }
         } else {
             TornadoInternalError.shouldNotReachHere("Expecting an array type");
@@ -219,7 +219,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
             if (value instanceof TornadoNativeArray nativeArray) {
                 return deviceContext.enqueueWriteBuffer(executionPlanId, bufferId, offset, bytes, nativeArray.getSegmentWithHeader().address(), hostOffset, waitEvents);
             } else {
-                throw new TornadoRuntimeException(STR."Type not supported: \{value.getClass()}");
+                throw new TornadoRuntimeException("Type not supported: " + value.getClass());
             }
         } else {
             TornadoInternalError.shouldNotReachHere("Expecting an array type");
@@ -261,7 +261,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
             if (value instanceof TornadoNativeArray nativeArray) {
                 return deviceContext.readBuffer(executionPlanId, bufferId, offset, bytes, nativeArray.getSegmentWithHeader().address(), hostOffset, waitEvents);
             } else {
-                throw new TornadoRuntimeException(STR."Type not supported: \{value.getClass()}");
+                throw new TornadoRuntimeException("Type not supported: " + value.getClass());
             }
         } else {
             TornadoInternalError.shouldNotReachHere("Expecting an array type");
@@ -333,7 +333,7 @@ public class SPIRVVectorWrapper implements XPUBuffer {
             if (value instanceof TornadoNativeArray nativeArray) {
                 deviceContext.writeBuffer(executionPlanId, bufferId, offset, bytes, nativeArray.getSegmentWithHeader().address(), hostOffset, waitEvents);
             } else {
-                throw new TornadoRuntimeException(STR."Data type not supported: \{value.getClass()}");
+                throw new TornadoRuntimeException("Data type not supported: " + value.getClass());
             }
         } else {
             TornadoInternalError.shouldNotReachHere("Expecting an array type");

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -193,7 +193,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
             logger.fatal("Unable to compile %s for device %s\n", task.getId(), getDeviceName());
             logger.fatal("Exception occurred when compiling %s\n", task.getMethod().getName());
             if (TornadoOptions.RECOVER_BAILOUT) {
-                throw new TornadoBailoutRuntimeException(STR."[Error During the Task Compilation]: \{e.getMessage()}");
+                throw new TornadoBailoutRuntimeException("[Error During the Task Compilation]: " + e.getMessage());
             } else {
                 throw e;
             }
@@ -296,7 +296,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
                 if (RuntimeUtilities.isPrimitiveArray(componentType)) {
                     return createMultiArrayWrapper(componentType, type, deviceContext, batchSize);
                 } else {
-                    throw new TornadoRuntimeException(STR."Multi-dimensional array of type \{type.getName()} not implemented.");
+                    throw new TornadoRuntimeException("Multi-dimensional array of type " + type.getName() + " not implemented.");
                 }
             }
         } else if (!type.isPrimitive()) {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/BlackAndWhiteTransform.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/BlackAndWhiteTransform.java
@@ -104,7 +104,7 @@ public class BlackAndWhiteTransform {
             try {
                 ImageIO.write(image, "jpg", new File("/tmp/" + fileName));
             } catch (IOException e) {
-                throw new RuntimeException(STR."Input file not found: \{IMAGE_FILE}");
+                throw new RuntimeException("Input file not found: " + IMAGE_FILE);
             }
         }
 
@@ -137,7 +137,7 @@ public class BlackAndWhiteTransform {
                 start = System.nanoTime();
                 executor.execute();
                 end = System.nanoTime();
-                System.out.println(STR."Total TornadoVM time: \{end - start} (ns)");
+                System.out.println("Total TornadoVM time: " + (end - start) + " (ns)");
             }
 
             // unmarshall data from IntArray to BufferedImage to draw on the screen
@@ -176,7 +176,7 @@ public class BlackAndWhiteTransform {
                     }
                 }
                 end = System.nanoTime();
-                System.out.println(STR."Total sequential time: \{end - start} (ns)");
+                System.out.println("Total sequential time: " + (end - start) + " (ns)");
             }
 
             // draw the image

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoCoreRuntime.java
@@ -177,7 +177,7 @@ public final class TornadoCoreRuntime implements TornadoRuntime {
                 return backendIndex;
             }
         }
-        throw shouldNotReachHere(STR."Could not find index for backend: \{backendClass}");
+        throw shouldNotReachHere("Could not find index for backend: " + backendClass);
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BatchConfiguration.java
@@ -105,11 +105,11 @@ public class BatchConfiguration {
                     case ShortArray _ -> DataTypeSize.SHORT.getSize();
                     case ByteArray _ -> DataTypeSize.BYTE.getSize();
                     case CharArray _ -> DataTypeSize.CHAR.getSize();
-                    default -> throw new TornadoRuntimeException(STR."Unsupported array type: \{o.getClass()}");
+                    default -> throw new TornadoRuntimeException("Unsupported array type: " + o.getClass());
                 };
                 elementSizes.add(elementSize);
             } else {
-                throw new TornadoRuntimeException(STR."Unsupported type: \{o.getClass()}");
+                throw new TornadoRuntimeException("Unsupported type: " + o.getClass());
             }
         }
 
@@ -125,9 +125,9 @@ public class BatchConfiguration {
         int remainingChunkSize = (int) (totalSize % batchSize);
 
         if (TornadoOptions.DEBUG) {
-            System.out.println(STR."Batch Size: \{batchSize}");
-            System.out.println(STR."Total chunks: \{totalChunks}");
-            System.out.println(STR."remainingChunkSize: \{remainingChunkSize}");
+            System.out.println("Batch Size: " + batchSize);
+            System.out.println("Total chunks: " + totalChunks);
+            System.out.println("remainingChunkSize: " + remainingChunkSize);
         }
         return new BatchConfiguration(totalChunks, remainingChunkSize, elementSizes.getFirst());
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/compiler/TornadoCompilerIdentifier.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/compiler/TornadoCompilerIdentifier.java
@@ -35,6 +35,6 @@ public class TornadoCompilerIdentifier implements CompilationIdentifier {
 
     @Override
     public String toString(Verbosity verbosity) {
-        return STR."\{name}-\{id}";
+        return name + "-" + id;
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -185,7 +185,7 @@ public class TornadoExecutionContext {
             } else if (parameter instanceof KernelContext || parameter instanceof AtomicInteger) {
                 // ignore
             } else {
-                throw new TornadoRuntimeException(STR."Unsupported type: \{parameter.getClass()}");
+                throw new TornadoRuntimeException("Unsupported type: " + parameter.getClass());
             }
         }
 
@@ -295,7 +295,7 @@ public class TornadoExecutionContext {
             apply(task -> task.mapTo(tornadoDevice));
             Arrays.fill(taskToDeviceMapTable, tornadoDevice);
         } else {
-            throw new TornadoRuntimeException(STR."Device \{tornadoDevice.getClass()} not supported yet");
+            throw new TornadoRuntimeException("Device " + tornadoDevice.getClass() + " not supported yet");
         }
     }
 
@@ -323,7 +323,7 @@ public class TornadoExecutionContext {
         if (target instanceof TornadoXPUDevice tornadoAcceleratorDevice) {
             accelerator = tornadoAcceleratorDevice;
         } else {
-            throw new TornadoRuntimeException(STR."Device \{target.getClass()} not supported yet");
+            throw new TornadoRuntimeException("Device " + target.getClass() + " not supported yet");
         }
 
         setDevice(accelerator);
@@ -507,7 +507,7 @@ public class TornadoExecutionContext {
     }
 
     private String canonicalizeId(String id) {
-        return id.startsWith(getId()) ? id : STR."\{getId()}.\{id}";
+        return id.startsWith(getId()) ? id : getId() + "." + id;
     }
 
     public TornadoXPUDevice getDeviceForTask(String id) {
@@ -516,7 +516,7 @@ public class TornadoExecutionContext {
         if (device instanceof TornadoXPUDevice) {
             tornadoDevice = (TornadoXPUDevice) device;
         } else {
-            throw new RuntimeException(STR."Device \{device.getClass()} not supported yet");
+            throw new RuntimeException("Device " + device.getClass() + " not supported yet");
         }
         return getTask(id) == null ? null : tornadoDevice;
     }
@@ -610,27 +610,28 @@ public class TornadoExecutionContext {
         final String ansiPurple = "\u001B[35m";
         final String ansiGreen = "\u001B[32m";
         System.out.println("-----------------------------------");
-        System.out.println(STR."\{ansiCyan}Device Table:\{ansiReset}");
+        System.out.println(ansiCyan + "Device Table:" + ansiReset);
         for (int i = 0; i < devices.size(); i++) {
             System.out.printf("[%d]: %s\n", i, devices.get(i));
         }
 
-        System.out.println(STR."\{ansiYellow}Constant Table:\{ansiReset}");
+        System.out.println(ansiYellow + "Constant Table:" + ansiReset);
         for (int i = 0; i < constants.size(); i++) {
             System.out.printf("[%d]: %s\n", i, constants.get(i));
         }
 
-        System.out.println(STR."\{ansiPurple}Object Table:\{ansiReset}");
+        System.out.println(ansiPurple + "Object Table:" + ansiReset);
         for (int i = 0; i < objects.size(); i++) {
             final Object obj = objects.get(i);
             System.out.printf("[%d]: 0x%x %s\n", i, obj.hashCode(), obj);
         }
 
-        System.out.println(STR."\{ansiGreen}Task Table:\{ansiReset}");
+        System.out.println(ansiGreen + "Task Table:" + ansiReset);
         for (int i = 0; i < tasks.size(); i++) {
             final SchedulableTask task = tasks.get(i);
             System.out.printf("[%d]: %s\n", i, task.getFullName());
         }
+
         System.out.println("-----------------------------------");
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
@@ -180,7 +180,7 @@ public class TornadoVMGraphCompiler {
                                 tornadoVMBytecodeBuilder.emitAsyncNode(asyncNode, (dependencies[i].isEmpty()) ? -1 : depLists[i], offset, bufferBatchSize, nThreads);
                             } catch (BufferOverflowException e) {
                                 throw new TornadoRuntimeException(
-                                        STR."[ERROR] Buffer Overflow exception. Use -Dtornado.tvm.maxbytecodesize=<value> with value > \{TornadoVMBytecodeBuilder.MAX_TORNADO_VM_BYTECODE_SIZE} to increase the buffer code size");
+                                        "[ERROR] Buffer Overflow exception. Use -Dtornado.tvm.maxbytecodesize=<value> with value > " + TornadoVMBytecodeBuilder.MAX_TORNADO_VM_BYTECODE_SIZE + " to increase the buffer code size");
                             }
                         }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -249,7 +249,7 @@ public class TornadoVMInterpreter {
         interpreterDevice.enableThreadSharing();
 
         if (isMemoryLimitEnabled() && executionContext.doesExceedExecutionPlanLimit()) {
-            throw new TornadoMemoryException(STR."OutofMemoryException due to executionPlan.withMemoryLimit of \{executionContext.getExecutionPlanMemoryLimit()}");
+            throw new TornadoMemoryException("OutofMemoryException due to executionPlan.withMemoryLimit of " + executionContext.getExecutionPlanMemoryLimit());
         }
 
         final long t0 = System.nanoTime();
@@ -404,8 +404,7 @@ public class TornadoVMInterpreter {
             objectStates[i] = resolveObjectState(args[i]);
 
             if (TornadoOptions.PRINT_BYTECODES) {
-                String verbose = String.format(STR."bc: \{InterpreterUtilities.debugHighLightBC("ALLOC")}%s on %s, size=%d", objects[i], InterpreterUtilities.debugDeviceBC(interpreterDevice),
-                        sizeBatch);
+                String verbose = String.format("bc: %s%s on %s, size=%d", InterpreterUtilities.debugHighLightBC("ALLOC"), objects[i], InterpreterUtilities.debugDeviceBC(interpreterDevice), sizeBatch);
                 tornadoVMBytecodeList.append(verbose).append("\n");
             }
         }
@@ -428,8 +427,7 @@ public class TornadoVMInterpreter {
         Object object = objects.get(objectIndex);
 
         if (TornadoOptions.PRINT_BYTECODES && isNotObjectAtomic(object)) {
-            String verbose = String.format(STR."bc: \{InterpreterUtilities.debugHighLightBC("DEALLOC")}[0x%x] %s on %s", object.hashCode(), object, InterpreterUtilities.debugDeviceBC(
-                    interpreterDevice));
+            String verbose = String.format("bc: %s[0x%x] %s on %s", InterpreterUtilities.debugHighLightBC("DEALLOC"), object.hashCode(), object, InterpreterUtilities.debugDeviceBC(interpreterDevice));
             tornadoVMBytecodeList.append(verbose).append("\n");
 
         }
@@ -939,7 +937,8 @@ public class TornadoVMInterpreter {
 
         static void logTransferToDeviceAlways(Object object, TornadoXPUDevice deviceForInterpreter, long sizeBatch, long offset, final int eventList,
                                               StringBuilder tornadoVMBytecodeList) {
-            String verbose = String.format(STR."bc: \{InterpreterUtilities.debugHighLightBC("TRANSFER_HOST_TO_DEVICE_ALWAYS")} [0x%x] %s on %s, size=%d, offset=%d [event list=%d]", //
+            String verbose = String.format("bc: %s [0x%x] %s on %s, size=%d, offset=%d [event list=%d]",
+                    InterpreterUtilities.debugHighLightBC("TRANSFER_HOST_TO_DEVICE_ALWAYS"), //
                     object.hashCode(), //
                     object, //
                     InterpreterUtilities.debugDeviceBC(deviceForInterpreter), //

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
@@ -142,12 +142,12 @@ public class TornadoSketcher {
         Builder builder = new Builder(getOptions(), getDebugContext(), AllowAssumptions.YES);
         builder.method(resolvedMethod);
         builder.compilationId(id);
-        builder.name(STR."sketch-\{resolvedMethod.getName()}");
+        builder.name("sketch-" + resolvedMethod.getName());
         final StructuredGraph graph = builder.build();
 
         // Check legal Kernel Name
         if (OCLTokens.openCLTokens.contains(resolvedMethod.getName())) {
-            throw new TornadoRuntimeException(STR."[ERROR] Java method name corresponds to an OpenCL Token. Change the Java method's name: \{resolvedMethod.getName()}");
+            throw new TornadoRuntimeException("[ERROR] Java method name corresponds to an OpenCL Token. Change the Java method's name: " + resolvedMethod.getName());
         }
 
         try (DebugContext.Scope ignored = getDebugContext().scope("Tornado-Sketcher", new DebugDumpScope("Tornado-Sketcher")); DebugCloseable ignored1 = Sketcher.start(getDebugContext())) {
@@ -166,8 +166,7 @@ public class TornadoSketcher {
             graph.getInvokes() //
                     .forEach(invoke -> { //
                         if (OCLTokens.openCLTokens.contains(invoke.callTarget().targetMethod().getName())) {
-                            throw new TornadoRuntimeException(
-                                    STR."[ERROR] Java method name corresponds to an OpenCL Token. Change the Java method's name: \{invoke.callTarget().targetMethod().getName()}");
+                            throw new TornadoRuntimeException("[ERROR] Java method name corresponds to an OpenCL Token. Change the Java method's name: " + invoke.callTarget().targetMethod().getName());
                         }
                         SketchRequest newRequest = new SketchRequest(invoke.callTarget().targetMethod(), providers, graphBuilderSuite, sketchTier, backendIndex, deviceIndex);
                         buildSketch(newRequest);
@@ -187,7 +186,7 @@ public class TornadoSketcher {
             if (TornadoOptions.DEBUG) {
                 e.printStackTrace();
             }
-            throw new TornadoBailoutRuntimeException(STR."Unable to build sketch for method: \{resolvedMethod.getName()}(\{e.getMessage()})");
+            throw new TornadoBailoutRuntimeException("Unable to build sketch for method: " + resolvedMethod.getName() + " (" + e.getMessage() + ")");
         }
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
@@ -86,12 +86,12 @@ public class CompilableTask implements SchedulableTask {
 
     @Override
     public String getFullName() {
-        return STR."task \{meta.getId()} - \{method.getName()}";
+        return "task " + meta.getId() + " - " + method.getName();
     }
 
     @Override
     public String getNormalizedName() {
-        return STR."\{meta.getId()}.\{method.getName()}";
+        return meta.getId() + "." + method.getName();
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/LocalObjectState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/LocalObjectState.java
@@ -121,6 +121,6 @@ public class LocalObjectState {
 
     @Override
     public String toString() {
-        return STR."\{streamIn ? "SIN" : "--"}\{streamOut ? "SOUT" : "--"} \{dataObjectState} ";
+        return (streamIn ? "SIN" : "--") + (streamOut ? "SOUT" : "--") + " " + dataObjectState;
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
@@ -129,12 +129,12 @@ public class PrebuiltTask implements SchedulableTask {
 
     @Override
     public String getFullName() {
-        return STR."task - \{meta.getId()}[\{entryPoint}]";
+        return "task - " + meta.getId() + "[" + entryPoint + "]";
     }
 
     @Override
     public String getNormalizedName() {
-        return STR."\{meta.getId()}.\{entryPoint}";
+        return meta.getId() + "." + entryPoint;
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/ReduceTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/ReduceTaskGraph.java
@@ -172,7 +172,7 @@ class ReduceTaskGraph {
     }
 
     private static void inspectBinariesFPGA(String taskScheduleName, String graphName, String taskName, boolean sequential) {
-        String idTaskGraph = STR."\{graphName}.\{taskName}";
+        String idTaskGraph = graphName + "." + taskName;
         StringBuilder originalBinaries = TornadoOptions.FPGA_BINARIES;
         if (originalBinaries != null) {
             String[] binaries = originalBinaries.toString().split(",");
@@ -189,13 +189,13 @@ class ReduceTaskGraph {
             for (int i = 0; i < binaries.length; i += 2) {
                 String givenTaskName = binaries[i + 1].split(".device")[0];
                 if (givenTaskName.equals(idTaskGraph)) {
-                    int[] info = MetaDataUtils.resolveDriverDeviceIndexes(MetaDataUtils.getProperty(STR."\{idTaskGraph}.device"));
+                    int[] info = MetaDataUtils.resolveDriverDeviceIndexes(MetaDataUtils.getProperty(idTaskGraph + ".device"));
                     int deviceNumber = info[1];
 
                     if (!sequential) {
-                        originalBinaries.append(STR.",\{binaries[i]},\{taskScheduleName}.\{taskName}.device=0:\{deviceNumber}");
+                        originalBinaries.append("," + binaries[i] + "," + taskScheduleName + "." + taskName + ".device=0:" + deviceNumber);
                     } else {
-                        originalBinaries.append(STR.",\{binaries[i]},\{taskScheduleName}.\{SEQUENTIAL_TASK_REDUCE_NAME}\{counterSeqName}.device=0:\{deviceNumber}");
+                        originalBinaries.append("," + binaries[i] + "," + taskScheduleName + "." + SEQUENTIAL_TASK_REDUCE_NAME + counterSeqName + ".device=0:" + deviceNumber);
                     }
                 }
             }
@@ -208,13 +208,14 @@ class ReduceTaskGraph {
     }
 
     private int[] changeDriverAndDeviceIfNeeded(String taskScheduleName, String graphName, String taskName) {
-        String idTaskGraph = STR."\{graphName}.\{taskName}";
-        boolean isDeviceDefined = MetaDataUtils.getProperty(STR."\{idTaskGraph}.device") != null;
+        String idTaskGraph = graphName + "." + taskName;
+        boolean isDeviceDefined = MetaDataUtils.getProperty(idTaskGraph + ".device") != null;
+
         if (isDeviceDefined) {
-            int[] info = MetaDataUtils.resolveDriverDeviceIndexes(MetaDataUtils.getProperty(STR."\{idTaskGraph}.device"));
+            int[] info = MetaDataUtils.resolveDriverDeviceIndexes(MetaDataUtils.getProperty(idTaskGraph + ".device"));
             int driverNumber = info[0];
             int deviceNumber = info[1];
-            TornadoRuntimeProvider.setProperty(STR."\{taskScheduleName}.\{taskName}.device", STR."\{driverNumber}:\{deviceNumber}");
+            TornadoRuntimeProvider.setProperty(taskScheduleName + "." + taskName + ".device", driverNumber + ":" + deviceNumber);
             return info;
         }
         return null;
@@ -369,8 +370,8 @@ class ReduceTaskGraph {
     private void updateGlobalAndLocalDimensionsFPGA(final int deviceToRun, String taskScheduleReduceName, TaskPackage taskPackage, int inputSize) {
         // Update GLOBAL and LOCAL workgroup size if device to run is the FPGA
         if (isAheadOfTime() && isDeviceAnAccelerator(deviceToRun)) {
-            TornadoRuntimeProvider.setProperty(STR."\{taskScheduleReduceName}.\{taskPackage.getId()}\{TaskMetaData.GLOBAL_WORKGROUP_SUFFIX}", Integer.toString(inputSize));
-            TornadoRuntimeProvider.setProperty(STR."\{taskScheduleReduceName}.\{taskPackage.getId()}\{TaskMetaData.LOCAL_WORKGROUP_SUFFIX}", "64");
+            TornadoRuntimeProvider.setProperty(taskScheduleReduceName + "." + taskPackage.getId() + TaskMetaData.GLOBAL_WORKGROUP_SUFFIX, Integer.toString(inputSize));
+            TornadoRuntimeProvider.setProperty(taskScheduleReduceName + "." + taskPackage.getId() + TaskMetaData.LOCAL_WORKGROUP_SUFFIX, "64");
         }
     }
 
@@ -568,8 +569,8 @@ class ReduceTaskGraph {
                     int sizeReduceArray = sizesReductionArray.get(i);
                     for (REDUCE_OPERATION operation : operations) {
                         final String newTaskSequentialName = SEQUENTIAL_TASK_REDUCE_NAME + counterSeqName.get();
-                        String fullName = STR."\{rewrittenTaskGraph.getTaskGraphName()}.\{newTaskSequentialName}";
-                        TornadoRuntimeProvider.setProperty(STR."\{fullName}.device", driverToRun + ":" + deviceToRun);
+                        String fullName = rewrittenTaskGraph.getTaskGraphName() + "." + newTaskSequentialName;
+                        TornadoRuntimeProvider.setProperty(fullName + ".device", driverToRun + ":" + deviceToRun);
                         inspectBinariesFPGA(taskScheduleReduceName, graphName, taskPackage.getId(), true);
 
                         switch (operation) {
@@ -614,7 +615,7 @@ class ReduceTaskGraph {
                     continue;
                 }
                 if (!rewrittenTaskGraph.getArgumentsLookup().contains(parameter)) {
-                    throw new TornadoTaskRuntimeException(STR."Parameter #\{i} <\{parameter}> from task <\{task.getId()}> not specified either in `transferToDevice` or `transferToHost` functions");
+                    throw new TornadoTaskRuntimeException("Parameter #" + i + " <" + parameter + "> from task <" + task.getId() + "> not specified either in `transferToDevice` or `transferToHost` functions");
                 }
             }
         }
@@ -736,7 +737,7 @@ class ReduceTaskGraph {
             case FloatArray panamaFloatArray -> ((FloatArray) originalReduceVariable).set(0, panamaFloatArray.get(0));
             case DoubleArray panamaDoubleArray -> ((DoubleArray) originalReduceVariable).set(0, panamaDoubleArray.get(0));
             case LongArray panamaLongArray -> ((LongArray) originalReduceVariable).set(0, panamaLongArray.get(0));
-            default -> new TornadoRuntimeException(STR."[ERROR] Reduce data type not supported yet: \{newArray.getClass().getTypeName()}");
+            default -> throw new TornadoRuntimeException("[ERROR] Reduce data type not supported yet: " + newArray.getClass().getTypeName());
         }
     }
 
@@ -782,7 +783,7 @@ class ReduceTaskGraph {
                 long bnl = panamaLongArray.get(0);
                 ((LongArray) originalReduceVariable).set(0, operateFinalReduction(anl, bnl, hybridMergeTable.get(panamaLongArray)));
             }
-            default -> new TornadoRuntimeException(STR."[ERROR] Reduce data type not supported yet: \{newArray.getClass().getTypeName()}");
+            default -> throw new TornadoRuntimeException("[ERROR] Reduce data type not supported yet: " + newArray.getClass().getTypeName());
         }
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -290,7 +290,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                         inputObjects.get(14));
                 break;
             default:
-                System.out.println(STR."COPY-IN Not supported yet: \{numObjectsCopyIn}");
+                System.out.println("COPY-IN Not supported yet: " + numObjectsCopyIn);
                 break;
         }
     }
@@ -358,7 +358,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                         outputArrays.get(7), outputArrays.get(8), outputArrays.get(9), outputArrays.get(10), outputArrays.get(11), outputArrays.get(12), outputArrays.get(13), outputArrays.get(14));
                 break;
             default:
-                System.out.println(STR."COPY-OUT Not supported yet: \{numObjectsCopyOut}");
+                System.out.println("COPY-OUT Not supported yet: " + numObjectsCopyOut);
                 break;
         }
     }
@@ -673,7 +673,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         if ((task.getTaskName() != null) && (task.getId() != null)) {
             String methodName = (task instanceof PrebuiltTask prebuiltTask)
                     ? prebuiltTask.getFilename()
-                    : STR."\{((CompilableTask) task).getMethod().getDeclaringClass().getSimpleName()}.\{task.getTaskName()}";
+                    : ((CompilableTask) task).getMethod().getDeclaringClass().getSimpleName() + "." + task.getTaskName();
             timeProfiler.registerMethodHandle(ProfilerType.METHOD, task.getId(), methodName);
         }
 
@@ -852,11 +852,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     private void dumpDeoptimisationReason(TornadoBailoutRuntimeException e) {
         if (!TornadoOptions.DEBUG) {
-            System.err.println(STR."\{RED}[Bailout] Running the sequential implementation. Enable --debug to see the reason.\{RESET}");
+            System.err.println(RED + "[Bailout] Running the sequential implementation. Enable --debug to see the reason." + RESET);
         } else {
             System.err.println(e.getMessage());
             for (StackTraceElement s : e.getStackTrace()) {
-                System.err.println(STR."\t\{s}");
+                System.err.println("\t" + s);
             }
         }
     }
@@ -885,7 +885,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 if (TornadoOptions.DEBUG) {
                     e.printStackTrace();
                 }
-                throw new TornadoBailoutRuntimeException(STR."Bailout is disabled. \nReason: \{e.getMessage()}");
+                throw new TornadoBailoutRuntimeException("Bailout is disabled. \nReason: " + e.getMessage());
             }
         }
 
@@ -938,7 +938,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     public void transferToDevice(final int mode, Object... objects) {
         for (Object parameter : objects) {
             if (parameter == null) {
-                throw new TornadoRuntimeException(STR."[ERROR] null object passed into streamIn() in schedule \{executionContext.getId()}");
+                throw new TornadoRuntimeException("[ERROR] null object passed into streamIn() in schedule " + executionContext.getId());
             }
 
             if (parameter instanceof Number) {
@@ -1311,7 +1311,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                     continue;
                 }
                 if (!argumentsLookUp.contains(parameter)) {
-                    throw new TornadoTaskRuntimeException(STR."Parameter #\{i} <\{parameter}> from task <\{task.getId()}> not specified either in transferToDevice or transferToHost functions");
+                    throw new TornadoTaskRuntimeException("Parameter #" + i + " <" + parameter + "> from task <" + task.getId() + "> not specified either in transferToDevice or transferToHost functions");
                 }
             }
         }
@@ -1425,7 +1425,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     private boolean isTaskNamePresent(String taskName) {
         for (TaskPackage taskPackage : taskPackages) {
-            if (taskName.equals(STR."\{taskGraphName}.\{taskPackage.getId()}")) {
+            if (taskName.equals(taskGraphName + "." + taskPackage.getId())) {
                 return true;
             }
         }
@@ -1436,7 +1436,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         Set<String> gridTaskNames = gridScheduler.keySet();
         for (String gridName : gridTaskNames) {
             if (!isTaskNamePresent(gridName)) {
-                throw new TornadoRuntimeException(STR."[ERROR] Grid scheduler with name \{gridName} not found in the Task-Graph");
+                throw new TornadoRuntimeException("[ERROR] Grid scheduler with name " + gridName + " not found in the Task-Graph");
             }
         }
 
@@ -1532,7 +1532,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                         taskPackage.getTaskParameters()[13], taskPackage.getTaskParameters()[14], taskPackage.getTaskParameters()[15]);
                 break;
             default:
-                throw new TornadoRuntimeException(STR."Sequential Runner not supported yet. Number of parameters: \{type}");
+                throw new TornadoRuntimeException("Sequential Runner not supported yet. Number of parameters: " + type);
         }
     }
 
@@ -1558,7 +1558,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 deviceWinnerIndex = position;
                 break;
             default:
-                throw new TornadoDynamicReconfigurationException(STR."Policy \{policy} not defined yet");
+                throw new TornadoDynamicReconfigurationException("Policy " + policy + " not defined yet");
         }
 
         return deviceWinnerIndex;
@@ -1576,7 +1576,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 isAlive = threads[i].isAlive();
                 if (!isAlive) {
                     if (TornadoOptions.DEBUG) {
-                        System.out.println(STR."SELECTED Thread-Device: \{threads[i].getName()} ");
+                        System.out.println("SELECTED Thread-Device: " + threads[i].getName() + " ");
                     }
                     winner = i;
                     join = new Thread(() -> {
@@ -1618,7 +1618,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             runAllTasksJavaSequential();
             final long endSequentialCode = timer.time();
             if (TornadoOptions.DEBUG) {
-                System.out.println(STR."Seq finished: \{Thread.currentThread().getName()}");
+                System.out.println("Seq finished: " + Thread.currentThread().getName());
             }
 
             totalTimers[indexSequential] = (endSequentialCode - start);
@@ -1632,7 +1632,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 String newTaskScheduleName = TASK_GRAPH_PREFIX + taskScheduleNumber;
                 TaskGraph task = new TaskGraph(newTaskScheduleName);
 
-                Thread.currentThread().setName(STR."Thread-DEV: \{TornadoRuntimeProvider.getTornadoRuntime().getBackend(0).getDevice(taskScheduleNumber).getPhysicalDevice().getDeviceName()}");
+                Thread.currentThread().setName("Thread-DEV: " + TornadoRuntimeProvider.getTornadoRuntime().getBackend(0).getDevice(taskScheduleNumber).getPhysicalDevice().getDeviceName());
 
                 for (StreamingObject streamingObject : inputModesObjects) {
                     performStreamInObject(task, streamingObject.object, streamingObject.mode);
@@ -1640,9 +1640,9 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
                 for (TaskPackage taskPackage : taskPackages) {
                     String taskID = taskPackage.getId();
-                    TornadoRuntimeProvider.setProperty(STR."\{newTaskScheduleName}.\{taskID}.device", STR."0:\{taskScheduleNumber}");
+                    TornadoRuntimeProvider.setProperty(newTaskScheduleName + "." + taskID + ".device", "0:" + taskScheduleNumber);
                     if (TornadoOptions.DEBUG) {
-                        System.out.println(STR."SET DEVICE: \{newTaskScheduleName}.\{taskID}.device=0:\{taskScheduleNumber}");
+                        System.out.println("SET DEVICE: " + newTaskScheduleName + "." + taskID + ".device=0:" + taskScheduleNumber);
                     }
                     task.addTask(taskPackage);
                 }
@@ -1724,7 +1724,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             policyTimeTable.put(policy, deviceWinnerIndex);
             if (TornadoOptions.DEBUG) {
                 System.out.println(getListDevices());
-                System.out.println(STR."BEST Position: #\{deviceWinnerIndex} \{Arrays.toString(totalTimers)}");
+                System.out.println("BEST Position: #" + deviceWinnerIndex + " " + Arrays.toString(totalTimers));
             }
         }
     }
@@ -1742,7 +1742,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         performStreamInObject(taskToCompile, streamInObjects, DataTransferMode.EVERY_EXECUTION);
         for (TaskPackage taskPackage : taskPackages) {
             String taskID = taskPackage.getId();
-            TornadoRuntimeProvider.setProperty(STR."\{newTaskScheduleName}.\{taskID}.device", STR."0:\{deviceWinnerIndex}");
+            TornadoRuntimeProvider.setProperty(newTaskScheduleName + "." + taskID + ".device", "0:" + deviceWinnerIndex);
             taskToCompile.addTask(taskPackage);
         }
         performStreamOutThreads(DataTransferMode.EVERY_EXECUTION, taskToCompile, streamOutObjects);
@@ -1751,10 +1751,10 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     private void runTaskGraphParallelSelected(int deviceWinnerIndex) {
         for (TaskPackage taskPackage : taskPackages) {
-            TornadoRuntimeProvider.setProperty(STR."\{this.getTaskGraphName()}.\{taskPackage.getId()}.device", STR."0:\{deviceWinnerIndex}");
+            TornadoRuntimeProvider.setProperty(this.getTaskGraphName() + "." + taskPackage.getId() + ".device", "0:" + deviceWinnerIndex);
         }
         if (TornadoOptions.DEBUG) {
-            System.out.println(STR."Running in parallel device: \{deviceWinnerIndex}");
+            System.out.println("Running in parallel device: " + deviceWinnerIndex);
         }
         TaskGraph task = taskGraphIndex.get(deviceWinnerIndex);
         if (task == null) {
@@ -1857,7 +1857,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             for (TaskPackage taskPackage : taskPackages) {
                 String taskID = taskPackage.getId();
 
-                String name = STR."\{newTaskScheduleName}.\{taskID}";
+                String name = newTaskScheduleName + "." + taskID;
                 for (String s : ignoreTaskNames) {
                     if (s.equals(name)) {
                         totalTimers[taskNumber] = Long.MAX_VALUE;
@@ -1866,9 +1866,9 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                     }
                 }
 
-                TornadoRuntimeProvider.setProperty(STR."\{newTaskScheduleName}.\{taskID}.device", "0:" + taskNumber);
+                TornadoRuntimeProvider.setProperty(newTaskScheduleName + "." + taskID + ".device", "0:" + taskNumber);
                 if (TornadoOptions.DEBUG) {
-                    System.out.println(STR."SET DEVICE: \{newTaskScheduleName}.\{taskID}.device=0:\{taskNumber}");
+                    System.out.println("SET DEVICE: " + newTaskScheduleName + "." + taskID + ".device=0:" + taskNumber);
                 }
                 task.addTask(taskPackage);
             }
@@ -1982,7 +1982,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
             if (TornadoOptions.DEBUG) {
                 System.out.println(getListDevices());
-                System.out.println(STR."BEST Position: #\{deviceWinnerIndex} \{Arrays.toString(totalTimers)}");
+                System.out.println("BEST Position: #" + deviceWinnerIndex + " " + Arrays.toString(totalTimers));
             }
         }
     }
@@ -2130,7 +2130,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                                 parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14], parameters[15]));
                 break;
             default:
-                throw new TornadoRuntimeException(STR."Task not supported yet. Type: \{type}");
+                throw new TornadoRuntimeException("Task not supported yet. Type: " + type);
         }
     }
 
@@ -2194,7 +2194,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                         parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14], parameters[15]));
                 break;
             default:
-                throw new TornadoRuntimeException(STR."Task not supported yet. Type: \{type}");
+                throw new TornadoRuntimeException("Task not supported yet. Type: " + type);
         }
     }
 
@@ -2288,7 +2288,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         return switch (Objects.requireNonNull(units)) {
             case "MB" -> value * 1_000_000;
             case "GB" -> value * 1_000_000_000;
-            default -> throw new TornadoRuntimeException(STR + "Units not supported: " + units);
+            default -> throw new TornadoRuntimeException("Units not supported: " + units);
         };
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
@@ -50,17 +50,17 @@ public class TaskMetaData extends AbstractMetaData {
     private final byte[] constantData;
     private final ScheduleMetaData scheduleMetaData;
     private final int constantSize;
+    private final int localSize;
     protected Access[] argumentsAccess;
     protected DomainTree domain;
     private long[] globalOffset;
     private long[] globalWork;
-    private final int localSize;
     private long[] localWork;
     private boolean localWorkDefined;
     private boolean globalWorkDefined;
 
     public TaskMetaData(ScheduleMetaData scheduleMetaData, String taskID, int numParameters) {
-        super(STR."\{scheduleMetaData.getId()}.\{taskID}", scheduleMetaData);
+        super(scheduleMetaData.getId() + "." + taskID, scheduleMetaData);
         this.scheduleMetaData = scheduleMetaData;
         this.constantSize = 0;
         this.localSize = 0;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
@@ -306,25 +306,28 @@ public class TaskMetaData extends AbstractMetaData {
     public void printThreadDims() {
         StringBuilder deviceDebug = new StringBuilder();
         boolean deviceBelongsToPTX = isPTXDevice(getLogicDevice());
-        deviceDebug.append(STR."Task info: \{getId()}\n");
-        deviceDebug.append(STR."\tBackend           : \{getLogicDevice().getTornadoVMBackend().name()}\n");
-        deviceDebug.append(STR."\tDevice            : \{getLogicDevice().getDescription()}\n");
-        deviceDebug.append(STR."\tDims              : \{this.isWorkerGridAvailable() ? getWorkerGrid(getId()).dimension() : (hasDomain() ? domain.getDepth() : 0)}\n");
+        deviceDebug.append("Task info: " + getId() + "\n");
+        deviceDebug.append("\tBackend           : " + getLogicDevice().getTornadoVMBackend().name() + "\n");
+        deviceDebug.append("\tDevice            : " + getLogicDevice().getDescription() + "\n");
+        deviceDebug.append("\tDims              : " + (this.isWorkerGridAvailable() ? getWorkerGrid(getId()).dimension() : (hasDomain() ? domain.getDepth() : 0)) + "\n");
+
         if (!deviceBelongsToPTX) {
             long[] go = this.isWorkerGridAvailable() ? getWorkerGrid(getId()).getGlobalOffset() : globalOffset;
-            deviceDebug.append(STR."\tGlobal work offset: \{formatWorkDimensionArray(go, "0")}\n");
+            deviceDebug.append("\tGlobal work offset: " + formatWorkDimensionArray(go, "0") + "\n");
         }
+
         long[] gw = this.isWorkerGridAvailable() ? getWorkerGrid(getId()).getGlobalWork() : globalWork;
+
         if (deviceBelongsToPTX) {
-            deviceDebug.append(STR."\tThread dimensions : \{formatWorkDimensionArray(gw, "1")}\n");
-            deviceDebug.append(STR."\tBlocks dimensions : \{formatWorkDimensionArray(getPTXBlockDim(), "1")}\n");
-            deviceDebug.append(STR."\tGrids dimensions  : \{formatWorkDimensionArray(getPTXGridDim(), "1")}\n");
+            deviceDebug.append("\tThread dimensions : " + formatWorkDimensionArray(gw, "1") + "\n");
+            deviceDebug.append("\tBlocks dimensions : " + formatWorkDimensionArray(getPTXBlockDim(), "1") + "\n");
+            deviceDebug.append("\tGrids dimensions  : " + formatWorkDimensionArray(getPTXGridDim(), "1") + "\n");
         } else {
             long[] lw = this.isWorkerGridAvailable() ? getWorkerGrid(getId()).getLocalWork() : localWork;
             long[] nw = this.isWorkerGridAvailable() ? getWorkerGrid(getId()).getNumberOfWorkgroups() : (hasDomain() ? calculateNumberOfWorkgroupsFromDomain(domain) : null);
-            deviceDebug.append(STR."\tGlobal work size  : \{formatWorkDimensionArray(gw, "1")}\n");
-            deviceDebug.append(STR."\tLocal  work size  : \{lw == null ? "null" : formatWorkDimensionArray(lw, "1")}\n");
-            deviceDebug.append(STR."\tNumber of workgroups  : \{nw == null ? "null" : formatWorkDimensionArray(nw, "1")}\n");
+            deviceDebug.append("\tGlobal work size  : " + formatWorkDimensionArray(gw, "1") + "\n");
+            deviceDebug.append("\tLocal  work size  : " + (lw == null ? "null" : formatWorkDimensionArray(lw, "1")) + "\n");
+            deviceDebug.append("\tNumber of workgroups  : " + (nw == null ? "null" : formatWorkDimensionArray(nw, "1")) + "\n");
         }
         System.out.println(deviceDebug);
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -89,7 +89,7 @@ public abstract class TornadoTestBase {
                 case PTX -> throw new TornadoVMPTXNotSupported(customBackendAssertionMessage != null ? customBackendAssertionMessage : "Test not supported for the PTX backend");
                 case OPENCL -> throw new TornadoVMOpenCLNotSupported(customBackendAssertionMessage != null ? customBackendAssertionMessage : "Test not supported for the OpenCL backend");
                 case SPIRV -> throw new TornadoVMSPIRVNotSupported(customBackendAssertionMessage != null ? customBackendAssertionMessage : "Test not supported for the SPIR-V backend");
-                default -> throw new IllegalStateException(STR."Unexpected value for backend: \{backend}");
+                default -> throw new IllegalStateException("Unexpected value for backend: " + backend);
             }
         }
     }


### PR DESCRIPTION
#### Description

Reverse the usage of String templates as they are going to be removed from JDK23.
#### Problem description

If the patch provides a fix for a bug, please describe what was the issue and how to reproduce the issue.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
make jdk21 
```
----------------------------------------------------------------------------
