### PR TITLE
[fix] OCL compiler flags for math tests on Integrated GPUs

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -35,7 +35,7 @@ public class TornadoOptions {
     /**
      * Default OpenCL Compiler Flags.
      */
-    public static final String DEFAULT_OPENCL_COMPILER_FLAGS = getProperty("tornado.opencl.compiler.flags", "-cl-mad-enable -cl-fast-relaxed-math -w");
+    public static final String DEFAULT_OPENCL_COMPILER_FLAGS = getProperty("tornado.opencl.compiler.flags", "-cl-opt-disable -cl-mad-enable -cl-fast-relaxed-math -w");
 
     /**
      * Default PTX Compiler Flags.

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -35,7 +35,7 @@ public class TornadoOptions {
     /**
      * Default OpenCL Compiler Flags.
      */
-    public static final String DEFAULT_OPENCL_COMPILER_FLAGS = getProperty("tornado.opencl.compiler.flags", "-cl-opt-disable -cl-mad-enable -cl-fast-relaxed-math -w");
+    public static final String DEFAULT_OPENCL_COMPILER_FLAGS = getProperty("tornado.opencl.compiler.flags", "-cl-mad-enable -cl-fast-relaxed-math -w");
 
     /**
      * Default PTX Compiler Flags.

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestMath.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestMath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2022, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, 2024, APT Group, Department of Computer Science,
  * The University of Manchester.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -246,6 +246,7 @@ public class TestMath extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withCompilerFlags(TornadoVMBackendType.OPENCL, "-cl-opt-disable");
             executionPlan.execute();
         }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, APT Group, Department of Computer Science,
+ * Copyright (c) 2020-2022, 2024, APT Group, Department of Computer Science,
  * The University of Manchester.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -322,6 +322,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withCompilerFlags(TornadoVMBackendType.OPENCL, "-cl-opt-disable");
             executionPlan.execute();
         }
 
@@ -379,6 +380,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withCompilerFlags(TornadoVMBackendType.OPENCL, "-cl-opt-disable");
             executionPlan.execute();
         }
 
@@ -590,6 +592,7 @@ public class TestTornadoMathCollection extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withCompilerFlags(TornadoVMBackendType.OPENCL, "-cl-opt-disable");
             executionPlan.execute();
         }
 


### PR DESCRIPTION
#### Description

This PR adds a compiler flag for OpenCL which enables `math` unit-tests to pass on Integrated GPUs.

This is for the Integrated GPUs that support `FP64` operations. Otherwise, the message for unsupported operations is displayed and not an error in the result.

For example:
```bash
Running test: [34mtestMathAtan[0m               ................ [31m [FAILED] [0m
 		\_[REASON] expected:<0.7853981633974483> but was:<0.7470323434249905>
``` 

**Note:** I included only the `-cl-opt-disable` flag which was sufficient to compile the unit-tests that were breaking. There are more compiler flags that can be added via the `DEFAULT_OPENCL_COMPILER_FLAGS`. Some of them were available in previous commit points from the commit [ffddb98](https://github.com/beehive-lab/TornadoVM/commit/ffddb981441189b0124ab517b2c8f4e6d50b105b) which initiated the refactoring. For example see the [AbstractMetaData class](https://github.com/beehive-lab/TornadoVM/blob/a4265e5ee782d457c04f0c5d3576936f0a01d878/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/AbstractMetaData.java#L53).

#### Problem description

The refactoring of the compiler flags that was initiated in PR #539 had as an aftermath a change in the default OpenCL compiler flags. This change was not obvious for the majority of the devices, however it is breaking some `math` unit-tests for the Integrated Graphics (e.g., Intel UHD Graphics 630) with OpenCL.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Assuming that your Integrated graphics supports `FP64` operations and it is device "0:1", you can run the following tests:
```bash
tornado --jvm "-Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.verbose=True -Dtornado.ptx.priority=100 -Dtornado.unittests.device=0:1" -m tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner --params "uk.ac.manchester.tornado.unittests.math.TestTornadoMathCollection"
tornado --jvm "-Xmx6g -Dtornado.recover.bailout=False -Dtornado.unittests.verbose=True -Dtornado.ptx.priority=100 -Dtornado.unittests.device=0:1" -m tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner --params "uk.ac.manchester.tornado.unittests.math.TestMath"
```

----------------------------------------------------------------------------
