### PR TITLE
Fix the device switching for all backends

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/SchedulableTask.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/SchedulableTask.java
@@ -29,7 +29,7 @@ public interface SchedulableTask {
 
     TaskContextInterface meta();
 
-    SchedulableTask mapTo(TornadoDevice mapping);
+    void setDevice(TornadoDevice device);
 
     TornadoDevice getDevice();
 
@@ -68,4 +68,5 @@ public interface SchedulableTask {
     void setGridScheduler(GridScheduler gridScheduler);
 
     boolean isGridSchedulerEnabled();
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
@@ -181,7 +181,7 @@ public interface TornadoDevice {
 
     Object getDeviceInfo();
 
-    int getDriverIndex();
+    int getBackendIndex();
 
     /**
      * Returns the number of processors available to the JVM. We need to overwrite

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLBackendImpl.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLBackendImpl.java
@@ -147,7 +147,7 @@ public final class OCLBackendImpl implements TornadoAcceleratorBackend {
 
     @Override
     public TornadoXPUDevice getDefaultDevice() {
-        return flatBackends[0].getDeviceContext().asMapping();
+        return flatBackends[0].getDeviceContext().toDevice();
     }
 
     @Override
@@ -158,7 +158,7 @@ public final class OCLBackendImpl implements TornadoAcceleratorBackend {
     @Override
     public TornadoXPUDevice getDevice(int index) {
         if (index < flatBackends.length) {
-            return flatBackends[index].getDeviceContext().asMapping();
+            return flatBackends[index].getDeviceContext().toDevice();
         } else {
             throw new TornadoDeviceNotFound("[ERROR] device required not found: " + index + " - Max: " + flatBackends.length);
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -527,7 +527,7 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
         wasReset = true;
     }
 
-    public OCLTornadoDevice asMapping() {
+    public OCLTornadoDevice toDevice() {
         return new OCLTornadoDevice(context.getPlatformIndex(), device.getIndex());
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
@@ -52,7 +52,7 @@ public interface OCLDeviceContextInterface extends TornadoDeviceContext {
 
     void reset(long executionPlanId);
 
-    TornadoXPUDevice asMapping();
+    TornadoXPUDevice toDevice();
 
     void dumpEvents();
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -766,7 +766,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public int getDriverIndex() {
+    public int getBackendIndex() {
         return TornadoCoreRuntime.getTornadoRuntime().getBackendIndex(OCLBackendImpl.class);
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
@@ -152,7 +152,7 @@ public class VirtualOCLDeviceContext implements OCLDeviceContextInterface {
     }
 
     @Override
-    public VirtualOCLTornadoDevice asMapping() {
+    public VirtualOCLTornadoDevice toDevice() {
         return new VirtualOCLTornadoDevice(context.getPlatformIndex(), device.getIndex());
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -438,7 +438,7 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public int getDriverIndex() {
+    public int getBackendIndex() {
         return TornadoCoreRuntime.getTornadoRuntime().getBackendIndex(OCLBackendImpl.class);
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXBackendImpl.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXBackendImpl.java
@@ -96,7 +96,7 @@ public final class PTXBackendImpl implements TornadoAcceleratorBackend {
 
     @Override
     public TornadoDevice getDefaultDevice() {
-        return getDefaultBackend().getDeviceContext().asMapping();
+        return getDefaultBackend().getDeviceContext().toDevice();
     }
 
     @Override
@@ -123,7 +123,7 @@ public final class PTXBackendImpl implements TornadoAcceleratorBackend {
     @Override
     public TornadoXPUDevice getDevice(int index) {
         if (index < backends.length) {
-            return backends[index].getDeviceContext().asMapping();
+            return backends[index].getDeviceContext().toDevice();
         } else {
             throw new TornadoDeviceNotFound("[ERROR]-[PTX-DRIVER] Device required not found: " + index + " - Max: " + backends.length);
         }
@@ -134,7 +134,7 @@ public final class PTXBackendImpl implements TornadoAcceleratorBackend {
         if (devices == null) {
             devices = new ArrayList<>();
             for (int i = 0; i < getNumDevices(); i++) {
-                devices.add(backends[i].getDeviceContext().asMapping());
+                devices.add(backends[i].getDeviceContext().toDevice());
             }
         }
         return devices;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -116,7 +116,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         return true;
     }
 
-    public PTXTornadoDevice asMapping() {
+    public PTXTornadoDevice toDevice() {
         return new PTXTornadoDevice(device.getDeviceIndex());
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -635,7 +635,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public int getDriverIndex() {
+    public int getBackendIndex() {
         return TornadoCoreRuntime.getTornadoRuntime().getBackendIndex(PTXBackendImpl.class);
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
@@ -141,7 +141,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
 
     @Override
     public TornadoDevice getDefaultDevice() {
-        return getDefaultBackend().getDeviceContext().asMapping();
+        return getDefaultBackend().getDeviceContext().toDevice();
     }
 
     @Override
@@ -175,7 +175,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
     @Override
     public TornadoXPUDevice getDevice(int index) {
         if (index < flatBackends.length) {
-            return flatBackends[index].getDeviceContext().asMapping();
+            return flatBackends[index].getDeviceContext().toDevice();
         } else {
             throw new TornadoDeviceNotFound("[ERROR]-[SPIRV-DRIVER] Device required not found: " + index + " - Max: " + spirvBackends.length);
         }
@@ -186,7 +186,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
         if (devices == null) {
             devices = new ArrayList<>();
             for (int i = 0; i < getNumDevices(); i++) {
-                devices.add(flatBackends[i].getDeviceContext().asMapping());
+                devices.add(flatBackends[i].getDeviceContext().toDevice());
             }
         }
         return devices;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
@@ -149,7 +149,7 @@ public abstract class SPIRVDeviceContext implements TornadoDeviceContext {
         return TornadoRuntimeProvider.getTornadoRuntime().getBackendIndex(SPIRVBackendImpl.class);
     }
 
-    public SPIRVTornadoDevice asMapping() {
+    public SPIRVTornadoDevice toDevice() {
         return tornadoDevice;
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -54,7 +54,6 @@ import uk.ac.manchester.tornado.drivers.spirv.SPIRVBackend;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVBackendImpl;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDevice;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDeviceContext;
-import uk.ac.manchester.tornado.drivers.spirv.SPIRVRuntimeImpl;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVProviders;
 import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.SPIRVCompilationResult;
 import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.SPIRVCompiler;
@@ -93,12 +92,6 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     private final SPIRVDevice device;
     private final int deviceIndex;
     private final int platformIndex;
-
-    public SPIRVTornadoDevice(int platformIndex, int deviceIndex) {
-        this.platformIndex = platformIndex;
-        this.deviceIndex = deviceIndex;
-        device = SPIRVRuntimeImpl.getInstance().getPlatform(platformIndex).getDevice(deviceIndex);
-    }
 
     public SPIRVTornadoDevice(SPIRVDevice lowLevelDevice) {
         this.platformIndex = lowLevelDevice.getPlatformIndex();
@@ -563,7 +556,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public int getDriverIndex() {
+    public int getBackendIndex() {
         return TornadoCoreRuntime.getTornadoRuntime().getBackendIndex(SPIRVBackendImpl.class);
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestVM.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestVM.java
@@ -49,7 +49,7 @@ public class TestVM {
         // Get the backend from TornadoVM
         SPIRVBackend spirvBackend = TornadoRuntimeProvider.getTornadoRuntime().getBackend(SPIRVBackendImpl.class).getBackend(spirvRuntime);
         System.out.println("Query SPIR_V Runtime: " + spirvBackend);
-        return spirvBackend.getDeviceContext().asMapping();
+        return spirvBackend.getDeviceContext().toDevice();
     }
 
     public void runWithTornadoVM(SPIRVTornadoDevice device, int[] a, int[] b, int[] c) {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddInt.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddInt.java
@@ -23,6 +23,7 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 
 /**
@@ -41,7 +42,7 @@ public class ArrayAddInt {
         }
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws TornadoExecutionPlanException {
 
         final int numElements = 8;
         IntArray a = new IntArray(numElements);
@@ -58,8 +59,9 @@ public class ArrayAddInt {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph);
-        executor.execute();
+        try (TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executor.execute();
+        }
 
         System.out.println("a: " + a);
         System.out.println("b: " + b);

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddInt.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddInt.java
@@ -26,6 +26,8 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 
+import java.util.Arrays;
+
 /**
  * <p>
  * How to run?
@@ -63,9 +65,9 @@ public class ArrayAddInt {
             executor.execute();
         }
 
-        System.out.println("a: " + a);
-        System.out.println("b: " + b);
-        System.out.println("c: " + c);
+        System.out.println("a: " + Arrays.toString(a.toHeapArray()));
+        System.out.println("b: " + Arrays.toString(b.toHeapArray()));
+        System.out.println("c: " + Arrays.toString(c.toHeapArray()));
     }
 
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
@@ -276,7 +276,7 @@ public class JVMMapping implements TornadoXPUDevice {
     }
 
     @Override
-    public int getDriverIndex() {
+    public int getBackendIndex() {
         return 0;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -35,7 +35,6 @@ import java.util.function.Consumer;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.common.Event;
-
 import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoDeviceFP64NotSupported;
 import uk.ac.manchester.tornado.api.exceptions.TornadoFailureException;
@@ -91,7 +90,10 @@ public class TornadoVM {
         final Deque<Integer> activeDevices = executionContext.getActiveDeviceIndexes();
         int bound = executionContext.getValidContextSize();
         for (int i = 0; i < bound; i++) {
-            tornadoVMInterpreters[i] = new TornadoVMInterpreter(executionContext, tornadoVMBytecodes[i], timeProfiler, executionContext.getDevice(activeDevices.pop()));
+            tornadoVMInterpreters[i] = new TornadoVMInterpreter(executionContext, //
+                    tornadoVMBytecodes[i],  //
+                    timeProfiler,  //
+                    executionContext.getDevice(activeDevices.pop()));
         }
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoXPUDevice.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoXPUDevice.java
@@ -180,6 +180,7 @@ public interface TornadoXPUDevice extends TornadoDevice {
      * It returns from the sketch of a task whether the loop index is written in the output buffer.
      * 
      * @param task
+     *     {@link SchedulableTask}
      * @return
      */
     default boolean loopIndexInWrite(SchedulableTask task) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -292,7 +292,7 @@ public class TornadoExecutionContext {
         if (tornadoDevice instanceof TornadoXPUDevice tornadoAcceleratorDevice) {
             devices.clear();
             devices.addFirst(tornadoAcceleratorDevice);
-            apply(task -> task.mapTo(tornadoDevice));
+            apply(task -> task.setDevice(tornadoDevice));
             Arrays.fill(taskToDeviceMapTable, tornadoDevice);
         } else {
             throw new TornadoRuntimeException("Device " + tornadoDevice.getClass() + " not supported yet");
@@ -453,7 +453,6 @@ public class TornadoExecutionContext {
 
     public Deque<Integer> getActiveDeviceIndexes() {
         Deque<Integer> nonNullIndexes = new ArrayDeque<>();
-
         for (int i = devices.size() - 1; i >= 0; i--) {
             TornadoXPUDevice device = devices.get(i);
             if (device != null) {
@@ -470,15 +469,13 @@ public class TornadoExecutionContext {
      *
      * @param deviceContext
      *     The device context of the device.
-     * @param driverIndex
-     *     The index of the driver.
      * @return A list of {@link SchedulableTask} objects associated with the
      *     specified device and driver.
      */
-    public List<SchedulableTask> getTasksForDevice(TornadoDeviceContext deviceContext, int driverIndex) {
+    public List<SchedulableTask> getTasksForDevice(TornadoDeviceContext deviceContext) {
         List<SchedulableTask> tasksForDevice = new ArrayList<>();
         for (SchedulableTask task : tasks) {
-            task.getDevice().getDriverIndex();
+            task.getDevice().getBackendIndex();
             if (task.getDevice().getDeviceContext() == deviceContext) {
                 tasksForDevice.add(task);
             }
@@ -512,7 +509,7 @@ public class TornadoExecutionContext {
 
     public TornadoXPUDevice getDeviceForTask(String id) {
         TornadoDevice device = getTask(id).getDevice();
-        TornadoXPUDevice tornadoDevice = null;
+        TornadoXPUDevice tornadoDevice;
         if (device instanceof TornadoXPUDevice) {
             tornadoDevice = (TornadoXPUDevice) device;
         } else {
@@ -611,7 +608,7 @@ public class TornadoExecutionContext {
     public TornadoExecutionContext clone() {
         TornadoExecutionContext newExecutionContext = new TornadoExecutionContext(this.getId());
 
-        newExecutionContext.tasks = new ArrayList<>(this.tasks);
+        newExecutionContext.tasks = new ArrayList<>(tasks);
 
         newExecutionContext.kernelStackFrame = this.kernelStackFrame.clone();
 
@@ -638,6 +635,7 @@ public class TornadoExecutionContext {
         newExecutionContext.profiler = this.profiler;
         newExecutionContext.nextTask = this.nextTask;
         newExecutionContext.executionPlanMemoryLimit = this.executionPlanMemoryLimit;
+
         return newExecutionContext;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -88,11 +88,11 @@ public class TornadoVMInterpreter {
     private final TornadoInstalledCode[] installedCodes;
 
     private final List<Object> constants;
-    private final List<SchedulableTask> tasks;
+    private final List<SchedulableTask> taskExecutionContexts;
     private final List<SchedulableTask> localTaskList;
 
     private TornadoProfiler timeProfiler;
-    private final TornadoExecutionContext executionContext;
+    private final TornadoExecutionContext graphExecutionContext;
     private final TornadoVMBytecodeResult bytecodeResult;
     private double totalTime;
     private long invocations;
@@ -105,7 +105,7 @@ public class TornadoVMInterpreter {
     /**
      * It constructs a new TornadoVMInterpreter object.
      *
-     * @param executionContext
+     * @param graphExecutionContext
      *     The {@link TornadoExecutionContext}
      * @param bytecodeResult
      *     The {@link TornadoVMBytecodeResult}.
@@ -114,8 +114,8 @@ public class TornadoVMInterpreter {
      * @param device
      *     The {@link TornadoXPUDevice} device.
      */
-    public TornadoVMInterpreter(TornadoExecutionContext executionContext, TornadoVMBytecodeResult bytecodeResult, TornadoProfiler timeProfiler, TornadoXPUDevice device) {
-        this.executionContext = executionContext;
+    public TornadoVMInterpreter(TornadoExecutionContext graphExecutionContext, TornadoVMBytecodeResult bytecodeResult, TornadoProfiler timeProfiler, TornadoXPUDevice device) {
+        this.graphExecutionContext = graphExecutionContext;
         this.timeProfiler = timeProfiler;
         this.bytecodeResult = bytecodeResult;
 
@@ -130,11 +130,11 @@ public class TornadoVMInterpreter {
 
         this.bytecodeResult.getLong(); // Skips bytes not needed
 
-        kernelStackFrame = executionContext.getKernelStackFrame();
+        kernelStackFrame = graphExecutionContext.getKernelStackFrame();
         events = new int[this.bytecodeResult.getInt()][MAX_EVENTS];
         eventsIndexes = new int[events.length];
 
-        localTaskList = executionContext.getTasksForDevice(interpreterDevice.getDeviceContext(), interpreterDevice.getDriverIndex());
+        localTaskList = graphExecutionContext.getTasksForDevice(interpreterDevice.getDeviceContext());
 
         installedCodes = new TornadoInstalledCode[localTaskList.size()];
 
@@ -146,14 +146,14 @@ public class TornadoVMInterpreter {
         logger.debug("created %d kernelStackFrame", kernelStackFrame.length);
         logger.debug("created %d event lists", events.length);
 
-        objects = executionContext.getObjects();
+        objects = graphExecutionContext.getObjects();
         dataObjectStates = new DataObjectState[objects.size()];
         fetchGlobalStates();
 
         rewindBufferToBegin();
 
-        constants = executionContext.getConstants();
-        tasks = executionContext.getTasks();
+        constants = graphExecutionContext.getConstants();
+        taskExecutionContexts = graphExecutionContext.getTasks();
 
         logger.debug("interpreter for device %s is ready to go", device.toString());
 
@@ -168,7 +168,7 @@ public class TornadoVMInterpreter {
         for (int i = 0; i < objects.size(); i++) {
             final Object object = objects.get(i);
             TornadoInternalError.guarantee(object != null, "null object found in TornadoVM");
-            dataObjectStates[i] = executionContext.getLocalStateObject(object).getDataObjectState();
+            dataObjectStates[i] = graphExecutionContext.getLocalStateObject(object).getDataObjectState();
         }
     }
 
@@ -180,7 +180,7 @@ public class TornadoVMInterpreter {
             assert deviceIndex == interpreterDevice.getDeviceContext().getDeviceIndex();
             logger.debug("loading context %s", interpreterDevice.toString());
             final long t0 = System.nanoTime();
-            interpreterDevice.ensureLoaded(executionContext.getExecutionPlanId());
+            interpreterDevice.ensureLoaded(graphExecutionContext.getExecutionPlanId());
             final long t1 = System.nanoTime();
             logger.debug("loaded in %.9f s", (t1 - t0) * 1e-9);
             op = bytecodeResult.get();
@@ -196,8 +196,8 @@ public class TornadoVMInterpreter {
     }
 
     public void clearProfiles() {
-        for (final SchedulableTask task : tasks) {
-            task.meta().getProfiles(executionContext.getExecutionPlanId()).clear();
+        for (final SchedulableTask task : taskExecutionContexts) {
+            task.meta().getProfiles(graphExecutionContext.getExecutionPlanId()).clear();
         }
     }
 
@@ -207,14 +207,14 @@ public class TornadoVMInterpreter {
             return;
         }
 
-        interpreterDevice.dumpEvents(executionContext.getExecutionPlanId());
+        interpreterDevice.dumpEvents(graphExecutionContext.getExecutionPlanId());
     }
 
     private void dumpEventProfiled(TornadoEvents eventSet, TaskDataContext meta) {
         final BitSet profiles = eventSet.getProfiles();
         for (int i = profiles.nextSetBit(0); i != -1; i = profiles.nextSetBit(i + 1)) {
             if (eventSet.getDevice() instanceof TornadoXPUDevice device) {
-                final Event profile = device.resolveEvent(executionContext.getExecutionPlanId(), i);
+                final Event profile = device.resolveEvent(graphExecutionContext.getExecutionPlanId(), i);
                 if (profile.getStatus() == COMPLETE) {
                     System.out.printf("task: %s %s %9d %9d %9d %9d %9d%n", device.getDeviceName(), meta.getId(), profile.getElapsedTime(), profile.getQueuedTime(), profile.getSubmitTime(), profile
                             .getStartTime(), profile.getEndTime());
@@ -226,9 +226,9 @@ public class TornadoVMInterpreter {
     }
 
     public void dumpProfiles() {
-        for (final SchedulableTask task : tasks) {
+        for (final SchedulableTask task : taskExecutionContexts) {
             final TaskDataContext meta = (TaskDataContext) task.meta();
-            meta.getProfiles(executionContext.getExecutionPlanId()).forEach(eventSet -> dumpEventProfiled(eventSet, meta));
+            meta.getProfiles(graphExecutionContext.getExecutionPlanId()).forEach(eventSet -> dumpEventProfiled(eventSet, meta));
         }
     }
 
@@ -238,15 +238,15 @@ public class TornadoVMInterpreter {
     }
 
     private boolean isMemoryLimitEnabled() {
-        return executionContext.isMemoryLimited();
+        return graphExecutionContext.isMemoryLimited();
     }
 
     private Event execute(boolean isWarmup) {
         isWarmup = isWarmup || VIRTUAL_DEVICE_ENABLED;
         interpreterDevice.enableThreadSharing();
 
-        if (isMemoryLimitEnabled() && executionContext.doesExceedExecutionPlanLimit()) {
-            throw new TornadoMemoryException("OutofMemoryException due to executionPlan.withMemoryLimit of " + executionContext.getExecutionPlanMemoryLimit());
+        if (isMemoryLimitEnabled() && graphExecutionContext.doesExceedExecutionPlanLimit()) {
+            throw new TornadoMemoryException("OutofMemoryException due to executionPlan.withMemoryLimit of " + graphExecutionContext.getExecutionPlanMemoryLimit());
         }
 
         final long t0 = System.nanoTime();
@@ -358,12 +358,12 @@ public class TornadoVMInterpreter {
         Event barrier = EMPTY_EVENT;
         if (!isWarmup) {
             if (useDependencies) {
-                final int event = interpreterDevice.enqueueMarker(executionContext.getExecutionPlanId());
-                barrier = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), event);
+                final int event = interpreterDevice.enqueueMarker(graphExecutionContext.getExecutionPlanId());
+                barrier = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), event);
             }
 
             if (TornadoOptions.USE_VM_FLUSH) {
-                interpreterDevice.flush(executionContext.getExecutionPlanId());
+                interpreterDevice.flush(graphExecutionContext.getExecutionPlanId());
             }
         }
 
@@ -374,7 +374,7 @@ public class TornadoVMInterpreter {
             invocations++;
         }
 
-        if (executionContext.meta().isDebug()) {
+        if (graphExecutionContext.meta().isDebug()) {
             logger.debug("bc: complete elapsed=%.9f s (%d iterations, %.9f s mean)", elapsed, invocations, (totalTime / invocations));
         }
 
@@ -408,7 +408,7 @@ public class TornadoVMInterpreter {
 
         long allocationsTotalSize = interpreterDevice.allocateObjects(objects, sizeBatch, objectStates);
 
-        executionContext.setCurrentDeviceMemoryUsage(allocationsTotalSize);
+        graphExecutionContext.setCurrentDeviceMemoryUsage(allocationsTotalSize);
 
         if (TornadoOptions.isProfilerEnabled()) {
             // Register allocations in the profiler
@@ -432,7 +432,7 @@ public class TornadoVMInterpreter {
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
         long spaceDeallocated = interpreterDevice.deallocate(objectState);
         // Update current device area use 
-        executionContext.setCurrentDeviceMemoryUsage(executionContext.getCurrentDeviceMemoryUsage() - spaceDeallocated);
+        graphExecutionContext.setCurrentDeviceMemoryUsage(graphExecutionContext.getCurrentDeviceMemoryUsage() - spaceDeallocated);
         return -1;
     }
 
@@ -448,9 +448,9 @@ public class TornadoVMInterpreter {
         // We need to stream-in when using batches, because the whole data is not copied
         List<Integer> allEvents;
         if (sizeBatch > 0) {
-            allEvents = interpreterDevice.streamIn(executionContext.getExecutionPlanId(), object, sizeBatch, offset, objectState, waitList);
+            allEvents = interpreterDevice.streamIn(graphExecutionContext.getExecutionPlanId(), object, sizeBatch, offset, objectState, waitList);
         } else {
-            allEvents = interpreterDevice.ensurePresent(executionContext.getExecutionPlanId(), object, objectState, waitList, sizeBatch, offset);
+            allEvents = interpreterDevice.ensurePresent(graphExecutionContext.getExecutionPlanId(), object, objectState, waitList, sizeBatch, offset);
         }
         resetEventIndexes(eventList);
 
@@ -460,8 +460,8 @@ public class TornadoVMInterpreter {
 
         if (TornadoOptions.isProfilerEnabled() && allEvents != null) {
             for (Integer e : allEvents) {
-                Event event = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), e);
-                event.waitForEvents(executionContext.getExecutionPlanId());
+                Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), e);
+                event.waitForEvents(graphExecutionContext.getExecutionPlanId());
                 long copyInTimer = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
                 copyInTimer += event.getElapsedTime();
                 timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
@@ -487,14 +487,14 @@ public class TornadoVMInterpreter {
         }
 
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
-        List<Integer> allEvents = interpreterDevice.streamIn(executionContext.getExecutionPlanId(), object, sizeBatch, offset, objectState, waitList);
+        List<Integer> allEvents = interpreterDevice.streamIn(graphExecutionContext.getExecutionPlanId(), object, sizeBatch, offset, objectState, waitList);
 
         resetEventIndexes(eventList);
 
         if (TornadoOptions.isProfilerEnabled() && allEvents != null) {
             for (Integer e : allEvents) {
-                Event event = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), e);
-                event.waitForEvents(executionContext.getExecutionPlanId());
+                Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), e);
+                event.waitForEvents(graphExecutionContext.getExecutionPlanId());
                 long copyInTimer = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
                 copyInTimer += event.getElapsedTime();
                 timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
@@ -523,13 +523,13 @@ public class TornadoVMInterpreter {
         }
 
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
-        int readEvent = interpreterDevice.streamOutBlocking(executionContext.getExecutionPlanId(), object, offset, objectState, waitList);
+        int readEvent = interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, waitList);
 
         resetEventIndexes(eventList);
 
         if (TornadoOptions.isProfilerEnabled() && readEvent != -1) {
-            Event event = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), readEvent);
-            event.waitForEvents(executionContext.getExecutionPlanId());
+            Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), readEvent);
+            event.waitForEvents(graphExecutionContext.getExecutionPlanId());
             long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
             value += event.getElapsedTime();
             timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
@@ -560,11 +560,11 @@ public class TornadoVMInterpreter {
 
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
 
-        final int readEvent = interpreterDevice.streamOutBlocking(executionContext.getExecutionPlanId(), object, offset, objectState, waitList);
+        final int readEvent = interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, waitList);
 
         if (TornadoOptions.isProfilerEnabled() && readEvent != -1) {
-            Event event = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), readEvent);
-            event.waitForEvents(executionContext.getExecutionPlanId());
+            Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), readEvent);
+            event.waitForEvents(graphExecutionContext.getExecutionPlanId());
             long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
             value += event.getElapsedTime();
             timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
@@ -603,10 +603,10 @@ public class TornadoVMInterpreter {
     }
 
     private void updateMeta(TaskContextInterface meta) {
-        meta.setPrintKernelFlag(executionContext.meta().isPrintKernelEnabled());
-        meta.setCompilerFlags(TornadoVMBackendType.OPENCL, executionContext.meta().getCompilerFlags(TornadoVMBackendType.OPENCL));
-        meta.setCompilerFlags(TornadoVMBackendType.PTX, executionContext.meta().getCompilerFlags(TornadoVMBackendType.PTX));
-        meta.setCompilerFlags(TornadoVMBackendType.SPIRV, executionContext.meta().getCompilerFlags(TornadoVMBackendType.SPIRV));
+        meta.setPrintKernelFlag(graphExecutionContext.meta().isPrintKernelEnabled());
+        meta.setCompilerFlags(TornadoVMBackendType.OPENCL, graphExecutionContext.meta().getCompilerFlags(TornadoVMBackendType.OPENCL));
+        meta.setCompilerFlags(TornadoVMBackendType.PTX, graphExecutionContext.meta().getCompilerFlags(TornadoVMBackendType.PTX));
+        meta.setCompilerFlags(TornadoVMBackendType.SPIRV, graphExecutionContext.meta().getCompilerFlags(TornadoVMBackendType.SPIRV));
     }
 
     private XPUExecutionFrame compileTaskFromBytecodeToBinary(final int callWrapperIndex, final int numArgs, final int eventList, final int taskIndex, final long batchThreads) {
@@ -615,12 +615,12 @@ public class TornadoVMInterpreter {
             throw new TornadoFailureException("[ERROR] reset() was called after warmup() on device: " + interpreterDevice + "!");
         }
 
-        boolean redeployOnDevice = executionContext.redeployOnDevice();
+        boolean redeployOnDevice = graphExecutionContext.redeployOnDevice();
 
         final KernelStackFrame callWrapper = resolveCallWrapper(callWrapperIndex, numArgs, kernelStackFrame, interpreterDevice, redeployOnDevice);
 
         final int[] waitList = (useDependencies && eventList != -1) ? events[eventList] : null;
-        final SchedulableTask task = tasks.get(taskIndex);
+        final SchedulableTask task = taskExecutionContexts.get(taskIndex);
         int currentBatch = task.getBatchNumber();
         TaskContextInterface meta = task.meta();
         updateMeta(meta);
@@ -636,7 +636,7 @@ public class TornadoVMInterpreter {
 
         updateBatchThreads(task, batchThreads, indexInWrite, currentBatch);
 
-        task.enableDefaultThreadScheduler(executionContext.useDefaultThreadScheduler());
+        task.enableDefaultThreadScheduler(graphExecutionContext.useDefaultThreadScheduler());
 
         if (gridScheduler != null && gridScheduler.get(task.getId()) != null) {
             task.setUseGridScheduler(true);
@@ -651,10 +651,10 @@ public class TornadoVMInterpreter {
         }
 
         if (shouldCompile(installedCodes[globalToLocalTaskIndex(taskIndex)])) {
-            task.mapTo(interpreterDevice);
+            task.setDevice(interpreterDevice);
             try {
                 task.attachProfiler(timeProfiler);
-                if (taskIndex == (tasks.size() - 1)) {
+                if (taskIndex == (taskExecutionContexts.size() - 1)) {
                     // If it is the last task within the task-schedule or doUpdate is true -> we
                     // force compilation. This is useful when compiling code for Xilinx/Altera
                     // FPGAs, that has to be a single source.
@@ -690,7 +690,7 @@ public class TornadoVMInterpreter {
     private int executeLaunch(StringBuilder tornadoVMBytecodeList, final int numArgs, final int eventList, final int taskIndex, final long batchThreads, final long offset,
             XPUExecutionFrame executionFrame) {
 
-        final SchedulableTask task = tasks.get(taskIndex);
+        final SchedulableTask task = taskExecutionContexts.get(taskIndex);
         KernelStackFrame stackFrame = executionFrame.stackFrame;
         int[] waitList = executionFrame.waitList;
 
@@ -755,11 +755,11 @@ public class TornadoVMInterpreter {
 
         if (atomicsArray != null) {
             bufferAtomics = interpreterDevice.createOrReuseAtomicsBuffer(atomicsArray);
-            List<Integer> allEvents = bufferAtomics.enqueueWrite(executionContext.getExecutionPlanId(), null, 0, 0, null, false);
+            List<Integer> allEvents = bufferAtomics.enqueueWrite(graphExecutionContext.getExecutionPlanId(), null, 0, 0, null, false);
             if (TornadoOptions.isProfilerEnabled()) {
                 for (Integer e : allEvents) {
-                    Event event = interpreterDevice.resolveEvent(executionContext.getExecutionPlanId(), e);
-                    event.waitForEvents(executionContext.getExecutionPlanId());
+                    Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), e);
+                    event.waitForEvents(graphExecutionContext.getExecutionPlanId());
                     long value = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
                     value += event.getElapsedTime();
                     timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, value);
@@ -779,30 +779,28 @@ public class TornadoVMInterpreter {
             tornadoVMBytecodeList.append(verbose).append("\n");
         }
 
-        TaskDataContext dataContext;
-        try {
-            dataContext = (TaskDataContext) task.meta();
-        } catch (ClassCastException e) {
-            throw new TornadoRuntimeException("task.meta is not instanceof TaskMetadata");
-        }
+        if (task.meta() instanceof TaskDataContext dataContext) {
+            // We attach the profiler information, grid information and global threads
+            dataContext.attachProfiler(timeProfiler);
+            dataContext.setGridScheduler(gridScheduler);
+            dataContext.setThreadInfoEnabled(graphExecutionContext.meta().isThreadInfoEnabled());
 
-        // We attach the profiler information, grid information and global threads
-        dataContext.attachProfiler(timeProfiler);
-        dataContext.setGridScheduler(gridScheduler);
-        dataContext.setThreadInfoEnabled(executionContext.meta().isThreadInfoEnabled());
+            try {
+                int lastEvent = useDependencies
+                        ? installedCode.launchWithDependencies(graphExecutionContext.getExecutionPlanId(), stackFrame, bufferAtomics, dataContext, batchThreads, waitList)
+                        : installedCode.launchWithoutDependencies(graphExecutionContext.getExecutionPlanId(), stackFrame, bufferAtomics, dataContext, batchThreads);
 
-        try {
-            int lastEvent = useDependencies
-                    ? installedCode.launchWithDependencies(executionContext.getExecutionPlanId(), stackFrame, bufferAtomics, dataContext, batchThreads, waitList)
-                    : installedCode.launchWithoutDependencies(executionContext.getExecutionPlanId(), stackFrame, bufferAtomics, dataContext, batchThreads);
+                resetEventIndexes(eventList);
+                return lastEvent;
 
-            resetEventIndexes(eventList);
-            return lastEvent;
-        } catch (Exception e) {
-            if (TornadoOptions.DEBUG) {
-                e.printStackTrace();
+            } catch (Exception e) {
+                if (TornadoOptions.DEBUG) {
+                    e.printStackTrace();
+                }
+                throw new TornadoBailoutRuntimeException("Bailout from LAUNCH Bytecode: \nReason: " + e, e);
             }
-            throw new TornadoBailoutRuntimeException("Bailout from LAUNCH Bytecode: \nReason: " + e.toString(), e);
+        } else {
+            throw new TornadoRuntimeException("task.meta is not instanceof TaskDataContext");
         }
     }
 
@@ -824,14 +822,14 @@ public class TornadoVMInterpreter {
             tornadoVMBytecodeList.append(String.format("bc: " + InterpreterUtilities.debugHighLightBC("BARRIER") + " event-list %d%n", eventList));
         }
 
-        int lastEvent = interpreterDevice.enqueueMarker(executionContext.getExecutionPlanId(), waitList);
+        int lastEvent = interpreterDevice.enqueueMarker(graphExecutionContext.getExecutionPlanId(), waitList);
 
         resetEventIndexes(eventList);
         return lastEvent;
     }
 
     private void throwErrorInterpreter(byte op) {
-        if (executionContext.meta().isDebug()) {
+        if (graphExecutionContext.meta().isDebug()) {
             logger.debug("bc: invalid op 0x%x(%d)", op, op);
         }
         throw new TornadoRuntimeException("[ERROR] TornadoVM Bytecode not recognized");
@@ -856,11 +854,11 @@ public class TornadoVMInterpreter {
     }
 
     private KernelStackFrame resolveCallWrapper(int index, int numArgs, KernelStackFrame[] kernelStackFrame, TornadoXPUDevice device, boolean redeployOnDevice) {
-        if (executionContext.meta().isDebug() && redeployOnDevice) {
+        if (graphExecutionContext.meta().isDebug() && redeployOnDevice) {
             logger.debug("Recompiling task on device " + device);
         }
         if (kernelStackFrame[index] == null || !kernelStackFrame[index].isValid() || redeployOnDevice) {
-            kernelStackFrame[index] = device.createKernelStackFrame(executionContext.getExecutionPlanId(), numArgs);
+            kernelStackFrame[index] = device.createKernelStackFrame(graphExecutionContext.getExecutionPlanId(), numArgs);
         }
         return kernelStackFrame[index];
     }
@@ -879,12 +877,12 @@ public class TornadoVMInterpreter {
      *     the local task list.
      */
     private int globalToLocalTaskIndex(int taskIndex) {
-        return localTaskList.indexOf(tasks.get(taskIndex)) == -1 ? 0 : localTaskList.indexOf(tasks.get(taskIndex));
+        return localTaskList.indexOf(taskExecutionContexts.get(taskIndex)) == -1 ? 0 : localTaskList.indexOf(taskExecutionContexts.get(taskIndex));
     }
 
     private void profilerUpdateForPreCompiledTask(SchedulableTask task) {
         if (task instanceof PrebuiltTask prebuiltTask && timeProfiler instanceof TimeProfiler) {
-            timeProfiler.registerDeviceID(task.getId(), prebuiltTask.meta().getXPUDevice().getDriverIndex() + ":" + prebuiltTask.meta().getDeviceIndex());
+            timeProfiler.registerDeviceID(task.getId(), prebuiltTask.meta().getXPUDevice().getBackendIndex() + ":" + prebuiltTask.meta().getDeviceIndex());
             timeProfiler.registerDeviceName(task.getId(), prebuiltTask.meta().getXPUDevice().getPhysicalDevice().getDeviceName());
         }
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
@@ -100,9 +100,8 @@ public class CompilableTask implements SchedulableTask {
     }
 
     @Override
-    public CompilableTask mapTo(final TornadoDevice mapping) {
-        meta.setDevice(mapping);
-        return this;
+    public void setDevice(final TornadoDevice device) {
+        meta.setDevice(device);
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
@@ -36,8 +36,8 @@ import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class PrebuiltTask implements SchedulableTask {
 
-    protected final Object[] args;
-    protected final TaskDataContext meta;
+    private final Object[] args;
+    private TaskDataContext meta;
     private final String entryPoint;
     private final String filename;
     private final Access[] argumentsAccess;
@@ -92,9 +92,8 @@ public class PrebuiltTask implements SchedulableTask {
     }
 
     @Override
-    public SchedulableTask mapTo(TornadoDevice mapping) {
-        meta.setDevice(mapping);
-        return this;
+    public void setDevice(TornadoDevice device) {
+        meta.setDevice(device);
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/ScheduleContext.java
@@ -23,10 +23,18 @@
  */
 package uk.ac.manchester.tornado.runtime.tasks.meta;
 
-public class ScheduleContext extends AbstractRTContext {
+public class ScheduleContext extends AbstractRTContext implements Cloneable {
 
     public ScheduleContext(String id) {
         super(id, null);
     }
 
+    @Override
+    public ScheduleContext clone() {
+        try {
+            return (ScheduleContext) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError();
+        }
+    }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -83,7 +83,7 @@ public abstract class TornadoTestBase {
     }
 
     public void assertNotBackend(TornadoVMBackendType backend, String customBackendAssertionMessage) {
-        int driverIndex = getTornadoRuntime().getDefaultDevice().getDriverIndex();
+        int driverIndex = getTornadoRuntime().getDefaultDevice().getBackendIndex();
         if (getTornadoRuntime().getBackendType(driverIndex) == backend) {
             switch (backend) {
                 case PTX -> throw new TornadoVMPTXNotSupported(customBackendAssertionMessage != null ? customBackendAssertionMessage : "Test not supported for the PTX backend");
@@ -98,7 +98,7 @@ public abstract class TornadoTestBase {
         if (!TornadoHelper.OPTIMIZE_LOAD_STORE_SPIRV) {
             return;
         }
-        int driverIndex = getTornadoRuntime().getDefaultDevice().getDriverIndex();
+        int driverIndex = getTornadoRuntime().getDefaultDevice().getBackendIndex();
         if (getTornadoRuntime().getBackendType(driverIndex) == backend) {
             if (backend == TornadoVMBackendType.SPIRV) {
                 throw new SPIRVOptNotSupported("Test not supported for the optimized SPIR-V BACKEND");

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
@@ -85,7 +85,7 @@ public class TestProfiler extends TornadoTestBase {
                 .task("t0", TestHello::add, a, b, c)//
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
 
-        int driverIndex = TornadoRuntimeProvider.getTornadoRuntime().getDefaultDevice().getDriverIndex();
+        int driverIndex = TornadoRuntimeProvider.getTornadoRuntime().getDefaultDevice().getBackendIndex();
 
         // Build ImmutableTaskGraph
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
@@ -183,7 +183,7 @@ public class TestProfiler extends TornadoTestBase {
             // Execute the plan (default TornadoVM optimization choices)
             TornadoExecutionResult executionResult = executionPlan.execute();
 
-            int driverIndex = TornadoRuntimeProvider.getTornadoRuntime().getDefaultDevice().getDriverIndex();
+            int driverIndex = TornadoRuntimeProvider.getTornadoRuntime().getDefaultDevice().getBackendIndex();
 
             TornadoProfilerResult profilerResult = executionResult.getProfilerResult();
 
@@ -232,7 +232,7 @@ public class TestProfiler extends TornadoTestBase {
             // Execute the plan (default TornadoVM optimization choices)
             TornadoExecutionResult executionResult = executionPlan.execute();
 
-            int driverIndex = TornadoRuntimeProvider.getTornadoRuntime().getDefaultDevice().getDriverIndex();
+            int driverIndex = TornadoRuntimeProvider.getTornadoRuntime().getDefaultDevice().getBackendIndex();
 
             assertTrue(executionResult.getProfilerResult().getTotalTime() > 0);
             assertTrue(executionResult.getProfilerResult().getTornadoCompilerTime() > 0);


### PR DESCRIPTION
#### Description

This PR fixes the device switching in the runtime. Some configurations (e.g., multple SPIR-V device from multiple vendors, or multiple OpenCL providers with different type of devices) could cause device switching to the wrong device. 

This PR fixes the problem by comparing the device to switch based on the vendor information, rather than the logic names that TornadoVM sets to devices. This guarantees switching to the correct device. 

#### Problem description

Described  above. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

I realised this error when having multiple implementations for the Compute Aorta (Codeplay) such as one for CPUs (x86_64) and another one for RISC-V. Both configurations share the same platform name. However, the device to access is different. 

Based on the following configuration:

```bash
$ tornado --jvm="-Dtornado.spirv.version=1.0" --devices
WARNING: Using incubator modules: jdk.incubator.vector

Number of Tornado drivers: 2
Driver: SPIR-V
  Total number of SPIR-V devices  : 4
  Tornado device=0:0  (DEFAULT)
	SPIRV -- SPIRV OCL - Intel(R) HD Graphics 630
		Global Memory Size: 28.9 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [256]
		Max WorkGroup Configuration: [256, 256, 256]
		Device OpenCL C version: OpenCL C 1.2

  Tornado device=0:1
	SPIRV -- SPIRV OCL - ComputeAorta x86_64
		Global Memory Size: 7.8 GB
		Local Memory Size: 32.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [1024]
		Max WorkGroup Configuration: [1024, 1024, 1024]
		Device OpenCL C version: OpenCL C 1.2 Clang 18.1.8

  Tornado device=0:2
	SPIRV -- SPIRV OCL - RefSi G1 RV64
		Global Memory Size: 2.0 GB
		Local Memory Size: 256.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [1024]
		Max WorkGroup Configuration: [1024, 1024, 1024]
		Device OpenCL C version: OpenCL C 1.2 Clang 18.1.8

  Tornado device=0:3
	SPIRV -- SPIRV LevelZero - Intel(R) HD Graphics 630
		Global Memory Size: 28.9 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [256]
		Max WorkGroup Configuration: [256, 256, 256]
		Device OpenCL C version:  (LEVEL ZERO) 1.3

Driver: OpenCL
  Total number of OpenCL devices  : 4
  Tornado device=1:0
	OPENCL --  [NVIDIA CUDA] -- NVIDIA GeForce GTX 1050
		Global Memory Size: 3.9 GB
		Local Memory Size: 48.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [1024]
		Max WorkGroup Configuration: [1024, 1024, 64]
		Device OpenCL C version: OpenCL C 1.2

  Tornado device=1:1
	OPENCL --  [Intel(R) OpenCL Graphics] -- Intel(R) HD Graphics 630
		Global Memory Size: 28.9 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [256]
		Max WorkGroup Configuration: [256, 256, 256]
		Device OpenCL C version: OpenCL C 1.2

  Tornado device=1:2
	OPENCL --  [ComputeAorta] -- ComputeAorta x86_64
		Global Memory Size: 7.8 GB
		Local Memory Size: 32.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [1024]
		Max WorkGroup Configuration: [1024, 1024, 1024]
		Device OpenCL C version: OpenCL C 1.2 Clang 18.1.8

  Tornado device=1:3
	OPENCL --  [ComputeAorta] -- RefSi G1 RV64
		Global Memory Size: 2.0 GB
		Local Memory Size: 256.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [1024]
		Max WorkGroup Configuration: [1024, 1024, 1024]
		Device OpenCL C version: OpenCL C 1.2 Clang 18.1.8
```

Running the following command now works:


```bash
tornado --jvm="-Dtornado.spirv.version=1.0 -Ds0.t0.device=0:2" --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.arrays.ArrayAddInt
WARNING: Using incubator modules: jdk.incubator.vector
Task info: s0.t0
	Backend           : SPIRV
	Device            : SPIRV OCL - RefSi G1 RV64 FPGA     << RISC-V Accelerator
	Dims              : 1
	Global work offset: [0]
	Global work size  : [8]
	Local  work size  : [8, 1, 1]
	Number of workgroups  : [1]
```


