### PR TITLE
Add helper menu by default when args are 0 to the tornado launcher script

### DIFF
--- a/tornado-assembly/src/bin/tornado
+++ b/tornado-assembly/src/bin/tornado
@@ -482,8 +482,13 @@ def parseArguments():
     parser.add_argument("param13", nargs="?")
     parser.add_argument("param14", nargs="?")
     parser.add_argument("param15", nargs="?")
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
     args = parser.parse_args()
-    return args
+    return args 
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Description
If the user runs `tornado` without any args it shows a cryptic error.
Now, with this change, by default it throws the helper menu similar to what `java` does.

```bash 
╰─cmd ➜ tornado
WARNING: Using incubator modules: jdk.incubator.vector
Error: Could not find or load main class None
Caused by: java.lang.ClassNotFoundException: None


```

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
tornado
```
----------------------------------------------------------------------------
