### PR TITLE
[spirv] flag to be able to run with prev. versions of SPIR-V 1.2

### DIFF
--- a/docs/source/spirv-backend.rst
+++ b/docs/source/spirv-backend.rst
@@ -23,7 +23,7 @@ To build the SPIR-V Backend, enable the backend as follows:
 .. code:: bash
 
    $ cd <tornadovm-directory>
-   $ ./scripts/tornadovm-installer --jdk jdk21 --backend=spirv
+   $ ./bin/tornadovm-installer --jdk jdk21 --backend=spirv
    $ . setvars.sh
 
 Running examples with the SPIR-V backend

--- a/docs/source/spirv-backend.rst
+++ b/docs/source/spirv-backend.rst
@@ -23,8 +23,8 @@ To build the SPIR-V Backend, enable the backend as follows:
 .. code:: bash
 
    $ cd <tornadovm-directory>
-   $ ./scripts/tornadoVMInstaller.sh --jdk17 --spirv
-   $ . source.sh
+   $ ./scripts/tornadovm-installer --jdk jdk21 --backend=spirv
+   $ . setvars.sh
 
 Running examples with the SPIR-V backend
 ------------------------------------------
@@ -62,6 +62,18 @@ Note: Usually, ``spirv-dis`` can be installed from the common OS repositories (e
 
    ## Ubuntu OS:
    sudo apt-get install spirv-tools
+
+
+TornadoVM/Java Options for SPIR-V:
+''''''''''''''''''''''''''''''
+
+- ``-Dtornado.spirv.version=1.2``: Modify the minimum version supported. By default is 1.2. However, developers can change this value. Note that the generated code might not work, as TornadoVM requires at least 1.2.
+
+- ``-Dtornado.spirv.dispatcher=opencl``: It sets the runtime to dispatch SPIR-V kernels. Allowed values are: ``opencl`` and ``levelzero``.
+
+- ``-Dtornado.spirv.levelzero.extended.memory=True``: It uses Level Zero extended memory mode. It is set to ``true`` by default. 
+
+
 
 Disassemble the SPIR-V binary:
 ''''''''''''''''''''''''''''''

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDevice.java
@@ -39,6 +39,7 @@ import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceInfo;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLLocalMemType;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public class OCLDevice implements OCLTargetDevice {
 
@@ -79,7 +80,7 @@ public class OCLDevice implements OCLTargetDevice {
 
     private static final int SPIRV_VERSION_INIT = -1;
     private static final int SPIRV_NOT_SUPPORTED = -2;
-    private static final float SPIRV_SUPPPORTED = 1.2f;
+    private static final float SPIRV_SUPPPORTED = TornadoOptions.SPIRV_VERSION_SUPPORTED;
 
     public OCLDevice(int index, long devicePointer) {
         this.index = index;
@@ -470,7 +471,7 @@ public class OCLDevice implements OCLTargetDevice {
                     String v = version.split("_")[1];
                     try {
                         spirvVersion = Float.parseFloat(v);
-                        return spirvVersion >= 1.2;
+                        return spirvVersion >= SPIRV_SUPPPORTED;
                     } catch (NumberFormatException e) {
                     }
                 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
@@ -146,6 +146,17 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
 
     @Override
     public void setDefaultDevice(int index) {
+        swapDefaultDevice(index);
+    }
+
+    private void swapDefaultDevice(final int device) {
+        SPIRVBackend tmp = flatBackends[0];
+        flatBackends[0] = flatBackends[device];
+        flatBackends[device] = tmp;
+        SPIRVBackend backend = flatBackends[0];
+        if (!backend.isInitialised()) {
+            backend.init();
+        }
     }
 
     private int getNumDevicesForPlatform(int platform) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -217,6 +217,11 @@ public class TornadoOptions {
      * generated SPIRV kernel.
      */
     public static final boolean SPIRV_DIRECT_CALL_WITH_LOAD_HEAP = getBooleanValue("tornado.spirv.directcall.heap", FALSE);
+
+    /**
+     * Set the SPIR-V Version Supported. It is set to 1.2 by default.
+     */
+    public static final float SPIRV_VERSION_SUPPORTED = getFloatValue("tornado.spirv.version", "1.2");
     /**
      * Trace code generation.
      */
@@ -403,6 +408,10 @@ public class TornadoOptions {
 
     private static int getIntValue(String property, String defaultValue) {
         return Integer.parseInt(System.getProperty(property, defaultValue));
+    }
+
+    private static float getFloatValue(String property, String defaultValue) {
+        return Float.parseFloat(System.getProperty(property, defaultValue));
     }
 
     private static boolean isFPGAEmulation() {


### PR DESCRIPTION
#### Description

This PR adds a flag to indicate TornadoVM to use a device with SPIR-V < 1.2. 
By default is 1.2, and this is the minimum required, as OpenCL Intel and Level Zero implementations requires this version of SPIR-V. However, there are other implementation (e.g., Codeplay) which supports 1.0. 

Since not all the kernels will pass (e.g., not FP16), This must be explicitly enabled by the user. 

The new flag: `-Dtornado.spirv.version=1.2`

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Using the [OneAPI Construction Kit](https://github.com/codeplaysoftware/oneapi-construction-kit) to dispatch SPIR-V code on the CPU:

Without the new flag, we can't see the SPIR-V device for CPU from Compute Aorta:

```bash
tornado  --devices

Number of Tornado drivers: 2
Driver: SPIR-V
  Total number of SPIR-V devices  : 2
  Tornado device=0:0  (DEFAULT)
	SPIRV -- SPIRV OCL - Intel(R) HD Graphics 630
		Global Memory Size: 28.9 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [256]
		Max WorkGroup Configuration: [256, 256, 256]
		Device OpenCL C version: OpenCL C 1.2

  Tornado device=0:1
	SPIRV -- SPIRV LevelZero - Intel(R) HD Graphics 630
		Global Memory Size: 28.9 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [256]
		Max WorkGroup Configuration: [256, 256, 256]
		Device OpenCL C version:  (LEVEL ZERO) 1.3

Driver: OpenCL
  Total number of OpenCL devices  : 3
  Tornado device=1:0
	OPENCL --  [NVIDIA CUDA] -- NVIDIA GeForce GTX 1050
		Global Memory Size: 3.9 GB
		Local Memory Size: 48.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [1024]
		Max WorkGroup Configuration: [1024, 1024, 64]
		Device OpenCL C version: OpenCL C 1.2

  Tornado device=1:1
	OPENCL --  [Intel(R) OpenCL Graphics] -- Intel(R) HD Graphics 630
		Global Memory Size: 28.9 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [256]
		Max WorkGroup Configuration: [256, 256, 256]
		Device OpenCL C version: OpenCL C 1.2

  Tornado device=1:2
	OPENCL --  [ComputeAorta] -- ComputeAorta x86_64
		Global Memory Size: 7.8 GB
		Local Memory Size: 32.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [1024]
		Max WorkGroup Configuration: [1024, 1024, 1024]
		Device OpenCL C version: OpenCL C 1.2 Clang 18.1.8
```


With the flag:

```bash
tornado --jvm="-Dtornado.spirv.version=1.0" --devices
WARNING: Using incubator modules: jdk.incubator.vector

Number of Tornado drivers: 2
Driver: SPIR-V
  Total number of SPIR-V devices  : 3
  Tornado device=0:0  (DEFAULT)
	SPIRV -- SPIRV OCL - Intel(R) HD Graphics 630
		Global Memory Size: 28.9 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [256]
		Max WorkGroup Configuration: [256, 256, 256]
		Device OpenCL C version: OpenCL C 1.2

  Tornado device=0:1                                                                    <<<<<<<<<<<< 
	SPIRV -- SPIRV OCL - ComputeAorta x86_64
		Global Memory Size: 7.8 GB
		Local Memory Size: 32.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [1024]
		Max WorkGroup Configuration: [1024, 1024, 1024]
		Device OpenCL C version: OpenCL C 1.2 Clang 18.1.8

  Tornado device=0:2
	SPIRV -- SPIRV LevelZero - Intel(R) HD Graphics 630
		Global Memory Size: 28.9 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [256]
		Max WorkGroup Configuration: [256, 256, 256]
		Device OpenCL C version:  (LEVEL ZERO) 1.3

Driver: OpenCL
  Total number of OpenCL devices  : 3
  Tornado device=1:0
	OPENCL --  [NVIDIA CUDA] -- NVIDIA GeForce GTX 1050
		Global Memory Size: 3.9 GB
		Local Memory Size: 48.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [1024]
		Max WorkGroup Configuration: [1024, 1024, 64]
		Device OpenCL C version: OpenCL C 1.2

  Tornado device=1:1
	OPENCL --  [Intel(R) OpenCL Graphics] -- Intel(R) HD Graphics 630
		Global Memory Size: 28.9 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [256]
		Max WorkGroup Configuration: [256, 256, 256]
		Device OpenCL C version: OpenCL C 1.2

  Tornado device=1:2
	OPENCL --  [ComputeAorta] -- ComputeAorta x86_64
		Global Memory Size: 7.8 GB
		Local Memory Size: 32.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [1024]
		Max WorkGroup Configuration: [1024, 1024, 1024]
		Device OpenCL C version: OpenCL C 1.2 Clang 18.1.8
```


