### PR TITLE
Print list of failed tests at the end of the tornado-tests script

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -609,7 +609,6 @@ def runTests(args):
                 print(f"{test} - [WHITELISTED]: {whitelisted}")
             print("==================================================")
             if len(segFaults) != 0:
-                print("==================================================")
                 print("SEGFAULT TESTS")
                 print("==================================================")
                 for test in segFaults:

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -474,7 +474,7 @@ def runSingleCommand(cmd, args):
     print("Total Time (s): " + str(end - start))
 
 
-def processStats(out, stats, failedTests):
+def processStats(out, stats, failedTests, segFaults, unittest):
     """ It updates the hash table `stats` for reporting the total number
         of methods that were failed and passed
     """
@@ -487,6 +487,9 @@ def processStats(out, stats, failedTests):
     statsProcessing = out.splitlines()
     className = ""
     for line in statsProcessing:
+        if "SIGSEGV" in line:
+            segFaults.append(unittest)
+
         match = regex.search(line)
         if match != None:
             className = match.groups(0)[0]
@@ -516,13 +519,15 @@ def processStats(out, stats, failedTests):
         elif (l.find("UNSUPPORTED") != -1):
             stats["[UNSUPPORTED]"] = stats["[UNSUPPORTED]"] + 1
 
-    return stats, failedTests
+    return stats, failedTests, segFaults
 
 
-def runCommandWithStats(command, stats, failedTests, monitorClass):
+def runCommandWithStats(command, stats, failedTests, segFaults, monitorClass):
     """ Run a command and update the stats dictionary """
     p = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     monitor_status = runMonitorClass(monitorClass, command, p.pid)
+    params = re.search(r'--params\s+"([^"]+)"', command)
+    unittest = params.group(1)
     monitor_failed_msg = ""
     if not monitor_status:
         print(f"Monitor {args.monitorClass} failed. Killing process {p.pid}")
@@ -548,7 +553,7 @@ def runCommandWithStats(command, stats, failedTests, monitorClass):
     print(err)
     print(out)
 
-    return processStats(out, stats, failedTests)
+    return processStats(out, stats, failedTests, segFaults, unittest)
 
 
 def appendTestRunnerClassToCmd(cmd, args):
@@ -580,7 +585,7 @@ def runTests(args):
             runSingleCommand(command, args)
     else:
         start = time.time()
-        stats, failedTests = runTestTheWorld(options, args)
+        stats, failedTests, segFaults = runTestTheWorld(options, args)
         end = time.time()
         print(Colors.CYAN)
 
@@ -602,8 +607,14 @@ def runTests(args):
             print("==================================================")
             for test, whitelisted in failedTests.items():
                 print(f"{test} - [WHITELISTED]: {whitelisted}")
-
             print("==================================================")
+            if len(segFaults) != 0:
+                print("==================================================")
+                print("SEGFAULT TESTS")
+                print("==================================================")
+                for test in segFaults:
+                    print(test)
+                print("==================================================")
 
         print(Colors.CYAN + "Total Time(s): " + str(end - start))
         print(Colors.RESET)
@@ -612,6 +623,7 @@ def runTests(args):
 def runTestTheWorld(options, args):
     stats = {"[PASS]": 0, "[FAILED]": 0, "[UNSUPPORTED]": 0}
     failedTests = {}
+    segFaults = []
 
     __TORNADO_QUICK_PASS_SKIP_TESTS__ = __TORNADO_HEAVY_TESTS__ + __TORNADO_MEMORY_TESTS__
 
@@ -634,16 +646,16 @@ def runTestTheWorld(options, args):
                 if (args.fast):
                     os.system(testMethodCmd)
                 else:
-                    stats, failedTests = runCommandWithStats(testMethodCmd, stats, failedTests, t.monitorClass)
+                    stats, failedTests, segFaults = runCommandWithStats(testMethodCmd, stats, failedTests, segFaults, t.monitorClass)
         elif (args.fast):
             command += "\""
             os.system(command)
         else:
             command += "\""
             print(command)
-            stats, failedTests = runCommandWithStats(command, stats, failedTests, t.monitorClass)
+            stats, failedTests, segFaults = runCommandWithStats(command, stats, failedTests, segFaults, t.monitorClass)
 
-    return stats, failedTests
+    return stats, failedTests, segFaults
 
 
 def runWithJUnit(args):

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -473,7 +473,7 @@ def runSingleCommand(cmd, args):
     print("Total Time (s): " + str(end - start))
 
 
-def processStats(out, stats):
+def processStats(out, stats, failedTests):
     """ It updates the hash table `stats` for reporting the total number
         of methods that were failed and passed
     """
@@ -505,18 +505,20 @@ def processStats(out, stats):
                 name = name[:-16]
 
             if (className + "#" + name in __TORNADO_TESTS_WHITE_LIST__):
+                failedTests[className + "#" + name] = "YES"
                 print(Colors.RED + "Test: " + className + "#" + name + " in whiteList." + Colors.RESET)
             else:
                 ## set a flag
+                failedTests[className + "#" + name] = "NO"
                 __TEST_NOT_PASSED__ = True
 
         elif (l.find("UNSUPPORTED") != -1):
             stats["[UNSUPPORTED]"] = stats["[UNSUPPORTED]"] + 1
 
-    return stats
+    return stats, failedTests
 
 
-def runCommandWithStats(command, stats, monitorClass):
+def runCommandWithStats(command, stats, failedTests, monitorClass):
     """ Run a command and update the stats dictionary """
     p = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     monitor_status = runMonitorClass(monitorClass, command, p.pid)
@@ -545,7 +547,7 @@ def runCommandWithStats(command, stats, monitorClass):
     print(err)
     print(out)
 
-    return processStats(out, stats)
+    return processStats(out, stats, failedTests)
 
 
 def appendTestRunnerClassToCmd(cmd, args):
@@ -577,7 +579,7 @@ def runTests(args):
             runSingleCommand(command, args)
     else:
         start = time.time()
-        stats = runTestTheWorld(options, args)
+        stats, failedTests = runTestTheWorld(options, args)
         end = time.time()
         print(Colors.CYAN)
 
@@ -593,16 +595,22 @@ def runTests(args):
                 (stats["[PASS]"] + stats["[FAILED]"] + stats["[UNSUPPORTED]"])) * 100.0
             print("Coverage [PASS/(PASS+FAIL)]: " + str(round(coverage, 2)) + "%")
             print("Coverage [PASS/(PASS+FAIL+UNSUPPORTED)]: " + str(round(coverageTotal, 2)) + "%")
-            print(Colors.GREEN)
+            print(Colors.RED)
             print("==================================================")
-            print(Colors.CYAN)
+            print("FAILED TESTS")
+            print("==================================================")
+            for test, whitelisted in failedTests.items():
+                print(f"{test} - [WHITELISTED]: {whitelisted}")
 
-        print("Total Time(s): " + str(end - start))
+            print("==================================================")
+
+        print(Colors.CYAN + "Total Time(s): " + str(end - start))
         print(Colors.RESET)
 
 
 def runTestTheWorld(options, args):
     stats = {"[PASS]": 0, "[FAILED]": 0, "[UNSUPPORTED]": 0}
+    failedTests = {}
 
     __TORNADO_QUICK_PASS_SKIP_TESTS__ = __TORNADO_HEAVY_TESTS__ + __TORNADO_MEMORY_TESTS__
 
@@ -625,16 +633,16 @@ def runTestTheWorld(options, args):
                 if (args.fast):
                     os.system(testMethodCmd)
                 else:
-                    stats = runCommandWithStats(testMethodCmd, stats, t.monitorClass)
+                    stats, failedTests = runCommandWithStats(testMethodCmd, stats, failedTests, t.monitorClass)
         elif (args.fast):
             command += "\""
             os.system(command)
         else:
             command += "\""
             print(command)
-            stats = runCommandWithStats(command, stats, t.monitorClass)
+            stats, failedTests = runCommandWithStats(command, stats, failedTests, t.monitorClass)
 
-    return stats
+    return stats, failedTests
 
 
 def runWithJUnit(args):

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -369,6 +369,7 @@ class Colors:
     RESET = "\033[0;0m"
     BOLD = "\033[;1m"
     REVERSE = "\033[;7m"
+    ORANGE = "\033[38;5;214m"
 
 
 def composeAllOptions(args):
@@ -606,7 +607,11 @@ def runTests(args):
             print("FAILED TESTS")
             print("==================================================")
             for test, whitelisted in failedTests.items():
-                print(f"{test} - [WHITELISTED]: {whitelisted}")
+                if whitelisted == "YES":
+                    print(Colors.ORANGE + f"{test} - [WHITELISTED]: {whitelisted}")
+                else:
+                    print(Colors.RED + f"{test} - [WHITELISTED]: {whitelisted}")
+            print(Colors.RED)
             print("==================================================")
             if len(segFaults) != 0:
                 print("SEGFAULT TESTS")


### PR DESCRIPTION
#### Description

This PR extends the `tornado-tests` script to print a summary of the tests that fail along with information about whether they are whilelisted or not. This way it's easy to track the failing tests without having to go through all the output of the `tornado-tests` script. 
Below is the output of the test script with the proposed extension:

```
==================================================
              Unit tests report 
==================================================

{'[PASS]': 666, '[FAILED]': 5, '[UNSUPPORTED]': 46}
Coverage [PASS/(PASS+FAIL)]: 99.25%
Coverage [PASS/(PASS+FAIL+UNSUPPORTED)]: 92.89%

==================================================
FAILED TESTS
==================================================
uk.ac.manchester.tornado.unittests.foundation.TestIf#test06 - [WHITELISTED]: YES
uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext#mxm2DKernelContext01 - [WHITELISTED]: YES
uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext#mxm2DKernelContext02 - [WHITELISTED]: YES
uk.ac.manchester.tornado.unittests.compute.ComputeTests#testMandelbrot - [WHITELISTED]: YES
uk.ac.manchester.tornado.unittests.compute.ComputeTests#testJuliaSets - [WHITELISTED]: YES
==================================================
Total Time(s): 400.74899530410767

```

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Run `make tests`

----------------------------------------------------------------------------
