### PR TITLE
[release] TornadoVM 1.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TornadoVM
 
-![TornadoVM version](https://img.shields.io/badge/version-1.0.6-purple)  [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2) [![License: GPL v2](https://img.shields.io/badge/License-GPL%20V2%20Classpth%20Exeception-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+![TornadoVM version](https://img.shields.io/badge/version-1.0.7-purple)  [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2) [![License: GPL v2](https://img.shields.io/badge/License-GPL%20V2%20Classpth%20Exeception-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 
 <img align="left" width="250" height="250" src="etc/tornadoVM_Logo.jpg">
 
@@ -20,7 +20,7 @@ Developers can choose which backends to install and run.
 
 For a quick introduction please read the following [FAQ](https://tornadovm.readthedocs.io/en/latest/).
 
-**Latest Release:** TornadoVM 1.0.6 - 27/06/2024 :
+**Latest Release:** TornadoVM 1.0.7 - 30/08/2024 :
 See [CHANGELOG](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html).
 
 ----------------------
@@ -261,12 +261,12 @@ You can import the TornadoVM API by setting this the following dependency in the
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
 </dependency>
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-matrices</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
 </dependency>
 </dependencies>
 ```

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -5,6 +5,51 @@ TornadoVM Changelog
 
 This file summarizes the new features and major changes for each *TornadoVM* version.
 
+TornadoVM 1.0.7
+----------------
+30th August 2024
+
+Improvements
+~~~~~~~~~~~~~~~~~~
+
+- `#468 <https://github.com/beehive-lab/TornadoVM/pull/468>`_: Cleanup Abstract Metadata Class.
+- `#473 <https://github.com/beehive-lab/TornadoVM/pull/473>`_: Add maven plugin to build TornadoVM source for the releases.
+- `#474 <https://github.com/beehive-lab/TornadoVM/pull/474>`_: Refactor <X>TornadoDevice to place common methods in the ``TornadoXPUInterface``.
+- `#482 <https://github.com/beehive-lab/TornadoVM/pull/482>`_: Help messages improved when an out-of-memory exception is raised.
+- `#484 <https://github.com/beehive-lab/TornadoVM/pull/484>`_: Double-type for the trigonometric functions added in the ``TornadoMath`` class.
+- `#487 <https://github.com/beehive-lab/TornadoVM/pull/487>`_: Prebuilt API simplified.
+- `#494 <https://github.com/beehive-lab/TornadoVM/pull/494>`_: Add test to trigger unsupported features related to direct use of Memory Segments.
+- `#509 <https://github.com/beehive-lab/TornadoVM/pull/509>`_: Add a quick pass configuration to skip the heavy tests during active development.
+- `#532 <https://github.com/beehive-lab/TornadoVM/pull/532>`_: Improve thread scheduler to support RISC-V Accelerators from Codeplay.
+- `#533 <https://github.com/beehive-lab/TornadoVM/pull/533>`_: Support for scalar values to be passed via lambda expressions as tasks.
+- `#538 <https://github.com/beehive-lab/TornadoVM/pull/538>`_: ``README`` file updated.
+- `#539 <https://github.com/beehive-lab/TornadoVM/pull/539>`_: Refactor core classes and add new API methods to pass compilation flags to the low-level driver compilers (OpenCL, PTX and Level Zero).
+- `#542 <https://github.com/beehive-lab/TornadoVM/pull/542>`_: Tagged LevelZero JNI and Beehive Toolkit dependencies added in the build and installer.
+
+Compatibility
+~~~~~~~~~~~~~~~~~~
+
+- `#465 <https://github.com/beehive-lab/TornadoVM/pull/465>`_: Support for JDK 22 and GraalVM 24.0.2.
+- `#486 <https://github.com/beehive-lab/TornadoVM/pull/486>`_: Temurin for Windows added in the list of supported JDKs.
+- `#525 <https://github.com/beehive-lab/TornadoVM/pull/525>`_: Revert usage of String Templates in preparation for JDK 23.
+- `#527 <https://github.com/beehive-lab/TornadoVM/pull/527>`_: SPIR-V version parameter added. TornadoVM may run previous SPIR-V versions (e.g., ComputeAorta from Codeplay).
+- `#513 <https://github.com/beehive-lab/TornadoVM/pull/531>`_: LevelZero JNI Library updated to v0.1.4.
+
+Bug Fixes
+~~~~~~~~~~~~~~~~~~
+
+- `#470 <https://github.com/beehive-lab/TornadoVM/pull/470>`_: README documentation fixed.
+- `#478 <https://github.com/beehive-lab/TornadoVM/pull/478>`_: Fix the test names that are present in the white list.
+- `#488 <https://github.com/beehive-lab/TornadoVM/pull/488>`_: FP64 Kind for radian operations and the PTX backend fixed.
+- `#493 <https://github.com/beehive-lab/TornadoVM/pull/493>`_: Tests Whitelist for PTX backend fixed.
+- `#502 <https://github.com/beehive-lab/TornadoVM/pull/502>`_: Fix barrier type in the documentation regarding programmability of reductions.
+- `#514 <https://github.com/beehive-lab/TornadoVM/pull/514>`_: Installer script fixed.
+- `#540 <https://github.com/beehive-lab/TornadoVM/pull/540>`_: Fix  issue with clean-up execution IDs function.
+- `#541 <https://github.com/beehive-lab/TornadoVM/pull/541>`_: Fix Data Accessors for the prebuilt API.
+- `#543 <https://github.com/beehive-lab/TornadoVM/pull/543>`_: Fix checkstyle condition and FP16 error message improved.
+
+
+
 TornadoVM 1.0.6
 ----------------
 27th June 2024

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,8 +6,8 @@ project = "TornadoVM"
 copyright = "2013-2024, APT Group, Department of Computer Science"
 author = "The University of Manchester"
 
-release = "v1.0.4"
-version = "v1.0.4"
+release = "v1.0.7"
+version = "v1.0.7"
 
 # -- General configuration
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -509,13 +509,13 @@ To use the TornadoVM API in your projects, you can checkout our maven repository
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>1.0.6</version>
+         <version>1.0.7</version>
       </dependency>
 
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>1.0.6</version>
+         <version>1.0.7</version>
       </dependency>
    </dependencies>
 
@@ -526,6 +526,7 @@ Notice that, for running with TornadoVM, you will need either the docker images 
 Versions available
 ========================
 
+* 1.0.7
 * 1.0.6
 * 1.0.5
 * 1.0.4

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>tornado</groupId>
     <artifactId>tornado</artifactId>
-    <version>1.0.7-dev</version>
+    <version>1.0.7</version>
     <packaging>pom</packaging>
     <name>tornado</name>
     <url>https://github.com/beehive-lab/tornadovm</url>

--- a/tornado-annotation/pom.xml
+++ b/tornado-annotation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
 
     <artifactId>tornado-annotation</artifactId>

--- a/tornado-api/pom.xml
+++ b/tornado-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
 
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.7-dev</version>
+    <version>1.0.7</version>
 
     <name>tornado-api</name>
     <url>https://tornadovm.org</url>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-assembly</artifactId>
     <packaging>pom</packaging>

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -254,7 +254,7 @@ else:
 
 ENABLE_ASSERTIONS = "-ea "
 
-__VERSION__ = "0.16_10032024"
+__VERSION__ = "1.0.7"
 
 try:
     javaHome = os.environ["JAVA_HOME"]

--- a/tornado-benchmarks/pom.xml
+++ b/tornado-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
 
     <artifactId>tornado-benchmarks</artifactId>

--- a/tornado-drivers/drivers-common/pom.xml
+++ b/tornado-drivers/drivers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tornado-drivers/opencl-jni/pom.xml
+++ b/tornado-drivers/opencl-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-drivers-opencl-jni</artifactId>
     <name>tornado-drivers-opencl-jni</name>

--- a/tornado-drivers/opencl/pom.xml
+++ b/tornado-drivers/opencl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-drivers-opencl</artifactId>
     <name>tornado-drivers-opencl</name>

--- a/tornado-drivers/pom.xml
+++ b/tornado-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-drivers</artifactId>
     <name>tornado-drivers</name>

--- a/tornado-drivers/ptx-jni/pom.xml
+++ b/tornado-drivers/ptx-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-drivers-ptx-jni</artifactId>
     <name>tornado-drivers-ptx-jni</name>

--- a/tornado-drivers/ptx/pom.xml
+++ b/tornado-drivers/ptx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tornado-drivers</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-drivers-ptx</artifactId>
     <name>tornado-drivers-ptx</name>

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-drivers-spirv</artifactId>
     <name>tornado-drivers-spirv</name>

--- a/tornado-examples/pom.xml
+++ b/tornado-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-examples</artifactId>
     <name>tornado-examples</name>

--- a/tornado-matrices/pom.xml
+++ b/tornado-matrices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-matrices</artifactId>
     <name>tornado-matrices</name>

--- a/tornado-runtime/pom.xml
+++ b/tornado-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-runtime</artifactId>
     <name>tornado-runtime</name>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.7-dev</version>
+        <version>1.0.7</version>
     </parent>
     <artifactId>tornado-unittests</artifactId>
     <name>tornado-unittests</name>


### PR DESCRIPTION
Improvements
=============

- #468: Cleanup Abstract Metadata Class.
- #473: Add maven plugin to build TornadoVM source for the releases.
- #474: Refactor `<X>TornadoDevice` to place common methods in the `TornadoXPUInterface`.
- #482: Help messages improved when an out-of-memory exception is raised.
- #484: Double-type for the trigonometric functions added in the `TornadoMath` class.
- #487: Prebuilt API simplified.
- #494: Add test to trigger unsupported features related to direct use of Memory Segments.
- #509: Add a quick pass configuration to skip the heavy tests during active development.
- #532: Improve thread scheduler to support RISC-V Accelerators from Codeplay.
- #533: Support for scalar values to be passed via lambda expressions as tasks.
- #538: `README` file updated.
- #539: Refactor core classes and add new API methods to pass compilation flags to the low-level driver compilers (OpenCL, PTX and Level Zero).
- #542: Tagged LevelZero JNI and Beehive Toolkit dependencies added in the build and installer.

Compatibility
=============

- #465: Support for JDK 22 and GraalVM 24.0.2.
- #486: Temurin for Windows added in the list of supported JDKs.
- #525: Revert usage of String Templates in preparation for JDK 23.
- #527: SPIR-V version parameter added. TornadoVM may run previous SPIR-V versions (e.g., ComputeAorta from Codeplay).
- #513: LevelZero JNI Library updated to v0.1.4.

Bug Fixes
=============

- #470: README documentation fixed.
- #478: Fix the test names that are present in the white list.
- #488: FP64 Kind for radian operations and the PTX backend fixed.
- #493: Tests Whitelist for PTX backend fixed.
- #502: Fix barrier type in the documentation regarding programmability of reductions.
- #514: Installer script fixed.
- #540: Fix  issue with clean-up execution IDs function.
- #541: Fix Data Accessors for the prebuilt API.
- #543: Fix checkstyle condition and FP16 error message improved.


#### How to test the new patch?

```bash
tornado --version
version=1.0.7
branch=release/1.0.7
commit=9ca3610

Backends installed: 
	 - spirv
	 - opencl
	 - ptx
```


```bash
## Pass Unittests using the OpenCL backend
$ make BACKEND=opencl
$ make tests

## If the changes are also applicable to the PTX backend: 
## Pass unittests using the PTX backend
$ make BACKEND=ptx
$ make tests 

## If the changes are also applicable to the SPIR-V backend: 
## Pass unittests using the SPIRV backend
$ make BACKEND=spirv
$ make tests 
```

