### PR TITLE
[fix] Print default execution plans

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -17,6 +17,7 @@
  */
 package uk.ac.manchester.tornado.api;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
@@ -28,7 +29,6 @@ import uk.ac.manchester.tornado.api.plan.types.OffMemoryLimit;
 import uk.ac.manchester.tornado.api.plan.types.OffPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.OffProfiler;
 import uk.ac.manchester.tornado.api.plan.types.OffThreadInfo;
-import uk.ac.manchester.tornado.api.plan.types.WithWarmUp;
 import uk.ac.manchester.tornado.api.plan.types.WithBatch;
 import uk.ac.manchester.tornado.api.plan.types.WithClearProfiles;
 import uk.ac.manchester.tornado.api.plan.types.WithCompilerFlags;
@@ -43,6 +43,7 @@ import uk.ac.manchester.tornado.api.plan.types.WithPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.WithProfiler;
 import uk.ac.manchester.tornado.api.plan.types.WithResetDevice;
 import uk.ac.manchester.tornado.api.plan.types.WithThreadInfo;
+import uk.ac.manchester.tornado.api.plan.types.WithWarmUp;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 
@@ -184,7 +185,7 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      * @since 1.0.8
      */
     public void printTraceExecutionPlan() {
-        System.out.println(childLink);
+        System.out.println(Objects.requireNonNullElse(childLink, this));
     }
 
     /**
@@ -194,7 +195,10 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      * @since 1.0.8
      */
     public String getTraceExecutionPlan() {
-        return childLink.toString();
+        if (childLink != null) {
+            return childLink.toString();
+        }
+        return toString();
     }
 
     @Override

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
@@ -19,12 +19,12 @@ package uk.ac.manchester.tornado.unittests.executor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 
 import org.junit.Test;
 
-import uk.ac.manchester.tornado.api.ExecutionPlanType;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
@@ -262,6 +262,14 @@ public class TestExecutor extends TornadoTestBase {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
 
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())) {
+
+            executionPlan.execute();
+            executionPlan.printTraceExecutionPlan();
+            try {
+                String traceExecutionPlan = executionPlan.getTraceExecutionPlan();
+            } catch (NullPointerException e) {
+                fail();
+            }
 
             TornadoDevice device = TornadoExecutionPlan.getDevice(0, 0);
 


### PR DESCRIPTION
#### Description

Fix log/printing paths for default execution plans (when no new actions are invoked) .

#### Problem description

NPE were launched for default execution plans. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-test -V uk.ac.manchester.tornado.unittests.executor.TestExecutor#test05
```