### PR TITLE
[release] TornadoVM 1.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TornadoVM
 
-![TornadoVM version](https://img.shields.io/badge/version-1.0.7-purple)  [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2) [![License: GPL v2](https://img.shields.io/badge/License-GPL%20V2%20Classpth%20Exeception-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+![TornadoVM version](https://img.shields.io/badge/version-1.0.8-purple)  [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2) [![License: GPL v2](https://img.shields.io/badge/License-GPL%20V2%20Classpth%20Exeception-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 
 <img align="left" width="250" height="250" src="etc/tornadoVM_Logo.jpg">
 
@@ -20,7 +20,7 @@ Developers can choose which backends to install and run.
 
 For a quick introduction please read the following [FAQ](https://tornadovm.readthedocs.io/en/latest/).
 
-**Latest Release:** TornadoVM 1.0.7 - 30/08/2024 :
+**Latest Release:** TornadoVM 1.0.8 - 30/09/2024 :
 See [CHANGELOG](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html).
 
 ----------------------
@@ -261,12 +261,12 @@ You can import the TornadoVM API by setting this the following dependency in the
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
 </dependency>
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-matrices</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
 </dependency>
 </dependencies>
 ```

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -5,12 +5,41 @@ TornadoVM Changelog
 
 This file summarizes the new features and major changes for each *TornadoVM* version.
 
+TornadoVM 1.0.8
+---------------
+30th September 2024
+
+Improvements
+~~~~~~~~~~~~
+
+- `#565 <https://github.com/beehive-lab/TornadoVM/pull/565>`_: New API call in the Execution Plan to log/trace the executed configuration plans.
+- `#563 <https://github.com/beehive-lab/TornadoVM/pull/563>`_: Expand the TornadoVM profiler with Level Zero Sysman Energy Metrics.
+- `#559 <https://github.com/beehive-lab/TornadoVM/pull/559>`_: Refactoring Power Metric handlers for PTX and OpenCL.
+- `#548 <https://github.com/beehive-lab/TornadoVM/pull/548>`_: Benchmarking improvements.
+- `#549 <https://github.com/beehive-lab/TornadoVM/pull/549>`_: Prebuilt API tests added using multiple backend-setup.
+- Add internal tests for monitoring memory management `(link) <https://github.com/beehive-lab/TornadoVM/commit/0644225a641bd859372743b59d46c6c9a4613337>`_.
+
+Compatibility
+~~~~~~~~~~~~~
+- `#561 <https://github.com/beehive-lab/TornadoVM/pull/561>`_: Build for OSx 14.6 and OSx 15 fixed.
+
+Bug Fixes
+~~~~~~~~~
+
+- `#564 <https://github.com/beehive-lab/TornadoVM/pull/564>`_: Jenkins configuration fixed to run KFusion per backend.
+- `#562 <https://github.com/beehive-lab/TornadoVM/pull/562>`_: Warmup action from the Execution Plan fixed to run with correct internal IDs.
+- `#557 <https://github.com/beehive-lab/TornadoVM/pull/557>`_: Shared Execution Plans Context fixed.
+- `#553 <https://github.com/beehive-lab/TornadoVM/pull/553>`_: OpenCL compiler flags for Intel Integrated GPUs fixed.
+- `#552 <https://github.com/beehive-lab/TornadoVM/pull/552>`_: Fixed runtime to select any device among multiple SPIR-V devices.
+- Fixed zero extend arithmetic operations: `link <https://github.com/beehive-lab/TornadoVM/commit/ea7b60263072ba0299da205cb920d0c68b3d1749>`_
+
+
 TornadoVM 1.0.7
 ----------------
 30th August 2024
 
 Improvements
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~
 
 - `#468 <https://github.com/beehive-lab/TornadoVM/pull/468>`_: Cleanup Abstract Metadata Class.
 - `#473 <https://github.com/beehive-lab/TornadoVM/pull/473>`_: Add maven plugin to build TornadoVM source for the releases.
@@ -27,7 +56,7 @@ Improvements
 - `#542 <https://github.com/beehive-lab/TornadoVM/pull/542>`_: Tagged LevelZero JNI and Beehive Toolkit dependencies added in the build and installer.
 
 Compatibility
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 - `#465 <https://github.com/beehive-lab/TornadoVM/pull/465>`_: Support for JDK 22 and GraalVM 24.0.2.
 - `#486 <https://github.com/beehive-lab/TornadoVM/pull/486>`_: Temurin for Windows added in the list of supported JDKs.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,8 +6,8 @@ project = "TornadoVM"
 copyright = "2013-2024, APT Group, Department of Computer Science"
 author = "The University of Manchester"
 
-release = "v1.0.7"
-version = "v1.0.7"
+release = "v1.0.8"
+version = "v1.0.8"
 
 # -- General configuration
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -509,13 +509,13 @@ To use the TornadoVM API in your projects, you can checkout our maven repository
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>1.0.7</version>
+         <version>1.0.8</version>
       </dependency>
 
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>1.0.7</version>
+         <version>1.0.8</version>
       </dependency>
    </dependencies>
 
@@ -526,6 +526,7 @@ Notice that, for running with TornadoVM, you will need either the docker images 
 Versions available
 ========================
 
+* 1.0.8
 * 1.0.7
 * 1.0.6
 * 1.0.5

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>tornado</groupId>
     <artifactId>tornado</artifactId>
-    <version>1.0.8-dev</version>
+    <version>1.0.8</version>
     <packaging>pom</packaging>
     <name>tornado</name>
     <url>https://github.com/beehive-lab/tornadovm</url>

--- a/tornado-annotation/pom.xml
+++ b/tornado-annotation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
 
     <artifactId>tornado-annotation</artifactId>

--- a/tornado-api/pom.xml
+++ b/tornado-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
 
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.8-dev</version>
+    <version>1.0.8</version>
 
     <name>tornado-api</name>
     <url>https://tornadovm.org</url>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-assembly</artifactId>
     <packaging>pom</packaging>

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -349,7 +349,7 @@ else:
 
 ENABLE_ASSERTIONS = "-ea "
 
-__VERSION__ = "1.0.8-dev"
+__VERSION__ = "1.0.8"
 
 try:
     javaHome = os.environ["JAVA_HOME"]

--- a/tornado-benchmarks/pom.xml
+++ b/tornado-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
 
     <artifactId>tornado-benchmarks</artifactId>

--- a/tornado-drivers/drivers-common/pom.xml
+++ b/tornado-drivers/drivers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tornado-drivers/opencl-jni/pom.xml
+++ b/tornado-drivers/opencl-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-drivers-opencl-jni</artifactId>
     <name>tornado-drivers-opencl-jni</name>

--- a/tornado-drivers/opencl/pom.xml
+++ b/tornado-drivers/opencl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-drivers-opencl</artifactId>
     <name>tornado-drivers-opencl</name>

--- a/tornado-drivers/pom.xml
+++ b/tornado-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-drivers</artifactId>
     <name>tornado-drivers</name>

--- a/tornado-drivers/ptx-jni/pom.xml
+++ b/tornado-drivers/ptx-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-drivers-ptx-jni</artifactId>
     <name>tornado-drivers-ptx-jni</name>

--- a/tornado-drivers/ptx/pom.xml
+++ b/tornado-drivers/ptx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tornado-drivers</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-drivers-ptx</artifactId>
     <name>tornado-drivers-ptx</name>

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-drivers-spirv</artifactId>
     <name>tornado-drivers-spirv</name>

--- a/tornado-examples/pom.xml
+++ b/tornado-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-examples</artifactId>
     <name>tornado-examples</name>

--- a/tornado-matrices/pom.xml
+++ b/tornado-matrices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-matrices</artifactId>
     <name>tornado-matrices</name>

--- a/tornado-runtime/pom.xml
+++ b/tornado-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-runtime</artifactId>
     <name>tornado-runtime</name>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.8-dev</version>
+        <version>1.0.8</version>
     </parent>
     <artifactId>tornado-unittests</artifactId>
     <name>tornado-unittests</name>


### PR DESCRIPTION
Improvements
============
- #565: New API call in the Execution Plan to log/trace the executed configuration plans.
- #563: Expand the TornadoVM profiler with Level Zero Sysman Energy Metrics.
- #559: Refactoring Power Metric handlers for PTX and OpenCL.
- #548: Benchmarking improvements.
- #549: Prebuilt API tests added using multiple backend-setup.
- Add internal tests for monitoring memory management [link](https://github.com/beehive-lab/TornadoVM/commit/0644225a641bd859372743b59d46c6c9a4613337).

Compatibility
=============
- #561: Build for OSx 14.6 and OSx 15 fixed.

Bug Fixes
==============
- #564: Jenkins configuration fixed to run KFusion per backend.
- #562: Warmup action from the Execution Plan fixed to run with correct internal IDs.
- #557: Shared Execution Plans Context fixed.
- #553: OpenCL compiler flags for Intel Integrated GPUs fixed.
- #552: Fixed runtime to select any device among multiple SPIR-V devices.
- Fixed zero extend arithmetic operations: [link](https://github.com/beehive-lab/TornadoVM/commit/ea7b60263072ba0299da205cb920d0c68b3d1749).

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make
tornado --version

make tests

tornado-benchmarks.py --skipSequential
```