### PR TITLE
Enable Partial Loop Unroll for all Backends

### DIFF
--- a/tornado-assembly/src/etc/exportLists/common-exports
+++ b/tornado-assembly/src/etc/exportLists/common-exports
@@ -96,3 +96,5 @@
 --add-exports jdk.internal.vm.compiler/org.graalvm.compiler.nodes.virtual=tornado.drivers.common
 --add-exports jdk.internal.vm.compiler/org.graalvm.compiler.loop.phases=tornado.drivers.common
 --add-exports jdk.internal.vm.compiler/org.graalvm.compiler.core.common.util=tornado.drivers.common
+--add-exports jdk.internal.vm.compiler/org.graalvm.compiler.phases.tiers=tornado.drivers.common
+--add-exports jdk.internal.vm.compiler/org.graalvm.compiler.phases.common=tornado.drivers.common

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/loops/TornadoPartialLoopUnrollPhase.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/loops/TornadoPartialLoopUnrollPhase.java
@@ -44,7 +44,8 @@ import uk.ac.manchester.tornado.runtime.graal.nodes.TornadoLoopsData;
  * @see org.graalvm.compiler.loop.phases.LoopTransformations
  */
 
-public class TornadoPartialLoopUnroll extends BasePhase<MidTierContext> {
+public class TornadoPartialLoopUnrollPhase extends BasePhase<MidTierContext> {
+
     private static final int LOOP_UNROLL_FACTOR_DEFAULT = 2;
     private static final int LOOP_BOUND_UPPER_LIMIT = 16384;
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLMidTier.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLMidTier.java
@@ -37,7 +37,7 @@ import org.graalvm.compiler.phases.common.RemoveValueProxyPhase;
 
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.guards.BoundCheckEliminationPhase;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.guards.ExceptionCheckingElimination;
-import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoPartialLoopUnroll;
+import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoPartialLoopUnrollPhase;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.memalloc.TornadoPanamaSegmentsHeaderPhase;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.TornadoFloatingReadReplacement;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
@@ -75,7 +75,7 @@ public class OCLMidTier extends TornadoMidTier {
         appendPhase(canonicalizer);
 
         if (TornadoOptions.isPartialUnrollEnabled()) {
-            appendPhase(new TornadoPartialLoopUnroll());
+            appendPhase(new TornadoPartialLoopUnrollPhase());
         }
 
         appendPhase(new MidTierLoweringPhase(canonicalizer));

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXMidTier.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXMidTier.java
@@ -38,8 +38,10 @@ import org.graalvm.compiler.phases.common.ReassociationPhase;
 
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.guards.BoundCheckEliminationPhase;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.guards.ExceptionCheckingElimination;
+import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoPartialLoopUnrollPhase;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.memalloc.TornadoPanamaSegmentsHeaderPhase;
 import uk.ac.manchester.tornado.drivers.ptx.graal.phases.TornadoFloatingReadReplacement;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoMidTier;
 
 public class PTXMidTier extends TornadoMidTier {
@@ -67,6 +69,10 @@ public class PTXMidTier extends TornadoMidTier {
         appendPhase(new GuardLoweringPhase());
 
         appendPhase(canonicalizer);
+
+        if (TornadoOptions.isPartialUnrollEnabled()) {
+            appendPhase(new TornadoPartialLoopUnrollPhase());
+        }
 
         appendPhase(new MidTierLoweringPhase(canonicalizer));
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLIRGenerator.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLIRGenerator.java
@@ -13,7 +13,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -229,13 +229,13 @@ public class SPIRVLIRGenerator extends LIRGenerator {
      * based on a bitwise and operation between two values.
      *
      * @param leftVal
-     *            the left value of a condition
+     *     the left value of a condition
      * @param right
-     *            the right value of a condition
+     *     the right value of a condition
      * @param trueValue
-     *            the true value to move in the result
+     *     the true value to move in the result
      * @param falseValue
-     *            the false value to move in the result
+     *     the false value to move in the result
      * @return Variable: reference to the variable that contains the result
      */
     @Override
@@ -387,8 +387,8 @@ public class SPIRVLIRGenerator extends LIRGenerator {
         return (SPIRVArithmeticTool) super.getArithmetic();
     }
 
-    public void emitConditionalBranch(Value condition, LabelRef trueBranch, LabelRef falseBranch) {
-        append(new SPIRVControlFlow.BranchConditional(condition, trueBranch, falseBranch));
+    public void emitConditionalBranch(Value condition, LabelRef trueBranch, LabelRef falseBranch, int unrollFactor) {
+        append(new SPIRVControlFlow.BranchConditional(condition, trueBranch, falseBranch, unrollFactor));
     }
 
     public void emitJump(LabelRef label, boolean isLoopEdgeBack) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLowTier.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLowTier.java
@@ -62,7 +62,7 @@ public class SPIRVLowTier extends TornadoLowTier {
 
         appendPhase(new LowTierLoweringPhase(canonicalizer));
 
-        if (TornadoOptions.ENABLE_PARTIAL_LOOP_UNROLL) {
+        if (TornadoOptions.ENABLE_SPIRV_LOOP_UNROLL) {
             appendPhase(new PartialLoopUnrollPhase());
         }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLowTier.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLowTier.java
@@ -43,18 +43,28 @@ import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoop
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.utils.DumpLowTierGraph;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.OCLFPGAPragmaPhase;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.OCLFPGAThreadScheduler;
-import uk.ac.manchester.tornado.drivers.spirv.graal.phases.*;
+import uk.ac.manchester.tornado.drivers.spirv.graal.phases.InverseSquareRootPhase;
+import uk.ac.manchester.tornado.drivers.spirv.graal.phases.PartialLoopUnrollPhase;
+import uk.ac.manchester.tornado.drivers.spirv.graal.phases.SPIRVFMAPhase;
+import uk.ac.manchester.tornado.drivers.spirv.graal.phases.SPIRVFP64SupportPhase;
+import uk.ac.manchester.tornado.drivers.spirv.graal.phases.TornadoFixedArrayCopyPhase;
+import uk.ac.manchester.tornado.drivers.spirv.graal.phases.TornadoHalfFloatVectorOffset;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoLowTier;
 
 public class SPIRVLowTier extends TornadoLowTier {
 
     public SPIRVLowTier(OptionValues options, TornadoDeviceContext deviceContext, AddressLoweringByNodePhase.AddressLowering addressLowering) {
-        CanonicalizerPhase canonicalizer = getCannonicalizer(options);
+
+        CanonicalizerPhase canonicalizer = getCannonicalizer();
 
         appendPhase(new SPIRVFP64SupportPhase(deviceContext));
 
         appendPhase(new LowTierLoweringPhase(canonicalizer));
+
+        if (TornadoOptions.ENABLE_PARTIAL_LOOP_UNROLL) {
+            appendPhase(new PartialLoopUnrollPhase());
+        }
 
         if (ConditionalElimination.getValue(options)) {
             appendPhase(new IterativeConditionalEliminationPhase(canonicalizer, false));
@@ -100,7 +110,7 @@ public class SPIRVLowTier extends TornadoLowTier {
         }
     }
 
-    private CanonicalizerPhase getCannonicalizer(OptionValues options) {
+    private CanonicalizerPhase getCannonicalizer() {
         return CanonicalizerPhase.create();
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVMidTier.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVMidTier.java
@@ -37,9 +37,9 @@ import org.graalvm.compiler.phases.common.MidTierLoweringPhase;
 import org.graalvm.compiler.phases.common.ReassociationPhase;
 import org.graalvm.compiler.phases.common.RemoveValueProxyPhase;
 
-import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoPartialLoopUnroll;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.guards.BoundCheckEliminationPhase;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.guards.ExceptionCheckingElimination;
+import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoPartialLoopUnrollPhase;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.memalloc.TornadoPanamaSegmentsHeaderPhase;
 import uk.ac.manchester.tornado.drivers.spirv.graal.phases.TornadoFloatingReadReplacement;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
@@ -88,7 +88,7 @@ public class SPIRVMidTier extends TornadoMidTier {
         appendPhase(canonicalizer);
 
         if (TornadoOptions.isPartialUnrollEnabled()) {
-            appendPhase(new TornadoPartialLoopUnroll());
+            appendPhase(new TornadoPartialLoopUnrollPhase());
         }
 
         appendPhase(new MidTierLoweringPhase(canonicalizer));

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/lir/SPIRVControlFlow.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/lir/SPIRVControlFlow.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -22,6 +22,8 @@
  *
  */
 package uk.ac.manchester.tornado.drivers.spirv.graal.lir;
+
+import java.util.ArrayList;
 
 import org.graalvm.compiler.core.common.cfg.BasicBlock;
 import org.graalvm.compiler.lir.LIRInstruction;
@@ -38,11 +40,15 @@ import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpBranch;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpBranchConditional;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpLabel;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpLoad;
+import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpLoopMerge;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpSwitch;
+import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVCapability;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVId;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVLiteralInteger;
+import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVLoopControl;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVMemoryAccess;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVMultipleOperands;
+import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVOperand;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVOptionalOperand;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVPairLiteralIntegerIdRef;
 import uk.ac.manchester.tornado.drivers.common.logging.Logger;
@@ -112,27 +118,32 @@ public class SPIRVControlFlow {
         @Use
         protected Value condition;
 
-        private LabelRef lirTrueBlock;
-        private LabelRef lirFalseBlock;
+        private final LabelRef lirTrueBlock;
+        private final LabelRef lirFalseBlock;
 
-        public BranchConditional(Value condition, LabelRef lirTrueBlock, LabelRef lirFalseBlock) {
+        private final int unrollFactor;
+
+        public BranchConditional(Value condition, LabelRef lirTrueBlock, LabelRef lirFalseBlock, int unrollFactor) {
             super(TYPE);
             this.condition = condition;
             this.lirTrueBlock = lirTrueBlock;
             this.lirFalseBlock = lirFalseBlock;
+            this.unrollFactor = unrollFactor;
         }
 
         /**
          * It emits the following pattern:
          *
+         * <p>
          * <code>
-         *     OpBranchConditional %condition %trueBranch %falseBranch
+         * OpBranchConditional %condition %trueBranch %falseBranch
          * </code>
+         * </p>
          *
          * @param crb
-         *            {@link SPIRVCompilationResultBuilder crb}
+         *     {@link SPIRVCompilationResultBuilder crb}
          * @param asm
-         *            {@link SPIRVAssembler}
+         *     {@link SPIRVAssembler}
          */
         @Override
         protected void emitCode(SPIRVCompilationResultBuilder crb, SPIRVAssembler asm) {
@@ -141,6 +152,10 @@ public class SPIRVControlFlow {
 
             SPIRVId trueBranch = getIdForBranch(lirTrueBlock, asm);
             SPIRVId falseBranch = getIdForBranch(lirFalseBlock, asm);
+
+            if (unrollFactor != 0) {
+                emitLoopUnrollSuggestion(trueBranch, falseBranch, asm);
+            }
 
             Logger.traceCodeGen(Logger.BACKEND.SPIRV, "emit SPIRVOpBranchConditional: " + condition + "? " + lirTrueBlock + ":" + lirFalseBlock);
 
@@ -152,7 +167,18 @@ public class SPIRVControlFlow {
 
             // Note: we do not need to register a new ID, since this operation does not
             // generate one.
+        }
 
+        private void emitLoopUnrollSuggestion(SPIRVId trueBranch, SPIRVId falseBranch, SPIRVAssembler asm) {
+            Logger.traceCodeGen(Logger.BACKEND.SPIRV, "emit SPIRVOpLoopMerge with Loop Unroll");
+            // With Partial Loop Unroll Suggestion
+            ArrayList<SPIRVOperand> params = new ArrayList<>(1);
+            params.add(new SPIRVLiteralInteger(unrollFactor));
+            SPIRVLoopControl control = new SPIRVLoopControl(256, "PartialCount", params, new SPIRVCapability[0]);
+            asm.currentBlockScope().add(new SPIRVOpLoopMerge(falseBranch, trueBranch, control));
+
+            // With Loop-Unroll suggestion
+            //asm.currentBlockScope().add(new SPIRVOpLoopMerge(falseBranch, trueBranch, SPIRVLoopControl.Unroll()));
         }
     }
 
@@ -172,7 +198,7 @@ public class SPIRVControlFlow {
          * It emits the following pattern:
          *
          * <code>
-         *     SPIRVOpBranch %branch
+         * SPIRVOpBranch %branch
          * </code>
          *
          * @param crb
@@ -206,7 +232,7 @@ public class SPIRVControlFlow {
          * It emits the following pattern:
          *
          * <code>
-         *     SPIRVOpBranch %branch
+         * SPIRVOpBranch %branch
          * </code>
          *
          * @param crb

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/lir/SPIRVControlFlow.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/lir/SPIRVControlFlow.java
@@ -166,14 +166,8 @@ public class SPIRVControlFlow {
         }
 
         private void emitLoopUnrollSuggestion(SPIRVId trueBranch, SPIRVId falseBranch, SPIRVAssembler asm) {
-            Logger.traceCodeGen(Logger.BACKEND.SPIRV, "emit SPIRVOpLoopMerge with Loop Unroll");
-            // With Partial Loop Unroll Suggestion
-            //            ArrayList<SPIRVOperand> params = new ArrayList<>(1);
-            //            params.add(new SPIRVLiteralInteger(unrollFactor));
-            //            SPIRVLoopControl control = new SPIRVLoopControl(256, "PartialCount", params, new SPIRVCapability[0]);
-            //            asm.currentBlockScope().add(new SPIRVOpLoopMerge(falseBranch, trueBranch, control));
-
             // With Loop-Unroll suggestion
+            Logger.traceCodeGen(Logger.BACKEND.SPIRV, "emit SPIRVOpLoopMerge: " + falseBranch + " - " + trueBranch + " - UNROLL");
             asm.currentBlockScope().add(new SPIRVOpLoopMerge(falseBranch, trueBranch, SPIRVLoopControl.Unroll()));
         }
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/lir/SPIRVControlFlow.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/lir/SPIRVControlFlow.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv.graal.lir;
 
-import java.util.ArrayList;
-
 import org.graalvm.compiler.core.common.cfg.BasicBlock;
 import org.graalvm.compiler.lir.LIRInstruction;
 import org.graalvm.compiler.lir.LIRInstructionClass;
@@ -42,13 +40,11 @@ import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpLabel;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpLoad;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpLoopMerge;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpSwitch;
-import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVCapability;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVId;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVLiteralInteger;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVLoopControl;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVMemoryAccess;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVMultipleOperands;
-import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVOperand;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVOptionalOperand;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.operands.SPIRVPairLiteralIntegerIdRef;
 import uk.ac.manchester.tornado.drivers.common.logging.Logger;
@@ -172,13 +168,13 @@ public class SPIRVControlFlow {
         private void emitLoopUnrollSuggestion(SPIRVId trueBranch, SPIRVId falseBranch, SPIRVAssembler asm) {
             Logger.traceCodeGen(Logger.BACKEND.SPIRV, "emit SPIRVOpLoopMerge with Loop Unroll");
             // With Partial Loop Unroll Suggestion
-            ArrayList<SPIRVOperand> params = new ArrayList<>(1);
-            params.add(new SPIRVLiteralInteger(unrollFactor));
-            SPIRVLoopControl control = new SPIRVLoopControl(256, "PartialCount", params, new SPIRVCapability[0]);
-            asm.currentBlockScope().add(new SPIRVOpLoopMerge(falseBranch, trueBranch, control));
+            //            ArrayList<SPIRVOperand> params = new ArrayList<>(1);
+            //            params.add(new SPIRVLiteralInteger(unrollFactor));
+            //            SPIRVLoopControl control = new SPIRVLoopControl(256, "PartialCount", params, new SPIRVCapability[0]);
+            //            asm.currentBlockScope().add(new SPIRVOpLoopMerge(falseBranch, trueBranch, control));
 
             // With Loop-Unroll suggestion
-            //asm.currentBlockScope().add(new SPIRVOpLoopMerge(falseBranch, trueBranch, SPIRVLoopControl.Unroll()));
+            asm.currentBlockScope().add(new SPIRVOpLoopMerge(falseBranch, trueBranch, SPIRVLoopControl.Unroll()));
         }
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/PartialUnrollNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/PartialUnrollNode.java
@@ -13,7 +13,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -28,26 +28,27 @@ import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.FixedWithNextNode;
-import org.graalvm.compiler.nodes.LoopBeginNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
-@NodeInfo
-public class PragmaUnrollNode extends FixedWithNextNode implements LIRLowerable {
+@NodeInfo(shortName = "SPIRVLoopPartialUnroll")
+public class PartialUnrollNode extends FixedWithNextNode implements LIRLowerable {
 
-    @Successor
-    LoopBeginNode loopBgNd;
-    public static final NodeClass<PragmaUnrollNode> TYPE = NodeClass.create(PragmaUnrollNode.class);
+    public static final NodeClass<PartialUnrollNode> TYPE = NodeClass.create(PartialUnrollNode.class);
 
-    private int unroll;
+    private final int partialUnrollFactor;
 
-    public PragmaUnrollNode(int unroll) {
+    public PartialUnrollNode(int unroll) {
         super(TYPE, StampFactory.forVoid());
-        this.unroll = unroll;
+        this.partialUnrollFactor = unroll;
+    }
+
+    public int getPartialUnrollFactor() {
+        return partialUnrollFactor;
     }
 
     @Override
     public void generate(NodeLIRBuilderTool nodeLIRBuilderTool) {
-        throw new RuntimeException("PRAGMA UNROLL NOT SUPPORTED YET");
+
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/PartialLoopUnrollPhase.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/PartialLoopUnrollPhase.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.spirv.graal.phases;
+
+import java.util.Optional;
+
+import org.graalvm.compiler.graph.NodeInputList;
+import org.graalvm.compiler.graph.iterators.NodeIterable;
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.FixedNode;
+import org.graalvm.compiler.nodes.GraphState;
+import org.graalvm.compiler.nodes.IfNode;
+import org.graalvm.compiler.nodes.LoopBeginNode;
+import org.graalvm.compiler.nodes.PhiNode;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.ValuePhiNode;
+import org.graalvm.compiler.nodes.calc.BinaryNode;
+import org.graalvm.compiler.nodes.calc.IntegerLessThanNode;
+import org.graalvm.compiler.phases.Phase;
+
+import jdk.vm.ci.meta.JavaConstant;
+import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.GlobalThreadIdNode;
+import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.PartialUnrollNode;
+
+/**
+ * Compilation phase that inserts a {@link PartialUnrollNode} right after the {@link LoopBeginNode}
+ * only for the loops in which unrolling can be applied. TornadoVM does not unroll parallel loops,
+ * It only inserts a partial unroll for sequential loops within the kernel.
+ *
+ * <p>Note that both "Unroll" and "PartialUnroll" control loop for SPIR-V are considered requests to the
+ * underlying compiler. Thus, these instructions do not force loop unroll.
+ * </p>
+ */
+public class PartialLoopUnrollPhase extends Phase {
+
+    final int LOOP_UNROLL_FACTOR = 32;
+
+    public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
+        return ALWAYS_APPLICABLE;
+    }
+
+    private int getLoopIncrement(ValueNode valueNode) {
+        if (valueNode instanceof PhiNode phiNode) {
+            ValueNode incrementOperation = phiNode.values().get(1);
+            if (incrementOperation instanceof BinaryNode binaryNode) {
+                if (binaryNode.getX() instanceof ConstantNode constantNode) {
+                    return constantNode.asJavaConstant().asInt();
+                } else if (binaryNode.getY() instanceof ConstantNode constantNode) {
+                    return constantNode.asJavaConstant().asInt();
+                }
+            }
+        }
+        return 1;
+    }
+
+    private int getLoopBound(ValueNode valueNode) {
+        if (valueNode instanceof ConstantNode constantNode) {
+            JavaConstant javaConstant = constantNode.asJavaConstant();
+            return javaConstant.asInt();
+        }
+        return 0;
+    }
+
+    @Override
+    protected void run(StructuredGraph graph) {
+
+        graph.getNodes().filter(LoopBeginNode.class).forEach(loopBeginNode -> {
+            boolean candidateForUnroll = true;
+            NodeIterable<ValuePhiNode> valuePhiNodes = loopBeginNode.valuePhis();
+            // obtain the loop bound
+            int loopBound = 0;
+
+            // set the default increment
+            int increments = 1;
+
+            // We get the graal unroll factor to detect if graal also will inline the loop
+            int graalUnrollFactor = loopBeginNode.getUnrollFactor();
+
+            // Obtain loop bound and increments
+            if (loopBeginNode.next() instanceof IfNode ifNode) {
+                if (ifNode.condition() instanceof IntegerLessThanNode lessThanNode) {
+                    loopBound = getLoopBound(lessThanNode.getY());
+                    increments = getLoopIncrement(lessThanNode.getX());
+                }
+            }
+
+            // Detect loop is parallel or sequential
+            for (ValuePhiNode phiNode : valuePhiNodes) {
+                NodeInputList<ValueNode> values = phiNode.values();
+                for (ValueNode value : values) {
+                    if (value instanceof GlobalThreadIdNode) {
+                        // We detected a parallel loop, thus, we avoid the insertion
+                        // of the partial loop unroll.
+                        candidateForUnroll = false;
+                        break;
+                    }
+                }
+                if (!candidateForUnroll) {
+                    break;
+                }
+            }
+
+            if (graalUnrollFactor == loopBound) {
+                // loop was fully unrolled by graalJTT
+                return;
+            }
+
+            loopBound /= graalUnrollFactor;
+            loopBound /= increments;
+
+            if (candidateForUnroll && loopBound != 0) {
+                // Insert unroll node
+                // TODO: Pass the unroll factor from the API level
+
+                // Depending on LoopBound, check if we can apply unroll
+                if ((loopBound > LOOP_UNROLL_FACTOR) && (loopBound % LOOP_UNROLL_FACTOR == 0)) {
+                    System.out.println("Applying Loop Unrolling --> " + loopBound);
+                    PartialUnrollNode partialUnrollNode = graph.addOrUnique(new PartialUnrollNode(LOOP_UNROLL_FACTOR));
+                    FixedNode successorLoop = loopBeginNode.next();
+                    loopBeginNode.setNext(partialUnrollNode);
+                    partialUnrollNode.setNext(successorLoop);
+                }
+            }
+        });
+    }
+}

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/PartialLoopUnrollPhase.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/PartialLoopUnrollPhase.java
@@ -137,7 +137,6 @@ public class PartialLoopUnrollPhase extends Phase {
 
                 // Depending on LoopBound, check if we can apply unroll
                 if ((loopBound > LOOP_UNROLL_FACTOR) && (loopBound % LOOP_UNROLL_FACTOR == 0)) {
-                    System.out.println("Applying Loop Unrolling --> " + loopBound);
                     PartialUnrollNode partialUnrollNode = graph.addOrUnique(new PartialUnrollNode(LOOP_UNROLL_FACTOR));
                     FixedNode successorLoop = loopBeginNode.next();
                     loopBeginNode.setNext(partialUnrollNode);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -350,7 +350,7 @@ public class TornadoOptions {
     /**
      * Set Loop unrolling factor for the FPGA compilation. Default is set to 2.
      */
-    public static final int UNROLL_FACTOR = Integer.parseInt(getProperty("tornado.unroll.factor", "2"));
+    public static final int UNROLL_FACTOR = Integer.parseInt(getProperty("tornado.unroll.factor", "4"));
 
     /**
      * Enable basic debug information. Disabled by default.

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -129,6 +129,11 @@ public class TornadoOptions {
      * Enable/Disable FMA Optimizations. True by default.
      */
     public static final boolean ENABLE_FMA = getBooleanValue("tornado.enable.fma", TRUE);
+
+    /**
+     * Enable/Disable Partial Loop Unroll: True by default
+     */
+    public static final boolean ENABLE_PARTIAL_LOOP_UNROLL = getBooleanValue("tornado.enable.loopunroll", TRUE);
     /**
      * Enable/Disable Fix Reads Optimization. True by default.
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -419,7 +419,7 @@ public class TornadoOptions {
      * @return boolean.
      */
     public static boolean isPartialUnrollEnabled() {
-        return getBooleanValue("tornado.experimental.partial.unroll", FALSE);
+        return getBooleanValue("tornado.experimental.partial.unroll", TRUE);
     }
 
     private static boolean getBooleanValue(String property, String defaultValue) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -131,9 +131,11 @@ public class TornadoOptions {
     public static final boolean ENABLE_FMA = getBooleanValue("tornado.enable.fma", TRUE);
 
     /**
-     * Enable/Disable Partial Loop Unroll: True by default
+     * Enable/Disable Loop Unroll SPIR-V instruction: True by default.
+     *
+     * <p>This flag only applies for the SPIR-V Backend</p>
      */
-    public static final boolean ENABLE_PARTIAL_LOOP_UNROLL = getBooleanValue("tornado.enable.loopunroll", TRUE);
+    public static final boolean ENABLE_SPIRV_LOOP_UNROLL = getBooleanValue("tornado.spirv.loopunroll", TRUE);
     /**
      * Enable/Disable Fix Reads Optimization. True by default.
      */
@@ -419,7 +421,7 @@ public class TornadoOptions {
      * @return boolean.
      */
     public static boolean isPartialUnrollEnabled() {
-        return getBooleanValue("tornado.experimental.partial.unroll", TRUE);
+        return getBooleanValue("tornado.experimental.partial.unroll", FALSE);
     }
 
     private static boolean getBooleanValue(String property, String defaultValue) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -348,7 +348,7 @@ public class TornadoOptions {
     }
 
     /**
-     * Set Loop unrolling factor for the FPGA compilation. Default is set to 2.
+     * Set Loop unrolling factor. Default is set to 4.
      */
     public static final int UNROLL_FACTOR = Integer.parseInt(getProperty("tornado.unroll.factor", "4"));
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskDataContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/meta/TaskDataContext.java
@@ -38,6 +38,7 @@ import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.TornadoEvents;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.runtime.EventSet;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.domain.DomainTree;
 
@@ -318,5 +319,9 @@ public class TaskDataContext extends AbstractRTContext {
     @Override
     public String toString() {
         return String.format("task meta data: domain=%s, global workgroup size=%s%n", domain, (getGlobalWork() == null) ? "null" : formatWorkDimensionArray(getGlobalWork(), "1"));
+    }
+
+    public boolean applyPartialLoopUnroll() {
+        return TornadoOptions.isPartialUnrollEnabled();
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
@@ -293,8 +293,7 @@ public class TestMatrices extends TornadoTestBase {
                 .task("t0", TestMatrices::matrixVector, matrix, vector, result, N) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
 
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
             executionPlan.execute();
         }
 


### PR DESCRIPTION
#### Description

This patch enhances the JIT compiler with a phase for partial loop unroll and full loop unroll suggestions for SPIR-V.

In a nutshell: 
1. It introduces a full loop unroll suggestion for the SPIR-V compiler. 
2. It introduces partial loop unroller for the PTX compiler.
3. It fixes the partial loop unroll configuration for OpenCL 
4. It enables partial loop unroll for OpenCL 

Note that the partial loop unroll flag is **off** by default, since more experimentation is needed.  If `ON`, there are some tests failing (~14) due to some failures in the Graal JIT compiler. However, for some compute applications this optimisations must be beneficial, and, in the case of the SPIR-V, it works in combination of SPIR-V unroll suggestions as well as explicit loop unroll. 

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash

## In the case of SPIR-V
make BACKEND=spirv

tornado-test --printKernel --jvm="-Dgraph.mv.device=0:0" -V uk.ac.manchester.tornado.unittests.compute.ComputeTests#matrixVector
```

A section of the generated code is as follows:

```llvm
   %B3_kernel0 = OpLabel 
   %102 = OpPhi %float {%55 %B2_kernel0} {%101 %B4_kernel0} 
   %104 = OpPhi %uint {%56 %B2_kernel0} {%103 %B4_kernel0} 
   %105 = OpSLessThan %bool %104 %51
   OpLoopMerge %B5_kernel0 %B4_kernel0 Unroll          << Loop Unroll suggestion enabled
   OpBranchConditional %105 %B4_kernel0 %B5_kernel0 
```

Enabling explicit loop unroll:

```bash
tornado-test --printKernel --jvm="-Dgraph.mv.device=0:0 -Dtornado.experimental.partial.unroll=True" -V uk.ac.manchester.tornado.unittests.compute.ComputeTests#matrixVector
```

Run the previous command for each of the backends.
