### PR TITLE
[test] Removed double entry from tornado-test

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -51,7 +51,6 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.TestHello"),
     TestEntry("uk.ac.manchester.tornado.unittests.arrays.TestArrays"),
     TestEntry("uk.ac.manchester.tornado.unittests.arrays.TestArrayCopies"),
-    TestEntry("uk.ac.manchester.tornado.unittests.functional.TestLambdas"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestFloats"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestHalfFloats"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestDoubles"),


### PR DESCRIPTION
Following a leftover from previous PR regarding a double entry in the `tornado-test` script, this PR removes the second entry.

Lines 54 and 98.