### PR TITLE
[deps] Level Zero JNI v0.1.4 updated

### DIFF
--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>beehive-lab</groupId>
             <artifactId>beehive-levelzero-jni</artifactId>
-            <version>0.1.3</version>
+            <version>0.1.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
#### Description

Update the LevelZero JNI dependency with the new version 0.1.4. This new version brings passing constant parameters to Level Zero Kernels.

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

To use the new version:

```bash
$ rm -Rf levelzero-jni/ level-zero/
$ source setvars.sh
$ make BACKEND=spirv
```

