### PR TITLE
Extend type support for 3D matrices

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DDouble.java
@@ -18,7 +18,7 @@
 package uk.ac.manchester.tornado.api.types.matrix;
 
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
-import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.utils.DoubleOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 
 import java.lang.foreign.MemorySegment;
@@ -115,7 +115,7 @@ public final class Matrix3DDouble extends Matrix3DType implements TornadoMatrixI
     public String toString() {
         String result = String.format("Matrix3DDouble <%d x %d x %d>", ROWS, COLUMNS, DEPTH);
         if (ROWS < 16 && COLUMNS < 16 && DEPTH < 16) {
-            result += "\n" + toString(FloatOps.FMT);
+            result += "\n" + toString(DoubleOps.FMT);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DDouble.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DDouble.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.types.matrix;
+
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.DoubleBuffer;
+
+public final class Matrix3DDouble extends Matrix3DType implements TornadoMatrixInterface<DoubleBuffer> {
+
+    /**
+     * backing array.
+     */
+    private final DoubleArray storage;
+
+    /**
+     * number of elements in the storage.
+     */
+    private final int numElements;
+
+    /**
+     * Storage format for matrix.
+     *
+     * @param rows    number of rows
+     * @param columns number of columns
+     * @param array   array reference which contains data
+     */
+    public Matrix3DDouble(int rows, int columns, int depth, DoubleArray array) {
+        super(rows, columns, depth);
+        storage = array;
+        numElements = rows * columns * depth;
+    }
+
+    /**
+     * Storage format for matrix.
+     *
+     * @param rows    number of columns
+     * @param columns number of columns
+     */
+    public Matrix3DDouble(int rows, int columns, int depth) {
+        this(rows, columns, depth, new DoubleArray(rows * columns * depth));
+    }
+
+    public Matrix3DDouble(double[][][] matrix) {
+        this(matrix.length, matrix[0].length, matrix[0][0].length, StorageFormats.toRowMajor3D(matrix));
+    }
+
+    public static void scale(Matrix3DDouble matrix, double value) {
+        for (int i = 0; i < matrix.storage.getSize(); i++) {
+            matrix.storage.set(i, matrix.storage.get(i) * value);
+        }
+    }
+
+    @Override
+    public void clear() {
+        storage.clear();
+    }
+
+    public double get(int i, int j, int k) {
+        return storage.get(StorageFormats.toRowMajor3D(i, j, k, DEPTH, COLUMNS));
+    }
+
+    public void set(int i, int j, int k, double value) {
+        storage.set(StorageFormats.toRowMajor3D(i, j, k, DEPTH, COLUMNS), value);
+    }
+
+    public void fill(double value) {
+        storage.init(value);
+    }
+
+    public Matrix3DDouble duplicate() {
+        Matrix3DDouble matrix = new Matrix3DDouble(ROWS, COLUMNS, DEPTH);
+        matrix.set(this);
+        return matrix;
+    }
+
+    public void set(Matrix3DDouble m) {
+        for (int i = 0; i < m.storage.getSize(); i++) {
+            storage.set(i, m.storage.get(i));
+        }
+    }
+
+    public String toString(String fmt) {
+        StringBuilder str = new StringBuilder("");
+        for (int i = 0; i < ROWS; i++) {
+            for (int j = 0; j < COLUMNS; j++) {
+                for (int k = 0; k < DEPTH; k++) {
+                    str.append(String.format(fmt, get(i, j, k)) + " ");
+                }
+            }
+            str.append("\n");
+        }
+        return str.toString().trim();
+    }
+
+    @Override
+    public String toString() {
+        String result = String.format("Matrix3DDouble <%d x %d x %d>", ROWS, COLUMNS, DEPTH);
+        if (ROWS < 16 && COLUMNS < 16 && DEPTH < 16) {
+            result += "\n" + toString(FloatOps.FMT);
+        }
+        return result;
+    }
+
+    @Override
+    public void loadFromBuffer(DoubleBuffer buffer) {
+        asBuffer().put(buffer);
+    }
+
+    @Override
+    public DoubleBuffer asBuffer() {
+        return DoubleBuffer.wrap(storage.toHeapArray());
+    }
+
+    @Override
+    public int size() {
+        return numElements;
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
+
+    @Override
+    public long getNumBytesWithHeader() {
+        return storage.getNumBytesOfSegment();
+    }
+
+    @Override
+    public MemorySegment getSegment() {
+        return storage.getSegment();
+    }
+
+    @Override
+    public MemorySegment getSegmentWithHeader() {
+        return storage.getSegmentWithHeader();
+
+    }
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DInt.java
@@ -18,7 +18,7 @@
 package uk.ac.manchester.tornado.api.types.matrix;
 
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.utils.IntOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 
 import java.lang.foreign.MemorySegment;
@@ -115,7 +115,7 @@ public final class Matrix3DInt extends Matrix3DType implements TornadoMatrixInte
     public String toString() {
         String result = String.format("Matrix3DInt <%d x %d x %d>", ROWS, COLUMNS, DEPTH);
         if (ROWS < 16 && COLUMNS < 16 && DEPTH < 16) {
-            result += "\n" + toString(FloatOps.FMT);
+            result += "\n" + toString(IntOps.FMT);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DInt.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DInt.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.types.matrix;
+
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.IntBuffer;
+
+public final class Matrix3DInt extends Matrix3DType implements TornadoMatrixInterface<IntBuffer> {
+
+    /**
+     * backing array.
+     */
+    private final IntArray storage;
+
+    /**
+     * number of elements in the storage.
+     */
+    private final int numElements;
+
+    /**
+     * Storage format for matrix.
+     *
+     * @param rows    number of rows
+     * @param columns number of columns
+     * @param array   array reference which contains data
+     */
+    public Matrix3DInt(int rows, int columns, int depth, IntArray array) {
+        super(rows, columns, depth);
+        storage = array;
+        numElements = rows * columns * depth;
+    }
+
+    /**
+     * Storage format for matrix.
+     *
+     * @param rows    number of columns
+     * @param columns number of columns
+     */
+    public Matrix3DInt(int rows, int columns, int depth) {
+        this(rows, columns, depth, new IntArray(rows * columns * depth));
+    }
+
+    public Matrix3DInt(int[][][] matrix) {
+        this(matrix.length, matrix[0].length, matrix[0][0].length, StorageFormats.toRowMajor3D(matrix));
+    }
+
+    public static void scale(Matrix3DInt matrix, int value) {
+        for (int i = 0; i < matrix.storage.getSize(); i++) {
+            matrix.storage.set(i, matrix.storage.get(i) * value);
+        }
+    }
+
+    @Override
+    public void clear() {
+        storage.clear();
+    }
+
+    public int get(int i, int j, int k) {
+        return storage.get(StorageFormats.toRowMajor3D(i, j, k, DEPTH, COLUMNS));
+    }
+
+    public void set(int i, int j, int k, int value) {
+        storage.set(StorageFormats.toRowMajor3D(i, j, k, DEPTH, COLUMNS), value);
+    }
+
+    public void fill(int value) {
+        storage.init(value);
+    }
+
+    public Matrix3DInt duplicate() {
+        Matrix3DInt matrix = new Matrix3DInt(ROWS, COLUMNS, DEPTH);
+        matrix.set(this);
+        return matrix;
+    }
+
+    public void set(Matrix3DInt m) {
+        for (int i = 0; i < m.storage.getSize(); i++) {
+            storage.set(i, m.storage.get(i));
+        }
+    }
+
+    public String toString(String fmt) {
+        StringBuilder str = new StringBuilder("");
+        for (int i = 0; i < ROWS; i++) {
+            for (int j = 0; j < COLUMNS; j++) {
+                for (int k = 0; k < DEPTH; k++) {
+                    str.append(String.format(fmt, get(i, j, k)) + " ");
+                }
+            }
+            str.append("\n");
+        }
+        return str.toString().trim();
+    }
+
+    @Override
+    public String toString() {
+        String result = String.format("Matrix3DInt <%d x %d x %d>", ROWS, COLUMNS, DEPTH);
+        if (ROWS < 16 && COLUMNS < 16 && DEPTH < 16) {
+            result += "\n" + toString(FloatOps.FMT);
+        }
+        return result;
+    }
+
+    @Override
+    public void loadFromBuffer(IntBuffer buffer) {
+        asBuffer().put(buffer);
+    }
+
+    @Override
+    public IntBuffer asBuffer() {
+        return IntBuffer.wrap(storage.toHeapArray());
+    }
+
+    @Override
+    public int size() {
+        return numElements;
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
+
+    @Override
+    public long getNumBytesWithHeader() {
+        return storage.getNumBytesOfSegment();
+    }
+
+    @Override
+    public MemorySegment getSegment() {
+        return storage.getSegment();
+    }
+
+    @Override
+    public MemorySegment getSegmentWithHeader() {
+        return storage.getSegmentWithHeader();
+
+    }
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DLong.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DLong.java
@@ -19,6 +19,8 @@ package uk.ac.manchester.tornado.api.types.matrix;
 
 import uk.ac.manchester.tornado.api.types.arrays.LongArray;
 import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.utils.LongOps;
+import uk.ac.manchester.tornado.api.types.utils.ShortOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 
 import java.lang.foreign.MemorySegment;
@@ -115,7 +117,7 @@ public final class Matrix3DLong extends Matrix3DType implements TornadoMatrixInt
     public String toString() {
         String result = String.format("Matrix3DLong <%d x %d x %d>", ROWS, COLUMNS, DEPTH);
         if (ROWS < 16 && COLUMNS < 16 && DEPTH < 16) {
-            result += "\n" + toString(FloatOps.FMT);
+            result += "\n" + toString(LongOps.FMT);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DLong.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DLong.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.types.matrix;
+
+import uk.ac.manchester.tornado.api.types.arrays.LongArray;
+import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.LongBuffer;
+
+public final class Matrix3DLong extends Matrix3DType implements TornadoMatrixInterface<LongBuffer> {
+
+    /**
+     * backing array.
+     */
+    private final LongArray storage;
+
+    /**
+     * number of elements in the storage.
+     */
+    private final int numElements;
+
+    /**
+     * Storage format for matrix.
+     *
+     * @param rows    number of rows
+     * @param columns number of columns
+     * @param array   array reference which contains data
+     */
+    public Matrix3DLong(int rows, int columns, int depth, LongArray array) {
+        super(rows, columns, depth);
+        storage = array;
+        numElements = rows * columns * depth;
+    }
+
+    /**
+     * Storage format for matrix.
+     *
+     * @param rows    number of columns
+     * @param columns number of columns
+     */
+    public Matrix3DLong(int rows, int columns, int depth) {
+        this(rows, columns, depth, new LongArray(rows * columns * depth));
+    }
+
+    public Matrix3DLong(long[][][] matrix) {
+        this(matrix.length, matrix[0].length, matrix[0][0].length, StorageFormats.toRowMajor3D(matrix));
+    }
+
+    public static void scale(Matrix3DLong matrix, long value) {
+        for (int i = 0; i < matrix.storage.getSize(); i++) {
+            matrix.storage.set(i, matrix.storage.get(i) * value);
+        }
+    }
+
+    @Override
+    public void clear() {
+        storage.clear();
+    }
+
+    public long get(int i, int j, int k) {
+        return storage.get(StorageFormats.toRowMajor3D(i, j, k, DEPTH, COLUMNS));
+    }
+
+    public void set(int i, int j, int k, long value) {
+        storage.set(StorageFormats.toRowMajor3D(i, j, k, DEPTH, COLUMNS), value);
+    }
+
+    public void fill(long value) {
+        storage.init(value);
+    }
+
+    public Matrix3DLong duplicate() {
+        Matrix3DLong matrix = new Matrix3DLong(ROWS, COLUMNS, DEPTH);
+        matrix.set(this);
+        return matrix;
+    }
+
+    public void set(Matrix3DLong m) {
+        for (int i = 0; i < m.storage.getSize(); i++) {
+            storage.set(i, m.storage.get(i));
+        }
+    }
+
+    public String toString(String fmt) {
+        StringBuilder str = new StringBuilder("");
+        for (int i = 0; i < ROWS; i++) {
+            for (int j = 0; j < COLUMNS; j++) {
+                for (int k = 0; k < DEPTH; k++) {
+                    str.append(String.format(fmt, get(i, j, k)) + " ");
+                }
+            }
+            str.append("\n");
+        }
+        return str.toString().trim();
+    }
+
+    @Override
+    public String toString() {
+        String result = String.format("Matrix3DLong <%d x %d x %d>", ROWS, COLUMNS, DEPTH);
+        if (ROWS < 16 && COLUMNS < 16 && DEPTH < 16) {
+            result += "\n" + toString(FloatOps.FMT);
+        }
+        return result;
+    }
+
+    @Override
+    public void loadFromBuffer(LongBuffer buffer) {
+        asBuffer().put(buffer);
+    }
+
+    @Override
+    public LongBuffer asBuffer() {
+        return LongBuffer.wrap(storage.toHeapArray());
+    }
+
+    @Override
+    public int size() {
+        return numElements;
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
+
+    @Override
+    public long getNumBytesWithHeader() {
+        return storage.getNumBytesOfSegment();
+    }
+
+    @Override
+    public MemorySegment getSegment() {
+        return storage.getSegment();
+    }
+
+    @Override
+    public MemorySegment getSegmentWithHeader() {
+        return storage.getSegmentWithHeader();
+
+    }
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DShort.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DShort.java
@@ -18,7 +18,7 @@
 package uk.ac.manchester.tornado.api.types.matrix;
 
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
-import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.utils.ShortOps;
 import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
 
 import java.lang.foreign.MemorySegment;
@@ -115,7 +115,7 @@ public final class Matrix3DShort extends Matrix3DType implements TornadoMatrixIn
     public String toString() {
         String result = String.format("Matrix3DShort <%d x %d x %d>", ROWS, COLUMNS, DEPTH);
         if (ROWS < 16 && COLUMNS < 16 && DEPTH < 16) {
-            result += "\n" + toString(FloatOps.FMT);
+            result += "\n" + toString(ShortOps.FMT);
         }
         return result;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DShort.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix3DShort.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.types.matrix;
+
+import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
+import uk.ac.manchester.tornado.api.types.utils.FloatOps;
+import uk.ac.manchester.tornado.api.types.utils.StorageFormats;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ShortBuffer;
+
+public final class Matrix3DShort extends Matrix3DType implements TornadoMatrixInterface<ShortBuffer> {
+
+    /**
+     * backing array.
+     */
+    private final ShortArray storage;
+
+    /**
+     * number of elements in the storage.
+     */
+    private final int numElements;
+
+    /**
+     * Storage format for matrix.
+     *
+     * @param rows    number of rows
+     * @param columns number of columns
+     * @param array   array reference which contains data
+     */
+    public Matrix3DShort(int rows, int columns, int depth, ShortArray array) {
+        super(rows, columns, depth);
+        storage = array;
+        numElements = rows * columns * depth;
+    }
+
+    /**
+     * Storage format for matrix.
+     *
+     * @param rows    number of columns
+     * @param columns number of columns
+     */
+    public Matrix3DShort(int rows, int columns, int depth) {
+        this(rows, columns, depth, new ShortArray(rows * columns * depth));
+    }
+
+    public Matrix3DShort(short[][][] matrix) {
+        this(matrix.length, matrix[0].length, matrix[0][0].length, StorageFormats.toRowMajor3D(matrix));
+    }
+
+    public static void scale(Matrix3DShort matrix, short value) {
+        for (int i = 0; i < matrix.storage.getSize(); i++) {
+            matrix.storage.set(i, (short) (matrix.storage.get(i) * value));
+        }
+    }
+
+    @Override
+    public void clear() {
+        storage.clear();
+    }
+
+    public short get(int i, int j, int k) {
+        return storage.get(StorageFormats.toRowMajor3D(i, j, k, DEPTH, COLUMNS));
+    }
+
+    public void set(int i, int j, int k, short value) {
+        storage.set(StorageFormats.toRowMajor3D(i, j, k, DEPTH, COLUMNS), value);
+    }
+
+    public void fill(short value) {
+        storage.init(value);
+    }
+
+    public Matrix3DShort duplicate() {
+        Matrix3DShort matrix = new Matrix3DShort(ROWS, COLUMNS, DEPTH);
+        matrix.set(this);
+        return matrix;
+    }
+
+    public void set(Matrix3DShort m) {
+        for (int i = 0; i < m.storage.getSize(); i++) {
+            storage.set(i, m.storage.get(i));
+        }
+    }
+
+    public String toString(String fmt) {
+        StringBuilder str = new StringBuilder("");
+        for (int i = 0; i < ROWS; i++) {
+            for (int j = 0; j < COLUMNS; j++) {
+                for (int k = 0; k < DEPTH; k++) {
+                    str.append(String.format(fmt, get(i, j, k)) + " ");
+                }
+            }
+            str.append("\n");
+        }
+        return str.toString().trim();
+    }
+
+    @Override
+    public String toString() {
+        String result = String.format("Matrix3DShort <%d x %d x %d>", ROWS, COLUMNS, DEPTH);
+        if (ROWS < 16 && COLUMNS < 16 && DEPTH < 16) {
+            result += "\n" + toString(FloatOps.FMT);
+        }
+        return result;
+    }
+
+    @Override
+    public void loadFromBuffer(ShortBuffer buffer) {
+        asBuffer().put(buffer);
+    }
+
+    @Override
+    public ShortBuffer asBuffer() {
+        return ShortBuffer.wrap(storage.toHeapArray());
+    }
+
+    @Override
+    public int size() {
+        return numElements;
+    }
+
+    @Override
+    public long getNumBytes() {
+        return storage.getNumBytesOfSegment();
+    }
+
+    @Override
+    public long getNumBytesWithHeader() {
+        return storage.getNumBytesOfSegment();
+    }
+
+    @Override
+    public MemorySegment getSegment() {
+        return storage.getSegment();
+    }
+
+    @Override
+    public MemorySegment getSegmentWithHeader() {
+        return storage.getSegmentWithHeader();
+
+    }
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/TornadoMatrixInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/TornadoMatrixInterface.java
@@ -24,7 +24,8 @@ import uk.ac.manchester.tornado.api.types.common.PrimitiveStorage;
 
 public sealed interface TornadoMatrixInterface<T extends Buffer> extends PrimitiveStorage<T> //
         permits Matrix2DDouble, Matrix2DFloat, Matrix2DFloat4, Matrix2DInt, //
-        Matrix3DFloat, Matrix3DFloat4, Matrix4x4Float {
+        Matrix3DFloat, Matrix3DInt, Matrix3DDouble, Matrix3DLong, Matrix3DShort, //
+        Matrix3DFloat4, Matrix4x4Float {
 
     long getNumBytes();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/utils/LongOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/utils/LongOps.java
@@ -1,0 +1,13 @@
+package uk.ac.manchester.tornado.api.types.utils;
+
+public class LongOps {
+
+    public static final String FMT = "%d";
+    public static final String FMT_2 = "{%d,%d}";
+    public static final String FMT_3 = "{%d,%d,%d}";
+    public static final String FMT_4 = "{%d,%d,%d,%d}";
+    public static final String FMT_6 = "{%d,%d,%d,%d,%d,%d}";
+    public static final String FMT_8 = "{%d,%d,%d,%d,%d,%d,%d,%d}";
+    public static final String FMT_16 = "{%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d}";
+
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/utils/LongOps.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/utils/LongOps.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package uk.ac.manchester.tornado.api.types.utils;
 
 public class LongOps {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/utils/StorageFormats.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/utils/StorageFormats.java
@@ -21,6 +21,8 @@ import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.arrays.LongArray;
+import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 
 public final class StorageFormats {
 
@@ -188,6 +190,74 @@ public final class StorageFormats {
         final int dimY = matrix[0].length;
         final int dimZ = matrix[0][0].length;
         FloatArray flattenMatrix = new FloatArray(dimX * dimY * dimZ);
+
+        for (int i = 0; i < dimX; i++) {
+            for (int j = 0; j < dimY; j++) {
+                for (int k = 0; k < dimZ; k++) {
+                    int index = toRowMajor3D(i, j, k, dimZ, dimY);
+                    flattenMatrix.set(index, matrix[i][j][k]);
+                }
+            }
+        }
+        return flattenMatrix;
+    }
+
+    public static IntArray toRowMajor3D(int[][][] matrix) {
+        final int dimX = matrix.length;
+        final int dimY = matrix[0].length;
+        final int dimZ = matrix[0][0].length;
+        IntArray flattenMatrix = new IntArray(dimX * dimY * dimZ);
+
+        for (int i = 0; i < dimX; i++) {
+            for (int j = 0; j < dimY; j++) {
+                for (int k = 0; k < dimZ; k++) {
+                    int index = toRowMajor3D(i, j, k, dimZ, dimY);
+                    flattenMatrix.set(index, matrix[i][j][k]);
+                }
+            }
+        }
+        return flattenMatrix;
+    }
+
+    public static DoubleArray toRowMajor3D(double[][][] matrix) {
+        final int dimX = matrix.length;
+        final int dimY = matrix[0].length;
+        final int dimZ = matrix[0][0].length;
+        DoubleArray flattenMatrix = new DoubleArray(dimX * dimY * dimZ);
+
+        for (int i = 0; i < dimX; i++) {
+            for (int j = 0; j < dimY; j++) {
+                for (int k = 0; k < dimZ; k++) {
+                    int index = toRowMajor3D(i, j, k, dimZ, dimY);
+                    flattenMatrix.set(index, matrix[i][j][k]);
+                }
+            }
+        }
+        return flattenMatrix;
+    }
+
+    public static LongArray toRowMajor3D(long[][][] matrix) {
+        final int dimX = matrix.length;
+        final int dimY = matrix[0].length;
+        final int dimZ = matrix[0][0].length;
+        LongArray flattenMatrix = new LongArray(dimX * dimY * dimZ);
+
+        for (int i = 0; i < dimX; i++) {
+            for (int j = 0; j < dimY; j++) {
+                for (int k = 0; k < dimZ; k++) {
+                    int index = toRowMajor3D(i, j, k, dimZ, dimY);
+                    flattenMatrix.set(index, matrix[i][j][k]);
+                }
+            }
+        }
+        return flattenMatrix;
+    }
+
+    public static ShortArray toRowMajor3D(short[][][] matrix) {
+        final int dimX = matrix.length;
+        final int dimY = matrix[0].length;
+        final int dimZ = matrix[0][0].length;
+        ShortArray flattenMatrix = new ShortArray(dimX * dimY * dimZ);
 
         for (int i = 0; i < dimX; i++) {
             for (int j = 0; j < dimY; j++) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrixTypes.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrixTypes.java
@@ -40,8 +40,12 @@ import uk.ac.manchester.tornado.api.types.matrix.Matrix2DDouble;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat4;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix2DInt;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix3DDouble;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix3DFloat;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix3DFloat4;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix3DInt;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix3DLong;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix3DShort;
 import uk.ac.manchester.tornado.api.types.vectors.Float4;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
@@ -69,6 +73,46 @@ public class TestMatrixTypes extends TornadoTestBase {
             for (@Parallel int j = 0; j < N; j++) {
                 for (@Parallel int k = 0; k < N; k++) {
                     b.set(i, j, k, a.get(i, j, k) + a.get(i, j, k));
+                }
+            }
+        }
+    }
+
+    public static void computeMatrixSum(Matrix3DInt a, Matrix3DInt b, final int N) {
+        for (@Parallel int i = 0; i < N; i++) {
+            for (@Parallel int j = 0; j < N; j++) {
+                for (@Parallel int k = 0; k < N; k++) {
+                    b.set(i, j, k, a.get(i, j, k) + a.get(i, j, k));
+                }
+            }
+        }
+    }
+
+    public static void computeMatrixSum(Matrix3DDouble a, Matrix3DDouble b, final int N) {
+        for (@Parallel int i = 0; i < N; i++) {
+            for (@Parallel int j = 0; j < N; j++) {
+                for (@Parallel int k = 0; k < N; k++) {
+                    b.set(i, j, k, a.get(i, j, k) + a.get(i, j, k));
+                }
+            }
+        }
+    }
+
+    public static void computeMatrixSum(Matrix3DLong a, Matrix3DLong b, final int N) {
+        for (@Parallel int i = 0; i < N; i++) {
+            for (@Parallel int j = 0; j < N; j++) {
+                for (@Parallel int k = 0; k < N; k++) {
+                    b.set(i, j, k, a.get(i, j, k) + a.get(i, j, k));
+                }
+            }
+        }
+    }
+
+    public static void computeMatrixSum(Matrix3DShort a, Matrix3DShort b, final int N) {
+        for (@Parallel int i = 0; i < N; i++) {
+            for (@Parallel int j = 0; j < N; j++) {
+                for (@Parallel int k = 0; k < N; k++) {
+                    b.set(i, j, k, (short) (a.get(i, j, k) + a.get(i, j, k)));
                 }
             }
         }
@@ -839,6 +883,137 @@ public class TestMatrixTypes extends TornadoTestBase {
         for (int i = 0; i < X; i++) {
             for (int j = 0; j < Y; j++) {
                 assertEquals(matrixA.get(i, j) + matrixA.get(i, j), matrixB.get(i, j), 0.01f);
+            }
+        }
+    }
+
+    @Test
+    public void testMatrix24() throws TornadoExecutionPlanException {
+        final int N = 256;
+        Matrix3DInt matrixA = new Matrix3DInt(N, N, N);
+        Matrix3DInt matrixB = new Matrix3DInt(N, N, N);
+        Random r = new Random();
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < N; k++) {
+                    matrixA.set(i, j, k, r.nextInt());
+                }
+            }
+        }
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB) //
+                .task("t0", TestMatrixTypes::computeMatrixSum, matrixA, matrixB, N) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < N; k++) {
+                    assertEquals(matrixA.get(i, j, k) + matrixA.get(i, j, k), matrixB.get(i, j, k));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMatrix25() throws TornadoExecutionPlanException {
+        final int N = 256;
+        Matrix3DDouble matrixA = new Matrix3DDouble(N, N, N);
+        Matrix3DDouble matrixB = new Matrix3DDouble(N, N, N);
+        Random r = new Random();
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < N; k++) {
+                    matrixA.set(i, j, k, r.nextDouble());
+                }
+            }
+        }
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB) //
+                .task("t0", TestMatrixTypes::computeMatrixSum, matrixA, matrixB, N) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < N; k++) {
+                    assertEquals(matrixA.get(i, j, k) + matrixA.get(i, j, k), matrixB.get(i, j, k), 0.01);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMatrix26() throws TornadoExecutionPlanException {
+        final int N = 256;
+        Matrix3DLong matrixA = new Matrix3DLong(N, N, N);
+        Matrix3DLong matrixB = new Matrix3DLong(N, N, N);
+        Random r = new Random();
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < N; k++) {
+                    matrixA.set(i, j, k, r.nextLong());
+                }
+            }
+        }
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB) //
+                .task("t0", TestMatrixTypes::computeMatrixSum, matrixA, matrixB, N) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < N; k++) {
+                    assertEquals(matrixA.get(i, j, k) + matrixA.get(i, j, k), matrixB.get(i, j, k));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMatrix27() throws TornadoExecutionPlanException {
+        final int N = 256;
+        Matrix3DShort matrixA = new Matrix3DShort(N, N, N);
+        Matrix3DShort matrixB = new Matrix3DShort(N, N, N);
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < N; k++) {
+                    matrixA.set(i, j, k, (short) i);
+                }
+            }
+        }
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB) //
+                .task("t0", TestMatrixTypes::computeMatrixSum, matrixA, matrixB, N) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < N; k++) {
+                    assertEquals(matrixA.get(i, j, k) + matrixA.get(i, j, k), matrixB.get(i, j, k));
+                }
             }
         }
     }


### PR DESCRIPTION
#### Description

This PR provides support for int, double, long and short 3d arrays by creating new matrix classes.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

The `TestMatrixTypes` unittest has been extended with tests for the new 3d types. 
To test run: 
`tornado-test -V uk.ac.manchester.tornado.unittests.matrices.TestMatrixTypes`
