### PR TITLE
Restore building/running TornadoVM from IntelliJ & update of documentation

### DIFF
--- a/.build/TornadoVM-Build.run.xml
+++ b/.build/TornadoVM-Build.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-    <configuration default="false" name="TornadoVM-Full-OpenCL-Build" type="PythonConfigurationType"
+    <configuration default="false" name="TornadoVM-Build" type="PythonConfigurationType"
                    factoryName="Python">
         <module name="tornado-annotation"/>
         <option name="INTERPRETER_OPTIONS" value=""/>

--- a/.build/TornadoVM-Full-OpenCL-Build.run.xml
+++ b/.build/TornadoVM-Full-OpenCL-Build.run.xml
@@ -8,7 +8,7 @@
             <env name="PYTHONUNBUFFERED" value="1"/>
             <env name="BACKEND" value="opencl"/>
             <env name="TORNADO_SDK" value="$PROJECT_DIR$/bin/sdk"/>
-            <env name="selected_backends" value="opencl"/>
+            <env name="selected_backends" value="opencl-backend"/>
         </envs>
         <option name="SDK_HOME" value=""/>
         <option name="SDK_NAME" value="Python 3.9 (tornado)"/>

--- a/.build/TornadoVM-Tests.run.xml
+++ b/.build/TornadoVM-Tests.run.xml
@@ -1,0 +1,29 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="TornadoVM-Tests" type="PythonConfigurationType" factoryName="Python">
+    <module name="tornado-annotation" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+      <env name="BACKEND" value="opencl" />
+      <env name="TORNADO_SDK" value="$PROJECT_DIR$/bin/sdk" />
+      <env name="selected_backends" value="opencl-backend" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.10" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/bin/sdk/bin/tornado-test" />
+    <option name="PARAMETERS" value="--ea --verbose --quickPass" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.build/TornadoVM-Tests.run.xml
+++ b/.build/TornadoVM-Tests.run.xml
@@ -5,10 +5,11 @@
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
-      <env name="PYTHONUNBUFFERED" value="1" />
       <env name="BACKEND" value="opencl" />
-      <env name="TORNADO_SDK" value="$PROJECT_DIR$/bin/sdk" />
+      <env name="PYTHONUNBUFFERED" value="1" />
       <env name="selected_backends" value="opencl-backend" />
+      <env name="TORNADO_SDK" value="$PROJECT_DIR$/bin/sdk" />
+      <env name="JAVA_HOME" value="$PROJECT_DIR$/etc/dependencies/TornadoVM-graal-jdk-21/graalvm-community-openjdk-21.0.1+12.1" />
     </envs>
     <option name="SDK_HOME" value="" />
     <option name="SDK_NAME" value="Python 3.10" />

--- a/.build/_internal_TornadoVM_Maven-cleanAndinstall.run.xml
+++ b/.build/_internal_TornadoVM_Maven-cleanAndinstall.run.xml
@@ -16,7 +16,7 @@
           <option name="threads" />
           <option name="useMavenConfig" value="true" />
           <option name="usePluginRegistry" value="false" />
-          <option name="userSettingsFile" value="$USER_HOME$/.m2/settings.xml" />
+          <option name="userSettingsFile" value="" />
           <option name="workOffline" value="false" />
         </MavenGeneralSettings>
       </option>

--- a/bin/post_installation.py
+++ b/bin/post_installation.py
@@ -19,7 +19,7 @@
 
 import os
 import subprocess
-
+import config_utils as cutils
 
 def update_paths():
     """
@@ -81,6 +81,8 @@ def main():
     selected_backends_str = os.environ.get("selected_backends", "")
     update_backend_file(selected_backends_str)
     copy_graal_jars()
+    if os.name == 'nt':
+        cutils.runPyInstaller(os.getcwd(), os.environ['TORNADO_SDK'])
 
 
 if __name__ == "__main__":

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -53,19 +53,18 @@ __SUPPORTED_BACKENDS__ = ["opencl", "spirv", "ptx"]
 ## ################################################################
 
 class TornadoInstaller:
-    
+
     def __init__(self):
         self.workDirName = ""
+        self.dependenciesDirName = ""
         self.osPlatform = self.getOSPlatform()
         self.hardware = self.getMachineArc()
         self.env = {}
         self.env["PATH"] = [os.path.join(self.getCurrentDirectory(), "bin", "bin")]
         self.env["TORNADO_SDK"] = os.path.join(self.getCurrentDirectory(), "bin", "sdk")
 
-
     def getOSPlatform(self):
         return platform.system().lower()
-
 
     def getMachineArc(self):
         compatibleMachineTypes = {
@@ -77,10 +76,8 @@ class TornadoInstaller:
         machine = platform.machine().lower()
         return compatibleMachineTypes[machine]
 
-
     def processFileName(self, url):
         return os.path.basename(url)
-
 
     def setWorkDir(self, jdk):
         tornadoDir = "TornadoVM-" + jdk
@@ -88,10 +85,13 @@ class TornadoInstaller:
         if not os.path.exists(self.workDirName):
             os.makedirs(self.workDirName)
 
+    def setDependenciesDir(self):
+        self.dependenciesDirName = os.path.join(__DIRECTORY_DEPENDENCIES__)
+        if not os.path.exists(self.dependenciesDirName):
+            os.makedirs(self.dependenciesDirName)
 
     def getCurrentDirectory(self):
         return os.getcwd()
-
 
     def downloadCMake(self):
         url = config.CMAKE[self.osPlatform][self.hardware]
@@ -101,7 +101,7 @@ class TornadoInstaller:
 
         fileName = self.processFileName(url)
         print("\nChecking dependency: " + fileName)
-        fullPath = os.path.join(self.workDirName, fileName)
+        fullPath = os.path.join(self.dependenciesDirName, fileName)
 
         if not os.path.exists(fullPath):
             wget.download(url, fullPath)
@@ -110,14 +110,14 @@ class TornadoInstaller:
         try:
             if os.name == 'nt':
                 ar = zipfile.ZipFile(fullPath, 'r')
-                cmakeTLD = os.path.join(self.getCurrentDirectory(), self.workDirName, self.getTLDName(ar))
+                cmakeTLD = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
                 if not os.path.exists(cmakeTLD):
-                    ar.extractall(self.workDirName)
+                    ar.extractall(self.dependenciesDirName)
             else:
                 ar = tarfile.open(fullPath, "r:gz")
-                cmakeTLD = os.path.join(self.getCurrentDirectory(), self.workDirName, self.getTLDName(ar))
+                cmakeTLD = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
                 if not os.path.exists(cmakeTLD):
-                    ar.extractall(self.workDirName, numeric_owner=True)
+                    ar.extractall(self.dependenciesDirName, numeric_owner=True)
         except:
             print(f"Unpacking failed for CMake {url}")
             sys.exit(0)
@@ -132,7 +132,6 @@ class TornadoInstaller:
         extraPath = os.path.join(extraPath, "bin")
         self.env["PATH"].append(os.path.join(cmakeTLD, extraPath))
 
-
     def downloadMaven(self):
         url = config.MAVEN[self.osPlatform][self.hardware]
         if url == None:
@@ -141,7 +140,7 @@ class TornadoInstaller:
 
         fileName = self.processFileName(url)
         print("\nChecking dependency: " + fileName)
-        fullPath = os.path.join(self.workDirName, fileName)
+        fullPath = os.path.join(self.dependenciesDirName, fileName)
 
         if not os.path.exists(fullPath):
             wget.download(url, fullPath)
@@ -150,14 +149,14 @@ class TornadoInstaller:
         try:
             if os.name == 'nt':
                 ar = zipfile.ZipFile(fullPath, 'r')
-                mavenTLD = os.path.join(self.getCurrentDirectory(), self.workDirName, self.getTLDName(ar))
+                mavenTLD = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
                 if not os.path.exists(mavenTLD):
-                    ar.extractall(self.workDirName)
+                    ar.extractall(self.dependenciesDirName)
             else:
                 ar = tarfile.open(fullPath, "r:gz")
-                mavenTLD = os.path.join(self.getCurrentDirectory(), self.workDirName, self.getTLDName(ar))
+                mavenTLD = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
                 if not os.path.exists(mavenTLD):
-                    ar.extractall(self.workDirName, numeric_owner=True)
+                    ar.extractall(self.dependenciesDirName, numeric_owner=True)
         except:
             print(f"Unpacking failed for Maven {url}")
             sys.exit(0)
@@ -178,7 +177,6 @@ class TornadoInstaller:
         else:
             extractedDirectory = extractedNames[0]
         return extractedDirectory
-
 
     def downloadJDK(self, jdk):
         url = config.JDK[jdk][self.osPlatform][self.hardware]
@@ -225,7 +223,6 @@ class TornadoInstaller:
         ## Update env-variables
         self.env["JAVA_HOME"] = os.path.join(jdkTLD, extraPath)
 
-
     def setEnvironmentVariables(self):
         ## 1. PATH
         paths = self.env["PATH"]
@@ -241,14 +238,12 @@ class TornadoInstaller:
         ## 3. TORNADO_SDK
         os.environ["TORNADO_SDK"] = self.env["TORNADO_SDK"]
 
-
     def compileTornadoVM(self, makeJDK, backend, polyglotOption):
         if os.name == 'nt':
             command = "nmake /f Makefile.mak " + makeJDK + " " + backend + " " + polyglotOption
         else:
             command = "make " + makeJDK + " " + backend + " " + polyglotOption
         os.system(command)
-
 
     def createSourceFile(self):
         print(" ------------------------------------------")
@@ -306,7 +301,6 @@ class TornadoInstaller:
                 print("\t" + jdk)
             sys.exit(0)
 
-
     def composeBackendOption(sekf, args):
         backend = args.backend.replace(" ", "").lower()
         for b in backend.split(","):
@@ -316,19 +310,16 @@ class TornadoInstaller:
         backend = "BACKEND=" + backend
         return backend
 
-
     def composePolyglotOption(self, args):
         if args.polyglot:
             polyglotOption = "polyglot"
         else:
             polyglotOption = ""
         return polyglotOption
-    
 
     def check_or_install_python_modules(self):
         command = "pip3 install -r bin/tornadoDepModules.txt"
         os.system(command)
-
 
     def install(self, args):
 
@@ -354,6 +345,7 @@ class TornadoInstaller:
         else:
             directoryPostfix = args.jdk
 
+        self.setDependenciesDir()
         self.setWorkDir(directoryPostfix)
 
         self.downloadCMake()

--- a/docs/source/ide-integration.rst
+++ b/docs/source/ide-integration.rst
@@ -1,5 +1,3 @@
-.. _build-run-with-ide:
-
 Build and Run with IDE
 ======================
 
@@ -41,7 +39,7 @@ Install the following plugins:
 2. **Save Actions**
    Install it from:
    https://plugins.jetbrains.com/plugin/7642-save-actions
-   This plugin allows post-save actions (e.g., code formatting on save).
+   This plugin allows post-save actions (e.g. code formatting on save).
 
    - To enable auto-formatter with save-actions:
      - Go to: **Settings > Other Settings > Save Actions**
@@ -72,19 +70,19 @@ Prerequisites
 
 Ensure that **cmake** is installed and available in your system's PATH.
 
-1. **Check if cmake is in your PATH:**
+1. **Check if cmake is in your PATH**
    Verify that your system recognizes `cmake` by running:
 
    .. code:: bash
 
       $ cmake --version
 
-   If it is recognised, skip the next step. Otherwise, you need to add cmake to your system's PATH.
+   If it is recognized, skip the next step. Otherwise, you need to add cmake to your system's PATH.
 
-2. **Add cmake to PATH (macOS/Linux):**
-You can add cmake to your PATH by updating your shell configuration file.
+2. **Add cmake to PATH (macOS/Linux)**
+You can add `cmake` to your PATH by updating your shell configuration file.
 
-a. Open your shell configuration file (e.g., `.bashrc`, `.zshrc`):
+a. Open your shell configuration file (e.g. `.bashrc`, `.zshrc`):
 
    .. code:: bash
 
@@ -102,6 +100,36 @@ c. Save and apply the changes:
 
       $ source ~/.zshrc  # or source ~/.bashrc
 
+3. **Add cmake and pyInstaller to PATH (Windows)**
+
+a. Find the path of the `cmake` and `pyInstaller` commands:
+Open your shell configuration (e.g. x64 Native Tools Command Prompt for VS 2022) and initialize the environment:
+
+   .. code:: bash
+
+      $ cd <path-to-TornadoVM-directory>
+      $ .\bin\windowsMicrosoftStudioTools2022.cmd
+
+Verify that your system recognizes `cmake` and `pyInstaller` by running:
+
+   .. code:: bash
+
+      $ where cmake
+      $ where pyInstaller
+
+b. Update the PATH:
+You can add the variables to your PATH by searching **Edit the system environment variables**, clicking **Environment Variables...**, and editing the **PATH** with your cmake directory.
+
+   **Examples**:
+
+   .. code:: bash
+
+      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\
+
+   .. code:: bash
+
+      <path-to-TornadoVM-directory>\.venv\Scripts
+
 Configure the Project Structure
 ===============================
 
@@ -109,12 +137,12 @@ Configure the Project Structure
 
 a. In the **Project** tab:
 
-   - The *SDK* uses a valid Java version (e.g., OpenJDK 21, GraalVM JDK 21, etc.).
-   - The *Language level* is set to match the Java version (e.g., Java 21).
+   - The *SDK* uses a valid Java version (e.g. OpenJDK 21, GraalVM JDK 21, etc.).
+   - The *Language level* is set to match the Java version (e.g. Java 21).
 
 b. In the **Modules** tab:
 
-   - Ensure that the *Language level* of every module matches the project level (e.g., Java 21).
+   - Ensure that the *Language level* of every module matches the project level (e.g. Java 21).
 
 Configuring the TornadoVM Utilities
 ===================================
@@ -122,10 +150,10 @@ Configuring the TornadoVM Utilities
 1. **Configure the TornadoVM Maven Build**
 
 a. Navigate to the Maven configuration:
-   Go to **Run > Edit Configurations > Maven > _internal_TornadoVM_Maven-cleanAndinstall_**
+Go to **Run > Edit Configurations > Maven > _internal_TornadoVM_Maven-cleanAndinstall_**
 
 b. Set up the build profiles:
-   In the **Profiles** field, list the profiles you want to build, separated by spaces.
+In the **Profiles** field, list the profiles you want to build, separated by spaces.
 
    **Examples**:
 
@@ -142,20 +170,20 @@ b. Set up the build profiles:
         graal-jdk-21 opencl-backend ptx-backend spirv-backend
 
 c. Check available profiles:
-   You can find the available profiles in the right-hand vertical bar in IntelliJ under **Maven > Profiles**.
+You can find the available profiles in the right-hand vertical bar in IntelliJ under **Maven > Profiles**.
 
    **Important:** Even though profiles are listed in the Maven pane, you must explicitly configure them in the **_internal_TornadoVM_Maven-cleanAndinstall_** utility. The enablement/disablement of profiles in the Maven pane does not always reflect in this utility.
 
 2. **Configure the TornadoVM Python Build**
 
 a. Navigate to the Python configuration:
-   Go to **Run > Edit Configurations > Python > TornadoVM-Full-Build**
+Go to **Run > Edit Configurations > Python > TornadoVM-Full-Build**
 
 b. Configure the Python interpreter:
-   In the **Use specified interpreter** field, select a valid Python interpreter installed on your system.
+In the **Use specified interpreter** field, select a valid Python interpreter installed on your system.
 
 c. Update environment variables for selected backends:
-   In the **Environmental variables** section, locate the `selected_backends` field. Update the list of backends you want to use, separated by commas.
+In the **Environmental variables** section, locate the `selected_backends` field. Update the list of backends you want to use, separated by commas.
 
    **Examples**:
 
@@ -176,9 +204,21 @@ Configure Applications to Debug/Run
 
 To run and debug Java applications with TornadoVM on IntelliJ, you need to obtain the TornadoVM `JAVA_FLAGS`. Open a terminal and run:
 
+- **macOS/Linux:**
+
    .. code:: bash
 
+      $ cd <path-to-TornadoVM-directory>
       $ source setvars.sh
+      $ tornado --printJavaFlags
+
+- **Windows:**
+
+   .. code:: bash
+
+      $ cd <path-to-TornadoVM-directory>
+      $ .\bin\windowsMicrosoftStudioTools2022.cmd
+      $ setvars.cmd
       $ tornado --printJavaFlags
 
 The output will differ depending on the backends you've built. For example, if you build with all backends, it should be similar to this:
@@ -199,14 +239,14 @@ Copy the flags starting from `-server` to the end.
 2. **Configure new Applications**
 
 a. Add new configurations:
-   Go to **Run > Edit Configurations > Application > Add new run configuration...**
+Go to **Run > Edit Configurations > Application > Add new run configuration...**
 
    Add your own parameters, for example:
 
    - **Name:** MatrixMultiplication2D
    - **VM Options:** Add the flags you copied earlier
-   - **Main class:** e.g., `uk.ac.manchester.tornado.examples.compute.MatrixMultiplication2D`
-   - **Program arguments:** e.g., `128`
+   - **Main class:** e.g. `uk.ac.manchester.tornado.examples.compute.MatrixMultiplication2D`
+   - **Program arguments:** e.g. `128`
 
 b. Apply and run the application.
 

--- a/docs/source/ide-integration.rst
+++ b/docs/source/ide-integration.rst
@@ -1,8 +1,9 @@
 Build and Run with IDE
-======================
+##################################
 
-IntelliJ
---------
+
+JetBrains IntelliJ Installation
+*******************************
 
 Download and install the latest IntelliJ IDEA Community Edition:
 https://www.jetbrains.com/idea/download/
@@ -19,7 +20,7 @@ For IntelliJ to pick up the required TornadoVM dependencies from the `pom.xml` f
 .. _ide_plugins:
 
 Required JetBrains Plugins
-==========================
+**************************
 
 Open IntelliJ and go to **Preferences > Plugins > Browse Repositories**.
 Install the following plugins:
@@ -60,17 +61,19 @@ Install the following plugins:
 
 .. _ide_tornadovm_build:
 
-Build TornadoVM with IntelliJ
-=============================
+Building TornadoVM with IntelliJ
+********************************
 
 Follow these steps to build TornadoVM with IntelliJ.
 
 Prerequisites
--------------
+=============
 
 Ensure that **cmake** is installed and available in your system's PATH.
 
-1. **Check if cmake is in your PATH**
+1. Check if cmake is in the PATH
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
    Verify that your system recognizes `cmake` by running:
 
    .. code:: bash
@@ -79,7 +82,9 @@ Ensure that **cmake** is installed and available in your system's PATH.
 
    If it is recognized, skip the next step. Otherwise, you need to add cmake to your system's PATH.
 
-2. **Add cmake to PATH (macOS/Linux)**
+2. Add cmake to PATH (macOS/Linux)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 You can add `cmake` to your PATH by updating your shell configuration file.
 
 a. Open your shell configuration file (e.g. `.bashrc`, `.zshrc`):
@@ -100,7 +105,8 @@ c. Save and apply the changes:
 
       $ source ~/.zshrc  # or source ~/.bashrc
 
-3. **Add cmake and pyInstaller to PATH (Windows)**
+3. Add cmake and pyInstaller to PATH (Windows)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 a. Find the path of the `cmake` and `pyInstaller` commands:
 Open your shell configuration (e.g. x64 Native Tools Command Prompt for VS 2022) and initialize the environment:
@@ -120,6 +126,8 @@ Verify that your system recognizes `cmake` and `pyInstaller` by running:
 b. Update the PATH:
 You can add the variables to your PATH by searching **Edit the system environment variables**, clicking **Environment Variables...**, and editing the **PATH** with your cmake directory.
 
+**Important:** It is recommended to use the python interpreter under the virtual environment (.venv) as the Python SDK for your TornadoVM project, since it contains all dependent modules (i.e., PyInstaller, psutil) to build TornadoVM and run the tests from IntelliJ.
+
    **Examples**:
 
    .. code:: bash
@@ -130,8 +138,8 @@ You can add the variables to your PATH by searching **Edit the system environmen
 
       <path-to-TornadoVM-directory>\.venv\Scripts
 
-Configure the Project Structure
-===============================
+Configuring the Project Structure
+*********************************
 
 1. Go to **File > Project Structure** and apply the following configurations:
 
@@ -145,14 +153,18 @@ b. In the **Modules** tab:
    - Ensure that the *Language level* of every module matches the project level (e.g. Java 21).
 
 Configuring the TornadoVM Utilities
-===================================
+***********************************
 
-1. **Configure the TornadoVM Maven Build**
+1. Configuring the TornadoVM Maven Build Utility
+================================================
 
-a. Navigate to the Maven configuration:
+a. Navigate to the Maven configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Go to **Run > Edit Configurations > Maven > _internal_TornadoVM_Maven-cleanAndinstall_**
 
-b. Set up the build profiles:
+b. Set up the build profiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In the **Profiles** field, list the profiles you want to build, separated by spaces.
 
    **Examples**:
@@ -169,20 +181,29 @@ In the **Profiles** field, list the profiles you want to build, separated by spa
 
         graal-jdk-21 opencl-backend ptx-backend spirv-backend
 
-c. Check available profiles:
+c. Check available profiles
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 You can find the available profiles in the right-hand vertical bar in IntelliJ under **Maven > Profiles**.
 
    **Important:** Even though profiles are listed in the Maven pane, you must explicitly configure them in the **_internal_TornadoVM_Maven-cleanAndinstall_** utility. The enablement/disablement of profiles in the Maven pane does not always reflect in this utility.
 
-2. **Configure the TornadoVM Python Build**
+2. Configuring the TornadoVM Python Build Utility
+=================================================
 
-a. Navigate to the Python configuration:
+a. Navigate to the Python configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Go to **Run > Edit Configurations > Python > TornadoVM-Full-Build**
 
-b. Configure the Python interpreter:
+b. Configure the Python interpreter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 In the **Use specified interpreter** field, select a valid Python interpreter installed on your system.
 
-c. Update environment variables for selected backends:
+c. Update environment variables for selected backends
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 In the **Environmental variables** section, locate the `selected_backends` field. Update the list of backends you want to use, separated by commas.
 
    **Examples**:
@@ -193,14 +214,13 @@ In the **Environmental variables** section, locate the `selected_backends` field
 
         opencl-backend,ptx-backend,spirv-backend
 
-d. Apply to save your settings and run the build by clicking **Run TornadoVM-Full-Build**.
+Apply to save your settings and run the build by clicking **Run TornadoVM-Full-Build**.
 
-.. _ide_tornadovm_run:
+Configuring Applications to Debug/Run
+*************************************
 
-Configure Applications to Debug/Run
-===================================
-
-1. **Obtain the TornadoVM Java flags**
+1. Obtain the TornadoVM Java flags
+==================================
 
 To run and debug Java applications with TornadoVM on IntelliJ, you need to obtain the TornadoVM `JAVA_FLAGS`. Open a terminal and run:
 
@@ -236,9 +256,11 @@ The output will differ depending on the backends you've built. For example, if y
 
 Copy the flags starting from `-server` to the end.
 
-2. **Configure new Applications**
+2. Configure new Applications
+=============================
 
 a. Add new configurations:
+
 Go to **Run > Edit Configurations > Application > Add new run configuration...**
 
    Add your own parameters, for example:
@@ -250,10 +272,9 @@ Go to **Run > Edit Configurations > Application > Add new run configuration...**
 
 b. Apply and run the application.
 
-.. _ide_checkstyle:
 
-Configure the IDEA CheckStyle
-=============================
+Configuring the IDEA CheckStyle
+*******************************
 
 1. Go to **File > Settings > Tools > CheckStyle**.
 

--- a/docs/source/ide-integration.rst
+++ b/docs/source/ide-integration.rst
@@ -194,7 +194,7 @@ You can find the available profiles in the right-hand vertical bar in IntelliJ u
 a. Navigate to the Python configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Go to **Run > Edit Configurations > Python > TornadoVM-Full-Build**
+Go to **Run > Edit Configurations > Python > TornadoVM-Build**
 
 b. Configure the Python interpreter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -214,7 +214,7 @@ In the **Environmental variables** section, locate the `selected_backends` field
 
         opencl-backend,ptx-backend,spirv-backend
 
-Apply to save your settings and run the build by clicking **Run TornadoVM-Full-Build**.
+Apply to save your settings and run the build by clicking **Run TornadoVM-Build**.
 
 Configuring Applications to Debug/Run
 *************************************

--- a/docs/source/ide-integration.rst
+++ b/docs/source/ide-integration.rst
@@ -1,147 +1,229 @@
-.. _ide-integration:
+.. _build-run-with-ide:
 
-IDE Integration
-===============================
+Build and Run with IDE
+======================
 
 IntelliJ
 --------
 
-Download and install the latest IntelliJ IDEA Community Edition: https://www.jetbrains.com/idea/download/
+Download and install the latest IntelliJ IDEA Community Edition:
+https://www.jetbrains.com/idea/download/
 
-Change the IntelliJ maximum memory to 2 GB or more `(instructions) <https://www.jetbrains.com/help/idea/increasing-memory-heap.html#d1366197e127>`__.
+Change the IntelliJ maximum memory to 2 GB or more (follow `these instructions <https://www.jetbrains.com/help/idea/increasing-memory-heap.html#d1366197e127>`__).
 
-For Intellij to pickup the required Tornado dependencies from the poms, go to **View > Tool Windows > Maven** and select **jdk-8, ptx-backend,
-opencl-backend** under profiles.
+For IntelliJ to pick up the required TornadoVM dependencies from the `pom.xml` file, go to **View > Tool Windows > Maven**, and select the following profiles:
 
-Required Plugins:
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+- **graal-jdk-21**
+- **ptx-backend**
+- **opencl-backend**
+- **spirv-backend**
+
+.. _ide_plugins:
+
+Required JetBrains Plugins
+==========================
 
 Open IntelliJ and go to **Preferences > Plugins > Browse Repositories**.
 Install the following plugins:
 
-1. `Eclipse Code Formatter: <https://plugins.jetbrains.com/plugin/6546-eclipse-code-formatter>`__
-   Formats source code according to eclipse standards (.xml). After the
-   installation of the plugin, go to: **File > Settings > Other Settings
-   > Ecliple Code Formatter**, and select **“Use the Eclipse code
-   formatter”**. Finally, load the TornadoVM code formatter
-   (**./scripts/templates/eclipse-settings/Tornado.xml**) as the Eclipse
-   Java Formatter config file, and click **Apply**.
+1. **Eclipse Code Formatter**
+   Install it from:
+   https://plugins.jetbrains.com/plugin/6546-eclipse-code-formatter
+   This plugin formats source code according to Eclipse standards (.xml).
 
-2. `Save Actions: <https://plugins.jetbrains.com/plugin/7642-save-actions>`__
-   Allows post-save actions (e.g. code formating on save).
+   After installation:
 
-   -  To enable the auto-formatter with save-actions, go to **Settings
-      -> Other Settings -> Save Actions**, and mark the following:
+   - Go to: **File > Settings > Other Settings > Eclipse Code Formatter**
+   - Select **Use the Eclipse code formatter**
+   - Load the TornadoVM code formatter from: `./scripts/templates/eclipse-settings/Tornado.xml`
+   - Click **Apply**
 
-      -  Activate save actions on save
-      -  Activate save actions in shortcut
-      -  Reformat file
+2. **Save Actions**
+   Install it from:
+   https://plugins.jetbrains.com/plugin/7642-save-actions
+   This plugin allows post-save actions (e.g., code formatting on save).
 
-3. `Python Plugin (Optional): <https://plugins.jetbrains.com/plugin/631-python>`__
-   Allows Python scripting.
+   - To enable auto-formatter with save-actions:
+     - Go to: **Settings > Other Settings > Save Actions**
+     - Check the following options:
+     - Activate save actions on save
+     - Activate save actions in shortcut
+     - Reformat file
 
-4. `CheckStyle-IDEA Plugin (Optional): <https://plugins.jetbrains.com/plugin/1065-checkstyle-idea>`__
-    Checks project for compliance with custom checkstyle rules.
+3. **Python Plugin (Optional)**
+   Install it from:
+   https://plugins.jetbrains.com/plugin/631-python
+   Allows Python scripting in IntelliJ.
 
-Run and Debug TornadoVM with Intellij
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+4. **CheckStyle-IDEA Plugin (Optional)**
+   Install it from:
+   https://plugins.jetbrains.com/plugin/1065-checkstyle-idea
+   Checks your project for compliance with custom checkstyle rules.
 
-Normal maven lifecycle goals like *package* and *install* will not
-result a succefull build for TornadoVM.
+.. _ide_tornadovm_build:
 
-Two different configurations are needed for **Build** and **Debug**.
+Build TornadoVM with IntelliJ
+=============================
 
-Build/Run Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Follow these steps to build TornadoVM with IntelliJ.
 
-1. Go to **File > Project Structure** and ensure that:
+Prerequisites
+-------------
 
--  **In the Project Tab:**
+Ensure that **cmake** is installed and available in your system's PATH.
 
-   -  The Project SDK uses the same java version as the project (e.g. Java 17).
-   -  The Project language level is using the same java version (e.g. Java 17 with Lambdas, type annotations etc.).
+1. **Check if cmake is in your PATH:**
+   Verify that your system recognizes `cmake` by running:
 
--  **In the Modules Tab:**
+   .. code:: bash
 
-   -  The module SDK of every module uses the same java version
-      (e.g. 1.8.0_131).
+      $ cmake --version
 
-1. In the right vertical bar in Intellij: **Maven Projects > tornadovm
-   (root) > Lifecycle > package > right click > create tornadovm
-   [package]**
+   If it is recognised, skip the next step. Otherwise, you need to add cmake to your system's PATH.
 
-2. Then: **Run > Edit Configurations > Maven > tornadovm Package**. You
-   need to manually add and check the following information:
+2. **Add cmake to PATH (macOS/Linux):**
+You can add cmake to your PATH by updating your shell configuration file.
 
--  In the **Parameters** tab :
+a. Open your shell configuration file (e.g., `.bashrc`, `.zshrc`):
 
-   -  In **Command line**, add the following:
+   .. code:: bash
 
-      -  ``-Dcmake.root.dir=/home/michalis/opt/cmake-3.10.2-Linux-x86_64/ clean package``
+      $ vim ~/.zshrc  # or ~/.bashrc depending on your shell
 
-         -  In case that you need to reduce the amount of maven warnings
-            add also on the above line the command **–quiet**, which
-            constraints maven verbose to only errors.
+b. Add the following line, replacing `<custom-path>` with the path to your cmake installation:
 
-   -  In **Profiles (separated with space)**, add the following:
+   .. code:: bash
 
-      -  ``jdk-8``
-      -  at least one backend depending on what you want to build
-         ``{opencl-backend, ptx-backend}``
+      $ export PATH=<custom-path>/cmake-3.25.2-macos-universal/CMake.app/Contents/bin:$PATH
 
--  In the **Runner** tab: Ensure that the selected **JRE** corresponds
-   to ``Use Project JDK`` (e.g.1.8.0_131).
+c. Save and apply the changes:
 
-Finally, one the top right corner drop-down menu select the adove
-custome ``tornadovm [package]`` configuration. To build either press the
-**play button** on the top right corner or **Shift+F10**.
+   .. code:: bash
 
-Debug/Run Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+      $ source ~/.zshrc  # or source ~/.bashrc
 
-In order to Run and Debug Java code running through TornadoVM another
-custom configuration is needed. For this configuration the TornadoVM
-``JAVA_FLAGS`` and ``CLASSPATHS`` are needed.
+Configure the Project Structure
+===============================
 
-**Firstly, you need to obtain the ``JAVA_FLAGS`` used by TornadoVM. Use
-the following commands to print the flags:**
+1. Go to **File > Project Structure** and apply the following configurations:
 
-.. code:: bash 
+a. In the **Project** tab:
 
-   $ make BACKENDS={opencl,ptx,spirv}
-   $ tornado --printJavaFlags
+   - The *SDK* uses a valid Java version (e.g., OpenJDK 21, GraalVM JDK 21, etc.).
+   - The *Language level* is set to match the Java version (e.g., Java 21).
 
-Output should be something similar to this:
+b. In the **Modules** tab:
 
-.. code:: bash
+   - Ensure that the *Language level* of every module matches the project level (e.g., Java 21).
 
-   /PATH_TO_JDK/jdk1.8.0_131/bin/java
-   -server -XX:-UseJVMCIClassLoader -XX:-UseCompressedOops -Djava.ext.dirs=/home/michalis/Tornado/tornado/bin/sdk/share/java/tornado -Djava.library.path=/home/michalis/Tornado/tornado/bin/sdk/lib -Dtornado.load.api.implementation=uk.ac.manchester.tornado.runtime.tasks.TornadoTaskGraph -Dtornado.load.runtime.implementation=uk.ac.manchester.tornado.runtime.TornadoCoreRuntime -Dtornado.load.tornado.implementation=uk.ac.manchester.tornado.runtime.common.Tornado
+Configuring the TornadoVM Utilities
+===================================
 
-You need to copy from ``-server`` to end.
+1. **Configure the TornadoVM Maven Build**
 
-**Now, introduce a new Run Configuration**
+a. Navigate to the Maven configuration:
+   Go to **Run > Edit Configurations > Maven > _internal_TornadoVM_Maven-cleanAndinstall_**
 
-Again, **Run > Edit Configurations > Application > Add new (e.g. plus
-sign)**
+b. Set up the build profiles:
+   In the **Profiles** field, list the profiles you want to build, separated by spaces.
 
-Then, add your own parameters similar to the following:
+   **Examples**:
 
--  **Main Class:**
-   uk.ac.manchester.tornado.examples.compute.MatrixMultiplication1D
--  **VM Options:** What you copied from ``-server`` and on
--  **Working Directory:** ``/home/tornadovm``
--  **JRE:** Default (Should point to the 1.8.0_131)
--  **Use classpath of module** Select from drop-down menu e.g
-   ``tornado-examples``
+   - To build with the *graal-jdk-21* and *opencl-backend* profiles, type:
 
-Finally, you can select the new custom configuration by selecting the
-configuration from the right top drop-down menu. Now, you can run it by
-pressing the **play button** on the top right corner or **Shift+F10**.
+     .. code:: text
 
-CheckStyle-IDEA Configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-First, add the custom checkstyle file to enable its rules go to  **IntelliJ > Settings > Tools > CheckStyle** then,
-under configuration file click plus then add the configuration file which is under `tornado-assembly/src/etc/checkstyle.xml`.
+        graal-jdk-21 opencl-backend
 
-Then, on the side on enabled plugins click on checkstyle and then in `rules` topdown menu click the custom rules file.
+   - To build with all backends, type:
+
+     .. code:: text
+
+        graal-jdk-21 opencl-backend ptx-backend spirv-backend
+
+c. Check available profiles:
+   You can find the available profiles in the right-hand vertical bar in IntelliJ under **Maven > Profiles**.
+
+   **Important:** Even though profiles are listed in the Maven pane, you must explicitly configure them in the **_internal_TornadoVM_Maven-cleanAndinstall_** utility. The enablement/disablement of profiles in the Maven pane does not always reflect in this utility.
+
+2. **Configure the TornadoVM Python Build**
+
+a. Navigate to the Python configuration:
+   Go to **Run > Edit Configurations > Python > TornadoVM-Full-Build**
+
+b. Configure the Python interpreter:
+   In the **Use specified interpreter** field, select a valid Python interpreter installed on your system.
+
+c. Update environment variables for selected backends:
+   In the **Environmental variables** section, locate the `selected_backends` field. Update the list of backends you want to use, separated by commas.
+
+   **Examples**:
+
+   - To use all backends, set the value to:
+
+     .. code:: text
+
+        opencl-backend,ptx-backend,spirv-backend
+
+d. Apply to save your settings and run the build by clicking **Run TornadoVM-Full-Build**.
+
+.. _ide_tornadovm_run:
+
+Configure Applications to Debug/Run
+===================================
+
+1. **Obtain the TornadoVM Java flags**
+
+To run and debug Java applications with TornadoVM on IntelliJ, you need to obtain the TornadoVM `JAVA_FLAGS`. Open a terminal and run:
+
+   .. code:: bash
+
+      $ source setvars.sh
+      $ tornado --printJavaFlags
+
+The output will differ depending on the backends you've built. For example, if you build with all backends, it should be similar to this:
+
+   .. code:: bash
+
+      <path-to-TornadoVM-directory>/etc/dependencies/TornadoVM-graal-jdk-21/graalvm-community-openjdk-21.0.1+12.1/bin/java
+      -server -XX:-UseCompressedOops -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -XX:-UseCompressedClassPointers --enable-preview -Djava.library.path=<path-to-TornadoVM-directory>/bin/sdk/lib  --module-path .:<path-to-TornadoVM-directory>/bin/sdk/share/java/tornado
+      -Dtornado.load.api.implementation=uk.ac.manchester.tornado.runtime.tasks.TornadoTaskGraph -Dtornado.load.runtime.implementation=uk.ac.manchester.tornado.runtime.TornadoCoreRuntime -Dtornado.load.tornado.implementation=uk.ac.manchester.tornado.runtime.common.Tornado
+      -Dtornado.load.annotation.implementation=uk.ac.manchester.tornado.annotation.ASMClassVisitor -Dtornado.load.annotation.parallel=uk.ac.manchester.tornado.api.annotations.Parallel  -XX:+UseParallelGC
+      @<path-to-TornadoVM-directory>/bin/sdk/etc/exportLists/common-exports
+      @<path-to-TornadoVM-directory>/bin/sdk/etc/exportLists/opencl-exports
+      @<path-to-TornadoVM-directory>/bin/sdk/etc/exportLists/spirv-exports
+      @<path-to-TornadoVM-directory>/bin/sdk/etc/exportLists/ptx-exports --add-modules ALL-SYSTEM,tornado.runtime,tornado.annotation,tornado.drivers.common,tornado.drivers.opencl,tornado.drivers.opencl,tornado.drivers.ptx
+
+Copy the flags starting from `-server` to the end.
+
+2. **Configure new Applications**
+
+a. Add new configurations:
+   Go to **Run > Edit Configurations > Application > Add new run configuration...**
+
+   Add your own parameters, for example:
+
+   - **Name:** MatrixMultiplication2D
+   - **VM Options:** Add the flags you copied earlier
+   - **Main class:** e.g., `uk.ac.manchester.tornado.examples.compute.MatrixMultiplication2D`
+   - **Program arguments:** e.g., `128`
+
+b. Apply and run the application.
+
+.. _ide_checkstyle:
+
+Configure the IDEA CheckStyle
+=============================
+
+1. Go to **File > Settings > Tools > CheckStyle**.
+
+2. Under **Configuration File**, click the *plus* sign to add a new configuration.
+
+3. Set the description to "TornadoVM Checkstyle".
+
+4. **Use a local Checkstyle file** and point to:
+   `<path-to-TornadoVM-directory>/tornado-assembly/src/etc/checkstyle.xml`.
+
+5. Click **Next**, then **Finish**.
+
+6. Enable the new CheckStyle configuration in the list of active configurations.

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -346,7 +346,7 @@ __TORNADOVM_ENABLE_PROFILER_CONSOLE__ = " -Dtornado.profiler=True "
 if (os.name == 'nt'):
     TORNADO_CMD = "python " + os.path.expandvars(r"%TORNADO_SDK%/bin/tornado").replace("\\", "/") + " "
 else:
-    TORNADO_CMD = "tornado "
+    TORNADO_CMD = os.environ["TORNADO_SDK"] + "/bin/tornado "
 
 ENABLE_ASSERTIONS = "-ea "
 


### PR DESCRIPTION
#### Description

This PR (is an update of #445) and provides the following:
1. a fix in the `tornadovm-installer` script to install `cmake` and `maven` in the path that is compliant with the IDE xml configurations.
2. a fix in the `post-installation` script for building TornadoVM from IntelliJ in Windows OS. This is to trigger the pyInstaller for building the `tornado` executables.
3. update the documentation for the TornadoVM [read-the-docs](https://tornadovm.readthedocs.io/en/latest/ide-integration.html).

The idea is that now TornadoVM users can:
1. build TornadoVM (with one or more backends) from IntelliJ in all OSs (Linux, macOS, Windows).
A user can use the Python application (**TornadoVM-Build**) that is in the repository, and update the Python interpreter and all configurations as described in the instructions (ide-integration.rst).
<img width="915" alt="Screenshot 2024-10-22 at 11 43 33" src="https://github.com/user-attachments/assets/b64dc765-105b-4e6d-899a-516a79621179">

2. run/debug TornadoVM tests from IntelliJ
A user can use the Python application (**TornadoVM-Build**) to run the tornado-test script. The default run invokes with the "--quickPass" argument, but it is configurable from IDE.
<img width="915" alt="Screenshot 2024-10-22 at 11 50 09" src="https://github.com/user-attachments/assets/1921d7cc-b31a-4dbb-976f-b05bf31e2cb2">

4. run/debug Java applications that use TornadoVM from IntelliJ
<img width="905" alt="Screenshot 2024-10-22 at 11 53 05" src="https://github.com/user-attachments/assets/e7395123-0b87-453a-a3d5-b1d52abc2023">

#### Problem description

The [instructions](https://tornadovm.readthedocs.io/en/latest/ide-integration.html) of building/running with IntelliJ in the TornadoVM documentation page are old and not applicable.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

No backends are affected. This PR does not touch the compiler.

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [x] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Instructions are provided in the [instructions (ide-integration.rst)](https://github.com/beehive-lab/TornadoVM/pull/582/files#diff-80072e12dac9fa5efd85975c1a67f6973afd880d3c131dcb03dc93047328e249)

----------------------------------------------------------------------------
