### PR TITLE
[fix] NVIDIA Thread Scheduler for new NVIDIA drivers

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLScheduler.java
@@ -59,7 +59,11 @@ public class OCLScheduler {
         int majorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[0]);
         int minorVersion = Integer.parseInt(device.getDriverVersion().split("\\.")[1]);
 
-        return majorVersion >= NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER && minorVersion >= NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER;
+        if (majorVersion == NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER && minorVersion >= NVIDIA_MINOR_VERSION_GENERIC_SCHEDULER) {
+            return true;
+        } else {
+            return majorVersion > NVIDIA_MAJOR_VERSION_GENERIC_SCHEDULER;
+        }
     }
 
     private static OCLKernelScheduler getInstanceGPUScheduler(final OCLDeviceContext context) {
@@ -67,11 +71,7 @@ public class OCLScheduler {
         if (device.getDeviceVendor().contains(SUPPORTED_VENDORS.AMD.getName())) {
             return new OCLAMDScheduler(context);
         } else if (device.getDeviceVendor().contains(SUPPORTED_VENDORS.NVIDIA.getName())) {
-            if (isDriverVersionCompatible(device)) {
-                return new OCLNVIDIAGPUScheduler(context);
-            } else {
-                return new OCLGenericGPUScheduler(context);
-            }
+            return isDriverVersionCompatible(device) ? new OCLNVIDIAGPUScheduler(context) : new OCLGenericGPUScheduler(context);
         } else {
             return new OCLGenericGPUScheduler(context);
         }


### PR DESCRIPTION
#### Description

This PR fixes the issue #586 by selecting the right scheduler for the OpenCL thread-block dispatcher. 

#### Problem description

The problem was the assumption that the minor version in NVIDIA drivers was sequential and incremental, even across different major versions. This PR fixes this issue. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [X] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
$ make BACKEND=opencl
$ make tests
$ tornado --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.compute.MatrixMultiplication2D
```


