### PR TITLE
[OpenCL] Fix issues with brackets for if-conditions in for-loops

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -64,6 +64,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.images.TestImages"),
     TestEntry("uk.ac.manchester.tornado.unittests.images.TestResizeImage"),
     TestEntry("uk.ac.manchester.tornado.unittests.branching.TestConditionals"),
+    TestEntry("uk.ac.manchester.tornado.unittests.branching.TestLoopConditions"),
     TestEntry("uk.ac.manchester.tornado.unittests.loops.TestLoops"),
     TestEntry("uk.ac.manchester.tornado.unittests.loops.TestParallelDimensions"),
     TestEntry("uk.ac.manchester.tornado.unittests.reductions.TestReductionsIntegers"),

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
@@ -213,7 +213,7 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
              * another if-condition, and the remaining condition is not a LoopEndNode
              * (because the block was already closed)
              */
-            if ((block.getDominator().getDominator() != null) && (isIfBlock(block.getDominator().getDominator()))) {
+           if ((((block.getDominator().getDominator() != null) && (isIfBlock(block.getDominator().getDominator())))) || (!(block.getDominator().getBeginNode() instanceof LoopBeginNode))) {
 
                 HIRBlock[] successors = IntStream.range(0, block.getDominator().getSuccessorCount()).mapToObj(i -> block.getDominator().getSuccessorAt(i)).toArray(HIRBlock[]::new);
 
@@ -381,9 +381,10 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
             } else if (!merges.contains(pdom) && isMergeBlock(pdom) && switches.contains(block) && isSwitchBlock(block.getDominator())) {
                 closeSwitchStatement(block);
             } else {
-
                 checkClosingBlockInsideIf(block, pdom);
             }
+        } else if (block.getBeginNode() instanceof LoopExitNode && block.getBeginNode().successors().filter(ReturnNode.class).isNotEmpty() && !wasBlockAlreadyClosed(block)) {
+            closeBlock(block);
         } else {
             closeBranchBlock(block);
         }
@@ -404,7 +405,7 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
             boolean isTrueBranch = ifNode.trueSuccessor() == block.getBeginNode();
             if (!(isTrueBranch && isLoopEnd)) {
                 closeBlock(block);
-                if (block.getLoop() != null) {
+                if (block.getLoop() != null && (dom.getEndNode() instanceof IfNode && dom.getEndNode().predecessor() instanceof LoopBeginNode)) {
                     incrementClosedLoops(block.getLoop().getHeader());
                 }
             }
@@ -510,6 +511,10 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
 
     private void closeBranchBlock(HIRBlock block) {
         final HIRBlock dom = block.getDominator();
+        if ((dom != null && wasBlockAlreadyClosed(block)) || (block.isLoopEnd() && !(block.getBeginNode() instanceof LoopExitNode))) {
+            return;
+        }
+
         if (isIfBlockNode(block)) {
             closeIfBlock(block, dom);
         } else if (isSwitchBlockNode(block)) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
@@ -405,7 +405,7 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
             boolean isTrueBranch = ifNode.trueSuccessor() == block.getBeginNode();
             if (!(isTrueBranch && isLoopEnd)) {
                 closeBlock(block);
-                if (block.getLoop() != null && (dom.getEndNode() instanceof IfNode && dom.getEndNode().predecessor() instanceof LoopBeginNode)) {
+                if (block.getLoop() != null) {
                     incrementClosedLoops(block.getLoop().getHeader());
                 }
             }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/branching/TestLoopConditions.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/branching/TestLoopConditions.java
@@ -1,0 +1,544 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.branching;
+
+import org.junit.Test;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix2DDouble;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * How to test?
+ *
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.branching.TestLoopConditions
+ * </code>
+ */
+public class TestLoopConditions extends TornadoTestBase {
+
+    public static void conditionBeforeSingleLoopReturn(IntArray a, IntArray b, IntArray c) {
+        if (a.get(0) > b.get(0)) {
+            return;
+        }
+        for (@Parallel int i = 0; i < c.getSize(); i++) {
+            c.set(i, a.get(i) + b.get(i));
+        }
+    }
+
+    public static void conditionBeforeSingleLoopComputation(IntArray a, IntArray b, IntArray c) {
+        if (a.get(0) > b.get(0)) {
+            b.set(0, a.get(0));
+        }
+        for (@Parallel int i = 0; i < c.getSize(); i++) {
+            c.set(i, a.get(i) + b.get(i));
+        }
+    }
+
+    public static void conditionInSingleLoopReturn(IntArray a, IntArray b, IntArray c) {
+        for (@Parallel int i = 0; i < c.getSize(); i++) {
+            if (a.get(0) > b.get(0)) {
+                return;
+            }
+            c.set(i, a.get(i) + b.get(i));
+        }
+    }
+
+    public static void conditionInSingleLoopComputation(IntArray a, IntArray b, IntArray c) {
+        for (@Parallel int i = 0; i < c.getSize(); i++) {
+            if (a.get(i) > b.get(i)) {
+                b.set(i, a.get(i));
+            }
+            c.set(i, a.get(i) + b.get(i));
+        }
+    }
+
+    public static void conditionBeforeOuterForLoopReturn(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
+        if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
+            return;
+        }
+        for (@Parallel int i = 0; i < result.getNumRows(); i++) {
+            for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
+                result.set(i, j, matrixA.get(i, j) + matrixB.get(i, j));
+            }
+        }
+    }
+
+    public static void conditionBeforeOuterForLoopComputation(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
+        if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
+            result.set(0, 0, matrixA.get(0, 0) + matrixB.get(0, 0));
+        }
+        for (@Parallel int i = 0; i < result.getNumRows(); i++) {
+            for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
+                result.set(i, j, matrixA.get(i, j) + matrixB.get(i, j));
+            }
+        }
+    }
+
+    public static void conditionBeforeInnerForLoopReturn(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
+        for (@Parallel int i = 0; i < result.getNumRows(); i++) {
+            if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
+                return;
+            }
+            for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
+                result.set(i, j, matrixA.get(i, j) + matrixB.get(i, j));
+            }
+        }
+    }
+
+    public static void conditionBeforeInnerForLoopComputation(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
+        for (@Parallel int i = 0; i < result.getNumRows(); i++) {
+            if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
+                result.set(0, 0, matrixA.get(0, 0) + matrixB.get(0, 0));
+            }
+            for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
+                result.set(i, j, matrixA.get(i, j) + matrixB.get(i, j));
+            }
+        }
+    }
+
+    public static void conditionInInnerForLoopReturn(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
+        for (@Parallel int i = 0; i < result.getNumRows(); i++) {
+            for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
+                if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
+                    return;
+                }
+                result.set(i, j, matrixA.get(i, j) + matrixB.get(i, j));
+            }
+        }
+    }
+
+    public static void conditionInInnerForLoopComputation(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
+        for (@Parallel int i = 0; i < result.getNumRows(); i++) {
+            for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
+                if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
+                    result.set(0, 0, matrixA.get(0, 0) + matrixB.get(0, 0));
+                }
+                result.set(i, j, matrixA.get(i, j) + matrixB.get(i, j));
+            }
+        }
+    }
+
+    public static void conditionAfterInnerForLoopComputation(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
+        for (@Parallel int i = 0; i < result.getNumRows(); i++) {
+            for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
+                result.set(i, j, matrixA.get(i, j) + matrixB.get(i, j));
+            }
+            if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
+                result.set(0, 0, matrixA.get(0, 0) + matrixB.get(0, 0));
+            }
+        }
+    }
+
+    public static void conditionAfterOuterForLoopComputation(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
+        for (@Parallel int i = 0; i < result.getNumRows(); i++) {
+            for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
+                result.set(i, j, matrixA.get(i, j) + matrixB.get(i, j));
+            }
+        }
+        if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
+            result.set(0, 0, matrixA.get(0, 0) + matrixB.get(0, 0));
+        }
+    }
+
+    public static Matrix2DDouble matrix2DDoubleInit(int X, int Y) {
+        double[][] a = new double[X][Y];
+        Random r = new Random();
+        for (int i = 0; i < X; i++) {
+            for (int j = 0; j < Y; j++) {
+                a[i][j] = r.nextDouble();
+            }
+        }
+        return new Matrix2DDouble(a);
+    }
+
+    @Test
+    public void testConditionBeforeSingleLoopReturn() throws TornadoExecutionPlanException {
+        final int numberOfElements = 2048;
+        IntArray a = new IntArray(numberOfElements);
+        IntArray b = new IntArray(numberOfElements);
+        IntArray c = new IntArray(numberOfElements);
+        IntArray serial = new IntArray(numberOfElements);
+
+        Random r = new Random();
+        IntStream.range(0, numberOfElements).sequential().forEach(i -> {
+            a.set(i, r.nextInt());
+            b.set(i, r.nextInt());
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestLoopConditions::conditionBeforeSingleLoopReturn, a, b, c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionBeforeSingleLoopReturn(a, b, serial);
+
+        for (int i = 0; i < numberOfElements; i++) {
+            assertEquals(serial.get(i), c.get(i));
+        }
+    }
+
+    @Test
+    public void testConditionBeforeSingleLoopComputation() throws TornadoExecutionPlanException {
+        final int numberOfElements = 2048;
+        IntArray a = new IntArray(numberOfElements);
+        IntArray b = new IntArray(numberOfElements);
+        IntArray c = new IntArray(numberOfElements);
+        IntArray serial = new IntArray(numberOfElements);
+
+        Random r = new Random();
+        IntStream.range(0, numberOfElements).sequential().forEach(i -> {
+            a.set(i, r.nextInt());
+            b.set(i, r.nextInt());
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestLoopConditions::conditionBeforeSingleLoopComputation, a, b, c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionBeforeSingleLoopComputation(a, b, serial);
+
+        for (int i = 0; i < numberOfElements; i++) {
+            assertEquals(serial.get(i), c.get(i));
+        }
+    }
+
+    @Test
+    public void testConditionInSingleLoopReturn() throws TornadoExecutionPlanException {
+        final int numberOfElements = 2048;
+        IntArray a = new IntArray(numberOfElements);
+        IntArray b = new IntArray(numberOfElements);
+        IntArray c = new IntArray(numberOfElements);
+        IntArray serial = new IntArray(numberOfElements);
+
+        Random r = new Random();
+        IntStream.range(0, numberOfElements).sequential().forEach(i -> {
+            a.set(i, r.nextInt());
+            b.set(i, r.nextInt());
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestLoopConditions::conditionInSingleLoopReturn, a, b, c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionInSingleLoopReturn(a, b, serial);
+
+        for (int i = 0; i < numberOfElements; i++) {
+            assertEquals(serial.get(i), c.get(i));
+        }
+    }
+
+    @Test
+    public void testConditionInSingleLoopComputation() throws TornadoExecutionPlanException {
+        final int numberOfElements = 2048;
+        IntArray a = new IntArray(numberOfElements);
+        IntArray b = new IntArray(numberOfElements);
+        IntArray c = new IntArray(numberOfElements);
+        IntArray serial = new IntArray(numberOfElements);
+
+        Random r = new Random();
+        IntStream.range(0, numberOfElements).sequential().forEach(i -> {
+            a.set(i, r.nextInt());
+            b.set(i, r.nextInt());
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestLoopConditions::conditionInSingleLoopComputation, a, b, c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionInSingleLoopComputation(a, b, serial);
+
+        for (int i = 0; i < numberOfElements; i++) {
+            assertEquals(serial.get(i), c.get(i));
+        }
+    }
+
+    @Test
+    public void testConditionBeforeOuterForLoopReturn() throws TornadoExecutionPlanException {
+        int X = 128;
+        int Y = 128;
+
+        Matrix2DDouble matrixA = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixB = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixC = new Matrix2DDouble(X, Y);
+        Matrix2DDouble matrixSerial = new Matrix2DDouble(X, Y);
+
+        TaskGraph taskGraph = new TaskGraph("t0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB)
+                .task("s0", TestLoopConditions::conditionBeforeOuterForLoopReturn, matrixA, matrixB, matrixC)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionBeforeOuterForLoopReturn(matrixA, matrixB, matrixSerial);
+
+        for (int i = 0; i < X; i++) {
+            for (int j = 0; j < Y; j++) {
+                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+            }
+        }
+    }
+
+    @Test
+    public void testConditionBeforeOuterForLoopComputation() throws TornadoExecutionPlanException {
+        int X = 128;
+        int Y = 128;
+
+        Matrix2DDouble matrixA = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixB = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixC = new Matrix2DDouble(X, Y);
+        Matrix2DDouble matrixSerial = new Matrix2DDouble(X, Y);
+
+        TaskGraph taskGraph = new TaskGraph("t0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB)
+                .task("s0", TestLoopConditions::conditionBeforeOuterForLoopComputation, matrixA, matrixB, matrixC)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionBeforeOuterForLoopComputation(matrixA, matrixB, matrixSerial);
+
+        for (int i = 0; i < X; i++) {
+            for (int j = 0; j < Y; j++) {
+                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+            }
+        }
+    }
+
+    @Test
+    public void testConditionBeforeInnerForLoopReturn() throws TornadoExecutionPlanException {
+        int X = 128;
+        int Y = 128;
+
+        Matrix2DDouble matrixA = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixB = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixC = new Matrix2DDouble(X, Y);
+        Matrix2DDouble matrixSerial = new Matrix2DDouble(X, Y);
+
+        TaskGraph taskGraph = new TaskGraph("t0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB)
+                .task("s0", TestLoopConditions::conditionBeforeInnerForLoopReturn, matrixA, matrixB, matrixC)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionBeforeInnerForLoopReturn(matrixA, matrixB, matrixSerial);
+
+        for (int i = 0; i < X; i++) {
+            for (int j = 0; j < Y; j++) {
+                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+            }
+        }
+    }
+
+    @Test
+    public void testConditionBeforeInnerForLoopComputation() throws TornadoExecutionPlanException {
+        int X = 128;
+        int Y = 128;
+
+        Matrix2DDouble matrixA = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixB = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixC = new Matrix2DDouble(X, Y);
+        Matrix2DDouble matrixSerial = new Matrix2DDouble(X, Y);
+
+        TaskGraph taskGraph = new TaskGraph("t0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB)
+                .task("s0", TestLoopConditions::conditionBeforeInnerForLoopComputation, matrixA, matrixB, matrixC)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionBeforeInnerForLoopComputation(matrixA, matrixB, matrixSerial);
+
+        for (int i = 0; i < X; i++) {
+            for (int j = 0; j < Y; j++) {
+                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+            }
+        }
+    }
+
+    @Test
+    public void testConditionInInnerForLoopReturn() throws TornadoExecutionPlanException {
+        int X = 128;
+        int Y = 128;
+
+        Matrix2DDouble matrixA = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixB = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixC = new Matrix2DDouble(X, Y);
+        Matrix2DDouble matrixSerial = new Matrix2DDouble(X, Y);
+
+        TaskGraph taskGraph = new TaskGraph("t0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB)
+                .task("s0", TestLoopConditions::conditionInInnerForLoopReturn, matrixA, matrixB, matrixC)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionInInnerForLoopReturn(matrixA, matrixB, matrixSerial);
+
+        for (int i = 0; i < X; i++) {
+            for (int j = 0; j < Y; j++) {
+                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+            }
+        }
+    }
+
+    @Test
+    public void testConditionInInnerForLoopComputation() throws TornadoExecutionPlanException {
+        int X = 128;
+        int Y = 128;
+
+        Matrix2DDouble matrixA = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixB = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixC = new Matrix2DDouble(X, Y);
+        Matrix2DDouble matrixSerial = new Matrix2DDouble(X, Y);
+
+        TaskGraph taskGraph = new TaskGraph("t0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB)
+                .task("s0", TestLoopConditions::conditionInInnerForLoopComputation, matrixA, matrixB, matrixC)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionInInnerForLoopComputation(matrixA, matrixB, matrixSerial);
+
+        for (int i = 0; i < X; i++) {
+            for (int j = 0; j < Y; j++) {
+                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+            }
+        }
+    }
+
+    @Test
+    public void testConditionAfterInnerForLoopComputation() throws TornadoExecutionPlanException {
+        int X = 128;
+        int Y = 128;
+
+        Matrix2DDouble matrixA = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixB = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixC = new Matrix2DDouble(X, Y);
+        Matrix2DDouble matrixSerial = new Matrix2DDouble(X, Y);
+
+        TaskGraph taskGraph = new TaskGraph("t0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB)
+                .task("s0", TestLoopConditions::conditionAfterInnerForLoopComputation, matrixA, matrixB, matrixC)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionAfterInnerForLoopComputation(matrixA, matrixB, matrixSerial);
+
+        for (int i = 0; i < X; i++) {
+            for (int j = 0; j < Y; j++) {
+                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+            }
+        }
+    }
+
+    @Test
+    public void testConditionAfterOuterForLoopComputation() throws TornadoExecutionPlanException {
+        int X = 128;
+        int Y = 128;
+
+        Matrix2DDouble matrixA = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixB = matrix2DDoubleInit(X, Y);
+        Matrix2DDouble matrixC = new Matrix2DDouble(X, Y);
+        Matrix2DDouble matrixSerial = new Matrix2DDouble(X, Y);
+
+        TaskGraph taskGraph = new TaskGraph("t0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB)
+                .task("s0", TestLoopConditions::conditionAfterOuterForLoopComputation, matrixA, matrixB, matrixC)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        conditionAfterOuterForLoopComputation(matrixA, matrixB, matrixSerial);
+
+        for (int i = 0; i < X; i++) {
+            for (int j = 0; j < Y; j++) {
+                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+            }
+        }
+    }
+
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/branching/TestLoopConditions.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/branching/TestLoopConditions.java
@@ -39,11 +39,16 @@ import static org.junit.Assert.assertEquals;
  * <code>
  * tornado-test -V uk.ac.manchester.tornado.unittests.branching.TestLoopConditions
  * </code>
+ *
+ * [DISCLAIMER] These tests are legal in TornadoVM because in the if-conditions all threads are operating on the same data.
  */
 public class TestLoopConditions extends TornadoTestBase {
 
+    /**
+     * This test is valid for TornadoVM because in the if-condition all threads are examining the same data.
+     */
     public static void conditionBeforeSingleLoopReturn(IntArray a, IntArray b, IntArray c) {
-        if (a.get(0) > b.get(0)) {
+        if (a.get(0) > b.get(0)) { // all threads examine the same values
             return;
         }
         for (@Parallel int i = 0; i < c.getSize(); i++) {
@@ -51,6 +56,9 @@ public class TestLoopConditions extends TornadoTestBase {
         }
     }
 
+    /**
+     * This test is valid for TornadoVM because in the if-condition all threads are examining the same data.
+     */
     public static void conditionBeforeSingleLoopComputation(IntArray a, IntArray b, IntArray c) {
         if (a.get(0) > b.get(0)) {
             b.set(0, a.get(0));
@@ -78,6 +86,9 @@ public class TestLoopConditions extends TornadoTestBase {
         }
     }
 
+    /**
+     * This test is valid for TornadoVM because in the if-condition all threads are examining the same data.
+     */
     public static void conditionBeforeOuterForLoopReturn(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
         if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
             return;
@@ -89,6 +100,9 @@ public class TestLoopConditions extends TornadoTestBase {
         }
     }
 
+    /**
+     * This test is valid for TornadoVM because in the if-condition all threads are examining the same data.
+     */
     public static void conditionBeforeOuterForLoopComputation(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
         if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
             result.set(0, 0, matrixA.get(0, 0) + matrixB.get(0, 0));
@@ -100,6 +114,9 @@ public class TestLoopConditions extends TornadoTestBase {
         }
     }
 
+    /**
+     * This test is valid for TornadoVM because in the if-condition all threads are examining the same data.
+     */
     public static void conditionBeforeInnerForLoopReturn(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
         for (@Parallel int i = 0; i < result.getNumRows(); i++) {
             if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
@@ -111,6 +128,9 @@ public class TestLoopConditions extends TornadoTestBase {
         }
     }
 
+    /**
+     * This test is valid for TornadoVM because in the if-condition all threads are examining the same data.
+     */
     public static void conditionBeforeInnerForLoopComputation(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
         for (@Parallel int i = 0; i < result.getNumRows(); i++) {
             if (matrixA.get(0, 0) != matrixB.get(1, 1)) {
@@ -122,6 +142,9 @@ public class TestLoopConditions extends TornadoTestBase {
         }
     }
 
+    /**
+     * This test is valid for TornadoVM because in the if-condition all threads are examining the same data.
+     */
     public static void conditionInInnerForLoopReturn(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
         for (@Parallel int i = 0; i < result.getNumRows(); i++) {
             for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
@@ -133,6 +156,9 @@ public class TestLoopConditions extends TornadoTestBase {
         }
     }
 
+    /**
+     * This test is valid for TornadoVM because in the if-condition all threads are examining the same data.
+     */
     public static void conditionInInnerForLoopComputation(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
         for (@Parallel int i = 0; i < result.getNumRows(); i++) {
             for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
@@ -144,6 +170,9 @@ public class TestLoopConditions extends TornadoTestBase {
         }
     }
 
+    /**
+     * This test is valid for TornadoVM because in the if-condition all threads are examining the same data.
+     */
     public static void conditionAfterInnerForLoopComputation(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
         for (@Parallel int i = 0; i < result.getNumRows(); i++) {
             for (@Parallel int j = 0; j < result.getNumColumns(); j++) {
@@ -155,6 +184,9 @@ public class TestLoopConditions extends TornadoTestBase {
         }
     }
 
+    /**
+     * This test is valid for TornadoVM because in the if-condition all threads are examining the same data.
+     */
     public static void conditionAfterOuterForLoopComputation(Matrix2DDouble matrixA, Matrix2DDouble matrixB, Matrix2DDouble result) {
         for (@Parallel int i = 0; i < result.getNumRows(); i++) {
             for (@Parallel int j = 0; j < result.getNumColumns(); j++) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/branching/TestLoopConditions.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/branching/TestLoopConditions.java
@@ -326,7 +326,7 @@ public class TestLoopConditions extends TornadoTestBase {
 
         for (int i = 0; i < X; i++) {
             for (int j = 0; j < Y; j++) {
-                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+                assertEquals(matrixSerial.get(i, j), matrixC.get(i, j), 0.01);
             }
         }
     }
@@ -356,7 +356,7 @@ public class TestLoopConditions extends TornadoTestBase {
 
         for (int i = 0; i < X; i++) {
             for (int j = 0; j < Y; j++) {
-                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+                assertEquals(matrixSerial.get(i, j), matrixC.get(i, j), 0.01);
             }
         }
     }
@@ -386,7 +386,7 @@ public class TestLoopConditions extends TornadoTestBase {
 
         for (int i = 0; i < X; i++) {
             for (int j = 0; j < Y; j++) {
-                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+                assertEquals(matrixSerial.get(i, j), matrixC.get(i, j), 0.01);
             }
         }
     }
@@ -416,7 +416,7 @@ public class TestLoopConditions extends TornadoTestBase {
 
         for (int i = 0; i < X; i++) {
             for (int j = 0; j < Y; j++) {
-                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+                assertEquals(matrixSerial.get(i, j), matrixC.get(i, j), 0.01);
             }
         }
     }
@@ -446,7 +446,7 @@ public class TestLoopConditions extends TornadoTestBase {
 
         for (int i = 0; i < X; i++) {
             for (int j = 0; j < Y; j++) {
-                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+                assertEquals(matrixSerial.get(i, j), matrixC.get(i, j), 0.01);
             }
         }
     }
@@ -476,7 +476,7 @@ public class TestLoopConditions extends TornadoTestBase {
 
         for (int i = 0; i < X; i++) {
             for (int j = 0; j < Y; j++) {
-                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+                assertEquals(matrixSerial.get(i, j), matrixC.get(i, j), 0.01);
             }
         }
     }
@@ -506,7 +506,7 @@ public class TestLoopConditions extends TornadoTestBase {
 
         for (int i = 0; i < X; i++) {
             for (int j = 0; j < Y; j++) {
-                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+                assertEquals(matrixSerial.get(i, j), matrixC.get(i, j), 0.01);
             }
         }
     }
@@ -536,7 +536,7 @@ public class TestLoopConditions extends TornadoTestBase {
 
         for (int i = 0; i < X; i++) {
             for (int j = 0; j < Y; j++) {
-                assertEquals(matrixC.get(i, j), matrixSerial.get(i, j), 0.01);
+                assertEquals(matrixSerial.get(i, j), matrixC.get(i, j), 0.01);
             }
         }
     }


### PR DESCRIPTION
#### Description

This PR fixes the closing brackets for OpenCL kernels that contain if-conditions either before or in for-loops. 

#### Problem description

It was observed that in some cases where there was an if-condition in a kernel that contained for-loop(s)  (e.g. before a for-loop, in an inner for-loop etc.) , either some closing brackets were missing or unnecessary additional closing brackets were included. With this PR, the code generation examines these cases and generates the correct brackets.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?
Run `tornado-test -V -pk uk.ac.manchester.tornado.unittests.branching.TestLoopConditions`
All unittests have been tested along with RayTracer and KFusion. 
