### PR TITLE
[refactor] Removed the getHandleByIndex from the PowerMetric interfac…

### DIFF
--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/power/PowerMetric.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/power/PowerMetric.java
@@ -27,7 +27,5 @@ public interface PowerMetric {
 
     void initializePowerLibrary();
 
-    void getHandleByIndex(long[] device);
-
-    void getPowerUsage(long[] device, long[] powerUsage);
+    void getPowerUsage(long[] powerUsage);
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLDeviceContext.java
@@ -192,10 +192,8 @@ public class OCLDeviceContext implements OCLDeviceContextInterface {
     }
 
     public long getPowerUsage() {
-        long[] device = new long[1];
         long[] powerUsage = new long[1];
-        powerMetric.getHandleByIndex(device);
-        powerMetric.getPowerUsage(device, powerUsage);
+        powerMetric.getPowerUsage(powerUsage);
         return powerUsage[0];
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/power/OCLEmptyPowerMetric.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/power/OCLEmptyPowerMetric.java
@@ -35,11 +35,7 @@ public class OCLEmptyPowerMetric implements PowerMetric {
     }
 
     @Override
-    public void getHandleByIndex(long[] device) {
-    }
-
-    @Override
-    public void getPowerUsage(long[] device, long[] powerUsage) {
+    public void getPowerUsage(long[] powerUsage) {
 
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/power/OCLNvidiaPowerMetric.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/power/OCLNvidiaPowerMetric.java
@@ -32,6 +32,7 @@ public class OCLNvidiaPowerMetric implements PowerMetric {
 
     private final OCLDeviceContext deviceContext;
     private final TornadoLogger logger;
+    private long[] oclDevice = new long[1];
 
     public OCLNvidiaPowerMetric(OCLDeviceContext deviceContext) {
         this.deviceContext = deviceContext;
@@ -49,24 +50,16 @@ public class OCLNvidiaPowerMetric implements PowerMetric {
     public void initializePowerLibrary() {
         try {
             clNvmlInit();
+            clNvmlDeviceGetHandleByIndex(this.deviceContext.getDevice().getIndex(), this.oclDevice);
         } catch (OCLException e) {
             logger.error(e.getMessage());
         }
     }
 
     @Override
-    public void getHandleByIndex(long[] device) {
+    public void getPowerUsage(long[] powerUsage) {
         try {
-            clNvmlDeviceGetHandleByIndex(this.deviceContext.getDevice().getIndex(), device);
-        } catch (OCLException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    @Override
-    public void getPowerUsage(long[] device, long[] powerUsage) {
-        try {
-            clNvmlDeviceGetPowerUsage(device, powerUsage);
+            clNvmlDeviceGetPowerUsage(this.oclDevice, powerUsage);
         } catch (OCLException e) {
             logger.error(e.getMessage());
         }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -166,10 +166,8 @@ public class PTXDeviceContext implements TornadoDeviceContext {
     }
 
     public long getPowerUsage() {
-        long[] device = new long[1];
         long[] powerUsage = new long[1];
-        powerMetric.getHandleByIndex(device);
-        powerMetric.getPowerUsage(device, powerUsage);
+        powerMetric.getPowerUsage(powerUsage);
         return powerUsage[0];
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/power/PTXNvidiaPowerMetric.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/power/PTXNvidiaPowerMetric.java
@@ -31,6 +31,7 @@ public class PTXNvidiaPowerMetric implements PowerMetric {
 
     private final PTXDeviceContext deviceContext;
     private final TornadoLogger logger;
+    private long[] ptxDevice = new long[1];
 
     public PTXNvidiaPowerMetric(PTXDeviceContext deviceContext) {
         this.deviceContext = deviceContext;
@@ -48,24 +49,16 @@ public class PTXNvidiaPowerMetric implements PowerMetric {
     public void initializePowerLibrary() throws RuntimeException {
         try {
             ptxNvmlInit();
+            ptxNvmlDeviceGetHandleByIndex(this.deviceContext.getDevice().getDeviceIndex(), this.ptxDevice);
         } catch (RuntimeException e) {
             logger.error(e.getMessage());
         }
     }
 
     @Override
-    public void getHandleByIndex(long[] device) {
+    public void getPowerUsage(long[] powerUsage) {
         try {
-            ptxNvmlDeviceGetHandleByIndex(this.deviceContext.getDevice().getDeviceIndex(), device);
-        } catch (RuntimeException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    @Override
-    public void getPowerUsage(long[] device, long[] powerUsage) {
-        try {
-            ptxNvmlDeviceGetPowerUsage(device, powerUsage);
+            ptxNvmlDeviceGetPowerUsage(this.ptxDevice, powerUsage);
         } catch (RuntimeException e) {
             logger.error(e.getMessage());
         }


### PR DESCRIPTION
#### Description

This PR refactors the interface of [PowerMetric.java](https://github.com/beehive-lab/TornadoVM/blob/develop/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/power/PowerMetric.java). This interface exposed three methods:
- `initializePowerLibrary()`: responsible for initializing data structures to be used for querying underlying power metrics from the heterogeneous libraries (e.g., CUDA NVML).
- `getHandleByIndex(long[] device)`: this method was using a device index from the device context in order to load the device pointers into an array.
- `getPowerUsage(long[] powerUsage)`: this method loads the power metrics in an input array.

The second method performs inner low-level functionality, and is not necessary to be exposed in the device context. This is because the `PowerMetric` constructor in the `OpenCL` and `PTX` implementations accepts as input the device context. So, this method can be removed from the interface and be performed during the initialization (as part of the first method).

Relevance to previous PRs: #377 

#### Problem description

This refactoring will enable the smooth integration of the power functions for the `LevelZero` implementation and the `SPIR-V` backend.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

To test, you can run:
```bash
make BACKEND=opencl
tornado --enableProfiler console -m tornado.examples/uk.ac.manchester.tornado.examples.VectorAddInt --params="100000"

make BACKEND=ptx
tornado --enableProfiler console -m tornado.examples/uk.ac.manchester.tornado.examples.VectorAddInt --params="100000"
```

----------------------------------------------------------------------------
