### PR TITLE
[hotfix] Used a fixed Level Zero version for Intel integrated graphics

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -234,7 +234,7 @@ def build_spirv_toolkit_and_level_zero(rebuild=False):
         level_zero_lib = "level-zero"
 
         if not os.path.exists(level_zero_lib):
-            subprocess.run(["git", "clone", "https://github.com/oneapi-src/level-zero"])
+            subprocess.run(["git", "clone", "--branch", "v1.17.45", "https://github.com/oneapi-src/level-zero"])
             os.chdir(level_zero_lib)
             os.mkdir("build")
             os.chdir("build")


### PR DESCRIPTION
#### Description

This PR forces the TornadoVM installation script to use a specific Level Zero version (v1.17.45) because the recent merge of the changes for the L0 specification 1.11 do not allow Intel integrated graphics to be recognized as Level Zero devices.

A relevant issue is opened in the level-zero repository: https://github.com/oneapi-src/level-zero/issues/209

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

To test this PR, you should have an Intel integrated graphics in your system, and to remove first any existing level-zero directories.

```bash
rm -rf level*
make BACKEND=spirv
tornado --devices
```
----------------------------------------------------------------------------
