### PR TITLE
Fix issue with multiple SPIR-V devices

### DIFF
--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
@@ -79,7 +79,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
         }
         platforms = new ArrayList<>();
         spirvBackends = new SPIRVBackend[numPlatforms][];
-	backendPerDevice = new HashMap<>();
+	    backendPerDevice = new HashMap<>();
 
         discoverDevices(options, vmRuntime, vmConfigAccess, numPlatforms);
 
@@ -223,10 +223,6 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
             }
         }
         return null;
-    }
-
-    public SPIRVBackend getBackend(int platformIndex, int deviceIndex) {
-        return checkAndInitBackend(platformIndex, deviceIndex);
     }
 
     public SPIRVBackend getBackendOfDevice(SPIRVDevice device) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
@@ -24,6 +24,7 @@
 package uk.ac.manchester.tornado.drivers.spirv;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import org.graalvm.compiler.options.OptionValues;
@@ -59,6 +60,8 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
 
     private final TornadoLogger logger;
 
+    private final HashMap<SPIRVDevice, SPIRVBackend> backendPerDevice;
+
     /**
      * Total number of devices available (include all backends platform and
      * devices).
@@ -76,6 +79,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
         }
         platforms = new ArrayList<>();
         spirvBackends = new SPIRVBackend[numPlatforms][];
+	backendPerDevice = new HashMap<>();
 
         discoverDevices(options, vmRuntime, vmConfigAccess, numPlatforms);
 
@@ -102,7 +106,9 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
             for (int deviceIndex = 0; deviceIndex < numDevices; deviceIndex++) {
                 SPIRVDevice device = platform.getDevice(deviceIndex);
                 if (device.isSPIRVSupported()) {
-                    backendImplementations.add(createSPIRVJITCompilerBackend(options, vmRuntime, vmCon, device, context, device.getSPIRVRuntime()));
+                    SPIRVBackend backend = createSPIRVJITCompilerBackend(options, vmRuntime, vmCon, device, context, device.getSPIRVRuntime());
+                    backendPerDevice.put(device, backend);
+                    backendImplementations.add(backend);
                     backendCounter++;
                 }
             }
@@ -221,6 +227,10 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
 
     public SPIRVBackend getBackend(int platformIndex, int deviceIndex) {
         return checkAndInitBackend(platformIndex, deviceIndex);
+    }
+
+    public SPIRVBackend getBackendOfDevice(SPIRVDevice device) {
+        return backendPerDevice.get(device);
     }
 
     public List<SPIRVPlatform> getPlatforms() {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
@@ -79,7 +79,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
         }
         platforms = new ArrayList<>();
         spirvBackends = new SPIRVBackend[numPlatforms][];
-	    backendPerDevice = new HashMap<>();
+        backendPerDevice = new HashMap<>();
 
         discoverDevices(options, vmRuntime, vmConfigAccess, numPlatforms);
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -92,11 +92,9 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     private static SPIRVBackendImpl driver = null;
     private final SPIRVDevice device;
     private final int deviceIndex;
-    private final SPIRVDevice lowLevelDevice;
 
     public SPIRVTornadoDevice(SPIRVDevice lowLevelDevice) {
         this.deviceIndex = lowLevelDevice.getDeviceIndex();
-	    this.lowLevelDevice = lowLevelDevice;
         device = lowLevelDevice;
     }
 
@@ -145,7 +143,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     }
 
     public SPIRVBackend getBackend() {
-        return findDriver().getBackendOfDevice(lowLevelDevice);
+        return findDriver().getBackendOfDevice(device);
     }
 
     private TornadoInstalledCode compileTask(CompilableTask task) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -92,13 +92,11 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     private static SPIRVBackendImpl driver = null;
     private final SPIRVDevice device;
     private final int deviceIndex;
-    private final int platformIndex;
     private final SPIRVDevice lowLevelDevice;
 
     public SPIRVTornadoDevice(SPIRVDevice lowLevelDevice) {
-        this.platformIndex = lowLevelDevice.getPlatformIndex();
         this.deviceIndex = lowLevelDevice.getDeviceIndex();
-	this.lowLevelDevice = lowLevelDevice;
+	    this.lowLevelDevice = lowLevelDevice;
         device = lowLevelDevice;
     }
 
@@ -147,8 +145,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     }
 
     public SPIRVBackend getBackend() {
-        SPIRVBackend backend = findDriver().getBackendOfDevice(lowLevelDevice);
-        return backend;
+        return findDriver().getBackendOfDevice(lowLevelDevice);
     }
 
     private TornadoInstalledCode compileTask(CompilableTask task) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -93,10 +93,12 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     private final SPIRVDevice device;
     private final int deviceIndex;
     private final int platformIndex;
+    private final SPIRVDevice lowLevelDevice;
 
     public SPIRVTornadoDevice(SPIRVDevice lowLevelDevice) {
         this.platformIndex = lowLevelDevice.getPlatformIndex();
         this.deviceIndex = lowLevelDevice.getDeviceIndex();
+	this.lowLevelDevice = lowLevelDevice;
         device = lowLevelDevice;
     }
 
@@ -145,7 +147,8 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
     }
 
     public SPIRVBackend getBackend() {
-        return findDriver().getBackend(platformIndex, deviceIndex);
+        SPIRVBackend backend = findDriver().getBackendOfDevice(lowLevelDevice);
+        return backend;
     }
 
     private TornadoInstalledCode compileTask(CompilableTask task) {


### PR DESCRIPTION
#### Description
It was observed that when having more than one SPIR-V devices, the following error was generated depending on the specified device of execution. 
```
Unable to compile task s0.t0 - add
The internal error is: [Error During the Task Compilation]: Index 1 out of bounds for length 1
Stacktrace: [tornado.drivers.spirv@1.0.8-dev/uk.ac.manchester.tornado.drivers.spirv.runtime.SPIRVTornadoDevice.compileTask(SPIRVTornadoDevice.java:191), tornado.drivers.spirv@1.0.8-dev/uk.ac.manchester.tornado.drivers.spirv.runtime.SPIRVTornadoDevice.installCode(SPIRVTornadoDevice.java:129), tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.interpreter.TornadoVMInterpreter.compileTaskFromBytecodeToBinary(TornadoVMInterpreter.java:664), tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.interpreter.TornadoVMInterpreter.execute(TornadoVMInterpreter.java:329), tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.interpreter.TornadoVMInterpreter.execute(TornadoVMInterpreter.java:903), java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024), java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762), tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.TornadoVM.executeInterpreterSingleThreaded(TornadoVM.java:127), tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.TornadoVM.execute(TornadoVM.java:114), tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.tasks.TornadoTaskGraph.scheduleInner(TornadoTaskGraph.java:884), tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.tasks.TornadoTaskGraph.execute(TornadoTaskGraph.java:1410), tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.tasks.TornadoTaskGraph.execute(TornadoTaskGraph.java:1422), tornado.api@1.0.8-dev/uk.ac.manchester.tornado.api.TaskGraph.execute(TaskGraph.java:759), tornado.api@1.0.8-dev/uk.ac.manchester.tornado.api.ImmutableTaskGraph.execute(ImmutableTaskGraph.java:50), tornado.api@1.0.8-dev/uk.ac.manchester.tornado.api.TornadoExecutionPlan$TornadoExecutor.lambda$execute$0(TornadoExecutionPlan.java:466), java.base/java.util.ArrayList.forEach(ArrayList.java:1596), tornado.api@1.0.8-dev/uk.ac.manchester.tornado.api.TornadoExecutionPlan$TornadoExecutor.execute(TornadoExecutionPlan.java:466), tornado.api@1.0.8-dev/uk.ac.manchester.tornado.api.TornadoExecutionPlan.execute(TornadoExecutionPlan.java:118), tornado.examples@1.0.8-dev/uk.ac.manchester.tornado.examples.arrays.ArrayAddInt.main(ArrayAddInt.java:65)]
        tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.interpreter.TornadoVMInterpreter.compileTaskFromBytecodeToBinary(TornadoVMInterpreter.java:672)
        tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.interpreter.TornadoVMInterpreter.execute(TornadoVMInterpreter.java:329)
        tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.interpreter.TornadoVMInterpreter.execute(TornadoVMInterpreter.java:903)
        java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024)
        java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
        tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.TornadoVM.executeInterpreterSingleThreaded(TornadoVM.java:127)
        tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.TornadoVM.execute(TornadoVM.java:114)
        tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.tasks.TornadoTaskGraph.scheduleInner(TornadoTaskGraph.java:884)
        tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.tasks.TornadoTaskGraph.execute(TornadoTaskGraph.java:1410)
        tornado.runtime@1.0.8-dev/uk.ac.manchester.tornado.runtime.tasks.TornadoTaskGraph.execute(TornadoTaskGraph.java:1422)
        tornado.api@1.0.8-dev/uk.ac.manchester.tornado.api.TaskGraph.execute(TaskGraph.java:759)
        tornado.api@1.0.8-dev/uk.ac.manchester.tornado.api.ImmutableTaskGraph.execute(ImmutableTaskGraph.java:50)
        tornado.api@1.0.8-dev/uk.ac.manchester.tornado.api.TornadoExecutionPlan$TornadoExecutor.lambda$execute$0(TornadoExecutionPlan.java:466)
        java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
        tornado.api@1.0.8-dev/uk.ac.manchester.tornado.api.TornadoExecutionPlan$TornadoExecutor.execute(TornadoExecutionPlan.java:466)
        tornado.api@1.0.8-dev/uk.ac.manchester.tornado.api.TornadoExecutionPlan.execute(TornadoExecutionPlan.java:118)
        tornado.examples@1.0.8-dev/uk.ac.manchester.tornado.examples.arrays.ArrayAddInt.main(ArrayAddInt.java:65) 
```
This PR proposes a fix. 

#### Problem description
The error above is generated from this function of the `SPIRVTornadoDevice` class:
```
public SPIRVBackend getBackend() {
    return findDriver().getBackend(platformIndex, deviceIndex);
}
```
Specifically, the error is triggered by the `getBackend()` function, which attempts to get the backend of the SPIR-V device from the 2D array `spirvBackends`, which is created in the `SPIRVBackendImpl` class.  
The `spirvBackends` array is initialized in the following way. The number of rows corresponds to the number of SPIR-V dispatch drivers (OpenCL and LevelZero) and each row contains an array that stores the backends of the devices associated with each driver. For the example, on the cyclone server, for the following devices: 
```
Number of Tornado drivers: 2
Driver: SPIR-V
  Total number of SPIR-V devices  : 4
  Tornado device=0:0  (DEFAULT)
        SPIRV -- SPIRV OCL - Intel(R) Arc(TM) A770 Graphics
                Global Memory Size: 15.1 GB
                Local Memory Size: 64.0 KB
                Workgroup Dimensions: 3
                Total Number of Block Threads: [1024]
                Max WorkGroup Configuration: [1024, 1024, 1024]
                Device OpenCL C version: OpenCL C 1.2

  Tornado device=0:1
        SPIRV -- SPIRV OCL - Intel(R) UHD Graphics 770
                Global Memory Size: 117.5 GB
                Local Memory Size: 64.0 KB
                Workgroup Dimensions: 3
                Total Number of Block Threads: [512]
                Max WorkGroup Configuration: [512, 512, 512]
                Device OpenCL C version: OpenCL C 1.2

  Tornado device=0:2
        SPIRV -- SPIRV LevelZero - Intel(R) Arc(TM) A770 Graphics
                Global Memory Size: 15.1 GB
                Local Memory Size: 64.0 KB
                Workgroup Dimensions: 3
                Total Number of Block Threads: [1024]
                Max WorkGroup Configuration: [1024, 1024, 1024]
                Device OpenCL C version:  (LEVEL ZERO) 1.3

  Tornado device=0:3
        SPIRV -- SPIRV LevelZero - Intel(R) UHD Graphics 770
                Global Memory Size: 117.5 GB
                Local Memory Size: 64.0 KB
                Workgroup Dimensions: 3
                Total Number of Block Threads: [512]
                Max WorkGroup Configuration: [512, 512, 512]
                Device OpenCL C version:  (LEVEL ZERO) 1.3
```
the contents of the `spirvBackends` array are: 
```
spirvBackends[0][0] = Backend: arch=TornadoVM SPIR-V@OPENCL, device=Intel(R) Arc(TM) A770 Graphics
spirvBackends[1][0] = Backend: arch=TornadoVM SPIR-V@OPENCL, device=Intel(R) UHD Graphics 770
spirvBackends[2][0] = Backend: arch=TornadoVM SPIR-V@LEVEL_ZERO, device=Intel(R) Arc(TM) A770 Graphics
spirvBackends[2][1] = Backend: arch=TornadoVM SPIR-V@LEVEL_ZERO, device=Intel(R) UHD Graphics 770
```

When trying to run on device 0:3 (`SPIRV LevelZero - Intel(R) UHD Graphics 770`) the platform and device indices passed in the `getBackend()` function were 0-1. However, since there is no such entry in the `spirvBackends` array, the exception was thrown. To get the backend from the array correctly, the platform index should have been 2 instead, so as to follow the same semantics. 

However, each SPIR-V device instance (OpenCL and LevelZero) has a view of its own dispatch drivers and based on this it sets the platform index for it. Since there is one LevelZero dispatch driver, the index 0 is correct for the device, but it does not match the representation in the `spirvBackends` array which as a universal view of all the drivers.

This PR proposes the following. Instead of getting the backend using the platform index, get it based on the SPIR-V device instance. This way, the LevelZero and OpenCL instances of the SPIR-V devices do not need to have a view of all the drivers and it is guaranteed that we will get the backend associated with the specific SPIR-V device.  

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

The problem was identified by running the following test on the cyclone server: 
`tornado --jvm="-Dtornado.spirv.version=1.0 -Ds0.t0.device=0:3" --debug -m tornado.examples/uk.ac.manchester.tornado.examples.arrays.ArrayAddInt`

----------------------------------------------------------------------------
