### PR TITLE
[fix] Shared Execution Context fixed when having Multi-Threaded Java applicatons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ tornado-examples/target/
 tornado-runtime/target/
 tornado.iml
 tornado_unittests.log
-
+OpenCL-Headers/

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceContext.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceContext.java
@@ -40,7 +40,7 @@ public interface TornadoDeviceContext {
 
     boolean isFP64Supported();
 
-    boolean isCached(String methodName, SchedulableTask task);
+    boolean isCached(long executionPlanId, String methodName, SchedulableTask task);
 
     int getDeviceIndex();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -66,8 +66,7 @@ public class TornadoExecutionPlan implements AutoCloseable {
      */
     public TornadoExecutionPlan(ImmutableTaskGraph... immutableTaskGraphs) {
         this.tornadoExecutor = new TornadoExecutor(immutableTaskGraphs);
-        final long id = globalExecutionPlanCounter.get();
-        globalExecutionPlanCounter.incrementAndGet();
+        final long id = globalExecutionPlanCounter.incrementAndGet();
         executionPackage = new ExecutorFrame(id);
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -66,7 +66,8 @@ public class TornadoExecutionPlan implements AutoCloseable {
      */
     public TornadoExecutionPlan(ImmutableTaskGraph... immutableTaskGraphs) {
         this.tornadoExecutor = new TornadoExecutor(immutableTaskGraphs);
-        long id = globalExecutionPlanCounter.incrementAndGet();
+        final long id = globalExecutionPlanCounter.get();
+        globalExecutionPlanCounter.incrementAndGet();
         executionPackage = new ExecutorFrame(id);
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -67,6 +67,11 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
     private final TornadoBufferProvider bufferProvider;
     private boolean wasReset;
     private final Set<Long> executionIDs;
+
+    /**
+     * Map table to represent the compiled-code per execution plan. Each entry in the execution plan has its own
+     * code cache. The code cache manages the compilation and the cache for each task within an execution plan.
+     */
     private final Map<Long, OCLCodeCache> codeCache;
 
     public OCLDeviceContext(OCLTargetDevice device, OCLContext context) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -68,7 +68,7 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
     private final Map<Long, OCLEventPool> oclEventPool;
     private final TornadoBufferProvider bufferProvider;
     private boolean wasReset;
-    private Set<Long> executionIDs;
+    private final Set<Long> executionIDs;
     private final Map<Long, OCLCodeCache> codeCache;
 
     public OCLDeviceContext(OCLTargetDevice device, OCLContext context) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -509,7 +509,7 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
     }
 
     @Override
-    public synchronized void reset(long executionPlanId) {
+    public void reset(long executionPlanId) {
         OCLEventPool eventPool = getOCLEventPool(executionPlanId);
         eventPool.reset();
         oclEventPool.remove(executionPlanId);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import uk.ac.manchester.tornado.api.common.Event;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
-import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 import uk.ac.manchester.tornado.drivers.common.TornadoBufferProvider;
 import uk.ac.manchester.tornado.drivers.common.power.PowerMetric;
@@ -60,8 +59,7 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
     /**
      * Table to represent {@link uk.ac.manchester.tornado.api.TornadoExecutionPlan} -> {@link OCLCommandQueueTable}
      */
-    private Map<Long, OCLCommandQueueTable> commandQueueTable;
-
+    private final Map<Long, OCLCommandQueueTable> commandQueueTable;
     private final OCLContext context;
     private final PowerMetric powerMetric;
     private final OCLMemoryManager memoryManager;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContextInterface.java
@@ -36,19 +36,19 @@ public interface OCLDeviceContextInterface extends TornadoDeviceContext {
 
     OCLTargetDevice getDevice();
 
-    OCLCodeCache getCodeCache();
+    OCLCodeCache getCodeCache(long executionPlanId);
 
-    boolean isCached(String id, String entryPoint);
+    boolean isCached(long executionPlanId, String id, String entryPoint);
 
-    OCLInstalledCode getInstalledCode(String id, String entryPoint);
+    OCLInstalledCode getInstalledCode(long executionPlanId, String id, String entryPoint);
 
-    OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean printKernel);
+    OCLInstalledCode installCode(long executionPlanId, OCLCompilationResult result);
 
-    OCLInstalledCode installCode(OCLCompilationResult result);
+    OCLInstalledCode installCode(long executionPlanId, TaskDataContext meta, String id, String entryPoint, byte[] code);
 
-    OCLInstalledCode installCode(TaskDataContext meta, String id, String entryPoint, byte[] code);
+    OCLInstalledCode installCode(long executionPlanId, String id, String entryPoint, byte[] code, boolean printKernel);
 
-    boolean isKernelAvailable();
+    boolean isKernelAvailable(long executionPlanId);
 
     void reset(long executionPlanId);
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLJIT.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLJIT.java
@@ -72,7 +72,9 @@ public class OCLJIT {
 
             OCLCompilationResult result = OCLCompiler.compileCodeForDevice(resolvedMethod, new Object[] {}, meta, (OCLProviders) backend.getProviders(), backend, new EmptyProfiler());
 
-            OCLInstalledCode code = OpenCL.defaultDevice().getDeviceContext().installCode(result);
+            final long executionPlanId = 0;
+
+            OCLInstalledCode code = OpenCL.defaultDevice().getDeviceContext().installCode(executionPlanId, result);
 
             for (byte b : code.getCode()) {
                 System.out.printf("%c", b);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLJITCompiler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/tests/TestOpenCLJITCompiler.java
@@ -75,7 +75,7 @@ public class TestOpenCLJITCompiler {
         new TestOpenCLJITCompiler().test();
     }
 
-    public MetaCompilation compileMethod(Class<?> klass, String methodName, OCLTornadoDevice tornadoDevice, Object... parameters) {
+    public MetaCompilation compileMethod(long executionPlanId, Class<?> klass, String methodName, OCLTornadoDevice tornadoDevice, Object... parameters) {
 
         // Get the method object to be compiled
         Method methodToCompile = CompilerUtil.getMethodForName(klass, methodName);
@@ -108,7 +108,7 @@ public class TestOpenCLJITCompiler {
         OCLCompilationResult compilationResult = OCLCompiler.compileSketchForDevice(sketch, compilableTask, (OCLProviders) providers, openCLBackend, new EmptyProfiler());
 
         // Install the OpenCL Code in the VM
-        OCLInstalledCode openCLCode = tornadoDevice.getDeviceContext().installCode(compilationResult);
+        OCLInstalledCode openCLCode = tornadoDevice.getDeviceContext().installCode(executionPlanId, compilationResult);
 
         return new MetaCompilation(taskMeta, openCLCode);
     }
@@ -164,15 +164,16 @@ public class TestOpenCLJITCompiler {
 
         Arrays.fill(a, -10);
         Arrays.fill(b, 10);
+        long executionPlanId = 0;
 
         OCLTornadoDevice tornadoDevice = OpenCL.defaultDevice();
 
-        MetaCompilation compileMethod = compileMethod(TestOpenCLJITCompiler.class, "methodToCompile", tornadoDevice, a, b, c);
+        MetaCompilation compileMethod = compileMethod(executionPlanId, TestOpenCLJITCompiler.class, "methodToCompile", tornadoDevice, a, b, c);
 
         // Check with all internal APIs
         run(tornadoDevice, (OCLInstalledCode) compileMethod.getInstalledCode(), compileMethod.getTaskMeta(), a, b, c);
 
-        long executionPlanId = 0;
+
         // Check with OpenCL API
         runWithOpenCLAPI(executionPlanId, tornadoDevice, (OCLInstalledCode) compileMethod.getInstalledCode(), compileMethod.getTaskMeta(), a, b, c);
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLDeviceContext.java
@@ -204,42 +204,42 @@ public class VirtualOCLDeviceContext implements OCLDeviceContextInterface {
     }
 
     @Override
-    public boolean isKernelAvailable() {
+    public boolean isKernelAvailable(long executionPlanId) {
         return true;
     }
 
     @Override
-    public OCLInstalledCode installCode(OCLCompilationResult result) {
+    public OCLInstalledCode installCode(long executionPlanId, OCLCompilationResult result) {
         return null;
     }
 
     @Override
-    public OCLInstalledCode installCode(TaskDataContext meta, String id, String entryPoint, byte[] code) {
+    public OCLInstalledCode installCode(long executionPlanId, TaskDataContext meta, String id, String entryPoint, byte[] code) {
         return null;
     }
 
     @Override
-    public OCLInstalledCode installCode(String id, String entryPoint, byte[] code, boolean printKernel) {
+    public OCLInstalledCode installCode(long executionPlanId, String id, String entryPoint, byte[] code, boolean printKernel) {
         return null;
     }
 
     @Override
-    public boolean isCached(String id, String entryPoint) {
+    public boolean isCached(long executionPlanId, String id, String entryPoint) {
         return false;
     }
 
     @Override
-    public OCLInstalledCode getInstalledCode(String id, String entryPoint) {
+    public OCLInstalledCode getInstalledCode(long executionPlanId, String id, String entryPoint) {
         return null;
     }
 
     @Override
-    public OCLCodeCache getCodeCache() {
+    public OCLCodeCache getCodeCache(long executionPlanId) {
         return codeCache;
     }
 
     @Override
-    public boolean isCached(String methodName, SchedulableTask task) {
+    public boolean isCached(long executionPlanId, String methodName, SchedulableTask task) {
         return false;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualOCLTornadoDevice.java
@@ -244,12 +244,12 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public boolean isFullJITMode(SchedulableTask task) {
+    public boolean isFullJITMode(long executionPlanId, SchedulableTask task) {
         return true;
     }
 
     @Override
-    public TornadoInstalledCode getCodeFromCache(SchedulableTask task) {
+    public TornadoInstalledCode getCodeFromCache(long executionPlanId, SchedulableTask task) {
         return null;
     }
 
@@ -279,7 +279,7 @@ public class VirtualOCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public TornadoInstalledCode installCode(SchedulableTask task) {
+    public TornadoInstalledCode installCode(long executionPlanId, SchedulableTask task) {
         return compileJavaToAccelerator(task);
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXCodeCache.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXCodeCache.java
@@ -34,7 +34,7 @@ public class PTXCodeCache {
     private final PTXDeviceContext deviceContext;
     private final ConcurrentHashMap<String, PTXInstalledCode> cache;
 
-    public PTXCodeCache(PTXDeviceContext deviceContext) {
+    PTXCodeCache(PTXDeviceContext deviceContext) {
         this.deviceContext = deviceContext;
         cache = new ConcurrentHashMap<>();
     }
@@ -60,15 +60,15 @@ public class PTXCodeCache {
         return cache.get(name);
     }
 
-    public PTXInstalledCode getCachedCode(String name) {
+    PTXInstalledCode getCachedCode(String name) {
         return cache.get(name);
     }
 
-    public boolean isCached(String name) {
+    boolean isCached(String name) {
         return cache.containsKey(name);
     }
 
-    public void reset() {
+    void reset() {
         for (PTXInstalledCode code : cache.values()) {
             code.invalidate();
         }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -29,12 +29,7 @@ import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernel
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;
@@ -62,7 +57,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
 
     private final PTXDevice device;
     private final PTXMemoryManager memoryManager;
-    private final PTXCodeCache codeCache;
+    private final Map<Long, PTXCodeCache> codeCache;
     private final PTXScheduler scheduler;
     private final TornadoBufferProvider bufferProvider;
     private final PowerMetric powerMetric;
@@ -75,7 +70,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         streamTable = new ConcurrentHashMap<>();
         this.scheduler = new PTXScheduler(device);
         this.powerMetric = new PTXNvidiaPowerMetric(this);
-        codeCache = new PTXCodeCache(this);
+        codeCache = new ConcurrentHashMap<>();
         memoryManager = new PTXMemoryManager(this);
         bufferProvider = new PTXBufferProvider(this);
         wasReset = false;
@@ -120,20 +115,23 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         return new PTXTornadoDevice(device.getDeviceIndex());
     }
 
-    public TornadoInstalledCode installCode(PTXCompilationResult result, String resolvedMethodName) {
-        return codeCache.installSource(result.getName(), result.getTargetCode(), resolvedMethodName, result.metaData().isPrintKernelEnabled());
+    public TornadoInstalledCode installCode(long executionPlanId, PTXCompilationResult result, String resolvedMethodName) {
+        PTXCodeCache ptxCodeCache = getPTXCodeCache(executionPlanId);
+        return ptxCodeCache.installSource(result.getName(), result.getTargetCode(), resolvedMethodName, result.metaData().isPrintKernelEnabled());
     }
 
-    public TornadoInstalledCode installCode(String name, byte[] code, String resolvedMethodName, boolean printKernel) {
-        return codeCache.installSource(name, code, resolvedMethodName, printKernel);
+    public TornadoInstalledCode installCode(long executionPlanId, String name, byte[] code, String resolvedMethodName, boolean printKernel) {
+        PTXCodeCache ptxCodeCache = getPTXCodeCache(executionPlanId);
+        return ptxCodeCache.installSource(name, code, resolvedMethodName, printKernel);
     }
 
-    public TornadoInstalledCode getInstalledCode(String name) {
-        return codeCache.getCachedCode(name);
+    public TornadoInstalledCode getInstalledCode(long executionPlanId, String name) {
+        PTXCodeCache ptxCodeCache = getPTXCodeCache(executionPlanId);
+        return ptxCodeCache.getCachedCode(name);
     }
 
-    public PTXCodeCache getCodeCache() {
-        return codeCache;
+    public PTXCodeCache getCodeCache(long executionPlanId) {
+        return getPTXCodeCache(executionPlanId);
     }
 
     public PTXDevice getDevice() {
@@ -237,12 +235,12 @@ public class PTXDeviceContext implements TornadoDeviceContext {
     }
 
     public void flush(long executionPlanId) {
-        // I don't think there is anything like this in CUDA so I am calling sync
+        // I don't think there is anything like this in CUDA, so I am calling sync
         sync(executionPlanId);
     }
 
     @Override
-    public void reset(long executionPlanId) {
+    public synchronized void reset(long executionPlanId) {
         PTXStreamTable table = streamTable.get(executionPlanId);
         if (table != null) {
             table.cleanup(device);
@@ -252,7 +250,8 @@ public class PTXDeviceContext implements TornadoDeviceContext {
             executionIDs.remove(executionPlanId);
         }
         getMemoryManager().releaseKernelStackFrame(executionPlanId);
-        codeCache.reset();
+        PTXCodeCache ptxCodeCache = getPTXCodeCache(executionPlanId);
+        ptxCodeCache.reset();
         wasReset = true;
     }
 
@@ -359,8 +358,9 @@ public class PTXDeviceContext implements TornadoDeviceContext {
     }
 
     @Override
-    public boolean isCached(String methodName, SchedulableTask task) {
-        return codeCache.isCached(buildKernelName(methodName, task));
+    public boolean isCached(long executionPlanId, String methodName, SchedulableTask task) {
+        PTXCodeCache ptxCodeCache = getPTXCodeCache(executionPlanId);
+        return ptxCodeCache.isCached(buildKernelName(methodName, task));
     }
 
     public void destroyStream(long executionPlanId) {
@@ -568,6 +568,13 @@ public class PTXDeviceContext implements TornadoDeviceContext {
             streamTable.put(executionPlanId, ptxStreamTable);
         }
         return streamTable.get(executionPlanId).get(device);
+    }
+
+    private PTXCodeCache getPTXCodeCache(long executionPlanId) {
+        if (!codeCache.containsKey(executionPlanId)) {
+            codeCache.put(executionPlanId, new PTXCodeCache(this));
+        }
+        return codeCache.get(executionPlanId);
     }
 
     private PTXStream getStreamIfNeeded(long executionPlanId) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -29,7 +29,12 @@ import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernel
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import uk.ac.manchester.tornado.api.TornadoDeviceContext;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -57,13 +57,18 @@ public class PTXDeviceContext implements TornadoDeviceContext {
 
     private final PTXDevice device;
     private final PTXMemoryManager memoryManager;
-    private final Map<Long, PTXCodeCache> codeCache;
     private final PTXScheduler scheduler;
     private final TornadoBufferProvider bufferProvider;
     private final PowerMetric powerMetric;
     private final Map<Long, PTXStreamTable> streamTable;
     private boolean wasReset;
     private final Set<Long> executionIDs;
+
+    /**
+     * Map table to represent the compiled-code per execution plan. Each entry in the execution plan has its own
+     * code cache. The code cache manages the compilation and the cache for each task within an execution plan.
+     */
+    private final Map<Long, PTXCodeCache> codeCache;
 
     public PTXDeviceContext(PTXDevice device) {
         this.device = device;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -63,7 +63,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
     private final PowerMetric powerMetric;
     private final Map<Long, PTXStreamTable> streamTable;
     private boolean wasReset;
-    private Set<Long> executionIDs;
+    private final Set<Long> executionIDs;
 
     public PTXDeviceContext(PTXDevice device) {
         this.device = device;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXJITCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXJITCompiler.java
@@ -74,7 +74,7 @@ public class TestPTXJITCompiler {
         new TestPTXJITCompiler().test();
     }
 
-    public MetaCompilation compileMethod(Class<?> klass, String methodName, PTXTornadoDevice tornadoDevice, Object... parameters) {
+    public MetaCompilation compileMethod(long executionPlanId, Class<?> klass, String methodName, PTXTornadoDevice tornadoDevice, Object... parameters) {
 
         // Get the method object to be compiled
         Method methodToCompile = CompilerUtil.getMethodForName(klass, methodName);
@@ -107,7 +107,7 @@ public class TestPTXJITCompiler {
         PTXCompilationResult compilationResult = PTXCompiler.compileSketchForDevice(sketch, compilableTask, (PTXProviders) providers, ptxBackend, new EmptyProfiler());
 
         // Install the PTX Code in the VM
-        TornadoInstalledCode ptxCode = tornadoDevice.getDeviceContext().installCode(compilationResult, resolvedJavaMethod.getName());
+        TornadoInstalledCode ptxCode = tornadoDevice.getDeviceContext().installCode(executionPlanId, compilationResult, resolvedJavaMethod.getName());
 
         return new MetaCompilation(taskMeta, (PTXInstalledCode) ptxCode);
     }
@@ -161,10 +161,11 @@ public class TestPTXJITCompiler {
 
         Arrays.fill(a, -10);
         Arrays.fill(b, 10);
+        final long executionPlanId = 0;
 
         PTXTornadoDevice tornadoDevice = PTX.defaultDevice();
 
-        MetaCompilation compileMethod = compileMethod(TestPTXJITCompiler.class, "methodToCompile", tornadoDevice, a, b, c);
+        MetaCompilation compileMethod = compileMethod(executionPlanId, TestPTXJITCompiler.class, "methodToCompile", tornadoDevice, a, b, c);
 
         // Check with all internal APIs
         run(tornadoDevice, (PTXInstalledCode) compileMethod.getInstalledCode(), compileMethod.getTaskMeta(), a, b, c);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXTornadoCompiler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/tests/TestPTXTornadoCompiler.java
@@ -77,8 +77,9 @@ public class TestPTXTornadoCompiler {
 
     public static void main(String[] args) {
 
+        final long executionPlanId = 0;
         PTXPlatform platform = PTX.getPlatform();
-        PTXCodeCache codeCache = platform.getDevice(0).getPTXContext().getDeviceContext().getCodeCache();
+        PTXCodeCache codeCache = platform.getDevice(0).getPTXContext().getDeviceContext().getCodeCache(executionPlanId);
 
         TornadoCoreRuntime tornadoRuntime = TornadoCoreRuntime.getTornadoRuntime();
         PTXBackend backend = tornadoRuntime.getBackend(PTXBackendImpl.class).getDefaultBackend();

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
@@ -457,7 +457,7 @@ public abstract class SPIRVDeviceContext implements TornadoDeviceContext {
             OCLEventPool eventPool = context.getOCLEventPool(executionPlanId);
             return new OCLEvent(eventPool.getDescriptor(eventId).getNameDescription(), commandQueue, eventId, eventPool.getOCLEvent(eventId));
         } else {
-            throw new RuntimeException("Not implemented yet");
+            throw new TornadoRuntimeException("[Error] SPIR-V Device Context Class not implemented yet.");
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
@@ -65,11 +65,16 @@ public abstract class SPIRVDeviceContext implements TornadoDeviceContext {
     protected SPIRVContext spirvContext;
     protected SPIRVTornadoDevice tornadoDevice;
     protected SPIRVMemoryManager memoryManager;
-    protected Map<Long, SPIRVCodeCache> codeCache;
     protected boolean wasReset;
     protected Map<Long, SPIRVEventPool> spirvEventPool;
     private TornadoBufferProvider bufferProvider;
     private final Set<Long> executionIds;
+
+    /**
+     * Map table to represent the compiled-code per execution plan. Each entry in the execution plan has its own
+     * code cache. The code cache manages the compilation and the cache for each task within an execution plan.
+     */
+    protected Map<Long, SPIRVCodeCache> codeCache;
 
     protected SPIRVDeviceContext(SPIRVDevice device, SPIRVContext context) {
         init(device);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVDeviceContext.java
@@ -69,8 +69,7 @@ public abstract class SPIRVDeviceContext implements TornadoDeviceContext {
     protected boolean wasReset;
     protected Map<Long, SPIRVEventPool> spirvEventPool;
     private TornadoBufferProvider bufferProvider;
-
-    private Set<Long> executionIds;
+    private final Set<Long> executionIds;
 
     protected SPIRVDeviceContext(SPIRVDevice device, SPIRVContext context) {
         init(device);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVJITCompiler.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/tests/TestSPIRVJITCompiler.java
@@ -76,7 +76,7 @@ public class TestSPIRVJITCompiler {
         new TestSPIRVJITCompiler().test();
     }
 
-    public MetaCompilation compileMethod(Class<?> klass, String methodName, Object... parameters) {
+    public MetaCompilation compileMethod(long executionPlanId, Class<?> klass, String methodName, Object... parameters) {
 
         // Get the method object to be compiled
         Method methodToCompile = CompilerUtil.getMethodForName(klass, methodName);
@@ -111,7 +111,7 @@ public class TestSPIRVJITCompiler {
 
         // 3. Install the SPIR-V code into the VM
         SPIRVDevice spirvDevice = (SPIRVDevice) device.getDeviceContext().getDevice();
-        SPIRVInstalledCode spirvInstalledCode = (SPIRVInstalledCode) spirvDevice.getDeviceContext().installBinary(spirvCompilationResult);
+        SPIRVInstalledCode spirvInstalledCode = (SPIRVInstalledCode) spirvDevice.getDeviceContext().installBinary(executionPlanId, spirvCompilationResult);
 
         return new MetaCompilation(taskMeta, spirvInstalledCode);
     }
@@ -159,12 +159,13 @@ public class TestSPIRVJITCompiler {
         int[] a = new int[N];
         int[] b = new int[N];
         float[] c = new float[N];
+        final long executionPlanId = 0;
 
         Arrays.fill(a, -10);
         Arrays.fill(b, 10);
 
         // Obtain the SPIR-V binary from the Java method
-        MetaCompilation compileMethod = compileMethod(TestSPIRVJITCompiler.class, "methodToCompile", a, b, c);
+        MetaCompilation compileMethod = compileMethod(executionPlanId, TestSPIRVJITCompiler.class, "methodToCompile", a, b, c);
 
         TornadoDevice device = TornadoCoreRuntime.getTornadoRuntime().getBackend(SPIRVBackendImpl.class).getDefaultDevice();
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/JVMMapping.java
@@ -131,7 +131,7 @@ public class JVMMapping implements TornadoXPUDevice {
     }
 
     @Override
-    public TornadoInstalledCode installCode(SchedulableTask task) {
+    public TornadoInstalledCode installCode(long executionPlanId, SchedulableTask task) {
         return null;
     }
 
@@ -201,12 +201,12 @@ public class JVMMapping implements TornadoXPUDevice {
     }
 
     @Override
-    public boolean isFullJITMode(SchedulableTask task) {
+    public boolean isFullJITMode(long executionPlanId, SchedulableTask task) {
         return false;
     }
 
     @Override
-    public TornadoInstalledCode getCodeFromCache(SchedulableTask task) {
+    public TornadoInstalledCode getCodeFromCache(long executionPlanId, SchedulableTask task) {
         return null;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoXPUDevice.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoXPUDevice.java
@@ -66,7 +66,7 @@ public interface TornadoXPUDevice extends TornadoDevice {
      * It installs the Tornado code for the specified schedulable task.
      *
      * @param executionPlanId
-     *   ID number for the execution plan that the tasks belongs to.
+     *     ID number for the execution plan that the task belongs to.
      * @param task
      *     The {@link SchedulableTask} to install the code for.
      * @return The {@link TornadoInstalledCode} indicating the installation status.
@@ -78,7 +78,7 @@ public interface TornadoXPUDevice extends TornadoDevice {
      * mode.
      *
      * @param executionPlanId
-     *  ID for the execution plan to be compiled.
+     *     ID for the execution plan to be compiled.
      * @param task
      *     The {@link SchedulableTask} to check for full JIT mode.
      * @return True if the task is in full JIT mode, false otherwise.
@@ -90,7 +90,7 @@ public interface TornadoXPUDevice extends TornadoDevice {
      * schedulable task.
      *
      * @param executionPlanId
-     *  ID for the execution plan to be obtained from the code cache
+     *     ID for the execution plan to be obtained from the code cache
      * @param task
      *     The {@link SchedulableTask} to get the installed code from the
      *     cache.

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoXPUDevice.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoXPUDevice.java
@@ -65,32 +65,38 @@ public interface TornadoXPUDevice extends TornadoDevice {
     /**
      * It installs the Tornado code for the specified schedulable task.
      *
+     * @param executionPlanId
+     *   ID number for the execution plan that the tasks belongs to.
      * @param task
      *     The {@link SchedulableTask} to install the code for.
      * @return The {@link TornadoInstalledCode} indicating the installation status.
      */
-    TornadoInstalledCode installCode(SchedulableTask task);
+    TornadoInstalledCode installCode(long executionPlanId, SchedulableTask task);
 
     /**
      * It checks if the specified schedulable task is in full Just-In-Time (JIT)
      * mode.
      *
+     * @param executionPlanId
+     *  ID for the execution plan to be compiled.
      * @param task
      *     The {@link SchedulableTask} to check for full JIT mode.
      * @return True if the task is in full JIT mode, false otherwise.
      */
-    boolean isFullJITMode(SchedulableTask task);
+    boolean isFullJITMode(long executionPlanId, SchedulableTask task);
 
     /**
      * It retrieves the Tornado installed code from the cache for the specified
      * schedulable task.
      *
+     * @param executionPlanId
+     *  ID for the execution plan to be obtained from the code cache
      * @param task
      *     The {@link SchedulableTask} to get the installed code from the
      *     cache.
      * @return The {@link TornadoInstalledCode} from the cache.
      */
-    TornadoInstalledCode getCodeFromCache(SchedulableTask task);
+    TornadoInstalledCode getCodeFromCache(long executionPlanId, SchedulableTask task);
 
     /**
      * It checks for atomic operations in the specified schedulable task and returns

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -661,7 +661,7 @@ public class TornadoVMInterpreter {
                     task.forceCompilation();
                 }
 
-                installedCodes[globalToLocalTaskIndex(taskIndex)] = interpreterDevice.installCode(task);
+                installedCodes[globalToLocalTaskIndex(taskIndex)] = interpreterDevice.installCode(graphExecutionContext.getExecutionPlanId(), task);
                 profilerUpdateForPreCompiledTask(task);
                 // After the compilation has been completed, increment
                 // the batch number of the task and update it.
@@ -697,7 +697,7 @@ public class TornadoVMInterpreter {
         if (installedCodes[globalToLocalTaskIndex(taskIndex)] == null) {
             // After warming-up, it is possible to get a null pointer in the task-cache due
             // to lazy compilation for FPGAs. In tha case, we check again the code cache.
-            installedCodes[globalToLocalTaskIndex(taskIndex)] = interpreterDevice.getCodeFromCache(task);
+            installedCodes[globalToLocalTaskIndex(taskIndex)] = interpreterDevice.getCodeFromCache(graphExecutionContext.getExecutionPlanId(), task);
         }
 
         final TornadoInstalledCode installedCode = installedCodes[globalToLocalTaskIndex(taskIndex)];

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -541,7 +541,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             task.meta().setDevice(device);
             if (task instanceof CompilableTask compilableTask) {
                 ResolvedJavaMethod method = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(compilableTask.getMethod());
-                if (!meta().getXPUDevice().getDeviceContext().isCached(method.getName(), compilableTask)) {
+                if (!meta().getXPUDevice().getDeviceContext().isCached(executionPlanId, method.getName(), compilableTask)) {
                     updateInner(i, executionContext.getTask(i));
                 }
             }
@@ -584,7 +584,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 task.meta().setDevice(device);
                 if (task instanceof CompilableTask) {
                     ResolvedJavaMethod method = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(((CompilableTask) task).getMethod());
-                    if (!task.getDevice().getDeviceContext().isCached(method.getName(), task)) {
+                    if (!task.getDevice().getDeviceContext().isCached(executionPlanId, method.getName(), task)) {
                         updateInner(i, task);
                     }
                 }
@@ -817,7 +817,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         if (TornadoOptions.FPGA_EMULATION) {
             compile = true;
         } else if (executionContext.getDeviceOfFirstTask() instanceof TornadoXPUDevice tornadoAcceleratorDevice) {
-            if (tornadoAcceleratorDevice.isFullJITMode(executionContext.getTask(0))) {
+            if (tornadoAcceleratorDevice.isFullJITMode(executionPlanId, executionContext.getTask(0))) {
                 compile = true;
             }
         }


### PR DESCRIPTION
#### Description

This PR fixes multi-threaded execution plans. The issue (see below) was related to the unsafe shared of the code cache. The code cache was applied per device context, which is shared across all execution plans that run on the same device. Instead, what we need is to create a code-cache per execution plan ID. 

#### Problem description

The multi-threaded tests stop working due to unsafe sharing of the code-cache within the TornadoVM device context. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

For each backend:

```bash
tornado-test --jvm="-Dtornado.device.memory=2GB" -V --fast uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans
```

Before we merge, apart from all unit-test, we should test Ray-Tracer and Kfusion. 

