### PR TITLE
Refactor one of the core runtime classes - API new methods for adding Compilation Flags

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
 
 /**
@@ -195,6 +196,10 @@ public class ImmutableTaskGraph {
 
     void withoutPrintKernel() {
         taskGraph.withoutPrintKernel();
+    }
+
+    void withCompilerFlags(TornadoVMBackendType backendType, String compilerFlags) {
+        taskGraph.withCompilerFlags(backendType, compilerFlags);
     }
 
     void withGridScheduler(GridScheduler gridScheduler) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -41,6 +41,7 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task7;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task8;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task9;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoTaskRuntimeException;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
 import uk.ac.manchester.tornado.api.runtime.TornadoAPIProvider;
@@ -887,6 +888,10 @@ public class TaskGraph implements TaskGraphInterface {
 
     void withoutPrintKernel() {
         taskGraphImpl.withoutPrintKernel();
+    }
+
+    void withCompilerFlags(TornadoVMBackendType backendType, String compilerFlags) {
+        taskGraphImpl.withCompilerFlags(backendType, compilerFlags);
     }
 
     void withGridScheduler(GridScheduler gridScheduler) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -382,7 +382,7 @@ public class TornadoExecutionPlan implements AutoCloseable {
     }
 
     /**
-     * Disable Printing of the Thread-Block Deployment for the generated kernels.
+     * Disable printing of the Thread-Block Deployment for the generated kernels.
      *
      * @since 1.0.2
      * 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -407,7 +407,7 @@ public class TornadoExecutionPlan implements AutoCloseable {
     }
 
     /**
-     * Disable Printing of the generated kernels for each task in a task-graph.
+     * Disable printing of the generated kernels for each task in a task-graph.
      * 
      * @since 1.0.2
      *

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
@@ -382,6 +383,11 @@ public class TornadoExecutionPlan implements AutoCloseable {
         return this;
     }
 
+    public TornadoExecutionPlan withCompilerFlags(TornadoVMBackendType backend, String compilerFlags) {
+        tornadoExecutor.withCompilerFlags(backend, compilerFlags);
+        return this;
+    }
+
     @Override
     public void close() throws TornadoExecutionPlanException {
         tornadoExecutor.freeDeviceMemory();
@@ -577,6 +583,10 @@ public class TornadoExecutionPlan implements AutoCloseable {
 
         void withoutPrintKernel() {
             immutableTaskGraphList.forEach(ImmutableTaskGraph::withoutPrintKernel);
+        }
+
+        void withCompilerFlags(TornadoVMBackendType backendType, String compilerFlags) {
+            immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.withCompilerFlags(backendType, compilerFlags));
         }
 
         long getTotalBytesTransferred() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -394,7 +394,7 @@ public class TornadoExecutionPlan implements AutoCloseable {
     }
 
     /**
-     * Enable Printing of the generated kernels for each task in a task-graph.
+     * Enable printing of the generated kernels for each task in a task-graph.
      *
      * @since 1.0.2
      * 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -32,12 +32,13 @@ import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 
 /**
- * Object to create and optimize an execution plan for running a set of
- * immutable tasks-graphs. An executor plan contains an executor object, which
- * in turn, contains a set of immutable task-graphs. All actions applied to the
- * execution plan affect to all the immutable graphs associated with it.
+ * Class to create and optimize execution plans for running a set of
+ * immutable tasks-graphs on modern hardware. An executor plan contains an
+ * executor object, which in turn, contains a set of immutable task-graphs.
+ * All actions applied to the execution plan affect to all the immutable
+ * graphs associated with it.
  *
- * @since TornadoVM-0.15
+ * @since v0.15
  */
 public class TornadoExecutionPlan implements AutoCloseable {
 
@@ -46,13 +47,11 @@ public class TornadoExecutionPlan implements AutoCloseable {
      * to the device assigned to the driver (backend) with index 0 and device 0.
      */
     public static TornadoDevice DEFAULT_DEVICE = TornadoRuntimeProvider.getTornadoRuntime().getDefaultDevice();
-    private final TornadoExecutor tornadoExecutor;
 
+    private final TornadoExecutor tornadoExecutor;
     private ProfilerMode profilerMode;
     private boolean disableProfiler;
-
     private static final AtomicLong globalExecutionPlanCounter = new AtomicLong(0);
-
     private final ExecutorFrame executionPackage;
 
     /**
@@ -87,6 +86,13 @@ public class TornadoExecutionPlan implements AutoCloseable {
         return TornadoRuntimeProvider.getTornadoRuntime().getBackend(driverIndex).getDevice(deviceIndex);
     }
 
+    /**
+     * Method to return the total number of execution plans instantiated in a single JVM instance.
+     *
+     * @since 1.0.2
+     * 
+     * @return int
+     */
     public static int getTotalPlans() {
         return globalExecutionPlanCounter.intValue();
     }
@@ -363,31 +369,75 @@ public class TornadoExecutionPlan implements AutoCloseable {
         return this;
     }
 
+    /**
+     * Enable Printing of the Thread-Block Deployment for the generated kernels.
+     *
+     * @since 1.0.2
+     * 
+     * @return {@link TornadoExecutionPlan}
+     */
     public TornadoExecutionPlan withThreadInfo() {
         tornadoExecutor.withThreadInfo();
         return this;
     }
 
+    /**
+     * Disable Printing of the Thread-Block Deployment for the generated kernels.
+     *
+     * @since 1.0.2
+     * 
+     * @return {@link TornadoExecutionPlan}
+     */
     public TornadoExecutionPlan withoutThreadInfo() {
         tornadoExecutor.withoutThreadInfo();
         return this;
     }
+
+    /**
+     * Enable Printing of the generated kernels for each task in a task-graph.
+     *
+     * @since 1.0.2
+     * 
+     * @return {@link TornadoExecutionPlan}
+     */
 
     public TornadoExecutionPlan withPrintKernel() {
         tornadoExecutor.withPrintKernel();
         return this;
     }
 
+    /**
+     * Disable Printing of the generated kernels for each task in a task-graph.
+     * 
+     * @since 1.0.2
+     *
+     * @return {@link TornadoExecutionPlan}
+     */
     public TornadoExecutionPlan withoutPrintKernel() {
         tornadoExecutor.withoutPrintKernel();
         return this;
     }
 
+    /**
+     * Set compiler flags for each backend.
+     * 
+     * @param backend
+     *     {@link TornadoVMBackendType}
+     * @param compilerFlags
+     *     {@link String}
+     * @since 1.0.7
+     * @return {@link TornadoExecutionPlan}
+     */
     public TornadoExecutionPlan withCompilerFlags(TornadoVMBackendType backend, String compilerFlags) {
         tornadoExecutor.withCompilerFlags(backend, compilerFlags);
         return this;
     }
 
+    /**
+     * @since 1.0.4
+     * 
+     * @throws TornadoExecutionPlanException
+     */
     @Override
     public void close() throws TornadoExecutionPlanException {
         tornadoExecutor.freeDeviceMemory();

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -370,7 +370,7 @@ public class TornadoExecutionPlan implements AutoCloseable {
     }
 
     /**
-     * Enable Printing of the Thread-Block Deployment for the generated kernels.
+     * Enable printing of the Thread-Block Deployment for the generated kernels.
      *
      * @since 1.0.2
      * 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -25,6 +25,7 @@ import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.common.TaskPackage;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.memory.TaskMetaDataInterface;
 import uk.ac.manchester.tornado.api.profiler.ProfilerInterface;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
@@ -122,4 +123,6 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
     void withGridScheduler(GridScheduler gridScheduler);
 
     long getCurrentDeviceMemoryUsage();
+
+    void withCompilerFlags(TornadoVMBackendType backendType, String compilerFlags);
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -26,9 +26,9 @@ import uk.ac.manchester.tornado.api.common.TaskPackage;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
-import uk.ac.manchester.tornado.api.memory.TaskMetaDataInterface;
 import uk.ac.manchester.tornado.api.profiler.ProfilerInterface;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
+import uk.ac.manchester.tornado.api.runtime.TaskContextInterface;
 
 public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
@@ -84,7 +84,7 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     String getId();
 
-    TaskMetaDataInterface meta();
+    TaskContextInterface meta();
 
     TornadoTaskGraphInterface execute(ExecutorFrame executionPackage);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/SchedulableTask.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/SchedulableTask.java
@@ -18,8 +18,8 @@
 package uk.ac.manchester.tornado.api.common;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
-import uk.ac.manchester.tornado.api.memory.TaskMetaDataInterface;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
+import uk.ac.manchester.tornado.api.runtime.TaskContextInterface;
 
 public interface SchedulableTask {
 
@@ -27,7 +27,7 @@ public interface SchedulableTask {
 
     Access[] getArgumentsAccess();
 
-    TaskMetaDataInterface meta();
+    TaskContextInterface meta();
 
     SchedulableTask mapTo(TornadoDevice mapping);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/enums/TornadoVMBackendType.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/enums/TornadoVMBackendType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2024, APT Group, Department of Computer Science,
  * The University of Manchester.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@ public enum TornadoVMBackendType {
     JAVA("Java"), //
     VIRTUAL("Virtual");
 
-    String backendName;
+    final String backendName;
 
     TornadoVMBackendType(String backendName) {
         this.backendName = backendName;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/TaskMetaDataInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/TaskMetaDataInterface.java
@@ -21,14 +21,13 @@ import java.util.List;
 
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.common.TornadoEvents;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 
 public interface TaskMetaDataInterface {
 
     List<TornadoEvents> getProfiles(long executionPlanId);
 
-    String getCompilerFlags();
-
-    void setCompilerFlags(String flags);
+    void setCompilerFlags(TornadoVMBackendType backendType, String flags);
 
     void setGlobalWork(long[] global);
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/runtime/TaskContextInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/runtime/TaskContextInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2024, APT Group, Department of Computer Science,
  * The University of Manchester.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  */
-package uk.ac.manchester.tornado.api.memory;
+package uk.ac.manchester.tornado.api.runtime;
 
 import java.util.List;
 
@@ -23,7 +23,7 @@ import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.common.TornadoEvents;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 
-public interface TaskMetaDataInterface {
+public interface TaskContextInterface {
 
     List<TornadoEvents> getProfiles(long executionPlanId);
 

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -123,6 +123,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleTasksMultipleDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.vm.concurrency.TestConcurrentBackends"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestDevices"),
+    TestEntry("uk.ac.manchester.tornado.unittests.compiler.TestCompilerFlagsAPI"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestMemorySegmentsAsType"),
     TestEntry("uk.ac.manchester.tornado.unittests.runtime.TestRuntimeAPI"),
     TestEntry("uk.ac.manchester.tornado.unittests.tensors.TestTensorTypes"),

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/MetaCompilation.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/MetaCompilation.java
@@ -42,18 +42,18 @@
 package uk.ac.manchester.tornado.drivers.common;
 
 import jdk.vm.ci.code.InstalledCode;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class MetaCompilation {
-    TaskMetaData taskMeta;
+    TaskDataContext taskMeta;
     InstalledCode installedCode;
 
-    public MetaCompilation(TaskMetaData taskMeta, InstalledCode installedCode) {
+    public MetaCompilation(TaskDataContext taskMeta, InstalledCode installedCode) {
         this.taskMeta = taskMeta;
         this.installedCode = installedCode;
     }
 
-    public TaskMetaData getTaskMeta() {
+    public TaskDataContext getTaskMeta() {
         return taskMeta;
     }
 

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/utils/CompilerUtil.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/utils/CompilerUtil.java
@@ -50,7 +50,7 @@ import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoSuitesProvider;
 import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.sketcher.SketchRequest;
 import uk.ac.manchester.tornado.runtime.sketcher.TornadoSketcher;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class CompilerUtil {
 
@@ -64,7 +64,7 @@ public class CompilerUtil {
         return method;
     }
 
-    public static Sketch buildSketchForJavaMethod(ResolvedJavaMethod resolvedJavaMethod, TaskMetaData taskMetaData, Providers providers, TornadoSuitesProvider suites) {
+    public static Sketch buildSketchForJavaMethod(ResolvedJavaMethod resolvedJavaMethod, TaskDataContext taskMetaData, Providers providers, TornadoSuitesProvider suites) {
         new SketchRequest(resolvedJavaMethod, providers, suites.getGraphBuilderSuite(), suites.getSketchTier(), taskMetaData.getBackendIndex(), taskMetaData.getDeviceIndex())//
                 .run();
         return TornadoSketcher.lookup(resolvedJavaMethod, taskMetaData.getBackendIndex(), taskMetaData.getDeviceIndex());

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -601,7 +601,7 @@ public class OCLCodeCache {
         if (meta.isPrintKernelEnabled()) {
             RuntimeUtilities.dumpKernel(source);
         }
-
+        logger.debug("\tOpenCL compiler flags = %s", meta.getCompilerFlags(TornadoVMBackendType.OPENCL));
         program.build(meta.getCompilerFlags(TornadoVMBackendType.OPENCL));
         final OCLBuildStatus status = program.getStatus(deviceContext.getDeviceId());
         logger.debug("\tOpenCL compilation status = %s", status.toString());

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -56,7 +56,7 @@ import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLCodeCache {
 
@@ -572,7 +572,7 @@ public class OCLCodeCache {
         }
     }
 
-    public OCLInstalledCode installSource(TaskMetaData meta, String id, String entryPoint, byte[] source) {
+    public OCLInstalledCode installSource(TaskDataContext meta, String id, String entryPoint, byte[] source) {
 
         logger.info("Installing code for %s into code cache", entryPoint);
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -44,7 +44,9 @@ import java.util.StringJoiner;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoCompilationException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLBuildStatus;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
@@ -74,6 +76,7 @@ public class OCLCodeCache {
     private final String FPGA_CONFIGURATION_FILE = getProperty("tornado.fpga.conf.file", null);
     private static final String FPGA_CLEANUP_SCRIPT = System.getenv("TORNADO_SDK") + "/bin/cleanFpga.sh";
     private static final String FPGA_AWS_AFI_SCRIPT = System.getenv("TORNADO_SDK") + "/bin/aws_post_processing.sh";
+
     /**
      * OpenCL Binary Options: -Dtornado.precompiled.binary=<path/to/binary,task>
      *
@@ -181,17 +184,13 @@ public class OCLCodeCache {
                     }
 
                     switch (token) {
-                        case "DEVICE_NAME":
-                            fpgaName = tokenizer.nextToken(" =");
-                            break;
-                        case "COMPILER":
-                            fpgaCompiler = tokenizer.nextToken(" =");
-                            break;
-                        case "DIRECTORY_BITSTREAM":
+                        case "DEVICE_NAME" -> fpgaName = tokenizer.nextToken(" =");
+                        case "COMPILER" -> fpgaCompiler = tokenizer.nextToken(" =");
+                        case "DIRECTORY_BITSTREAM" -> {
                             directoryBitstream = resolveAbsoluteDirectory(tokenizer.nextToken(" ="));
                             fpgaSourceDir = directoryBitstream;
-                            break;
-                        case "FLAGS":
+                        }
+                        case "FLAGS" -> {
                             StringBuilder buildFlags = new StringBuilder();
 
                             // Iterate over tokens that correspond to multiple flags
@@ -210,12 +209,10 @@ public class OCLCodeCache {
                                     }
                                 }
                             }
-                            break;
-                        case "AWS_ENV":
-                            isFPGAInAWS = tokenizer.nextToken(" =").toLowerCase().equals("yes");
-                            break;
-                        default:
-                            break;
+                        }
+                        case "AWS_ENV" -> isFPGAInAWS = tokenizer.nextToken(" =").toLowerCase().equals("yes");
+                        default -> {
+                        }
                     }
                     break;
                 }
@@ -281,12 +278,12 @@ public class OCLCodeCache {
         } catch (FileNotFoundException e) {
             throw new RuntimeException("File: " + fileName + " not found");
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new TornadoCompilationException(e.getMessage());
         } finally {
             try {
                 fileContent.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                throw new TornadoCompilationException(e.getMessage());
             }
         }
         return listBinaries.toString().split(",");
@@ -565,10 +562,8 @@ public class OCLCodeCache {
 
     }
 
-    private void installCodeInCodeCache(OCLProgram program, TaskMetaData meta, String id, String entryPoint, OCLInstalledCode code) {
-        
+    private void installCodeInCodeCache(OCLProgram program, String id, String entryPoint, OCLInstalledCode code) {
         cache.put(id + "-" + entryPoint, code);
-
         // BUG Apple does not seem to like implementing the OpenCL spec
         // properly, this causes a SIGFAULT.
         if ((OPENCL_CACHE_ENABLE || OPENCL_DUMP_BINS) && !deviceContext.getPlatformContext().getPlatform().getVendor().equalsIgnoreCase("Apple")) {
@@ -607,10 +602,7 @@ public class OCLCodeCache {
             RuntimeUtilities.dumpKernel(source);
         }
 
-        final long t0 = System.nanoTime();
-        program.build(meta.getCompilerFlags());
-        final long t1 = System.nanoTime();
-
+        program.build(meta.getCompilerFlags(TornadoVMBackendType.OPENCL));
         final OCLBuildStatus status = program.getStatus(deviceContext.getDeviceId());
         logger.debug("\tOpenCL compilation status = %s", status.toString());
 
@@ -630,7 +622,7 @@ public class OCLCodeCache {
         final OCLInstalledCode code = new OCLInstalledCode(entryPoint, source, (OCLDeviceContext) deviceContext, program, kernel, isSPIRVBinary);
         if (status == CL_BUILD_SUCCESS) {
             logger.debug("\tOpenCL Kernel id = 0x%x", kernel.getOclKernelID());
-            installCodeInCodeCache(program, meta, id, entryPoint, code);
+            installCodeInCodeCache(program, id, entryPoint, code);
         } else {
             logger.warn("\tunable to compile %s", entryPoint);
             code.invalidate();

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -50,7 +50,7 @@ import uk.ac.manchester.tornado.drivers.opencl.power.OCLNvidiaPowerMetric;
 import uk.ac.manchester.tornado.drivers.opencl.runtime.OCLBufferProvider;
 import uk.ac.manchester.tornado.drivers.opencl.runtime.OCLTornadoDevice;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLDeviceContext implements OCLDeviceContextInterface {
 
@@ -630,7 +630,7 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
     }
 
     @Override
-    public OCLInstalledCode installCode(TaskMetaData meta, String id, String entryPoint, byte[] code) {
+    public OCLInstalledCode installCode(TaskDataContext meta, String id, String entryPoint, byte[] code) {
         entryPoint = checkKernelName(entryPoint);
         return codeCache.installSource(meta, id, entryPoint, code);
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
@@ -30,7 +30,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResult;
 import uk.ac.manchester.tornado.drivers.opencl.mm.OCLMemoryManager;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public interface OCLDeviceContextInterface extends TornadoDeviceContext {
 
@@ -46,7 +46,7 @@ public interface OCLDeviceContextInterface extends TornadoDeviceContext {
 
     OCLInstalledCode installCode(OCLCompilationResult result);
 
-    OCLInstalledCode installCode(TaskMetaData meta, String id, String entryPoint, byte[] code);
+    OCLInstalledCode installCode(TaskDataContext meta, String id, String entryPoint, byte[] code);
 
     boolean isKernelAvailable();
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLJIT.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLJIT.java
@@ -34,8 +34,8 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.backend.OCLBackend;
 import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResult;
 import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompiler;
 import uk.ac.manchester.tornado.runtime.profiler.EmptyProfiler;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLJIT {
 
@@ -68,7 +68,7 @@ public class OCLJIT {
 
             final OCLBackend backend = getTornadoRuntime().getBackend(OCLBackendImpl.class).getDefaultBackend();
 
-            TaskMetaData meta = TaskMetaData.create(new ScheduleMetaData("s0"), methodName, method);
+            TaskDataContext meta = TaskDataContext.create(new ScheduleContext("s0"), methodName, method);
 
             OCLCompilationResult result = OCLCompiler.compileCodeForDevice(resolvedMethod, new Object[] {}, meta, (OCLProviders) backend.getProviders(), backend, new EmptyProfiler());
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OpenCL.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OpenCL.java
@@ -42,7 +42,7 @@ import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 import uk.ac.manchester.tornado.runtime.tasks.DataObjectState;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OpenCL {
 
@@ -154,7 +154,7 @@ public class OpenCL {
      *     List of parameters.
      *
      */
-    public static void run(Long executionContextId, OCLTornadoDevice tornadoDevice, OCLInstalledCode openCLCode, TaskMetaData taskMeta, Access[] accesses, Object... parameters) {
+    public static void run(Long executionContextId, OCLTornadoDevice tornadoDevice, OCLInstalledCode openCLCode, TaskDataContext taskMeta, Access[] accesses, Object... parameters) {
         if (parameters.length != accesses.length) {
             throw new TornadoRuntimeException("[ERROR] Accesses and objects array should match in size");
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -230,11 +230,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
             task = deviceContext.enqueueNDRangeKernel(executionPlanId, kernel, 1, null, singleThreadGlobalWorkSize, singleThreadLocalWorkSize, waitEvents);
         } else {
             if (meta.isParallel()) {
-                if (meta.enableThreadCoarsener()) {
-                    task = DEFAULT_SCHEDULER.submit(executionPlanId, kernel, meta, waitEvents, batchThreads);
-                } else {
-                    task = scheduler.submit(executionPlanId, kernel, meta, waitEvents, batchThreads);
-                }
+                task = scheduler.submit(executionPlanId, kernel, meta, waitEvents, batchThreads);
             } else {
                 if (meta.isDebug()) {
                     printDebugLaunchInfo(meta);
@@ -284,13 +280,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
     }
 
     private int submitParallel(long executionPlanId, final TaskDataContext meta, long batchThreads) {
-        final int task;
-        if (meta.enableThreadCoarsener()) {
-            task = DEFAULT_SCHEDULER.submit(executionPlanId, kernel, meta, batchThreads);
-        } else {
-            task = scheduler.submit(executionPlanId, kernel, meta, batchThreads);
-        }
-        return task;
+        return scheduler.submit(executionPlanId, kernel, meta, batchThreads);
     }
 
     private void launchKernel(long executionPlanId, final OCLKernelStackFrame callWrapper, final TaskDataContext meta, long batchThreads) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
@@ -103,7 +103,7 @@ import uk.ac.manchester.tornado.runtime.common.OCLTokens;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.graal.backend.XPUBackend;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLBackend extends XPUBackend<OCLProviders> implements FrameMap.ReferenceMapBuilderFactory {
 
@@ -202,7 +202,7 @@ public class OCLBackend extends XPUBackend<OCLProviders> implements FrameMap.Ref
     }
 
     public void emitCode(OCLCompilationResultBuilder crb, LIR lir, ResolvedJavaMethod method, TornadoProfiler profiler) {
-        TaskMetaData taskMetaData = crb.getTaskMetaData();
+        TaskDataContext taskMetaData = crb.getTaskMetaData();
         profiler.start(ProfilerType.TASK_CODE_GENERATION_TIME, taskMetaData.getId());
 
         final OCLAssembler asm = (OCLAssembler) crb.asm;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCanonicalizer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCanonicalizer.java
@@ -30,16 +30,16 @@ import org.graalvm.compiler.phases.common.CanonicalizerPhase;
 import jdk.vm.ci.meta.MetaAccessProvider;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.vector.VectorElementOpNode;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLCanonicalizer implements CanonicalizerPhase.CustomSimplification {
 
     protected MetaAccessProvider metaAccess;
     protected ResolvedJavaMethod method;
-    protected TaskMetaData meta;
+    protected TaskDataContext meta;
     protected Object[] args;
 
-    public void setContext(MetaAccessProvider metaAccess, ResolvedJavaMethod method, Object[] args, TaskMetaData meta) {
+    public void setContext(MetaAccessProvider metaAccess, ResolvedJavaMethod method, Object[] args, TaskDataContext meta) {
         this.metaAccess = metaAccess;
         this.method = method;
         this.meta = meta;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompilationResult.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompilationResult.java
@@ -29,16 +29,16 @@ import org.graalvm.compiler.code.CompilationResult;
 
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.drivers.opencl.graal.backend.OCLBackend;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLCompilationResult extends CompilationResult {
 
     private Set<ResolvedJavaMethod> nonInlinedMethods;
-    private TaskMetaData meta;
+    private TaskDataContext meta;
     private OCLBackend backend;
     private String id;
 
-    public OCLCompilationResult(String id, String name, TaskMetaData meta, OCLBackend backend) {
+    public OCLCompilationResult(String id, String name, TaskDataContext meta, OCLBackend backend) {
         super(name);
         this.id = id;
         this.meta = meta;
@@ -67,7 +67,7 @@ public class OCLCompilationResult extends CompilationResult {
         setTargetCode(newCode, size);
     }
 
-    public TaskMetaData getMeta() {
+    public TaskDataContext getMeta() {
         return meta;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompilationResultBuilder.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompilationResultBuilder.java
@@ -78,7 +78,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLControlFlow.LoopInit
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLControlFlow.LoopPostOp;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt.AssignStmt;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLCompilationResultBuilder extends CompilationResultBuilder {
 
@@ -89,7 +89,7 @@ public class OCLCompilationResultBuilder extends CompilationResultBuilder {
     private boolean isKernel;
     private int loops = 0;
     private boolean isParallel;
-    private TaskMetaData metaData;
+    private TaskDataContext metaData;
     private long[] localGrid;
     private OCLDeviceContextInterface deviceContext;
 
@@ -543,7 +543,7 @@ public class OCLCompilationResultBuilder extends CompilationResultBuilder {
         return null;
     }
 
-    public TaskMetaData getTaskMetaData() {
+    public TaskDataContext getTaskMetaData() {
         return ((OCLCompilationResult) compilationResult).getMeta();
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompiler.java
@@ -96,7 +96,7 @@ import uk.ac.manchester.tornado.runtime.graal.phases.TornadoMidTierContext;
 import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.sketcher.TornadoSketcher;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * Static methods for orchestrating the compilation of a
@@ -156,7 +156,7 @@ public class OCLCompiler {
     /**
      * Builds the graph, optimizes it.
      */
-    private static void emitFrontEnd(Providers providers, OCLBackend backend, ResolvedJavaMethod method, Object[] args, TaskMetaData meta, StructuredGraph graph,
+    private static void emitFrontEnd(Providers providers, OCLBackend backend, ResolvedJavaMethod method, Object[] args, TaskDataContext meta, StructuredGraph graph,
             PhaseSuite<HighTierContext> graphBuilderSuite, OptimisticOptimizations optimisticOpts, ProfilingInfo profilingInfo, TornadoSuites suites, boolean isKernel, boolean buildGraph,
             BatchCompilationConfig batchCompilationConfig) {
         try (DebugContext.Scope s = getDebugContext().scope("OpenCLFrontend", new DebugDumpScope("OpenCLFrontend")); DebugCloseable a = FrontEnd.start(getDebugContext())) {
@@ -307,12 +307,13 @@ public class OCLCompiler {
         }
     }
 
-    public static OCLCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, OCLProviders providers, OCLBackend backend, TornadoProfiler profiler) {
+    public static OCLCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskDataContext meta, OCLProviders providers, OCLBackend backend,
+            TornadoProfiler profiler) {
         return compileCodeForDevice(resolvedMethod, args, meta, providers, backend, new BatchCompilationConfig(0, 0, 0), profiler);
 
     }
 
-    public static OCLCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, OCLProviders providers, OCLBackend backend,
+    public static OCLCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskDataContext meta, OCLProviders providers, OCLBackend backend,
             BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
         new TornadoLogger().info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
         final TornadoCompilerIdentifier id = new TornadoCompilerIdentifier("compile-kernel" + resolvedMethod.getName(), compilationId.getAndIncrement());
@@ -364,7 +365,7 @@ public class OCLCompiler {
 
         new TornadoLogger().info("Compiling sketch %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
 
-        final TaskMetaData taskMeta = task.meta();
+        final TaskDataContext taskMeta = task.meta();
         final Object[] args = task.getArguments();
         final long batchThreads = (taskMeta.getNumThreads() > 0) ? taskMeta.getNumThreads() : task.getBatchThreads();
         final int batchNumber = task.getBatchNumber();
@@ -466,7 +467,7 @@ public class OCLCompiler {
         public final StructuredGraph graph;
         public final ResolvedJavaMethod installedCodeOwner;
         public final Object[] args;
-        public final TaskMetaData meta;
+        public final TaskDataContext meta;
         public final Providers providers;
         public final OCLBackend backend;
         public final PhaseSuite<HighTierContext> graphBuilderSuite;
@@ -481,7 +482,7 @@ public class OCLCompiler {
         public final BatchCompilationConfig batchCompilationConfig;
         public TornadoProfiler profiler;
 
-        public Request(StructuredGraph graph, ResolvedJavaMethod installedCodeOwner, Object[] args, TaskMetaData meta, Providers providers, OCLBackend backend,
+        public Request(StructuredGraph graph, ResolvedJavaMethod installedCodeOwner, Object[] args, TaskDataContext meta, Providers providers, OCLBackend backend,
                 PhaseSuite<HighTierContext> graphBuilderSuite, OptimisticOptimizations optimisticOpts, ProfilingInfo profilingInfo, TornadoSuites suites, TornadoLIRSuites lirSuites,
                 T compilationResult, CompilationResultBuilderFactory factory, boolean isKernel, boolean buildGraph, BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
             this.graph = graph;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/OCLFPGAThreadScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/OCLFPGAThreadScheduler.java
@@ -35,7 +35,7 @@ import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.FPGAWorkGroupSizeNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.LocalWorkGroupDimensionsNode;
 import uk.ac.manchester.tornado.runtime.graal.phases.TornadoLowTierContext;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLFPGAThreadScheduler extends BasePhase<TornadoLowTierContext> {
 
@@ -60,7 +60,7 @@ public class OCLFPGAThreadScheduler extends BasePhase<TornadoLowTierContext> {
         if (graph.hasLoops()) {
             NodeIterable<EndNode> filter = graph.getNodes().filter(EndNode.class);
             EndNode end = filter.first();
-            TaskMetaData metaData;
+            TaskDataContext metaData;
 
             metaData = lowTierContext.getMeta();
             if (metaData != null) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoParallelScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoParallelScheduler.java
@@ -143,7 +143,7 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
 
     @Override
     protected void run(StructuredGraph graph, TornadoHighTierContext context) {
-        if (context.getMeta() == null || context.getMeta().enableThreadCoarsener()) {
+        if (context.getMeta() == null) {
             return;
         }
         TornadoXPUDevice device = context.getDeviceMapping();
@@ -151,7 +151,7 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
         long[] maxWorkItemSizes = device.getPhysicalDevice().getDeviceMaxWorkItemSizes();
 
         graph.getNodes().filter(ParallelRangeNode.class).forEach(node -> {
-            if (context.getMeta().enableParallelization() && maxWorkItemSizes[node.index()] > 1) {
+            if (maxWorkItemSizes[node.index()] > 1) {
                 ParallelOffsetNode offset = node.offset();
                 ParallelStrideNode stride = node.stride();
                 ValueNode blockSize = replaceRangeNode(strategy, graph, node);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLPrebuiltTask.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLPrebuiltTask.java
@@ -27,13 +27,13 @@ import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
 import uk.ac.manchester.tornado.runtime.domain.DomainTree;
 import uk.ac.manchester.tornado.runtime.tasks.PrebuiltTask;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
 
 public class OCLPrebuiltTask extends PrebuiltTask {
 
     private OCLInstalledCode code;
 
-    protected OCLPrebuiltTask(ScheduleMetaData meta, String id, String entryPoint, String filename, Object[] args, Access[] access, OCLTornadoDevice device, DomainTree domain) {
+    protected OCLPrebuiltTask(ScheduleContext meta, String id, String entryPoint, String filename, Object[] args, Access[] access, OCLTornadoDevice device, DomainTree domain) {
         super(meta, id, entryPoint, filename, args, access, device, domain);
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -48,11 +48,11 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.api.memory.DeviceBufferState;
-import uk.ac.manchester.tornado.api.memory.TaskMetaDataInterface;
 import uk.ac.manchester.tornado.api.memory.TornadoMemoryProvider;
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.api.profiler.ProfilerType;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
+import uk.ac.manchester.tornado.api.runtime.TaskContextInterface;
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
 import uk.ac.manchester.tornado.api.types.arrays.CharArray;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
@@ -365,7 +365,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     }
 
     private String getFullTaskIdDevice(SchedulableTask task) {
-        TaskMetaDataInterface meta = task.meta();
+        TaskContextInterface meta = task.meta();
         if (meta instanceof TaskMetaData) {
             TaskMetaData metaData = (TaskMetaData) task.meta();
             return task.getId() + ".device=" + metaData.getBackendIndex() + ":" + metaData.getDeviceIndex();

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -99,7 +99,7 @@ import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.sketcher.TornadoSketcher;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
 import uk.ac.manchester.tornado.runtime.tasks.PrebuiltTask;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLTornadoDevice implements TornadoXPUDevice {
 
@@ -254,7 +254,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         }
 
         // copy meta data into task
-        final TaskMetaData taskMeta = executable.meta();
+        final TaskDataContext taskMeta = executable.meta();
         final Access[] sketchAccess = sketch.getArgumentsAccess();
         final Access[] taskAccess = taskMeta.getArgumentsAccess();
         System.arraycopy(sketchAccess, 0, taskAccess, 0, sketchAccess.length);
@@ -366,8 +366,8 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
 
     private String getFullTaskIdDevice(SchedulableTask task) {
         TaskContextInterface meta = task.meta();
-        if (meta instanceof TaskMetaData) {
-            TaskMetaData metaData = (TaskMetaData) task.meta();
+        if (meta instanceof TaskDataContext) {
+            TaskDataContext metaData = (TaskDataContext) task.meta();
             return task.getId() + ".device=" + metaData.getBackendIndex() + ":" + metaData.getDeviceIndex();
         } else {
             throw new RuntimeException("[ERROR] TaskMetadata expected");

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLAMDScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLAMDScheduler.java
@@ -27,7 +27,7 @@ import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.drivers.opencl.OCLKernel;
 import uk.ac.manchester.tornado.drivers.opencl.OCLTargetDevice;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLAMDScheduler extends OCLKernelScheduler {
 
@@ -43,7 +43,7 @@ public class OCLAMDScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public int launch(long executionPlanId, OCLKernel kernel, TaskMetaData meta, int[] waitEvents, long batchThreads) {
+    public int launch(long executionPlanId, OCLKernel kernel, TaskDataContext meta, int[] waitEvents, long batchThreads) {
         if (meta.isWorkerGridAvailable()) {
             WorkerGrid grid = meta.getWorkerGrid(meta.getId());
             long[] global = grid.getGlobalWork();
@@ -56,7 +56,7 @@ public class OCLAMDScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void calculateGlobalWork(final TaskMetaData meta, long batchThreads) {
+    public void calculateGlobalWork(final TaskDataContext meta, long batchThreads) {
         final long[] globalWork = meta.getGlobalWork();
         for (int i = 0; i < meta.getDims(); i++) {
             long value = (batchThreads <= 0) ? (long) (meta.getDomain().get(i).cardinality()) : batchThreads;
@@ -69,7 +69,7 @@ public class OCLAMDScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void calculateLocalWork(final TaskMetaData meta) {
+    public void calculateLocalWork(final TaskDataContext meta) {
         final long[] localWork = meta.initLocalWork();
         switch (meta.getDims()) {
             case 3:
@@ -87,7 +87,7 @@ public class OCLAMDScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void checkAndAdaptLocalWork(TaskMetaData meta) {
+    public void checkAndAdaptLocalWork(TaskDataContext meta) {
     }
 
     private int calculateGroupSize(long maxBlockSize, long customBlockSize, long globalWorkSize) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLCPUScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLCPUScheduler.java
@@ -38,11 +38,7 @@ public class OCLCPUScheduler extends OCLKernelScheduler {
 
         final long[] globalWork = meta.getGlobalWork();
         for (int i = 0; i < meta.getDims(); i++) {
-            if (meta.enableThreadCoarsener()) {
-                globalWork[i] = maxItems[i] > 1 ? (long) (meta.getDomain().get(i).cardinality()) : 1;
-            } else {
-                globalWork[i] = i == 0 ? (long) (deviceContext.getDevice().getDeviceMaxComputeUnits()) : 1;
-            }
+            globalWork[i] = i == 0 ? (long) (deviceContext.getDevice().getDeviceMaxComputeUnits()) : 1;
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLCPUScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLCPUScheduler.java
@@ -24,7 +24,7 @@
 package uk.ac.manchester.tornado.drivers.opencl.scheduler;
 
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLCPUScheduler extends OCLKernelScheduler {
 
@@ -33,7 +33,7 @@ public class OCLCPUScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void calculateGlobalWork(final TaskMetaData meta, long batchThreads) {
+    public void calculateGlobalWork(final TaskDataContext meta, long batchThreads) {
         long[] maxItems = deviceContext.getDevice().getDeviceMaxWorkItemSizes();
 
         final long[] globalWork = meta.getGlobalWork();
@@ -47,12 +47,12 @@ public class OCLCPUScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void calculateLocalWork(final TaskMetaData meta) {
+    public void calculateLocalWork(final TaskDataContext meta) {
         meta.setLocalWorkToNull();
     }
 
     @Override
-    public void checkAndAdaptLocalWork(TaskMetaData meta) {
+    public void checkAndAdaptLocalWork(TaskDataContext meta) {
     }
 
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLFPGAScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLFPGAScheduler.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.drivers.opencl.OCLKernel;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLFPGAScheduler extends OCLKernelScheduler {
 
@@ -43,7 +43,7 @@ public class OCLFPGAScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void calculateGlobalWork(final TaskMetaData meta, long batchThreads) {
+    public void calculateGlobalWork(final TaskDataContext meta, long batchThreads) {
         final long[] globalWork = meta.getGlobalWork();
         for (int i = 0; i < meta.getDims(); i++) {
             long value = (batchThreads <= 0) ? (long) (meta.getDomain().get(i).cardinality()) : batchThreads;
@@ -55,7 +55,7 @@ public class OCLFPGAScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void calculateLocalWork(final TaskMetaData meta) {
+    public void calculateLocalWork(final TaskDataContext meta) {
         final long[] localWork = DEFAULT_LOCAL_WORK_SIZE;
         switch (meta.getDims()) {
             case 3:
@@ -73,11 +73,11 @@ public class OCLFPGAScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void checkAndAdaptLocalWork(TaskMetaData meta) {
+    public void checkAndAdaptLocalWork(TaskDataContext meta) {
     }
 
     @Override
-    public int launch(long executionPlanId, final OCLKernel kernel, final TaskMetaData meta, final int[] waitEvents, long batchThreads) {
+    public int launch(long executionPlanId, final OCLKernel kernel, final TaskDataContext meta, final int[] waitEvents, long batchThreads) {
         if (meta.isWorkerGridAvailable()) {
             WorkerGrid grid = meta.getWorkerGrid(meta.getId());
             long[] global = grid.getGlobalWork();
@@ -97,7 +97,7 @@ public class OCLFPGAScheduler extends OCLKernelScheduler {
         return DEFAULT_LOCAL_WORK_SIZE;
     }
 
-    private void setLocalWork(final int dimensions, long[] localWork, final TaskMetaData meta) {
+    private void setLocalWork(final int dimensions, long[] localWork, final TaskDataContext meta) {
         for (int i = 0; i < dimensions; i++) {
             localWork[i] = calculateGroupSize(DEFAULT_LOCAL_WORK_SIZE[i], meta.getGlobalWork()[i]);
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLGenericGPUScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLGenericGPUScheduler.java
@@ -25,7 +25,7 @@ package uk.ac.manchester.tornado.drivers.opencl.scheduler;
 
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.drivers.opencl.OCLTargetDevice;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class OCLGenericGPUScheduler extends OCLKernelScheduler {
 
@@ -41,7 +41,7 @@ public class OCLGenericGPUScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void calculateGlobalWork(final TaskMetaData meta, long batchThreads) {
+    public void calculateGlobalWork(final TaskDataContext meta, long batchThreads) {
         final long[] globalWork = meta.getGlobalWork();
 
         for (int i = 0; i < meta.getDims(); i++) {
@@ -54,7 +54,7 @@ public class OCLGenericGPUScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void calculateLocalWork(final TaskMetaData meta) {
+    public void calculateLocalWork(final TaskDataContext meta) {
         final long[] localWork = meta.initLocalWork();
 
         switch (meta.getDims()) {
@@ -76,7 +76,7 @@ public class OCLGenericGPUScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void checkAndAdaptLocalWork(TaskMetaData meta) {
+    public void checkAndAdaptLocalWork(TaskDataContext meta) {
     }
 
     private int calculateGroupSize(long maxBlockSize, long globalWorkSize) {
@@ -94,7 +94,7 @@ public class OCLGenericGPUScheduler extends OCLKernelScheduler {
         return value;
     }
 
-    private long[] calculateEffectiveMaxWorkItemSizes(TaskMetaData metaData) {
+    private long[] calculateEffectiveMaxWorkItemSizes(TaskDataContext metaData) {
         long[] intermediates = new long[] { 1, 1, 1 };
 
         switch (metaData.getDims()) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLKernelScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLKernelScheduler.java
@@ -31,7 +31,7 @@ import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.drivers.opencl.OCLGridInfo;
 import uk.ac.manchester.tornado.drivers.opencl.OCLKernel;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public abstract class OCLKernelScheduler {
 
@@ -50,21 +50,21 @@ public abstract class OCLKernelScheduler {
         deviceContext = context;
     }
 
-    public abstract void calculateGlobalWork(final TaskMetaData meta, long batchThreads);
+    public abstract void calculateGlobalWork(final TaskDataContext meta, long batchThreads);
 
-    public abstract void calculateLocalWork(final TaskMetaData meta);
+    public abstract void calculateLocalWork(final TaskDataContext meta);
 
-    public abstract void checkAndAdaptLocalWork(final TaskMetaData meta);
+    public abstract void checkAndAdaptLocalWork(final TaskDataContext meta);
 
     public long[] getDefaultLocalWorkGroup() {
         return null;
     }
 
-    public int submit(long executionPlanId, final OCLKernel kernel, final TaskMetaData meta, long batchThreads) {
+    public int submit(long executionPlanId, final OCLKernel kernel, final TaskDataContext meta, long batchThreads) {
         return submit(executionPlanId, kernel, meta, null, batchThreads);
     }
 
-    private void updateProfiler(long executionPlanId, final int taskEvent, final TaskMetaData meta) {
+    private void updateProfiler(long executionPlanId, final int taskEvent, final TaskDataContext meta) {
         if (TornadoOptions.isProfilerEnabled()) {
             Event tornadoKernelEvent = deviceContext.resolveEvent(executionPlanId, taskEvent);
             tornadoKernelEvent.waitForEvents(executionPlanId);
@@ -81,7 +81,7 @@ public abstract class OCLKernelScheduler {
         }
     }
 
-    public int launch(long executionPlanId, final OCLKernel kernel, final TaskMetaData meta, final int[] waitEvents, long batchThreads) {
+    public int launch(long executionPlanId, final OCLKernel kernel, final TaskDataContext meta, final int[] waitEvents, long batchThreads) {
         if (meta.isWorkerGridAvailable()) {
             WorkerGrid grid = meta.getWorkerGrid(meta.getId());
             long[] global = grid.getGlobalWork();
@@ -104,7 +104,7 @@ public abstract class OCLKernelScheduler {
      * @param meta
      *     TaskMetaData.
      */
-    private void checkLocalWorkGroupFitsOnDevice(final TaskMetaData meta) {
+    private void checkLocalWorkGroupFitsOnDevice(final TaskDataContext meta) {
         WorkerGrid grid = meta.getWorkerGrid(meta.getId());
         long[] local = grid.getLocalWork();
         if (local != null) {
@@ -124,7 +124,7 @@ public abstract class OCLKernelScheduler {
         }
     }
 
-    public int submit(long executionPlanId, final OCLKernel kernel, final TaskMetaData meta, final int[] waitEvents, long batchThreads) {
+    public int submit(long executionPlanId, final OCLKernel kernel, final TaskDataContext meta, final int[] waitEvents, long batchThreads) {
         if (!meta.isWorkerGridAvailable()) {
             if (!meta.isGlobalWorkDefined()) {
                 calculateGlobalWork(meta, batchThreads);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLNVIDIAGPUScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLNVIDIAGPUScheduler.java
@@ -25,7 +25,7 @@ package uk.ac.manchester.tornado.drivers.opencl.scheduler;
 
 import uk.ac.manchester.tornado.drivers.opencl.OCLDeviceContext;
 import uk.ac.manchester.tornado.drivers.opencl.OCLTargetDevice;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 import java.util.Arrays;
 
@@ -44,7 +44,7 @@ public class OCLNVIDIAGPUScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void calculateGlobalWork(final TaskMetaData meta, long batchThreads) {
+    public void calculateGlobalWork(final TaskDataContext meta, long batchThreads) {
         final long[] globalWork = meta.getGlobalWork();
         for (int i = 0; i < meta.getDims(); i++) {
             long value = (batchThreads <= 0) ? (long) (meta.getDomain().get(i).cardinality()) : batchThreads;
@@ -56,7 +56,7 @@ public class OCLNVIDIAGPUScheduler extends OCLKernelScheduler {
     }
 
     @Override
-    public void calculateLocalWork(final TaskMetaData meta) {
+    public void calculateLocalWork(final TaskDataContext meta) {
         final long[] localWork = meta.initLocalWork();
         switch (meta.getDims()) {
             case 3:
@@ -84,7 +84,7 @@ public class OCLNVIDIAGPUScheduler extends OCLKernelScheduler {
      *     TaskMetaData.
      */
     @Override
-    public void checkAndAdaptLocalWork(final TaskMetaData meta) {
+    public void checkAndAdaptLocalWork(final TaskDataContext meta) {
         final long[] localWork = meta.getLocalWork();
         if (localWork == null) {
             return;
@@ -158,7 +158,7 @@ public class OCLNVIDIAGPUScheduler extends OCLKernelScheduler {
         return value;
     }
 
-    private long[] calculateEffectiveMaxWorkItemSizes(TaskMetaData metaData) {
+    private long[] calculateEffectiveMaxWorkItemSizes(TaskDataContext metaData) {
         long[] localWorkGroups = new long[] { 1, 1, 1 };
         if (metaData.getDims() == 1) {
             localWorkGroups[0] = maxWorkItemSizes[0];

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLJITCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLJITCompiler.java
@@ -54,8 +54,8 @@ import uk.ac.manchester.tornado.runtime.profiler.EmptyProfiler;
 import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
 import uk.ac.manchester.tornado.runtime.tasks.DataObjectState;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * Test the OpenCL JIT Compiler and connection with the Tornado Runtime
@@ -93,10 +93,10 @@ public class TestOpenCLJITCompiler {
         TornadoDevice device = tornadoRuntime.getBackend(OCLBackendImpl.class).getDefaultDevice();
 
         // Create a new task for TornadoVM
-        ScheduleMetaData scheduleMetaData = new ScheduleMetaData("s0");
+        ScheduleContext scheduleMetaData = new ScheduleContext("s0");
         // Create a compilable task
         CompilableTask compilableTask = new CompilableTask(scheduleMetaData, "t0", methodToCompile, parameters);
-        TaskMetaData taskMeta = compilableTask.meta();
+        TaskDataContext taskMeta = compilableTask.meta();
         taskMeta.setDevice(device);
 
         // 1. Build Common Compiler Phase (Sketcher)
@@ -113,11 +113,11 @@ public class TestOpenCLJITCompiler {
         return new MetaCompilation(taskMeta, openCLCode);
     }
 
-    public void runWithOpenCLAPI(Long executionPlanId, OCLTornadoDevice tornadoDevice, OCLInstalledCode openCLCode, TaskMetaData taskMeta, int[] a, int[] b, float[] c) {
+    public void runWithOpenCLAPI(Long executionPlanId, OCLTornadoDevice tornadoDevice, OCLInstalledCode openCLCode, TaskDataContext taskMeta, int[] a, int[] b, float[] c) {
         OpenCL.run(executionPlanId, tornadoDevice, openCLCode, taskMeta, new Access[] { Access.READ_ONLY, Access.READ_ONLY, Access.WRITE_ONLY }, a, b, c);
     }
 
-    public void run(OCLTornadoDevice tornadoDevice, OCLInstalledCode openCLCode, TaskMetaData taskMeta, int[] a, int[] b, float[] c) {
+    public void run(OCLTornadoDevice tornadoDevice, OCLInstalledCode openCLCode, TaskDataContext taskMeta, int[] a, int[] b, float[] c) {
         // First we allocate, A, B and C
         DataObjectState stateA = new DataObjectState();
         XPUDeviceBufferState objectStateA = stateA.getDeviceBufferState(tornadoDevice);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLTornadoCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLTornadoCompiler.java
@@ -34,8 +34,8 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.backend.OCLBackend;
 import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResult;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class TestOpenCLTornadoCompiler {
 
@@ -62,8 +62,8 @@ public class TestOpenCLTornadoCompiler {
 
         TornadoCoreRuntime tornadoRuntime = TornadoCoreRuntime.getTornadoRuntime();
         OCLBackend backend = tornadoRuntime.getBackend(OCLBackendImpl.class).getDefaultBackend();
-        ScheduleMetaData scheduleMeta = new ScheduleMetaData("oclbackend");
-        TaskMetaData meta = new TaskMetaData(scheduleMeta, "saxpy");
+        ScheduleContext scheduleMeta = new ScheduleContext("oclbackend");
+        TaskDataContext meta = new TaskDataContext(scheduleMeta, "saxpy");
         new OCLCompilationResult("internal", "saxpy", meta, backend);
 
         byte[] source = OPENCL_KERNEL.getBytes();

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
@@ -39,7 +39,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResult;
 import uk.ac.manchester.tornado.drivers.opencl.mm.OCLMemoryManager;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class VirtualOCLDeviceContext implements OCLDeviceContextInterface {
 
@@ -214,7 +214,7 @@ public class VirtualOCLDeviceContext implements OCLDeviceContextInterface {
     }
 
     @Override
-    public OCLInstalledCode installCode(TaskMetaData meta, String id, String entryPoint, byte[] code) {
+    public OCLInstalledCode installCode(TaskDataContext meta, String id, String entryPoint, byte[] code) {
         return null;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -68,7 +68,7 @@ import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.sketcher.TornadoSketcher;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
 import uk.ac.manchester.tornado.runtime.tasks.PrebuiltTask;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
 
@@ -190,7 +190,7 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
         final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
 
         // copy meta data into task
-        final TaskMetaData taskMeta = executable.meta();
+        final TaskDataContext taskMeta = executable.meta();
         final Access[] sketchAccess = sketch.getArgumentsAccess();
         final Access[] taskAccess = taskMeta.getArgumentsAccess();
         System.arraycopy(sketchAccess, 0, taskAccess, 0, sketchAccess.length);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTX.java
@@ -34,7 +34,7 @@ import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.Tornado;
 import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 import uk.ac.manchester.tornado.runtime.tasks.DataObjectState;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PTX {
     public static final String PTX_JNI_LIBRARY = "tornado-ptx";
@@ -85,7 +85,7 @@ public class PTX {
         return new PTXTornadoDevice(deviceIndex);
     }
 
-    public static void run(PTXTornadoDevice tornadoDevice, PTXInstalledCode openCLCode, TaskMetaData taskMeta, Access[] accesses, Object... parameters) {
+    public static void run(PTXTornadoDevice tornadoDevice, PTXInstalledCode openCLCode, TaskDataContext taskMeta, Access[] accesses, Object... parameters) {
         if (parameters.length != accesses.length) {
             throw new TornadoRuntimeException("[ERROR] Accesses and objects array should match in size");
         }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -56,7 +56,7 @@ import uk.ac.manchester.tornado.drivers.ptx.runtime.PTXTornadoDevice;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PTXDeviceContext implements TornadoDeviceContext {
 
@@ -256,7 +256,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         wasReset = true;
     }
 
-    public int enqueueKernelLaunch(long executionPlanId, PTXModule module, KernelStackFrame kernelArgs, TaskMetaData taskMeta, long batchThreads) {
+    public int enqueueKernelLaunch(long executionPlanId, PTXModule module, KernelStackFrame kernelArgs, TaskDataContext taskMeta, long batchThreads) {
         int[] blockDimension = { 1, 1, 1 };
         int[] gridDimension = { 1, 1, 1 };
         if (taskMeta.isWorkerGridAvailable()) {
@@ -289,7 +289,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         return kernelLaunchEvent;
     }
 
-    private byte[] writePTXKernelContextOnDevice(long executionPlanId, PTXKernelStackFrame ptxKernelArgs, TaskMetaData meta) {
+    private byte[] writePTXKernelContextOnDevice(long executionPlanId, PTXKernelStackFrame ptxKernelArgs, TaskDataContext meta) {
         int capacity = Long.BYTES + ptxKernelArgs.getCallArguments().size() * Long.BYTES;
         ByteBuffer args = ByteBuffer.allocate(capacity);
         args.order(getByteOrder());
@@ -325,7 +325,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         return args.array();
     }
 
-    private void updateProfilerKernelContextWrite(long executionPlanId, int kernelContextWriteEventId, TaskMetaData meta, PTXKernelStackFrame callWrapper) {
+    private void updateProfilerKernelContextWrite(long executionPlanId, int kernelContextWriteEventId, TaskDataContext meta, PTXKernelStackFrame callWrapper) {
         if (TornadoOptions.isProfilerEnabled()) {
             TornadoProfiler profiler = meta.getProfiler();
             Event event = resolveEvent(executionPlanId, kernelContextWriteEventId);
@@ -341,7 +341,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         }
     }
 
-    private void updateProfiler(long executionPlanId, final int taskEvent, final TaskMetaData meta) {
+    private void updateProfiler(long executionPlanId, final int taskEvent, final TaskDataContext meta) {
         if (TornadoOptions.isProfilerEnabled()) {
             Event tornadoKernelEvent = resolveEvent(executionPlanId, taskEvent);
             tornadoKernelEvent.waitForEvents(executionPlanId);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
@@ -60,7 +60,7 @@ public class PTXScheduler {
             return Arrays.stream(taskMeta.getLocalWork()).mapToInt(l -> (int) l).toArray();
         }
 
-        long maxThreadsPerBlock = taskMeta.getLogicDevice().getPhysicalDevice().getMaxThreadsPerBlock();
+        long maxThreadsPerBlock = taskMeta.getXPUDevice().getPhysicalDevice().getMaxThreadsPerBlock();
         if (taskMeta.getDims() > 1) {
             maxThreadsPerBlock = module.getPotentialBlockSizeMaxOccupancy();
         }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXScheduler.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PTXScheduler {
 
@@ -43,7 +43,7 @@ public class PTXScheduler {
         this.logger = new TornadoLogger(this.getClass());
     }
 
-    public void calculateGlobalWork(final TaskMetaData meta, long batchThreads) {
+    public void calculateGlobalWork(final TaskDataContext meta, long batchThreads) {
         if (meta.isGlobalWorkDefined()) {
             return;
         }
@@ -55,7 +55,7 @@ public class PTXScheduler {
         }
     }
 
-    public int[] calculateBlockDimension(PTXModule module, TaskMetaData taskMeta) {
+    public int[] calculateBlockDimension(PTXModule module, TaskDataContext taskMeta) {
         if (taskMeta.isLocalWorkDefined()) {
             return Arrays.stream(taskMeta.getLocalWork()).mapToInt(l -> (int) l).toArray();
         }
@@ -107,7 +107,7 @@ public class PTXScheduler {
         return value;
     }
 
-    public int[] calculateGridDimension(PTXModule module, TaskMetaData taskMeta, int[] blockDimension) {
+    public int[] calculateGridDimension(PTXModule module, TaskDataContext taskMeta, int[] blockDimension) {
         int[] globalWork = Arrays.stream(taskMeta.getGlobalWork()).mapToInt(l -> (int) l).toArray();
         return calculateGridDimension(module.javaName, taskMeta.getDims(), globalWork, blockDimension);
     }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
@@ -32,7 +32,7 @@ import uk.ac.manchester.tornado.api.common.Event;
 import uk.ac.manchester.tornado.drivers.common.utils.EventDescriptor;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PTXStream {
 
@@ -171,7 +171,7 @@ public class PTXStream {
         PTXEvent.waitForEventArray((PTXEvent[]) events.toArray());
     }
 
-    public int enqueueKernelLaunch(long executionPlanId, PTXModule module, TaskMetaData taskMeta, byte[] kernelParams, int[] gridDim, int[] blockDim) {
+    public int enqueueKernelLaunch(long executionPlanId, PTXModule module, TaskDataContext taskMeta, byte[] kernelParams, int[] gridDim, int[] blockDim) {
         assert Arrays.stream(gridDim).filter(i -> i <= 0).count() == 0;
         assert Arrays.stream(blockDim).filter(i -> i <= 0).count() == 0;
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXInstalledCode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/PTXInstalledCode.java
@@ -29,7 +29,7 @@ import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
 import uk.ac.manchester.tornado.drivers.ptx.PTXModule;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PTXInstalledCode extends InstalledCode implements TornadoInstalledCode {
     private final PTXModule module;
@@ -44,13 +44,13 @@ public class PTXInstalledCode extends InstalledCode implements TornadoInstalledC
     }
 
     @Override
-    public int launchWithDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskMetaData meta, long batchThreads, int[] waitEvents) {
+    public int launchWithDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskDataContext meta, long batchThreads, int[] waitEvents) {
         unimplemented("launch with deps");
         return 0;
     }
 
     @Override
-    public int launchWithoutDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskMetaData meta, long batchThreads) {
+    public int launchWithoutDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskDataContext meta, long batchThreads) {
         return deviceContext.enqueueKernelLaunch(executionPlanId, module, callWrapper, meta, batchThreads);
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/backend/PTXBackend.java
@@ -90,7 +90,7 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXVectorSplit;
 import uk.ac.manchester.tornado.runtime.graal.backend.XPUBackend;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoSuitesProvider;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PTXBackend extends XPUBackend<PTXProviders> implements FrameMap.ReferenceMapBuilderFactory {
 
@@ -223,7 +223,7 @@ public class PTXBackend extends XPUBackend<PTXProviders> implements FrameMap.Ref
 
         // Enable Profiler for code generation
         PTXCompilationResultBuilder builder = (PTXCompilationResultBuilder) resultBuilder;
-        TaskMetaData taskMetaData = builder.getTaskMetaData();
+        TaskDataContext taskMetaData = builder.getTaskMetaData();
         profiler.start(ProfilerType.TASK_CODE_GENERATION_TIME, taskMetaData.getId());
 
         PTXCompilationResultBuilder crb = (PTXCompilationResultBuilder) resultBuilder;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompilationResult.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompilationResult.java
@@ -10,7 +10,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -32,14 +32,14 @@ import org.graalvm.compiler.code.CompilationResult;
 
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.drivers.ptx.graal.backend.PTXBackend;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PTXCompilationResult extends CompilationResult {
 
     private Set<ResolvedJavaMethod> nonInlinedMethods;
-    private TaskMetaData taskMetaData;
+    private TaskDataContext taskMetaData;
 
-    public PTXCompilationResult(String functionName, TaskMetaData meta) {
+    public PTXCompilationResult(String functionName, TaskDataContext meta) {
         super(functionName);
         this.taskMetaData = meta;
     }
@@ -62,7 +62,7 @@ public class PTXCompilationResult extends CompilationResult {
         setTargetCode(newCode, newCode.length);
     }
 
-    public TaskMetaData metaData() {
+    public TaskDataContext metaData() {
         return taskMetaData;
     }
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompilationResultBuilder.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompilationResultBuilder.java
@@ -10,7 +10,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -62,7 +62,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.ptx.PTXDeviceContext;
 import uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXControlFlow;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PTXCompilationResultBuilder extends CompilationResultBuilder {
     protected LIR lir;
@@ -74,7 +74,7 @@ public class PTXCompilationResultBuilder extends CompilationResultBuilder {
     private PTXDeviceContext deviceContext;
     private boolean includePrintf;
     private PTXLIRGenerationResult lirGenRes;
-    private TaskMetaData meta;
+    private TaskDataContext meta;
 
     public PTXCompilationResultBuilder(CodeGenProviders providers, FrameMap frameMap, Assembler asm, DataBuilder dataBuilder, FrameContext frameContext, OptionValues options, DebugContext debug,
             CompilationResult compilationResult, LIR lir) {
@@ -294,13 +294,13 @@ public class PTXCompilationResultBuilder extends CompilationResultBuilder {
      * control Split (due to nested control-flow).
      *
      * @param HIRBlock
-     *            {@link HIRBlock}
+     *     {@link HIRBlock}
      * @param visitor
-     *            {@link PTXBlockVisitor}
+     *     {@link PTXBlockVisitor}
      * @param visited
-     *            {@link HashSet}
+     *     {@link HashSet}
      * @param pending
-     *            {@link HashMap}
+     *     {@link HashMap}
      */
     private void rescheduleTrueBranchConditionsIfNeeded(HIRBlock basicBlock, PTXBlockVisitor visitor, HashSet<HIRBlock> visited, HashMap<HIRBlock, HIRBlock> pending) {
         if (!basicBlock.isLoopHeader() && basicBlock.getDominator() != null && basicBlock.getDominator().getEndNode() instanceof IfNode) {
@@ -399,11 +399,11 @@ public class PTXCompilationResultBuilder extends CompilationResultBuilder {
         this.deviceContext = deviceContext;
     }
 
-    public TaskMetaData getTaskMetaData() {
+    public TaskDataContext getTaskMetaData() {
         return meta;
     }
 
-    public void setTaskMetaData(TaskMetaData metaData) {
+    public void setTaskMetaData(TaskDataContext metaData) {
         this.meta = metaData;
     }
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompiler.java
@@ -87,7 +87,7 @@ import uk.ac.manchester.tornado.runtime.graal.phases.TornadoMidTierContext;
 import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.sketcher.TornadoSketcher;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PTXCompiler {
 
@@ -253,7 +253,7 @@ public class PTXCompiler {
 
         new TornadoLogger().info("Compiling sketch %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
 
-        final TaskMetaData taskMeta = task.meta();
+        final TaskDataContext taskMeta = task.meta();
         final Object[] args = task.getArguments();
         final long batchThreads = (taskMeta.getNumThreads() > 0) ? taskMeta.getNumThreads() : task.getBatchThreads();
         final int batchNumber = task.getBatchNumber();
@@ -380,7 +380,7 @@ public class PTXCompiler {
         return kernelCompResult;
     }
 
-    public static PTXCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskMetaData meta, PTXProviders providers, PTXBackend backend,
+    public static PTXCompilationResult compileCodeForDevice(ResolvedJavaMethod resolvedMethod, Object[] args, TaskDataContext meta, PTXProviders providers, PTXBackend backend,
             BatchCompilationConfig batchCompilationConfig, TornadoProfiler profiler) {
         new TornadoLogger().info("Compiling %s on %s", resolvedMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
         final TornadoCompilerIdentifier id = new TornadoCompilerIdentifier("compile-kernel" + resolvedMethod.getName(), compilationId.getAndIncrement());
@@ -472,7 +472,7 @@ public class PTXCompiler {
         public final StructuredGraph graph;
         public final ResolvedJavaMethod installedCodeOwner;
         public final Object[] args;
-        public final TaskMetaData meta;
+        public final TaskDataContext meta;
         public final Providers providers;
         public final PTXBackend backend;
         public final PhaseSuite<HighTierContext> graphBuilderSuite;
@@ -488,7 +488,7 @@ public class PTXCompiler {
         public final boolean includePrintf;
         private final TornadoProfiler profiler;
 
-        private PTXCompilationRequest(StructuredGraph graph, ResolvedJavaMethod installedCodeOwner, Object[] args, TaskMetaData meta, Providers providers, PTXBackend backend,
+        private PTXCompilationRequest(StructuredGraph graph, ResolvedJavaMethod installedCodeOwner, Object[] args, TaskDataContext meta, Providers providers, PTXBackend backend,
                 PhaseSuite<HighTierContext> graphBuilderSuite, OptimisticOptimizations optimisticOpts, ProfilingInfo profilingInfo, TornadoSuites suites, TornadoLIRSuites lirSuites,
                 PTXCompilationResult compilationResult, CompilationResultBuilderFactory factory, boolean isKernel, boolean buildGraph, BatchCompilationConfig batchCompilationConfig,
                 boolean includePrintf, TornadoProfiler profiler) {
@@ -521,7 +521,7 @@ public class PTXCompiler {
             private StructuredGraph graph;
             private ResolvedJavaMethod codeOwner;
             private Object[] args;
-            private TaskMetaData meta;
+            private TaskDataContext meta;
             private Providers providers;
             private PTXBackend backend;
             private PhaseSuite<HighTierContext> graphBuilderSuite;
@@ -565,7 +565,7 @@ public class PTXCompiler {
                 return this;
             }
 
-            public PTXCompilationRequestBuilder withMetaData(TaskMetaData metaData) {
+            public PTXCompilationRequestBuilder withMetaData(TaskDataContext metaData) {
                 this.meta = metaData;
                 return this;
             }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoParallelScheduler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoParallelScheduler.java
@@ -72,7 +72,7 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
 
     @Override
     protected void run(StructuredGraph graph, TornadoHighTierContext context) {
-        if (context.getMeta() == null || context.getMeta().enableThreadCoarsener()) {
+        if (context.getMeta() == null) {
             return;
         }
 
@@ -81,7 +81,7 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
         long[] maxWorkItemSizes = device.getPhysicalDevice().getDeviceMaxWorkItemSizes();
 
         graph.getNodes().filter(ParallelRangeNode.class).forEach(node -> {
-            if (context.getMeta().enableParallelization() && maxWorkItemSizes[node.index()] > 1) {
+            if (maxWorkItemSizes[node.index()] > 1) {
                 ParallelOffsetNode offset = node.offset();
                 ParallelStrideNode stride = node.stride();
                 replaceRangeNode(node);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -91,7 +91,7 @@ import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.sketcher.TornadoSketcher;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
 import uk.ac.manchester.tornado.runtime.tasks.PrebuiltTask;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PTXTornadoDevice implements TornadoXPUDevice {
 
@@ -169,7 +169,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
         final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
 
         // copy meta data into task
-        final TaskMetaData taskMeta = executable.meta();
+        final TaskDataContext taskMeta = executable.meta();
         final Access[] sketchAccess = sketch.getArgumentsAccess();
         final Access[] taskAccess = taskMeta.getArgumentsAccess();
         System.arraycopy(sketchAccess, 0, taskAccess, 0, sketchAccess.length);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXJITCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXJITCompiler.java
@@ -53,8 +53,8 @@ import uk.ac.manchester.tornado.runtime.profiler.EmptyProfiler;
 import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
 import uk.ac.manchester.tornado.runtime.tasks.DataObjectState;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * Test the PTX JIT Compiler and connection with the Tornado Runtime
@@ -91,10 +91,10 @@ public class TestPTXJITCompiler {
         TornadoDevice device = tornadoRuntime.getBackend(PTXBackendImpl.class).getDefaultDevice();
 
         // Create a new task for TornadoVM
-        ScheduleMetaData scheduleMetaData = new ScheduleMetaData("s0");
+        ScheduleContext scheduleMetaData = new ScheduleContext("s0");
         // Create a compilable task
         CompilableTask compilableTask = new CompilableTask(scheduleMetaData, "t0", methodToCompile, parameters);
-        TaskMetaData taskMeta = compilableTask.meta();
+        TaskDataContext taskMeta = compilableTask.meta();
         taskMeta.setDevice(device);
 
         // 1. Build Common Compiler Phase (Sketcher)
@@ -112,11 +112,11 @@ public class TestPTXJITCompiler {
         return new MetaCompilation(taskMeta, (PTXInstalledCode) ptxCode);
     }
 
-    public void runWithPTXAPI(PTXTornadoDevice tornadoDevice, PTXInstalledCode ptxCode, TaskMetaData taskMeta, int[] a, int[] b, float[] c) {
+    public void runWithPTXAPI(PTXTornadoDevice tornadoDevice, PTXInstalledCode ptxCode, TaskDataContext taskMeta, int[] a, int[] b, float[] c) {
         PTX.run(tornadoDevice, ptxCode, taskMeta, new Access[] { Access.READ_ONLY, Access.READ_ONLY, Access.WRITE_ONLY }, a, b, c);
     }
 
-    public void run(PTXTornadoDevice tornadoDevice, PTXInstalledCode ptxCode, TaskMetaData taskMeta, int[] a, int[] b, float[] c) {
+    public void run(PTXTornadoDevice tornadoDevice, PTXInstalledCode ptxCode, TaskDataContext taskMeta, int[] a, int[] b, float[] c) {
         // First we allocate, A, B and C
         DataObjectState stateA = new DataObjectState();
         XPUDeviceBufferState objectStateA = stateA.getDeviceBufferState(tornadoDevice);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXTornadoCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXTornadoCompiler.java
@@ -31,8 +31,8 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.PTXInstalledCode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.backend.PTXBackend;
 import uk.ac.manchester.tornado.drivers.ptx.graal.compiler.PTXCompilationResult;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class TestPTXTornadoCompiler {
 
@@ -82,7 +82,7 @@ public class TestPTXTornadoCompiler {
 
         TornadoCoreRuntime tornadoRuntime = TornadoCoreRuntime.getTornadoRuntime();
         PTXBackend backend = tornadoRuntime.getBackend(PTXBackendImpl.class).getDefaultBackend();
-        TaskMetaData meta = new TaskMetaData(new ScheduleMetaData("s0"), "add", 0);
+        TaskDataContext meta = new TaskDataContext(new ScheduleContext("s0"), "add", 0);
         new PTXCompilationResult("add", meta);
 
         byte[] source = PTX_KERNEL.getBytes();

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackend.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackend.java
@@ -136,7 +136,7 @@ import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.mm.SPIRVKernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graal.backend.XPUBackend;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class SPIRVBackend extends XPUBackend<SPIRVProviders> implements FrameMap.ReferenceMapBuilderFactory {
 
@@ -295,7 +295,7 @@ public class SPIRVBackend extends XPUBackend<SPIRVProviders> implements FrameMap
 
         // Enable Profiler for code generation
         SPIRVCompilationResultBuilder builder = (SPIRVCompilationResultBuilder) resultBuilder;
-        TaskMetaData taskMetaData = builder.getTaskMetaData();
+        TaskDataContext taskMetaData = builder.getTaskMetaData();
         profiler.start(ProfilerType.TASK_CODE_GENERATION_TIME, taskMetaData.getId());
 
         SPIRVCompilationResultBuilder crb = (SPIRVCompilationResultBuilder) resultBuilder;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVCodeCache.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public abstract class SPIRVCodeCache {
 
@@ -92,7 +92,7 @@ public abstract class SPIRVCodeCache {
         return tempDirectory + pathSeparator + user + pathSeparator + "tornadoVM-spirv";
     }
 
-    public SPIRVInstalledCode installSPIRVBinary(TaskMetaData meta, String id, String entryPoint, byte[] binary) {
+    public SPIRVInstalledCode installSPIRVBinary(TaskDataContext meta, String id, String entryPoint, byte[] binary) {
         if (binary == null || binary.length == 0) {
             throw new RuntimeException("[ERROR] SPIR-V Binary Module is Empty");
         }
@@ -117,5 +117,5 @@ public abstract class SPIRVCodeCache {
         return installSPIRVBinary(meta, id, entryPoint, spirvFile);
     }
 
-    public abstract SPIRVInstalledCode installSPIRVBinary(TaskMetaData meta, String id, String entryPoint, String pathToFile);
+    public abstract SPIRVInstalledCode installSPIRVBinary(TaskDataContext meta, String id, String entryPoint, String pathToFile);
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
@@ -51,7 +51,7 @@ import uk.ac.manchester.tornado.drivers.spirv.timestamps.TimeStamp;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * Class to map a SPIR-V device (Device represented either in LevelZero or an
@@ -386,11 +386,11 @@ public abstract class SPIRVDeviceContext implements TornadoDeviceContext {
         return installBinary(result.getMeta(), result.getId(), result.getName(), result.getSPIRVBinary());
     }
 
-    public SPIRVInstalledCode installBinary(TaskMetaData meta, String id, String entryPoint, byte[] code) {
+    public SPIRVInstalledCode installBinary(TaskDataContext meta, String id, String entryPoint, byte[] code) {
         return codeCache.installSPIRVBinary(meta, id, entryPoint, code);
     }
 
-    public SPIRVInstalledCode installBinary(TaskMetaData meta, String id, String entryPoint, String pathToFile) {
+    public SPIRVInstalledCode installBinary(TaskDataContext meta, String id, String entryPoint, String pathToFile) {
         return codeCache.installSPIRVBinary(meta, id, entryPoint, pathToFile);
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
@@ -48,7 +48,7 @@ import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeResult;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.utils.LevelZeroUtils;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
 
@@ -57,7 +57,7 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
     }
 
     @Override
-    public synchronized SPIRVInstalledCode installSPIRVBinary(TaskMetaData meta, String id, String entryPoint, String pathToFile) {
+    public synchronized SPIRVInstalledCode installSPIRVBinary(TaskDataContext meta, String id, String entryPoint, String pathToFile) {
         ZeModuleHandle module = new ZeModuleHandle();
         ZeModuleDescriptor moduleDesc = new ZeModuleDescriptor();
         ZeBuildLogHandle buildLog = new ZeBuildLogHandle();

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
@@ -29,6 +29,7 @@ import uk.ac.manchester.beehivespirvtoolkit.lib.SPIRVTool;
 import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.Disassembler;
 import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.SPIRVDisassemblerOptions;
 import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.SPVFileReader;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.drivers.common.logging.Logger;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVInstalledCode;
@@ -60,7 +61,7 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
         ZeModuleDescriptor moduleDesc = new ZeModuleDescriptor();
         ZeBuildLogHandle buildLog = new ZeBuildLogHandle();
         moduleDesc.setFormat(ZeModuleFormat.ZE_MODULE_FORMAT_IL_SPIRV);
-        moduleDesc.setBuildFlags("-ze-opt-level 2 -ze-opt-large-register-file");
+        moduleDesc.setBuildFlags(meta.getCompilerFlags(TornadoVMBackendType.SPIRV));
 
         checkBinaryFileExists(pathToFile);
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVLevelZeroCodeCache.java
@@ -46,6 +46,7 @@ import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeModuleFormat;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeModuleHandle;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeResult;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.utils.LevelZeroUtils;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
@@ -61,7 +62,8 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
         ZeModuleDescriptor moduleDesc = new ZeModuleDescriptor();
         ZeBuildLogHandle buildLog = new ZeBuildLogHandle();
         moduleDesc.setFormat(ZeModuleFormat.ZE_MODULE_FORMAT_IL_SPIRV);
-        moduleDesc.setBuildFlags(meta.getCompilerFlags(TornadoVMBackendType.SPIRV));
+        final String compilerFlags = meta.getCompilerFlags(TornadoVMBackendType.SPIRV);
+        moduleDesc.setBuildFlags(compilerFlags);
 
         checkBinaryFileExists(pathToFile);
 
@@ -72,6 +74,9 @@ public class SPIRVLevelZeroCodeCache extends SPIRVCodeCache {
         SPIRVDevice spirvDevice = deviceContext.getDevice();
         SPIRVLevelZeroDevice levelZeroDevice = (SPIRVLevelZeroDevice) spirvDevice;
         LevelZeroDevice device = levelZeroDevice.getDeviceRuntime();
+
+        TornadoLogger logger = new TornadoLogger(this.getClass());
+        logger.debug("\tSPIR-V/LeveZero compiler flags = %s", compilerFlags);
 
         int result = context.zeModuleCreate(context.getDefaultContextPtr(), device.getDeviceHandlerPtr(), moduleDesc, module, buildLog, pathToFile);
         LevelZeroUtils.errorLog("zeModuleCreate", result);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
@@ -40,6 +40,7 @@ import uk.ac.manchester.tornado.drivers.opencl.OCLTargetDevice;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVInstalledCode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVOCLInstalledCode;
 import uk.ac.manchester.tornado.drivers.spirv.ocl.SPIRVOCLNativeDispatcher;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 public class SPIRVOCLCodeCache extends SPIRVCodeCache {
@@ -101,6 +102,9 @@ public class SPIRVOCLCodeCache extends SPIRVCodeCache {
 
         OCLTargetDevice oclDevice = (OCLTargetDevice) deviceContext.getDevice().getDeviceRuntime();
         String compilerFlags = meta.getCompilerFlags(TornadoVMBackendType.OPENCL);
+        TornadoLogger logger = new TornadoLogger(this.getClass());
+        logger.debug("\tSPIR-V/OpenCL compiler flags = %s", meta.getCompilerFlags(TornadoVMBackendType.OPENCL));
+
         int status = spirvoclNativeCompiler.clBuildProgram(programPointer, 1, new long[] { oclDevice.getDevicePointer() }, compilerFlags);
         if (status != OCLErrorCode.CL_SUCCESS) {
             String log = spirvoclNativeCompiler.clGetProgramBuildInfo(programPointer, oclDevice.getDevicePointer());

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
@@ -41,7 +41,7 @@ import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVInstalledCode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVOCLInstalledCode;
 import uk.ac.manchester.tornado.drivers.spirv.ocl.SPIRVOCLNativeDispatcher;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class SPIRVOCLCodeCache extends SPIRVCodeCache {
 
@@ -68,7 +68,7 @@ public class SPIRVOCLCodeCache extends SPIRVCodeCache {
     }
 
     @Override
-    public SPIRVInstalledCode installSPIRVBinary(TaskMetaData meta, String id, String entryPoint, String pathToFile) {
+    public SPIRVInstalledCode installSPIRVBinary(TaskDataContext meta, String id, String entryPoint, String pathToFile) {
 
         checkBinaryFileExists(pathToFile);
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOCLCodeCache.java
@@ -32,6 +32,7 @@ import uk.ac.manchester.beehivespirvtoolkit.lib.SPIRVTool;
 import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.Disassembler;
 import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.SPIRVDisassemblerOptions;
 import uk.ac.manchester.beehivespirvtoolkit.lib.disassembler.SPVFileReader;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.opencl.OCLErrorCode;
@@ -99,7 +100,8 @@ public class SPIRVOCLCodeCache extends SPIRVCodeCache {
         }
 
         OCLTargetDevice oclDevice = (OCLTargetDevice) deviceContext.getDevice().getDeviceRuntime();
-        int status = spirvoclNativeCompiler.clBuildProgram(programPointer, 1, new long[] { oclDevice.getDevicePointer() }, "");
+        String compilerFlags = meta.getCompilerFlags(TornadoVMBackendType.OPENCL);
+        int status = spirvoclNativeCompiler.clBuildProgram(programPointer, 1, new long[] { oclDevice.getDevicePointer() }, compilerFlags);
         if (status != OCLErrorCode.CL_SUCCESS) {
             String log = spirvoclNativeCompiler.clGetProgramBuildInfo(programPointer, oclDevice.getDevicePointer());
             System.out.println(log);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVLevelZeroInstalledCode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVLevelZeroInstalledCode.java
@@ -45,7 +45,7 @@ import uk.ac.manchester.tornado.drivers.spirv.timestamps.LevelZeroKernelTimeStam
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
 
@@ -64,7 +64,7 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
     }
 
     @Override
-    public int launchWithDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskMetaData meta, long batchThreads, int[] waitEvents) {
+    public int launchWithDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskDataContext meta, long batchThreads, int[] waitEvents) {
         throw new RuntimeException("Unimplemented");
     }
 
@@ -103,7 +103,7 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
         }
     }
 
-    private DeviceThreadScheduling calculateGlobalAndLocalBlockOfThreads(TaskMetaData meta, long batchThreads) {
+    private DeviceThreadScheduling calculateGlobalAndLocalBlockOfThreads(TaskDataContext meta, long batchThreads) {
         long[] globalWork = new long[3];
         long[] localWork = new long[3];
         Arrays.fill(globalWork, 1);
@@ -144,7 +144,7 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
         return result;
     }
 
-    private ThreadBlockDispatcher suggestThreadSchedulingToLevelZeroDriver(DeviceThreadScheduling threadScheduling, LevelZeroKernel levelZeroKernel, ZeKernelHandle kernel, TaskMetaData meta) {
+    private ThreadBlockDispatcher suggestThreadSchedulingToLevelZeroDriver(DeviceThreadScheduling threadScheduling, LevelZeroKernel levelZeroKernel, ZeKernelHandle kernel, TaskDataContext meta) {
 
         // Prepare kernel for launch
         // A) Suggest scheduling parameters to level-zero
@@ -206,12 +206,12 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
         LevelZeroUtils.errorLog("zeCommandListAppendBarrier", result);
     }
 
-    private boolean computeThreadBlock(TaskMetaData meta) {
+    private boolean computeThreadBlock(TaskDataContext meta) {
         return meta.shouldResetThreadsBlock() || deviceThreadScheduling == null || threadBlockDispatcher == null || meta.isWorkerGridAvailable();
     }
 
     @Override
-    public int launchWithoutDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskMetaData meta, long batchThreads) {
+    public int launchWithoutDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskDataContext meta, long batchThreads) {
         SPIRVLevelZeroModule module = (SPIRVLevelZeroModule) spirvModule;
         LevelZeroKernel levelZeroKernel = module.getKernel();
         ZeKernelHandle kernel = levelZeroKernel.getKernelHandle();
@@ -254,7 +254,7 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
         return 0;
     }
 
-    private void calculateLocalWork(TaskMetaData meta) {
+    private void calculateLocalWork(TaskDataContext meta) {
         final long[] localWork = meta.initLocalWork();
 
         switch (meta.getDims()) {
@@ -290,7 +290,7 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
         return value;
     }
 
-    private long[] calculateEffectiveMaxWorkItemSizes(TaskMetaData metaData) {
+    private long[] calculateEffectiveMaxWorkItemSizes(TaskDataContext metaData) {
         long[] intermediates = new long[] { 1, 1, 1 };
 
         long[] maxWorkItemSizes = deviceContext.getDevice().getDeviceMaxWorkItemSizes();
@@ -315,7 +315,7 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
         return intermediates;
     }
 
-    private void calculateGlobalWork(TaskMetaData meta, long batchThreads) {
+    private void calculateGlobalWork(TaskDataContext meta, long batchThreads) {
         final long[] globalWork = meta.getGlobalWork();
 
         for (int i = 0; i < meta.getDims(); i++) {
@@ -327,7 +327,7 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
         }
     }
 
-    private void checkLocalWorkGroupFitsOnDevice(final TaskMetaData meta) {
+    private void checkLocalWorkGroupFitsOnDevice(final TaskDataContext meta) {
         WorkerGrid grid = meta.getWorkerGrid(meta.getId());
         long[] local = grid.getLocalWork();
         if (local != null) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCanonicalizer.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCanonicalizer.java
@@ -30,16 +30,16 @@ import org.graalvm.compiler.phases.common.CanonicalizerPhase;
 
 import jdk.vm.ci.meta.MetaAccessProvider;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class SPIRVCanonicalizer implements CanonicalizerPhase.CustomSimplification {
 
     protected MetaAccessProvider metaAccess;
     protected ResolvedJavaMethod method;
-    protected TaskMetaData meta;
+    protected TaskDataContext meta;
     protected Object[] args;
 
-    public void setContext(MetaAccessProvider metaAccess, ResolvedJavaMethod method, Object[] args, TaskMetaData meta) {
+    public void setContext(MetaAccessProvider metaAccess, ResolvedJavaMethod method, Object[] args, TaskDataContext meta) {
         this.metaAccess = metaAccess;
         this.method = method;
         this.meta = meta;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompilationResult.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompilationResult.java
@@ -32,7 +32,7 @@ import org.graalvm.compiler.code.CompilationResult;
 
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.drivers.spirv.graal.asm.SPIRVAssembler;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * Object that represents the result of a SPIRV compilation (from GraalIR to
@@ -44,12 +44,12 @@ import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 public class SPIRVCompilationResult extends CompilationResult {
 
     private Set<ResolvedJavaMethod> nonInlinedMethods;
-    private TaskMetaData taskMetaData;
+    private TaskDataContext taskMetaData;
     private String compilationId;
     private ByteBuffer spirvBinary;
     private SPIRVAssembler spirvAssembler;
 
-    public SPIRVCompilationResult(String compilationId, String methodName, TaskMetaData taskMetaData) {
+    public SPIRVCompilationResult(String compilationId, String methodName, TaskDataContext taskMetaData) {
         super(methodName);
         this.compilationId = compilationId;
         this.taskMetaData = taskMetaData;
@@ -81,11 +81,11 @@ public class SPIRVCompilationResult extends CompilationResult {
         setTargetCode(newCode, newCode.length);
     }
 
-    public TaskMetaData getTaskMetaData() {
+    public TaskDataContext getTaskMetaData() {
         return this.taskMetaData;
     }
 
-    public TaskMetaData getMeta() {
+    public TaskDataContext getMeta() {
         return taskMetaData;
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompilationResultBuilder.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompilationResultBuilder.java
@@ -13,7 +13,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -63,7 +63,7 @@ import uk.ac.manchester.tornado.drivers.common.logging.Logger;
 import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLBlockVisitor;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
 import uk.ac.manchester.tornado.drivers.spirv.graal.asm.SPIRVAssembler;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class SPIRVCompilationResultBuilder extends CompilationResultBuilder {
 
@@ -209,13 +209,13 @@ public class SPIRVCompilationResultBuilder extends CompilationResultBuilder {
      * control Split (due to nested control-flow).
      *
      * @param basicBlock
-     *            {@link HIRBlock}
+     *     {@link HIRBlock}
      * @param visitor
-     *            {@link OCLBlockVisitor}
+     *     {@link OCLBlockVisitor}
      * @param visited
-     *            {@link HashSet}
+     *     {@link HashSet}
      * @param pending
-     *            {@link HashMap}
+     *     {@link HashMap}
      */
     private void rescheduleTrueBranchConditionsIfNeeded(HIRBlock basicBlock, SPIRVBlockVisitor visitor, HashSet<HIRBlock> visited, HashMap<HIRBlock, HIRBlock> pending) {
         if (!basicBlock.isLoopHeader() && basicBlock.getDominator() != null && basicBlock.getDominator().getEndNode() instanceof IfNode) {
@@ -356,7 +356,7 @@ public class SPIRVCompilationResultBuilder extends CompilationResultBuilder {
         nonInlinedMethods.add(targetMethod);
     }
 
-    public TaskMetaData getTaskMetaData() {
+    public TaskDataContext getTaskMetaData() {
         return ((SPIRVCompilationResult) compilationResult).getMeta();
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVCompiler.java
@@ -97,7 +97,7 @@ import uk.ac.manchester.tornado.runtime.graal.phases.TornadoMidTierContext;
 import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.sketcher.TornadoSketcher;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * SPIRV Compiler and Optimizer. It optimizes Graal IR for SPIRV devices and it
@@ -140,7 +140,7 @@ public class SPIRVCompiler {
         return graph.start().next() == null;
     }
 
-    private static void emitFrontEnd(Providers providers, SPIRVBackend backend, ResolvedJavaMethod installedCodeOwner, Object[] args, TaskMetaData meta, StructuredGraph graph,
+    private static void emitFrontEnd(Providers providers, SPIRVBackend backend, ResolvedJavaMethod installedCodeOwner, Object[] args, TaskDataContext meta, StructuredGraph graph,
             PhaseSuite<HighTierContext> graphBuilderSuite, OptimisticOptimizations optimisticOpts, ProfilingInfo profilingInfo, TornadoSuites suites, boolean isKernel, boolean buildGraph,
             BatchCompilationConfig batchCompilationConfig) {
 
@@ -323,7 +323,7 @@ public class SPIRVCompiler {
 
         new TornadoLogger().info("Compiling sketch %s on %s", resolvedJavaMethod.getName(), backend.getDeviceContext().getDevice().getDeviceName());
 
-        final TaskMetaData taskMeta = task.meta();
+        final TaskDataContext taskMeta = task.meta();
         final Object[] args = task.getArguments();
         final long batchThreads = (taskMeta.getNumThreads() > 0) ? taskMeta.getNumThreads() : task.getBatchThreads();
         final int batchNumber = task.getBatchNumber();
@@ -466,7 +466,7 @@ public class SPIRVCompiler {
         public final StructuredGraph graph;
         public final ResolvedJavaMethod installedCodeOwner;
         public final Object[] args;
-        public final TaskMetaData meta;
+        public final TaskDataContext meta;
         public final Providers providers;
         public final SPIRVBackend backend;
         public final PhaseSuite<HighTierContext> graphBuilderSuite;
@@ -481,7 +481,7 @@ public class SPIRVCompiler {
         public final BatchCompilationConfig batchCompilationConfig;
         public TornadoProfiler profiler;
 
-        public SPIRVCompilationRequest(StructuredGraph graph, ResolvedJavaMethod installedCodeOwner, Object[] args, TaskMetaData meta, Providers providers, SPIRVBackend backend,
+        public SPIRVCompilationRequest(StructuredGraph graph, ResolvedJavaMethod installedCodeOwner, Object[] args, TaskDataContext meta, Providers providers, SPIRVBackend backend,
                 PhaseSuite<HighTierContext> graphBuilderSuite, OptimisticOptimizations optimisticOpts, ProfilingInfo profilingInfo, TornadoSuites suites, TornadoLIRSuites lirSuites,
                 SPIRVCompilationResult compilationResult, CompilationResultBuilderFactory factory, boolean isKernel, boolean buildGraph, BatchCompilationConfig batchCompilationConfig,
                 TornadoProfiler profiler) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoParallelScheduler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoParallelScheduler.java
@@ -74,7 +74,7 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
 
     @Override
     protected void run(StructuredGraph graph, TornadoHighTierContext context) {
-        if (context.getMeta() == null || context.getMeta().enableThreadCoarsener()) {
+        if (context.getMeta() == null) {
             return;
         }
 
@@ -82,7 +82,7 @@ public class TornadoParallelScheduler extends BasePhase<TornadoHighTierContext> 
         long[] maxWorkItemSizes = device.getPhysicalDevice().getDeviceMaxWorkItemSizes();
 
         graph.getNodes().filter(ParallelRangeNode.class).forEach(parallelRange -> {
-            if (context.getMeta().enableParallelization() && maxWorkItemSizes[parallelRange.index()] > 1) {
+            if (maxWorkItemSizes[parallelRange.index()] > 1) {
                 ParallelOffsetNode offset = parallelRange.offset();
                 ParallelStrideNode stride = parallelRange.stride();
                 replaceRangeNode(parallelRange);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -82,7 +82,7 @@ import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.sketcher.TornadoSketcher;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
 import uk.ac.manchester.tornado.runtime.tasks.PrebuiltTask;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * This is the core class for the actual runtime.
@@ -162,7 +162,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
         final Sketch sketch = TornadoSketcher.lookup(resolvedMethod, task.meta().getBackendIndex(), task.meta().getDeviceIndex());
 
         // copy meta data into task
-        final TaskMetaData taskMeta = task.meta();
+        final TaskDataContext taskMeta = task.meta();
 
         // Return the code from the cache
         if (!task.shouldCompile() && deviceContext.isCached(task.getId(), resolvedMethod.getName())) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVJITCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVJITCompiler.java
@@ -51,8 +51,8 @@ import uk.ac.manchester.tornado.runtime.profiler.EmptyProfiler;
 import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
 import uk.ac.manchester.tornado.runtime.tasks.DataObjectState;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * Testing the SPIR-V JIT Compiler and integration with the TornadoVM SPIR-V Runtime.
@@ -94,10 +94,10 @@ public class TestSPIRVJITCompiler {
         TornadoDevice device = tornadoRuntime.getBackend(SPIRVBackendImpl.class).getDefaultDevice();
 
         // Create a new task for TornadoVM
-        ScheduleMetaData scheduleMetaData = new ScheduleMetaData("s0");
+        ScheduleContext scheduleMetaData = new ScheduleContext("s0");
         // Create a compilable task
         CompilableTask compilableTask = new CompilableTask(scheduleMetaData, "t0", methodToCompile, parameters);
-        TaskMetaData taskMeta = compilableTask.meta();
+        TaskDataContext taskMeta = compilableTask.meta();
         taskMeta.setDevice(device);
 
         // 1. Build Common Compiler Phase (Sketcher)
@@ -116,7 +116,7 @@ public class TestSPIRVJITCompiler {
         return new MetaCompilation(taskMeta, spirvInstalledCode);
     }
 
-    public void run(SPIRVTornadoDevice spirvTornadoDevice, SPIRVInstalledCode installedCode, TaskMetaData taskMeta, int[] a, int[] b, float[] c) {
+    public void run(SPIRVTornadoDevice spirvTornadoDevice, SPIRVInstalledCode installedCode, TaskDataContext taskMeta, int[] a, int[] b, float[] c) {
         // First we allocate, A, B and C
         DataObjectState stateA = new DataObjectState();
         XPUDeviceBufferState objectStateA = stateA.getDeviceBufferState(spirvTornadoDevice);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVTornadoCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVTornadoCompiler.java
@@ -34,8 +34,8 @@ import uk.ac.manchester.tornado.drivers.spirv.SPIRVPlatform;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVRuntimeImpl;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVInstalledCode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.SPIRVCompilationResult;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * How to test?
@@ -59,8 +59,8 @@ public class TestSPIRVTornadoCompiler {
             codeCache = new SPIRVLevelZeroCodeCache(deviceContext);
         }
 
-        ScheduleMetaData scheduleMetaData = new ScheduleMetaData("SPIRV-Backend");
-        TaskMetaData task = new TaskMetaData(scheduleMetaData, "saxpy");
+        ScheduleContext scheduleMetaData = new ScheduleContext("SPIRV-Backend");
+        TaskDataContext task = new TaskDataContext(scheduleMetaData, "saxpy");
         new SPIRVCompilationResult("saxpy", "saxpy", task);
 
         String tornadoSDK = System.getenv("TORNADO_SDK");

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/timestamps/LevelZeroKernelTimeStamp.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/timestamps/LevelZeroKernelTimeStamp.java
@@ -42,7 +42,7 @@ import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeHostMemAllocDescriptor
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.ZeKernelTimeStampResult;
 import uk.ac.manchester.tornado.drivers.spirv.levelzero.utils.LevelZeroUtils;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class LevelZeroKernelTimeStamp {
 
@@ -93,7 +93,7 @@ public class LevelZeroKernelTimeStamp {
         LevelZeroUtils.errorLog("zeEventCreate", result);
     }
 
-    public void solveEvent(long executionPlanId, TaskMetaData meta) {
+    public void solveEvent(long executionPlanId, TaskDataContext meta) {
         timeStampBuffer = new LevelZeroByteBuffer();
         ZeHostMemAllocDescriptor hostMemAllocDesc = new ZeHostMemAllocDescriptor();
         LevelZeroContext context = commandList.getContext();
@@ -121,7 +121,7 @@ public class LevelZeroKernelTimeStamp {
         }
     }
 
-    private void updateProfiler(ZeKernelTimeStampResult resultKernel, final TaskMetaData meta) {
+    private void updateProfiler(ZeKernelTimeStampResult resultKernel, final TaskDataContext meta) {
         long timer = meta.getProfiler().getTimer(ProfilerType.TOTAL_KERNEL_TIME);
         long kernelElapsedTime = (long) resultKernel.getKernelElapsedTime();
         // Register globalTime

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -59,7 +59,7 @@ import uk.ac.manchester.tornado.runtime.domain.DomainTree;
 import uk.ac.manchester.tornado.runtime.domain.IntDomain;
 import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
 import uk.ac.manchester.tornado.runtime.tasks.PrebuiltTask;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
 
 public class TaskUtils {
 
@@ -199,79 +199,79 @@ public class TaskUtils {
         return null;
     }
 
-    public static CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task code) {
+    public static CompilableTask createTask(Method method, ScheduleContext meta, String id, Task code) {
         return createTask(meta, id, method, code, true);
     }
 
-    public static <T1> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task1<T1> code, T1 arg1) {
+    public static <T1> CompilableTask createTask(Method method, ScheduleContext meta, String id, Task1<T1> code, T1 arg1) {
         return createTask(meta, id, method, code, true, arg1);
     }
 
-    public static <T1, T2> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task2<T1, T2> code, T1 arg1, T2 arg2) {
+    public static <T1, T2> CompilableTask createTask(Method method, ScheduleContext meta, String id, Task2<T1, T2> code, T1 arg1, T2 arg2) {
         return createTask(meta, id, method, code, true, arg1, arg2);
     }
 
-    public static <T1, T2, T3> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task3<T1, T2, T3> code, T1 arg1, T2 arg2, T3 arg3) {
+    public static <T1, T2, T3> CompilableTask createTask(Method method, ScheduleContext meta, String id, Task3<T1, T2, T3> code, T1 arg1, T2 arg2, T3 arg3) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3);
     }
 
-    public static <T1, T2, T3, T4> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task4<T1, T2, T3, T4> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
+    public static <T1, T2, T3, T4> CompilableTask createTask(Method method, ScheduleContext meta, String id, Task4<T1, T2, T3, T4> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4);
     }
 
-    public static <T1, T2, T3, T4, T5> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task5<T1, T2, T3, T4, T5> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
+    public static <T1, T2, T3, T4, T5> CompilableTask createTask(Method method, ScheduleContext meta, String id, Task5<T1, T2, T3, T4, T5> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5);
     }
 
-    public static <T1, T2, T3, T4, T5, T6> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task6<T1, T2, T3, T4, T5, T6> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
+    public static <T1, T2, T3, T4, T5, T6> CompilableTask createTask(Method method, ScheduleContext meta, String id, Task6<T1, T2, T3, T4, T5, T6> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
             T6 arg6) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6);
     }
 
-    public static <T1, T2, T3, T4, T5, T6, T7> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task7<T1, T2, T3, T4, T5, T6, T7> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+    public static <T1, T2, T3, T4, T5, T6, T7> CompilableTask createTask(Method method, ScheduleContext meta, String id, Task7<T1, T2, T3, T4, T5, T6, T7> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
             T5 arg5, T6 arg6, T7 arg7) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
     }
 
-    public static <T1, T2, T3, T4, T5, T6, T7, T8> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task8<T1, T2, T3, T4, T5, T6, T7, T8> code, T1 arg1, T2 arg2, T3 arg3,
+    public static <T1, T2, T3, T4, T5, T6, T7, T8> CompilableTask createTask(Method method, ScheduleContext meta, String id, Task8<T1, T2, T3, T4, T5, T6, T7, T8> code, T1 arg1, T2 arg2, T3 arg3,
             T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     }
 
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task9<T1, T2, T3, T4, T5, T6, T7, T8, T9> code, T1 arg1, T2 arg2,
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9> CompilableTask createTask(Method method, ScheduleContext meta, String id, Task9<T1, T2, T3, T4, T5, T6, T7, T8, T9> code, T1 arg1, T2 arg2,
             T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
     }
 
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> CompilableTask createTask(Method method, ScheduleMetaData meta, String id, Task10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> code, T1 arg1,
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> CompilableTask createTask(Method method, ScheduleContext meta, String id, Task10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> code, T1 arg1,
             T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
     }
 
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> CompilableTask createTask(Method method, ScheduleMetaData meta, String id,
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> CompilableTask createTask(Method method, ScheduleContext meta, String id,
             TornadoFunctions.Task11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
     }
 
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> CompilableTask createTask(Method method, ScheduleMetaData meta, String id,
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> CompilableTask createTask(Method method, ScheduleContext meta, String id,
             TornadoFunctions.Task12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
             T12 arg12) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
     }
 
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> CompilableTask createTask(Method method, ScheduleMetaData meta, String id,
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> CompilableTask createTask(Method method, ScheduleContext meta, String id,
             TornadoFunctions.Task13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
             T12 arg12, T13 arg13) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
     }
 
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> CompilableTask createTask(Method method, ScheduleMetaData meta, String id,
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> CompilableTask createTask(Method method, ScheduleContext meta, String id,
             TornadoFunctions.Task14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
             T11 arg11, T12 arg12, T13 arg13, T14 arg14) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
     }
 
-    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> CompilableTask createTask(Method method, ScheduleMetaData meta, String id,
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> CompilableTask createTask(Method method, ScheduleContext meta, String id,
             Task15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
             T12 arg12, T13 arg13, T14 arg14, T15 arg15) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
@@ -311,7 +311,7 @@ public class TaskUtils {
 
     }
 
-    public static PrebuiltTask createTask(ScheduleMetaData meta, PrebuiltTaskPackage taskPackage) {
+    public static PrebuiltTask createTask(ScheduleContext meta, PrebuiltTaskPackage taskPackage) {
         PrebuiltTask prebuiltTask = new PrebuiltTask(meta, //
                 taskPackage.getId(), //
                 taskPackage.getEntryPoint(), //
@@ -324,7 +324,7 @@ public class TaskUtils {
         return prebuiltTask;
     }
 
-    private static CompilableTask createTask(ScheduleMetaData meta, String id, Method method, Object code, boolean extractCVs, Object... args) {
+    private static CompilableTask createTask(ScheduleContext meta, String id, Method method, Object code, boolean extractCVs, Object... args) {
         final int numArgs;
         final Object[] cvs;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoInstalledCode.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoInstalledCode.java
@@ -24,13 +24,13 @@
 package uk.ac.manchester.tornado.runtime.common;
 
 import uk.ac.manchester.tornado.api.memory.XPUBuffer;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public interface TornadoInstalledCode {
 
-    int launchWithDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskMetaData meta, long batchThreads, int[] waitEvents);
+    int launchWithDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskDataContext meta, long batchThreads, int[] waitEvents);
 
-    int launchWithoutDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskMetaData meta, long batchThreads);
+    int launchWithoutDependencies(long executionPlanId, KernelStackFrame callWrapper, XPUBuffer atomicSpace, TaskDataContext meta, long batchThreads);
 
     boolean isValid();
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -33,6 +33,21 @@ public class TornadoOptions {
     private static final String TRUE = "TRUE";
 
     /**
+     * Default OpenCL Compiler Flags.
+     */
+    public static final String DEFAULT_OPENCL_COMPILER_FLAGS = getProperty("tornado.opencl.compiler.flags", "-cl-mad-enable -cl-fast-relaxed-math -w");
+
+    /**
+     * Default PTX Compiler Flags.
+     */
+    public static final String DEFAULT_PTX_COMPILER_FLAGS = getProperty("tornado.ptx.compiler.flags", "");
+
+    /**
+     * Default SPIR-V/LevelZero Flags.
+     */
+    public static final String DEFAULT_SPIRV_LEVEL_ZERO_COMPILER_FLAGS = getProperty("tornado.spirv.levelzero.flags", "-ze-opt-level 2 -ze-opt-large-register-file");
+
+    /**
      * Use internal timers for profiling in ns if enabled, in ms if disabled. Default is ns (enabled).
      */
     public static final boolean TIME_IN_NANOSECONDS = Boolean.parseBoolean(System.getProperty("tornado.ns.time", TRUE));

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoHighTierContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoHighTierContext.java
@@ -29,18 +29,18 @@ import org.graalvm.compiler.phases.util.Providers;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.runtime.common.BatchCompilationConfig;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class TornadoHighTierContext extends HighTierContext {
 
     protected final ResolvedJavaMethod method;
     protected final Object[] args;
-    protected final TaskMetaData meta;
+    protected final TaskDataContext meta;
     protected final boolean isKernel;
     private BatchCompilationConfig batchCompilationConfig;
 
     public TornadoHighTierContext(Providers providers, PhaseSuite<HighTierContext> graphBuilderSuite, OptimisticOptimizations optimisticOpts, ResolvedJavaMethod method, Object[] args,
-            TaskMetaData meta, boolean isKernel, BatchCompilationConfig batchCompilationConfig) {
+            TaskDataContext meta, boolean isKernel, BatchCompilationConfig batchCompilationConfig) {
         super(providers, graphBuilderSuite, optimisticOpts);
         this.method = method;
         this.args = args;
@@ -69,7 +69,7 @@ public class TornadoHighTierContext extends HighTierContext {
         return (hasArgs()) ? args.length : 0;
     }
 
-    public TaskMetaData getMeta() {
+    public TaskDataContext getMeta() {
         return meta;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoHighTierContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoHighTierContext.java
@@ -74,7 +74,7 @@ public class TornadoHighTierContext extends HighTierContext {
     }
 
     public TornadoXPUDevice getDeviceMapping() {
-        return meta.getLogicDevice();
+        return meta.getXPUDevice();
     }
 
     public boolean hasMeta() {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoLowTierContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoLowTierContext.java
@@ -10,7 +10,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -24,18 +24,19 @@ package uk.ac.manchester.tornado.runtime.graal.phases;
 import org.graalvm.compiler.phases.tiers.LowTierContext;
 import org.graalvm.compiler.phases.tiers.TargetProvider;
 import org.graalvm.compiler.phases.util.Providers;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class TornadoLowTierContext extends LowTierContext {
 
-    protected final TaskMetaData meta;
+    protected final TaskDataContext meta;
 
-    public TornadoLowTierContext(Providers copyFrom, TargetProvider target, TaskMetaData meta) {
+    public TornadoLowTierContext(Providers copyFrom, TargetProvider target, TaskDataContext meta) {
         super(copyFrom, target);
         this.meta = meta;
     }
 
-    public TaskMetaData getMeta() {
+    public TaskDataContext getMeta() {
         return meta;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoMidTierContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graal/phases/TornadoMidTierContext.java
@@ -25,18 +25,19 @@ import org.graalvm.compiler.phases.OptimisticOptimizations;
 import org.graalvm.compiler.phases.tiers.MidTierContext;
 import org.graalvm.compiler.phases.tiers.TargetProvider;
 import org.graalvm.compiler.phases.util.Providers;
+
 import jdk.vm.ci.meta.ProfilingInfo;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class TornadoMidTierContext extends MidTierContext {
 
     protected final ResolvedJavaMethod method;
     protected final Object[] args;
-    protected final TaskMetaData meta;
+    protected final TaskDataContext meta;
 
     public TornadoMidTierContext(Providers copyFrom, TargetProvider target, OptimisticOptimizations optimisticOpts, ProfilingInfo profilingInfo, ResolvedJavaMethod method, Object[] args,
-            TaskMetaData meta) {
+            TaskDataContext meta) {
         super(copyFrom, target, optimisticOpts, profilingInfo);
         this.method = method;
         this.args = args;
@@ -63,7 +64,7 @@ public class TornadoMidTierContext extends MidTierContext {
         return (hasArgs()) ? args.length : 0;
     }
 
-    public TaskMetaData getMeta() {
+    public TaskDataContext getMeta() {
         return meta;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -571,38 +571,6 @@ public class TornadoExecutionContext {
         return defaultScheduler;
     }
 
-    public void createImmutableExecutionContext(TornadoExecutionContext executionContext) {
-
-        List<SchedulableTask> schedulableTasksCopy = new ArrayList<>(tasks);
-        executionContext.tasks = schedulableTasksCopy;
-
-        List<Object> constantCopy = new ArrayList<>(constants);
-        executionContext.constants = constantCopy;
-
-        Map<Integer, Integer> objectsMapCopy = new HashMap<>(objectMap);
-        executionContext.objectMap = objectsMapCopy;
-
-        List<Object> objectsCopy = new ArrayList<>(objects);
-        executionContext.objects = objectsCopy;
-
-        List<LocalObjectState> objectStateCopy = new ArrayList<>(objectState);
-        executionContext.objectState = objectStateCopy;
-
-        List<TornadoXPUDevice> devicesCopy = new ArrayList<>(devices);
-        executionContext.devices = devicesCopy;
-
-        executionContext.taskToDeviceMapTable = this.taskToDeviceMapTable.clone();
-
-        Set<TornadoXPUDevice> lastDeviceCopy = new HashSet<>(lastDevices);
-        executionContext.lastDevices = lastDeviceCopy;
-
-        executionContext.meta = meta;
-        executionContext.isPrintKernel = this.isPrintKernel;
-
-        executionContext.profiler = this.profiler;
-        executionContext.nextTask = this.nextTask;
-    }
-
     public void dumpExecutionContextMeta() {
         final String ansiReset = "\u001B[0m";
         final String ansiCyan = "\u001B[36m";

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -465,7 +465,7 @@ public class TornadoExecutionContext {
 
     /**
      * It retrieves a list of tasks for a specific device and driver. Both
-     * deviceContext and driverIndex are checked to ensure the correct task
+     * deviceContext and backendIndex are checked to ensure the correct task
      * assignment.
      *
      * @param deviceContext
@@ -493,7 +493,7 @@ public class TornadoExecutionContext {
      */
     @Deprecated
     public TornadoXPUDevice getDefaultDevice() {
-        return meta.getLogicDevice();
+        return meta.getXPUDevice();
     }
 
     public SchedulableTask getTask(String id) {
@@ -534,13 +534,13 @@ public class TornadoExecutionContext {
             Object object = objects.get(i);
             if (object != null) {
                 final LocalObjectState localState = objectState.get(i);
-                Event event = localState.sync(executionPlanId, object, meta().getLogicDevice());
+                Event event = localState.sync(executionPlanId, object, meta().getXPUDevice());
 
                 if (TornadoOptions.isProfilerEnabled() && event != null) {
                     long value = profiler.getTimer(ProfilerType.COPY_OUT_TIME_SYNC);
                     value += event.getElapsedTime();
                     profiler.setTimer(ProfilerType.COPY_OUT_TIME_SYNC, value);
-                    XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceBufferState(meta().getLogicDevice());
+                    XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceBufferState(meta().getXPUDevice());
                     profiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getXPUBuffer().size());
                 }
             }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -62,7 +62,7 @@ import uk.ac.manchester.tornado.runtime.common.XPUDeviceBufferState;
 import uk.ac.manchester.tornado.runtime.common.enums.DataTypeSize;
 import uk.ac.manchester.tornado.runtime.profiler.TimeProfiler;
 import uk.ac.manchester.tornado.runtime.tasks.LocalObjectState;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
 
 public class TornadoExecutionContext {
 
@@ -70,7 +70,7 @@ public class TornadoExecutionContext {
     private final int MAX_TASKS = 256;
     private final int INITIAL_DEVICE_CAPACITY = 16;
     private final String name;
-    private ScheduleMetaData meta;
+    private ScheduleContext meta;
     private KernelStackFrame[] kernelStackFrame;
     private List<SchedulableTask> tasks;
     private List<Object> constants;
@@ -94,7 +94,7 @@ public class TornadoExecutionContext {
 
     public TornadoExecutionContext(String id) {
         name = id;
-        meta = new ScheduleMetaData(name);
+        meta = new ScheduleContext(name);
         tasks = new ArrayList<>();
         constants = new ArrayList<>();
         objectMap = new HashMap<>();
@@ -525,7 +525,7 @@ public class TornadoExecutionContext {
         return name;
     }
 
-    public ScheduleMetaData meta() {
+    public ScheduleContext meta() {
         return meta;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
@@ -93,7 +93,7 @@ public class TornadoVMGraphCompiler {
 
         }
 
-        if (executionContext.meta().shouldDumpTaskGraph()) {
+        if (executionContext.meta().isDebug()) {
             intermediateTornadoGraph.printDependencyMatrix();
         }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -779,22 +779,22 @@ public class TornadoVMInterpreter {
             tornadoVMBytecodeList.append(verbose).append("\n");
         }
 
-        TaskDataContext metadata;
+        TaskDataContext dataContext;
         try {
-            metadata = (TaskDataContext) task.meta();
+            dataContext = (TaskDataContext) task.meta();
         } catch (ClassCastException e) {
             throw new TornadoRuntimeException("task.meta is not instanceof TaskMetadata");
         }
 
-        // We attach the profiler information
-        metadata.attachProfiler(timeProfiler);
-        metadata.setGridScheduler(gridScheduler);
-        metadata.setThreadInfoEnabled(executionContext.meta().isThreadInfoEnabled());
+        // We attach the profiler information, grid information and global threads
+        dataContext.attachProfiler(timeProfiler);
+        dataContext.setGridScheduler(gridScheduler);
+        dataContext.setThreadInfoEnabled(executionContext.meta().isThreadInfoEnabled());
 
         try {
             int lastEvent = useDependencies
-                    ? installedCode.launchWithDependencies(executionContext.getExecutionPlanId(), stackFrame, bufferAtomics, metadata, batchThreads, waitList)
-                    : installedCode.launchWithoutDependencies(executionContext.getExecutionPlanId(), stackFrame, bufferAtomics, metadata, batchThreads);
+                    ? installedCode.launchWithDependencies(executionContext.getExecutionPlanId(), stackFrame, bufferAtomics, dataContext, batchThreads, waitList)
+                    : installedCode.launchWithoutDependencies(executionContext.getExecutionPlanId(), stackFrame, bufferAtomics, dataContext, batchThreads);
 
             resetEventIndexes(eventList);
             return lastEvent;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -63,7 +63,7 @@ import uk.ac.manchester.tornado.runtime.graph.TornadoVMBytecodes;
 import uk.ac.manchester.tornado.runtime.profiler.TimeProfiler;
 import uk.ac.manchester.tornado.runtime.tasks.DataObjectState;
 import uk.ac.manchester.tornado.runtime.tasks.PrebuiltTask;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * TornadoVMInterpreter: serves as a bytecode interpreter for TornadoVM
@@ -210,7 +210,7 @@ public class TornadoVMInterpreter {
         interpreterDevice.dumpEvents(executionContext.getExecutionPlanId());
     }
 
-    private void dumpEventProfiled(TornadoEvents eventSet, TaskMetaData meta) {
+    private void dumpEventProfiled(TornadoEvents eventSet, TaskDataContext meta) {
         final BitSet profiles = eventSet.getProfiles();
         for (int i = profiles.nextSetBit(0); i != -1; i = profiles.nextSetBit(i + 1)) {
             if (eventSet.getDevice() instanceof TornadoXPUDevice device) {
@@ -227,7 +227,7 @@ public class TornadoVMInterpreter {
 
     public void dumpProfiles() {
         for (final SchedulableTask task : tasks) {
-            final TaskMetaData meta = (TaskMetaData) task.meta();
+            final TaskDataContext meta = (TaskDataContext) task.meta();
             meta.getProfiles(executionContext.getExecutionPlanId()).forEach(eventSet -> dumpEventProfiled(eventSet, meta));
         }
     }
@@ -779,9 +779,9 @@ public class TornadoVMInterpreter {
             tornadoVMBytecodeList.append(verbose).append("\n");
         }
 
-        TaskMetaData metadata;
+        TaskDataContext metadata;
         try {
-            metadata = (TaskMetaData) task.meta();
+            metadata = (TaskDataContext) task.meta();
         } catch (ClassCastException e) {
             throw new TornadoRuntimeException("task.meta is not instanceof TaskMetadata");
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -202,7 +202,7 @@ public class TornadoVMInterpreter {
     }
 
     public void dumpEvents() {
-        if (!TornadoOptions.TORNADO_PROFILER || !executionContext.meta().shouldDumpEvents()) {
+        if (!TornadoOptions.TORNADO_PROFILER) {
             logger.info("profiling and/or event dumping is not enabled");
             return;
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -210,11 +210,6 @@ public class TornadoVMInterpreter {
     }
 
     public void dumpProfiles() {
-        if (!executionContext.meta().shouldDumpProfiles()) {
-            logger.info("profiling is not enabled");
-            return;
-        }
-
         for (final SchedulableTask task : tasks) {
             final TaskMetaData meta = (TaskMetaData) task.meta();
             for (final TornadoEvents eventSet : meta.getProfiles(executionContext.getExecutionPlanId())) {
@@ -409,7 +404,7 @@ public class TornadoVMInterpreter {
             }
         }
 
-        long allocationsTotalSize =  interpreterDevice.allocateObjects(objects, sizeBatch, objectStates);
+        long allocationsTotalSize = interpreterDevice.allocateObjects(objects, sizeBatch, objectStates);
 
         executionContext.setCurrentDeviceMemoryUsage(allocationsTotalSize);
 
@@ -419,7 +414,7 @@ public class TornadoVMInterpreter {
                 timeProfiler.addValueToMetric(ProfilerType.ALLOCATION_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
             }
         }
-        
+
         return -1;
     }
 
@@ -433,7 +428,7 @@ public class TornadoVMInterpreter {
         }
 
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
-        long spaceDeallocated =  interpreterDevice.deallocate(objectState);
+        long spaceDeallocated = interpreterDevice.deallocate(objectState);
         // Update current device area use 
         executionContext.setCurrentDeviceMemoryUsage(executionContext.getCurrentDeviceMemoryUsage() - spaceDeallocated);
         return -1;
@@ -880,8 +875,8 @@ public class TornadoVMInterpreter {
 
     private void profilerUpdateForPreCompiledTask(SchedulableTask task) {
         if (task instanceof PrebuiltTask prebuiltTask && timeProfiler instanceof TimeProfiler) {
-            timeProfiler.registerDeviceID(task.getId(), prebuiltTask.meta().getLogicDevice().getDriverIndex() + ":" + prebuiltTask.meta().getDeviceIndex());
-            timeProfiler.registerDeviceName(task.getId(), prebuiltTask.meta().getLogicDevice().getPhysicalDevice().getDeviceName());
+            timeProfiler.registerDeviceID(task.getId(), prebuiltTask.meta().getXPUDevice().getDriverIndex() + ":" + prebuiltTask.meta().getDeviceIndex());
+            timeProfiler.registerDeviceName(task.getId(), prebuiltTask.meta().getXPUDevice().getPhysicalDevice().getDeviceName());
         }
     }
 
@@ -935,10 +930,8 @@ public class TornadoVMInterpreter {
             tornadoVMBytecodeList.append(verbose).append("\n");
         }
 
-        static void logTransferToDeviceAlways(Object object, TornadoXPUDevice deviceForInterpreter, long sizeBatch, long offset, final int eventList,
-                                              StringBuilder tornadoVMBytecodeList) {
-            String verbose = String.format("bc: %s [0x%x] %s on %s, size=%d, offset=%d [event list=%d]",
-                    InterpreterUtilities.debugHighLightBC("TRANSFER_HOST_TO_DEVICE_ALWAYS"), //
+        static void logTransferToDeviceAlways(Object object, TornadoXPUDevice deviceForInterpreter, long sizeBatch, long offset, final int eventList, StringBuilder tornadoVMBytecodeList) {
+            String verbose = String.format("bc: %s [0x%x] %s on %s, size=%d, offset=%d [event list=%d]", InterpreterUtilities.debugHighLightBC("TRANSFER_HOST_TO_DEVICE_ALWAYS"), //
                     object.hashCode(), //
                     object, //
                     InterpreterUtilities.debugDeviceBC(deviceForInterpreter), //

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
@@ -81,7 +81,7 @@ public class CompilableTask implements SchedulableTask {
 
     @Override
     public TornadoXPUDevice getDevice() {
-        return meta.getLogicDevice();
+        return meta.getXPUDevice();
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
@@ -32,15 +32,15 @@ import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class CompilableTask implements SchedulableTask {
 
     protected final Object[] args;
     protected final Method method;
     private final Object[] resolvedArgs;
-    protected TaskMetaData meta;
+    protected TaskDataContext meta;
     protected boolean shouldCompile;
     private long batchNumThreads;
     private int batchNumber;
@@ -49,12 +49,12 @@ public class CompilableTask implements SchedulableTask {
     private TornadoProfiler profiler;
     private boolean forceCompiler;
 
-    public CompilableTask(ScheduleMetaData meta, String id, Method method, Object... args) {
+    public CompilableTask(ScheduleContext meta, String id, Method method, Object... args) {
         this.method = method;
         this.args = args;
         this.shouldCompile = true;
         this.resolvedArgs = args;
-        this.meta = TaskMetaData.create(meta, id, method);
+        this.meta = TaskDataContext.create(meta, id, method);
     }
 
     @Override
@@ -106,7 +106,7 @@ public class CompilableTask implements SchedulableTask {
     }
 
     @Override
-    public TaskMetaData meta() {
+    public TaskDataContext meta() {
         return meta;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
@@ -32,13 +32,13 @@ import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.domain.DomainTree;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PrebuiltTask implements SchedulableTask {
 
     protected final Object[] args;
-    protected final TaskMetaData meta;
+    protected final TaskDataContext meta;
     private final String entryPoint;
     private final String filename;
     private final Access[] argumentsAccess;
@@ -50,12 +50,12 @@ public class PrebuiltTask implements SchedulableTask {
     private boolean forceCompiler;
     private int[] atomics;
 
-    public PrebuiltTask(ScheduleMetaData scheduleMeta, String id, String entryPoint, String filename, Object[] args, Access[] access, TornadoDevice device, DomainTree domain) {
+    public PrebuiltTask(ScheduleContext scheduleMeta, String id, String entryPoint, String filename, Object[] args, Access[] access, TornadoDevice device, DomainTree domain) {
         this.entryPoint = entryPoint;
         this.filename = filename;
         this.args = args;
         this.argumentsAccess = access;
-        meta = new TaskMetaData(scheduleMeta, id, access.length);
+        meta = new TaskDataContext(scheduleMeta, id, access.length);
         for (int i = 0; i < access.length; i++) {
             meta.getArgumentsAccess()[i] = access[i];
         }
@@ -70,12 +70,12 @@ public class PrebuiltTask implements SchedulableTask {
 
     }
 
-    public PrebuiltTask(ScheduleMetaData scheduleMeta, String id, String entryPoint, String filename, Object[] args, Access[] access) {
+    public PrebuiltTask(ScheduleContext scheduleMeta, String id, String entryPoint, String filename, Object[] args, Access[] access) {
         this.entryPoint = entryPoint;
         this.filename = filename;
         this.args = args;
         this.argumentsAccess = access;
-        meta = new TaskMetaData(scheduleMeta, id, access.length);
+        meta = new TaskDataContext(scheduleMeta, id, access.length);
         for (int i = 0; i < access.length; i++) {
             meta.getArgumentsAccess()[i] = access[i];
         }
@@ -112,7 +112,7 @@ public class PrebuiltTask implements SchedulableTask {
     }
 
     @Override
-    public TaskMetaData meta() {
+    public TaskDataContext meta() {
         return meta;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
@@ -124,7 +124,7 @@ public class PrebuiltTask implements SchedulableTask {
 
     @Override
     public TornadoXPUDevice getDevice() {
-        return meta.getLogicDevice();
+        return meta.getXPUDevice();
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/ReduceTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/ReduceTaskGraph.java
@@ -66,7 +66,7 @@ import uk.ac.manchester.tornado.runtime.analyzer.ReduceCodeAnalysis.REDUCE_OPERA
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.MetaDataUtils;
 import uk.ac.manchester.tornado.runtime.tasks.meta.MetaDataUtils.BackendSelectionContainer;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 class ReduceTaskGraph {
 
@@ -371,8 +371,8 @@ class ReduceTaskGraph {
     private void updateGlobalAndLocalDimensionsFPGA(final int deviceToRun, String taskScheduleReduceName, TaskPackage taskPackage, int inputSize) {
         // Update GLOBAL and LOCAL workgroup size if device to run is the FPGA
         if (isAheadOfTime() && isDeviceAnAccelerator(deviceToRun)) {
-            TornadoRuntimeProvider.setProperty(taskScheduleReduceName + "." + taskPackage.getId() + TaskMetaData.GLOBAL_WORKGROUP_SUFFIX, Integer.toString(inputSize));
-            TornadoRuntimeProvider.setProperty(taskScheduleReduceName + "." + taskPackage.getId() + TaskMetaData.LOCAL_WORKGROUP_SUFFIX, "64");
+            TornadoRuntimeProvider.setProperty(taskScheduleReduceName + "." + taskPackage.getId() + TaskDataContext.GLOBAL_WORKGROUP_SUFFIX, Integer.toString(inputSize));
+            TornadoRuntimeProvider.setProperty(taskScheduleReduceName + "." + taskPackage.getId() + TaskDataContext.LOCAL_WORKGROUP_SUFFIX, "64");
         }
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/ReduceTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/ReduceTaskGraph.java
@@ -65,6 +65,7 @@ import uk.ac.manchester.tornado.runtime.analyzer.ReduceCodeAnalysis;
 import uk.ac.manchester.tornado.runtime.analyzer.ReduceCodeAnalysis.REDUCE_OPERATION;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.MetaDataUtils;
+import uk.ac.manchester.tornado.runtime.tasks.meta.MetaDataUtils.BackendSelectionContainer;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
 
 class ReduceTaskGraph {
@@ -75,7 +76,7 @@ class ReduceTaskGraph {
 
     private static final String TASK_GRAPH_PREFIX = "XXX__GENERATED_REDUCE";
     private static final int DEFAULT_GPU_WORK_GROUP = 256;
-    private static final int DEFAULT_DRIVER_INDEX = 0;
+    private static final int DEFAULT_BACKEND_INDEX = 0;
     private static final int DEFAULT_DEVICE_INDEX = 0;
     private static AtomicInteger counterName = new AtomicInteger(0);
     private static AtomicInteger counterSeqName = new AtomicInteger(0);
@@ -189,8 +190,8 @@ class ReduceTaskGraph {
             for (int i = 0; i < binaries.length; i += 2) {
                 String givenTaskName = binaries[i + 1].split(".device")[0];
                 if (givenTaskName.equals(idTaskGraph)) {
-                    int[] info = MetaDataUtils.resolveDriverDeviceIndexes(MetaDataUtils.getProperty(idTaskGraph + ".device"));
-                    int deviceNumber = info[1];
+                    BackendSelectionContainer info = MetaDataUtils.resolveDriverDeviceIndexes(MetaDataUtils.getProperty(idTaskGraph + ".device"));
+                    int deviceNumber = info.deviceIndex();
 
                     if (!sequential) {
                         originalBinaries.append("," + binaries[i] + "," + taskScheduleName + "." + taskName + ".device=0:" + deviceNumber);
@@ -207,15 +208,15 @@ class ReduceTaskGraph {
         return TornadoOptions.FPGA_BINARIES != null;
     }
 
-    private int[] changeDriverAndDeviceIfNeeded(String taskScheduleName, String graphName, String taskName) {
+    private BackendSelectionContainer changeDriverAndDeviceIfNeeded(String taskScheduleName, String graphName, String taskName) {
         String idTaskGraph = graphName + "." + taskName;
         boolean isDeviceDefined = MetaDataUtils.getProperty(idTaskGraph + ".device") != null;
 
         if (isDeviceDefined) {
-            int[] info = MetaDataUtils.resolveDriverDeviceIndexes(MetaDataUtils.getProperty(idTaskGraph + ".device"));
-            int driverNumber = info[0];
-            int deviceNumber = info[1];
-            TornadoRuntimeProvider.setProperty(taskScheduleName + "." + taskName + ".device", driverNumber + ":" + deviceNumber);
+            BackendSelectionContainer info = MetaDataUtils.resolveDriverDeviceIndexes(MetaDataUtils.getProperty(idTaskGraph + ".device"));
+            int backendIndex = info.backendIndex();
+            int deviceNumber = info.deviceIndex();
+            TornadoRuntimeProvider.setProperty(taskScheduleName + "." + taskName + ".device", backendIndex + ":" + deviceNumber);
             return info;
         }
         return null;
@@ -420,7 +421,7 @@ class ReduceTaskGraph {
             reduceOperandTable = new HashMap<>();
         }
 
-        int driverToRun = DEFAULT_DRIVER_INDEX;
+        int backendToRun = DEFAULT_BACKEND_INDEX;
         int deviceToRun = DEFAULT_DEVICE_INDEX;
 
         // Create new buffer variables and update the corresponding streamIn and
@@ -432,10 +433,10 @@ class ReduceTaskGraph {
 
             List<Object> streamReduceList = new ArrayList<>();
 
-            int[] driverAndDevice = changeDriverAndDeviceIfNeeded(taskScheduleReduceName, graphName, taskPackage.getId());
-            if (driverAndDevice != null) {
-                driverToRun = driverAndDevice[0];
-                deviceToRun = driverAndDevice[1];
+            BackendSelectionContainer selectionContainer = changeDriverAndDeviceIfNeeded(taskScheduleReduceName, graphName, taskPackage.getId());
+            if (selectionContainer != null) {
+                backendToRun = selectionContainer.backendIndex();
+                deviceToRun = selectionContainer.deviceIndex();
             }
             inspectBinariesFPGA(taskScheduleReduceName, graphName, taskPackage.getId(), false);
 
@@ -474,7 +475,7 @@ class ReduceTaskGraph {
                     }
 
                     // Set the new array size
-                    int sizeReductionArray = obtainSizeArrayResult(driverToRun, deviceToRun, inputSize);
+                    int sizeReductionArray = obtainSizeArrayResult(backendToRun, deviceToRun, inputSize);
                     Object newDeviceArray = createNewReduceArray(originalReduceArray, sizeReductionArray);
                     Object neutralElement = getNeutralElement(originalReduceArray);
                     fillOutputArrayWithNeutral(newDeviceArray, neutralElement);
@@ -570,7 +571,7 @@ class ReduceTaskGraph {
                     for (REDUCE_OPERATION operation : operations) {
                         final String newTaskSequentialName = SEQUENTIAL_TASK_REDUCE_NAME + counterSeqName.get();
                         String fullName = rewrittenTaskGraph.getTaskGraphName() + "." + newTaskSequentialName;
-                        TornadoRuntimeProvider.setProperty(fullName + ".device", driverToRun + ":" + deviceToRun);
+                        TornadoRuntimeProvider.setProperty(fullName + ".device", backendToRun + ":" + deviceToRun);
                         inspectBinariesFPGA(taskScheduleReduceName, graphName, taskPackage.getId(), true);
 
                         switch (operation) {
@@ -615,7 +616,8 @@ class ReduceTaskGraph {
                     continue;
                 }
                 if (!rewrittenTaskGraph.getArgumentsLookup().contains(parameter)) {
-                    throw new TornadoTaskRuntimeException("Parameter #" + i + " <" + parameter + "> from task <" + task.getId() + "> not specified either in `transferToDevice` or `transferToHost` functions");
+                    throw new TornadoTaskRuntimeException("Parameter #" + i + " <" + parameter + "> from task <" + task
+                            .getId() + "> not specified either in `transferToDevice` or `transferToHost` functions");
                 }
             }
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -125,8 +125,8 @@ import uk.ac.manchester.tornado.runtime.profiler.TimeProfiler;
 import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
 import uk.ac.manchester.tornado.runtime.sketcher.SketchRequest;
 import uk.ac.manchester.tornado.runtime.sketcher.TornadoSketcher;
-import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
-import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 /**
  * Implementation of the Tornado API for running on heterogeneous devices.
@@ -623,7 +623,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
         if (task instanceof CompilableTask compilableTask) {
             final ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(compilableTask.getMethod());
-            final TaskMetaData taskMetaData = compilableTask.meta();
+            final TaskDataContext taskMetaData = compilableTask.meta();
             new SketchRequest(resolvedMethod, providers, suites.getGraphBuilderSuite(), suites.getSketchTier(), taskMetaData.getBackendIndex(), taskMetaData.getDeviceIndex()).run();
 
             Sketch sketchGraph = TornadoSketcher.lookup(resolvedMethod, taskMetaData.getBackendIndex(), taskMetaData.getDeviceIndex());
@@ -643,7 +643,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             checkForMemorySegmentAsTaskParameter(compilableTask);
 
             final ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(compilableTask.getMethod());
-            final TaskMetaData taskMetaData = compilableTask.meta();
+            final TaskDataContext taskMetaData = compilableTask.meta();
             new SketchRequest(resolvedMethod, providers, suites.getGraphBuilderSuite(), suites.getSketchTier(), taskMetaData.getBackendIndex(), taskMetaData.getDeviceIndex()).run();
 
             Sketch lookup = TornadoSketcher.lookup(resolvedMethod, compilableTask.meta().getBackendIndex(), compilableTask.meta().getDeviceIndex());
@@ -1256,7 +1256,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
-    public ScheduleMetaData meta() {
+    public ScheduleContext meta() {
         return executionContext.meta();
     }
 
@@ -2067,7 +2067,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         return this;
     }
 
-    private void addInner(int index, int type, Method method, ScheduleMetaData meta, String id, Object[] parameters) {
+    private void addInner(int index, int type, Method method, ScheduleContext meta, String id, Object[] parameters) {
         switch (type) {
             case 0:
                 updateInner(index, TaskUtils.createTask(method, meta, id, (Task) parameters[0]));
@@ -2132,7 +2132,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private void addInner(int type, Method method, ScheduleMetaData meta, String id, Object[] parameters) {
+    private void addInner(int type, Method method, ScheduleContext meta, String id, Object[] parameters) {
         switch (type) {
             case 0:
                 addInner(TaskUtils.createTask(method, meta, id, (Task) parameters[0]));
@@ -2201,7 +2201,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         Object[] parameters = taskPackage.getTaskParameters();
 
         Method method = TaskUtils.resolveMethodHandle(parameters[0]);
-        ScheduleMetaData meta = meta();
+        ScheduleContext meta = meta();
 
         // Set the number of threads to run. If 0, it will execute as many
         // threads as input size (after Tornado analyses the right block-size).
@@ -2229,7 +2229,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         Object[] parameters = taskPackage.getTaskParameters();
 
         Method method = TaskUtils.resolveMethodHandle(parameters[0]);
-        ScheduleMetaData meta = meta();
+        ScheduleContext meta = meta();
 
         // Set the number of threads to run. If 0, it will execute as many
         // threads as input size (after Tornado analyses the right block-size).

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -711,7 +711,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         // TornadoVM byte-code generation
         TornadoVM tornadoVM = new TornadoVM(executionContext, tornadoGraph, timeProfiler);
 
-        if (meta().shouldDumpTaskGraph()) {
+        if (meta().isDebug()) {
             executionContext.dumpExecutionContextMeta();
             tornadoGraph.dumpTornadoGraph();
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -23,9 +23,38 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks;
 
-import jdk.vm.ci.meta.ResolvedJavaMethod;
+import static uk.ac.manchester.tornado.api.profiler.ProfilerType.ALLOCATION_BYTES;
+import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_COPY_IN_SIZE_BYTES;
+import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES;
+import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_KERNEL_TIME;
+
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.graalvm.compiler.graph.Graph;
 import org.graalvm.compiler.phases.util.Providers;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.api.DRMode;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
@@ -33,7 +62,6 @@ import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.Policy;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoBackend;
-import uk.ac.manchester.tornado.api.TornadoDeviceContext;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoRuntime;
 import uk.ac.manchester.tornado.api.TornadoTaskGraphInterface;
@@ -61,6 +89,7 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task9;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
 import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoDynamicReconfigurationException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
@@ -98,34 +127,6 @@ import uk.ac.manchester.tornado.runtime.sketcher.SketchRequest;
 import uk.ac.manchester.tornado.runtime.sketcher.TornadoSketcher;
 import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleMetaData;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskMetaData;
-
-import java.io.IOException;
-import java.lang.foreign.MemorySegment;
-import java.lang.reflect.Array;
-import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static uk.ac.manchester.tornado.api.profiler.ProfilerType.ALLOCATION_BYTES;
-import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_COPY_IN_SIZE_BYTES;
-import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES;
-import static uk.ac.manchester.tornado.api.profiler.ProfilerType.TOTAL_KERNEL_TIME;
 
 /**
  * Implementation of the Tornado API for running on heterogeneous devices.
@@ -206,7 +207,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
      * Task Schedule implementation that uses GPU/FPGA and multicore backends. This constructor must be public. It is invoked using the reflection API.
      *
      * @param taskScheduleName
-     *         Task-Schedule name
+     *     Task-Schedule name
      */
     public TornadoTaskGraph(String taskScheduleName) {
         executionContext = new TornadoExecutionContext(taskScheduleName);
@@ -253,41 +254,41 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5));
                 break;
             case 7:
-                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5),
-                        inputObjects.get(6));
+                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5), inputObjects.get(
+                        6));
                 break;
             case 8:
-                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5),
-                        inputObjects.get(6), inputObjects.get(7));
+                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5), inputObjects.get(
+                        6), inputObjects.get(7));
                 break;
             case 9:
-                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5),
-                        inputObjects.get(6), inputObjects.get(7), inputObjects.get(8));
+                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5), inputObjects.get(
+                        6), inputObjects.get(7), inputObjects.get(8));
                 break;
             case 10:
-                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5),
-                        inputObjects.get(6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9));
+                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5), inputObjects.get(
+                        6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9));
                 break;
             case 11:
-                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5),
-                        inputObjects.get(6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10));
+                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5), inputObjects.get(
+                        6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10));
                 break;
             case 12:
-                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5),
-                        inputObjects.get(6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10), inputObjects.get(11));
+                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5), inputObjects.get(
+                        6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10), inputObjects.get(11));
                 break;
             case 13:
-                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5),
-                        inputObjects.get(6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10), inputObjects.get(11), inputObjects.get(12));
+                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5), inputObjects.get(
+                        6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10), inputObjects.get(11), inputObjects.get(12));
                 break;
             case 14:
-                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5),
-                        inputObjects.get(6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10), inputObjects.get(11), inputObjects.get(12), inputObjects.get(13));
+                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5), inputObjects.get(
+                        6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10), inputObjects.get(11), inputObjects.get(12), inputObjects.get(13));
                 break;
             case 15:
-                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5),
-                        inputObjects.get(6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10), inputObjects.get(11), inputObjects.get(12), inputObjects.get(13),
-                        inputObjects.get(14));
+                task.transferToDevice(dataTransferMode, inputObjects.get(0), inputObjects.get(1), inputObjects.get(2), inputObjects.get(3), inputObjects.get(4), inputObjects.get(5), inputObjects.get(
+                        6), inputObjects.get(7), inputObjects.get(8), inputObjects.get(9), inputObjects.get(10), inputObjects.get(11), inputObjects.get(12), inputObjects.get(13), inputObjects.get(
+                                14));
                 break;
             default:
                 System.out.println("COPY-IN Not supported yet: " + numObjectsCopyIn);
@@ -491,6 +492,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
+    public void withCompilerFlags(TornadoVMBackendType backendType, String compilerFlags) {
+        executionContext.meta().setCompilerFlags(backendType, compilerFlags);
+    }
+
+    @Override
     public long getTotalBytesTransferred() {
         return getProfilerValue(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES) + getProfilerValue(TOTAL_COPY_OUT_SIZE_BYTES);
     }
@@ -519,7 +525,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     @Override
     public void setDevice(TornadoDevice device) {
 
-        TornadoDevice oldDevice = meta().getLogicDevice();
+        TornadoDevice oldDevice = meta().getXPUDevice();
 
         // prevent to set again the same device as it invalidates its state
         if (oldDevice.equals(device)) {
@@ -535,7 +541,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             task.meta().setDevice(device);
             if (task instanceof CompilableTask compilableTask) {
                 ResolvedJavaMethod method = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(compilableTask.getMethod());
-                if (!meta().getLogicDevice().getDeviceContext().isCached(method.getName(), compilableTask)) {
+                if (!meta().getXPUDevice().getDeviceContext().isCached(method.getName(), compilableTask)) {
                     updateInner(i, executionContext.getTask(i));
                 }
             }
@@ -568,7 +574,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     @Override
     public void setDevice(String taskName, TornadoDevice device) {
 
-        TornadoDevice oldDevice = meta().getLogicDevice();
+        TornadoDevice oldDevice = meta().getXPUDevice();
 
         // Make sure that a sketch is available for the device.
         for (int i = 0; i < executionContext.getTaskCount(); i++) {
@@ -680,14 +686,14 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     private void updateDeviceContext() {
-        executionContext.setDevice(meta().getLogicDevice());
+        executionContext.setDevice(meta().getXPUDevice());
     }
 
     /**
      * Compile a {@link TaskGraph} into TornadoVM byte-code.
      *
      * @param setNewDevice:
-     *         boolean that specifies if set a new device or not.
+     *     boolean that specifies if set a new device or not.
      */
     private TornadoVM compileGraphAndBuildVM(boolean setNewDevice) {
         final ByteBuffer buffer = ByteBuffer.wrap(highLevelCode);
@@ -737,7 +743,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             return COMPILE_ONLY;
         }
 
-        if (tornadoVMBytecodeBuilder != null && !isLastDeviceListEmpty() && !(compareDevices(executionContext.getLastDevices(), meta().getLogicDevice()))) {
+        if (tornadoVMBytecodeBuilder != null && !isLastDeviceListEmpty() && !(compareDevices(executionContext.getLastDevices(), meta().getXPUDevice()))) {
             return COMPILE_AND_UPDATE;
         }
 
@@ -745,7 +751,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             return COMPILE_ONLY;
         }
 
-        if (!compareDevices(executionContext.getLastDevices(), meta().getLogicDevice())) {
+        if (!compareDevices(executionContext.getLastDevices(), meta().getXPUDevice())) {
             return COMPILE_AND_UPDATE;
         }
 
@@ -775,12 +781,12 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             timeProfiler.start(ProfilerType.TOTAL_BYTE_CODE_GENERATION);
             executionContext.scheduleTaskToDevices();
             TornadoVM tornadoVM = compileGraphAndBuildVM(compileInfo.updateDevice);
-            vmTable.put(meta().getLogicDevice(), tornadoVM);
+            vmTable.put(meta().getXPUDevice(), tornadoVM);
             timeProfiler.stop(ProfilerType.TOTAL_BYTE_CODE_GENERATION);
         }
-        executionContext.addLastDevice(meta().getLogicDevice());
+        executionContext.addLastDevice(meta().getXPUDevice());
 
-        vm = vmTable.get(meta().getLogicDevice());
+        vm = vmTable.get(meta().getXPUDevice());
 
         /*
          * Set the grid scheduler outside the constructor of the {@link
@@ -1012,8 +1018,8 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     @Override
     public void dump() {
         final int width = 16;
-        System.out.printf("code  : capacity = %s, in use = %s %n", RuntimeUtilities.humanReadableByteCount(hlBuffer.capacity(), true),
-                RuntimeUtilities.humanReadableByteCount(hlBuffer.position(), true));
+        System.out.printf("code  : capacity = %s, in use = %s %n", RuntimeUtilities.humanReadableByteCount(hlBuffer.capacity(), true), RuntimeUtilities.humanReadableByteCount(hlBuffer.position(),
+                true));
         for (int i = 0; i < hlBuffer.position(); i += width) {
             System.out.printf("[0x%04x]: ", i);
             for (int j = 0; j < Math.min(hlBuffer.capacity() - i, width); j++) {
@@ -1079,12 +1085,12 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         }
         inputModesObjects.forEach(inputStreamObject -> freeDeviceMemoryObject(inputStreamObject.getObject()));
         outputModeObjects.forEach(outputStreamObject -> freeDeviceMemoryObject(outputStreamObject.getObject()));
-        meta().getLogicDevice().getDeviceContext().reset(executionPlanId);
+        meta().getXPUDevice().getDeviceContext().reset(executionPlanId);
     }
 
     private void freeDeviceMemoryObject(Object object) {
         final LocalObjectState localState = executionContext.getLocalStateObject(object);
-        releaseObjectFromDeviceMemory(localState, meta().getLogicDevice());
+        releaseObjectFromDeviceMemory(localState, meta().getXPUDevice());
     }
 
     private void releaseObjectFromDeviceMemory(final LocalObjectState localState, final TornadoDevice device) {
@@ -1109,7 +1115,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     private Event syncObjectInner(Object object) {
         final LocalObjectState localState = executionContext.getLocalStateObject(object);
         final DataObjectState dataObjectState = localState.getDataObjectState();
-        final TornadoXPUDevice device = meta().getLogicDevice();
+        final TornadoXPUDevice device = meta().getXPUDevice();
         final XPUDeviceBufferState deviceState = dataObjectState.getDeviceBufferState(device);
         if (deviceState.isLockedBuffer()) {
             return device.resolveEvent(executionPlanId, device.streamOutBlocking(executionPlanId, object, 0, deviceState, null));
@@ -1120,7 +1126,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     private Event syncObjectInner(Object object, long offset, long partialCopySize) {
         final LocalObjectState localState = executionContext.getLocalStateObject(object);
         final DataObjectState dataObjectState = localState.getDataObjectState();
-        final TornadoXPUDevice device = meta().getLogicDevice();
+        final TornadoXPUDevice device = meta().getXPUDevice();
         final XPUDeviceBufferState deviceState = dataObjectState.getDeviceBufferState(device);
         deviceState.setPartialCopySize(partialCopySize);
         if (deviceState.isLockedBuffer()) {
@@ -1132,7 +1138,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     private Event syncObjectInnerLazy(Object object, long hostOffset, long bufferSize) {
         final LocalObjectState localState = executionContext.getLocalStateObject(object);
         final DataObjectState dataObjectState = localState.getDataObjectState();
-        final TornadoXPUDevice device = meta().getLogicDevice();
+        final TornadoXPUDevice device = meta().getXPUDevice();
         final XPUDeviceBufferState deviceBufferState = dataObjectState.getDeviceBufferState(device);
         if (deviceBufferState.isLockedBuffer()) {
             deviceBufferState.getXPUBuffer().setSizeSubRegion(bufferSize);
@@ -1206,7 +1212,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 value += eventParameter.getElapsedTime();
                 timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME_SYNC, value);
                 LocalObjectState localState = executionContext.getLocalStateObject(objects[i]);
-                XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceBufferState(meta().getLogicDevice());
+                XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceBufferState(meta().getXPUDevice());
                 timeProfiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getXPUBuffer().size());
             }
             updateProfiler();
@@ -1237,7 +1243,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 value += event.getElapsedTime();
                 timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME_SYNC, value);
                 LocalObjectState localState = executionContext.getLocalStateObject(object);
-                XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceBufferState(meta().getLogicDevice());
+                XPUDeviceBufferState deviceObjectState = localState.getDataObjectState().getDeviceBufferState(meta().getXPUDevice());
                 timeProfiler.addValueToMetric(ProfilerType.COPY_OUT_SIZE_BYTES_SYNC, TimeProfiler.NO_TASK_NAME, deviceObjectState.getXPUBuffer().size());
                 updateProfiler();
             }
@@ -1311,7 +1317,8 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                     continue;
                 }
                 if (!argumentsLookUp.contains(parameter)) {
-                    throw new TornadoTaskRuntimeException("Parameter #" + i + " <" + parameter + "> from task <" + task.getId() + "> not specified either in transferToDevice or transferToHost functions");
+                    throw new TornadoTaskRuntimeException("Parameter #" + i + " <" + parameter + "> from task <" + task
+                            .getId() + "> not specified either in transferToDevice or transferToHost functions");
                 }
             }
         }
@@ -1468,68 +1475,66 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 break;
             case 5:
                 @SuppressWarnings("rawtypes") Task5 task5 = (Task5) taskPackage.getTaskParameters()[0];
-                task5.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5]);
+                task5.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5]);
                 break;
             case 6:
                 @SuppressWarnings("rawtypes") Task6 task6 = (Task6) taskPackage.getTaskParameters()[0];
-                task6.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5], taskPackage.getTaskParameters()[6]);
+                task6.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6]);
                 break;
             case 7:
                 @SuppressWarnings("rawtypes") Task7 task7 = (Task7) taskPackage.getTaskParameters()[0];
-                task7.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7]);
+                task7.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7]);
                 break;
             case 8:
                 @SuppressWarnings("rawtypes") Task8 task8 = (Task8) taskPackage.getTaskParameters()[0];
-                task8.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8]);
+                task8.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8]);
                 break;
             case 9:
                 @SuppressWarnings("rawtypes") Task9 task9 = (Task9) taskPackage.getTaskParameters()[0];
-                task9.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8],
-                        taskPackage.getTaskParameters()[9]);
+                task9.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9]);
                 break;
             case 10:
                 @SuppressWarnings("rawtypes") Task10 task10 = (Task10) taskPackage.getTaskParameters()[0];
-                task10.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8],
-                        taskPackage.getTaskParameters()[9], taskPackage.getTaskParameters()[10]);
+                task10.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10]);
                 break;
             case 11:
                 @SuppressWarnings("rawtypes") Task11 task11 = (Task11) taskPackage.getTaskParameters()[0];
-                task11.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8],
-                        taskPackage.getTaskParameters()[9], taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11]);
+                task11.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11]);
                 break;
             case 12:
                 @SuppressWarnings("rawtypes") Task12 task12 = (Task12) taskPackage.getTaskParameters()[0];
-                task12.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8],
-                        taskPackage.getTaskParameters()[9], taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12]);
+                task12.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12]);
                 break;
             case 13:
                 @SuppressWarnings("rawtypes") Task13 task13 = (Task13) taskPackage.getTaskParameters()[0];
-                task13.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8],
-                        taskPackage.getTaskParameters()[9], taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12],
-                        taskPackage.getTaskParameters()[13]);
+                task13.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13]);
                 break;
             case 14:
                 @SuppressWarnings("rawtypes") Task14 task14 = (Task14) taskPackage.getTaskParameters()[0];
-                task14.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8],
-                        taskPackage.getTaskParameters()[9], taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12],
-                        taskPackage.getTaskParameters()[13], taskPackage.getTaskParameters()[14]);
+                task14.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13], taskPackage
+                                .getTaskParameters()[14]);
                 break;
             case 15:
                 @SuppressWarnings("rawtypes") Task15 task15 = (Task15) taskPackage.getTaskParameters()[0];
-                task15.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4],
-                        taskPackage.getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8],
-                        taskPackage.getTaskParameters()[9], taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12],
-                        taskPackage.getTaskParameters()[13], taskPackage.getTaskParameters()[14], taskPackage.getTaskParameters()[15]);
+                task15.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13], taskPackage
+                                .getTaskParameters()[14], taskPackage.getTaskParameters()[15]);
                 break;
             default:
                 throw new TornadoRuntimeException("Sequential Runner not supported yet. Number of parameters: " + type);
@@ -1991,9 +1996,9 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
      * Experimental method to sync all objects when making a clone copy for all output objects per device.
      *
      * @param policy
-     *         input policy
+     *     input policy
      * @param numDevices
-     *         number of devices
+     *     number of devices
      */
     private void restoreVarsIntoJavaHeap(Policy policy, int numDevices) {
         if (policyTimeTable.get(policy) < numDevices) {
@@ -2086,55 +2091,47 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 updateInner(index, TaskUtils.createTask(method, meta, id, (Task6) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6]));
                 break;
             case 7:
-                updateInner(index,
-                        TaskUtils.createTask(method, meta, id, (Task7) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7]));
+                updateInner(index, TaskUtils.createTask(method, meta, id, (Task7) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6],
+                        parameters[7]));
                 break;
             case 8:
-                updateInner(index,
-                        TaskUtils.createTask(method, meta, id, (Task8) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
-                                parameters[8]));
+                updateInner(index, TaskUtils.createTask(method, meta, id, (Task8) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6],
+                        parameters[7], parameters[8]));
                 break;
             case 9:
-                updateInner(index,
-                        TaskUtils.createTask(method, meta, id, (Task9) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
-                                parameters[8], parameters[9]));
+                updateInner(index, TaskUtils.createTask(method, meta, id, (Task9) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6],
+                        parameters[7], parameters[8], parameters[9]));
                 break;
             case 10:
-                updateInner(index,
-                        TaskUtils.createTask(method, meta, id, (Task10) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
-                                parameters[8], parameters[9], parameters[10]));
+                updateInner(index, TaskUtils.createTask(method, meta, id, (Task10) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6],
+                        parameters[7], parameters[8], parameters[9], parameters[10]));
                 break;
             case 11:
-                updateInner(index,
-                        TaskUtils.createTask(method, meta, id, (Task11) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
-                                parameters[8], parameters[9], parameters[10], parameters[11]));
+                updateInner(index, TaskUtils.createTask(method, meta, id, (Task11) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6],
+                        parameters[7], parameters[8], parameters[9], parameters[10], parameters[11]));
                 break;
             case 12:
-                updateInner(index,
-                        TaskUtils.createTask(method, meta, id, (Task12) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
-                                parameters[8], parameters[9], parameters[10], parameters[11], parameters[12]));
+                updateInner(index, TaskUtils.createTask(method, meta, id, (Task12) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6],
+                        parameters[7], parameters[8], parameters[9], parameters[10], parameters[11], parameters[12]));
                 break;
             case 13:
-                updateInner(index,
-                        TaskUtils.createTask(method, meta, id, (Task13) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
-                                parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13]));
+                updateInner(index, TaskUtils.createTask(method, meta, id, (Task13) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6],
+                        parameters[7], parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13]));
                 break;
             case 14:
-                updateInner(index,
-                        TaskUtils.createTask(method, meta, id, (Task14) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
-                                parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14]));
+                updateInner(index, TaskUtils.createTask(method, meta, id, (Task14) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6],
+                        parameters[7], parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14]));
                 break;
             case 15:
-                updateInner(index,
-                        TaskUtils.createTask(method, meta, id, (Task15) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
-                                parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14], parameters[15]));
+                updateInner(index, TaskUtils.createTask(method, meta, id, (Task15) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6],
+                        parameters[7], parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14], parameters[15]));
                 break;
             default:
                 throw new TornadoRuntimeException("Task not supported yet. Type: " + type);
         }
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     private void addInner(int type, Method method, ScheduleMetaData meta, String id, Object[] parameters) {
         switch (type) {
             case 0:

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/MetaDataUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/MetaDataUtils.java
@@ -42,9 +42,12 @@ public final class MetaDataUtils {
         return (TornadoXPUDevice) driver.getDevice(Integer.parseInt(ids[1]));
     }
 
-    public static int[] resolveDriverDeviceIndexes(String device) {
+    public record BackendSelectionContainer(int backendIndex, int deviceIndex) {
+    }
+
+    public static BackendSelectionContainer resolveDriverDeviceIndexes(String device) {
         final String[] ids = device.split(":");
-        return new int[] { Integer.parseInt(ids[0]), Integer.parseInt(ids[1]) };
+        return new BackendSelectionContainer(Integer.parseInt(ids[0]), Integer.parseInt(ids[1]));
     }
 
     public static String[] processPrecompiledBinariesFromFile(String fileName) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleContext.java
@@ -23,9 +23,9 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks.meta;
 
-public class ScheduleMetaData extends AbstractRTContext {
+public class ScheduleContext extends AbstractRTContext {
 
-    public ScheduleMetaData(String id) {
+    public ScheduleContext(String id) {
         super(id, null);
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleMetaData.java
@@ -23,7 +23,7 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks.meta;
 
-public class ScheduleMetaData extends AbstractMetaData {
+public class ScheduleMetaData extends AbstractRTContext {
 
     public ScheduleMetaData(String id) {
         super(id, null);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskDataContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskDataContext.java
@@ -42,13 +42,13 @@ import uk.ac.manchester.tornado.runtime.EventSet;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.domain.DomainTree;
 
-public class TaskMetaData extends AbstractRTContext {
+public class TaskDataContext extends AbstractRTContext {
 
     public static final String LOCAL_WORKGROUP_SUFFIX = ".local.workgroup.size";
     public static final String GLOBAL_WORKGROUP_SUFFIX = ".global.workgroup.size";
     protected final Map<TornadoXPUDevice, BitSet> profiles;
     private final byte[] constantData;
-    private final ScheduleMetaData scheduleMetaData;
+    private final ScheduleContext scheduleMetaData;
     private final int constantSize;
     private final int localSize;
     protected Access[] argumentsAccess;
@@ -59,7 +59,7 @@ public class TaskMetaData extends AbstractRTContext {
     private boolean localWorkDefined;
     private boolean globalWorkDefined;
 
-    public TaskMetaData(ScheduleMetaData scheduleMetaData, String taskID, int numParameters) {
+    public TaskDataContext(ScheduleContext scheduleMetaData, String taskID, int numParameters) {
         super(scheduleMetaData.getId() + "." + taskID, scheduleMetaData);
         this.scheduleMetaData = scheduleMetaData;
         this.constantSize = 0;
@@ -76,13 +76,13 @@ public class TaskMetaData extends AbstractRTContext {
         setNumThreads(scheduleMetaData.getNumThreads());
     }
 
-    public TaskMetaData(ScheduleMetaData scheduleMetaData, String id) {
+    public TaskDataContext(ScheduleContext scheduleMetaData, String id) {
         this(scheduleMetaData, id, 0);
     }
 
-    public static TaskMetaData create(ScheduleMetaData scheduleMeta, String id, Method method) {
+    public static TaskDataContext create(ScheduleContext scheduleMeta, String id, Method method) {
         int numParameters = Modifier.isStatic(method.getModifiers()) ? method.getParameterCount() : method.getParameterCount() + 1;
-        return new TaskMetaData(scheduleMeta, id, numParameters);
+        return new TaskDataContext(scheduleMeta, id, numParameters);
     }
 
     private static String formatWorkDimensionArray(final long[] array, final String defaults) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskDataContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskDataContext.java
@@ -150,22 +150,6 @@ public class TaskDataContext extends AbstractRTContext {
         events.set(id);
     }
 
-    @Override
-    public boolean enableParallelization() {
-        return scheduleMetaData.isEnableParallelizationDefined() && !isEnableParallelizationDefined() ? scheduleMetaData.enableParallelization() : super.enableParallelization();
-    }
-
-    @Override
-    public String getCpuConfig() {
-        if (super.isCpuConfigDefined()) {
-            return super.getCpuConfig();
-        } else if (!super.isCpuConfigDefined() && scheduleMetaData.isCpuConfigDefined()) {
-            return scheduleMetaData.getCpuConfig();
-        } else {
-            return "";
-        }
-    }
-
     public Access[] getArgumentsAccess() {
         return argumentsAccess;
     }
@@ -285,7 +269,7 @@ public class TaskDataContext extends AbstractRTContext {
     }
 
     public boolean isParallel() {
-        return enableParallelization() && hasDomain() && domain.getDepth() > 0;
+        return hasDomain() && domain.getDepth() > 0;
     }
 
     private long[] calculateNumberOfWorkgroupsFromDomain(DomainTree domain) {
@@ -332,23 +316,8 @@ public class TaskDataContext extends AbstractRTContext {
     }
 
     @Override
-    public boolean shouldDumpEvents() {
-        return super.shouldDumpEvents() || scheduleMetaData.shouldDumpEvents();
-    }
-
-    @Override
     public boolean shouldUseOpenCLDriverScheduling() {
         return super.shouldUseOpenCLDriverScheduling() || scheduleMetaData.shouldUseOpenCLDriverScheduling();
-    }
-
-    @Override
-    public boolean enableThreadCoarsener() {
-        return super.enableThreadCoarsener() || scheduleMetaData.enableThreadCoarsener();
-    }
-
-    @Override
-    public boolean isCpuConfigDefined() {
-        return super.isCpuConfigDefined() || scheduleMetaData.isCpuConfigDefined();
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
@@ -143,7 +143,7 @@ public class TaskMetaData extends AbstractMetaData {
     }
 
     public void addProfile(int id) {
-        final TornadoXPUDevice device = getLogicDevice();
+        final TornadoXPUDevice device = getXPUDevice();
         BitSet events;
         profiles.computeIfAbsent(device, k -> new BitSet(EVENT_WINDOW));
         events = profiles.get(device);
@@ -179,11 +179,11 @@ public class TaskMetaData extends AbstractMetaData {
     }
 
     @Override
-    public TornadoXPUDevice getLogicDevice() {
+    public TornadoXPUDevice getXPUDevice() {
         if (scheduleMetaData.isDeviceManuallySet() || (scheduleMetaData.isDeviceDefined() && !isDeviceDefined())) {
-            return scheduleMetaData.getLogicDevice();
+            return scheduleMetaData.getXPUDevice();
         }
-        return super.getLogicDevice();
+        return super.getXPUDevice();
     }
 
     public int getDims() {
@@ -252,11 +252,6 @@ public class TaskMetaData extends AbstractMetaData {
     }
 
     @Override
-    public String getCompilerFlags() {
-        return isOpenclCompilerFlagsDefined() ? super.getCompilerFlags() : scheduleMetaData.getCompilerFlags();
-    }
-
-    @Override
     public int getOpenCLGpuBlock2DX() {
         return isOpenclGpuBlock2DXDefined() ? super.getOpenCLGpuBlock2DX() : scheduleMetaData.getOpenCLGpuBlock2DX();
     }
@@ -305,10 +300,10 @@ public class TaskMetaData extends AbstractMetaData {
 
     public void printThreadDims() {
         StringBuilder deviceDebug = new StringBuilder();
-        boolean deviceBelongsToPTX = isPTXDevice(getLogicDevice());
+        boolean deviceBelongsToPTX = isPTXDevice(getXPUDevice());
         deviceDebug.append("Task info: " + getId() + "\n");
-        deviceDebug.append("\tBackend           : " + getLogicDevice().getTornadoVMBackend().name() + "\n");
-        deviceDebug.append("\tDevice            : " + getLogicDevice().getDescription() + "\n");
+        deviceDebug.append("\tBackend           : " + getXPUDevice().getTornadoVMBackend().name() + "\n");
+        deviceDebug.append("\tDevice            : " + getXPUDevice().getDescription() + "\n");
         deviceDebug.append("\tDims              : " + (this.isWorkerGridAvailable() ? getWorkerGrid(getId()).dimension() : (hasDomain() ? domain.getDepth() : 0)) + "\n");
 
         if (!deviceBelongsToPTX) {
@@ -334,11 +329,6 @@ public class TaskMetaData extends AbstractMetaData {
 
     public boolean isPTXDevice(TornadoXPUDevice device) {
         return device.getTornadoVMBackend().equals(TornadoVMBackendType.PTX);
-    }
-
-    @Override
-    public boolean shouldDumpProfiles() {
-        return super.shouldDumpProfiles() || scheduleMetaData.shouldDumpProfiles();
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskMetaData.java
@@ -42,7 +42,7 @@ import uk.ac.manchester.tornado.runtime.EventSet;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.domain.DomainTree;
 
-public class TaskMetaData extends AbstractMetaData {
+public class TaskMetaData extends AbstractRTContext {
 
     public static final String LOCAL_WORKGROUP_SUFFIX = ".local.workgroup.size";
     public static final String GLOBAL_WORKGROUP_SUFFIX = ".global.workgroup.size";
@@ -311,16 +311,16 @@ public class TaskMetaData extends AbstractMetaData {
             deviceDebug.append("\tGlobal work offset: " + formatWorkDimensionArray(go, "0") + "\n");
         }
 
-        long[] gw = this.isWorkerGridAvailable() ? getWorkerGrid(getId()).getGlobalWork() : globalWork;
+        long[] workGroups = this.isWorkerGridAvailable() ? getWorkerGrid(getId()).getGlobalWork() : globalWork;
 
         if (deviceBelongsToPTX) {
-            deviceDebug.append("\tThread dimensions : " + formatWorkDimensionArray(gw, "1") + "\n");
+            deviceDebug.append("\tThread dimensions : " + formatWorkDimensionArray(workGroups, "1") + "\n");
             deviceDebug.append("\tBlocks dimensions : " + formatWorkDimensionArray(getPTXBlockDim(), "1") + "\n");
             deviceDebug.append("\tGrids dimensions  : " + formatWorkDimensionArray(getPTXGridDim(), "1") + "\n");
         } else {
             long[] lw = this.isWorkerGridAvailable() ? getWorkerGrid(getId()).getLocalWork() : localWork;
             long[] nw = this.isWorkerGridAvailable() ? getWorkerGrid(getId()).getNumberOfWorkgroups() : (hasDomain() ? calculateNumberOfWorkgroupsFromDomain(domain) : null);
-            deviceDebug.append("\tGlobal work size  : " + formatWorkDimensionArray(gw, "1") + "\n");
+            deviceDebug.append("\tGlobal work size  : " + formatWorkDimensionArray(workGroups, "1") + "\n");
             deviceDebug.append("\tLocal  work size  : " + (lw == null ? "null" : formatWorkDimensionArray(lw, "1")) + "\n");
             deviceDebug.append("\tNumber of workgroups  : " + (nw == null ? "null" : formatWorkDimensionArray(nw, "1")) + "\n");
         }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compiler/TestCompilerFlagsAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compiler/TestCompilerFlagsAPI.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.compiler;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * How to run?
+ *
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.compiler.TestCompilerFlagsAPI
+ * </code>
+ * </p>
+ */
+public class TestCompilerFlagsAPI extends TornadoTestBase {
+
+    private static void foo(FloatArray data) {
+        for (@Parallel int i = 0; i < data.getSize(); i++) {
+            data.set(i, data.get(i) + 1);
+        }
+    }
+
+    @Test
+    public void test() throws TornadoExecutionPlanException {
+        FloatArray data = new FloatArray(512);
+        data.init(1.0f);
+
+        TaskGraph taskGraph = new TaskGraph("init") //
+                .task("foo", TestCompilerFlagsAPI::foo, data) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.withCompilerFlags(TornadoVMBackendType.OPENCL, "-cl-opt-disable") //
+                    .withCompilerFlags(TornadoVMBackendType.PTX, " ") //
+                    .withCompilerFlags(TornadoVMBackendType.SPIRV, "-ze-opt-level 1") //
+                    .execute();
+        }
+
+    }
+}


### PR DESCRIPTION
#### Description

This PR refactors the old `AbstractMetaData` class and it adds a new method in the `TornadoExecutionPlan` to select the compilation flags. This addition is due to the refactoring the of the aforementioned class. 

API Changes:

```java
 try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
            executionPlan.withCompilerFlags(TornadoVMBackendType.OPENCL, "-cl-opt-disable") //
                    .withCompilerFlags(TornadoVMBackendType.PTX, " ") //
                    .withCompilerFlags(TornadoVMBackendType.SPIRV, "-ze-opt-level 1") //
                    .execute();
        }
```

We can specify the flags we want per backend. This is by design, because the TornadoVM runtime can migrate execution from one device to another, and even from different backends. 

#### Problem description

This  PR removes old fields and old functionality no longer needed. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make tests
tornado-test -V uk.ac.manchester.tornado.unittests.compiler.TestCompilerFlagsAPI
```