### PR TITLE
[TensorAPI] Add initial support for TensorQ8 to support quantization and dequantization of Floats

### DIFF
--- a/tornado-api/src/main/java/module-info.java
+++ b/tornado-api/src/main/java/module-info.java
@@ -16,6 +16,7 @@
  *
  */
 module tornado.api {
+    requires jdk.unsupported;
     exports uk.ac.manchester.tornado.api;
     exports uk.ac.manchester.tornado.api.annotations;
     exports uk.ac.manchester.tornado.api.common;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
+import uk.ac.manchester.tornado.api.types.tensors.GGMLType;
 
 /**
  * This class represents an array of bytes stored in native memory.
@@ -59,6 +60,23 @@ public final class ByteArray extends TornadoNativeArray {
 
         segment = Arena.ofAuto().allocate(segmentByteSize, 1);
         segment.setAtIndex(JAVA_INT, 0, numberOfElements);
+    }
+
+    public ByteArray(int numberOfElements, boolean noHeader) {
+        this.numberOfElements = numberOfElements;
+        baseIndex=0;
+        segmentByteSize = numberOfElements * BYTE_BYTES;
+        segment = Arena.ofAuto().allocate(segmentByteSize, 1);
+//        segment.setAtIndex(JAVA_INT, 0, numberOfElements);
+    }
+
+
+    public ByteArray(int numberOfElements, long requiredStorageSize) {
+        this.numberOfElements = numberOfElements;
+        baseIndex=0;
+//        segmentByteSize = numberOfElements * BYTE_BYTES;
+        segment = Arena.ofAuto().allocate(requiredStorageSize, 1);
+        //        segment.setAtIndex(JAVA_INT, 0, numberOfElements);
     }
 
     /**
@@ -119,6 +137,14 @@ public final class ByteArray extends TornadoNativeArray {
         long byteSize = segment.byteSize();
         int numElements = (int) (byteSize / BYTE_BYTES);
         ByteArray byteArray = new ByteArray(numElements);
+        MemorySegment.copy(segment, 0, byteArray.segment, byteArray.baseIndex * BYTE_BYTES, byteSize);
+        return byteArray;
+    }
+
+    public static ByteArray fromSegment(MemorySegment segment, boolean noHeader) {
+        long byteSize = segment.byteSize();
+        int numElements = (int) (byteSize / BYTE_BYTES);
+        ByteArray byteArray = new ByteArray(numElements, noHeader);
         MemorySegment.copy(segment, 0, byteArray.segment, byteArray.baseIndex * BYTE_BYTES, byteSize);
         return byteArray;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/Float16.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/Float16.java
@@ -1,0 +1,7 @@
+package uk.ac.manchester.tornado.api.types.tensors;
+
+
+public final class Float16 {
+    public static final int BYTES = 2;
+}
+

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/GGMLType.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/GGMLType.java
@@ -1,0 +1,66 @@
+package uk.ac.manchester.tornado.api.types.tensors;
+
+public enum GGMLType {
+    F32(Float.BYTES),
+    F16(Float16.BYTES),
+    Q4_0(Float16.BYTES + 16 * Byte.BYTES, 32),
+    Q4_1(2 * Float16.BYTES + 16 * Byte.BYTES, 32),
+    UNSUPPORTED_Q4_2(Integer.MAX_VALUE), // support has been removed
+    UNSUPPORTED_Q4_3(Integer.MAX_VALUE), // support has been removed
+    Q5_0(Integer.MAX_VALUE),
+    Q5_1(Integer.MAX_VALUE),
+    Q8_0(Float16.BYTES + 32 * Byte.BYTES, 32),
+    Q8_1(32 * Byte.BYTES + 2 * Float.BYTES, 32),
+    // k-quantizations
+    Q2_K(Integer.MAX_VALUE),
+    Q3_K(Integer.MAX_VALUE),
+    Q4_K(2 * Float16.BYTES + ((GGMLType.QK_K / 16) / 8 * 6) + GGMLType.QK_K / 2, GGMLType.QK_K),
+    Q5_K(2 * Float16.BYTES + ((GGMLType.QK_K / 16) / 8 * 6) + GGMLType.QK_K / 8 + GGMLType.QK_K / 2, GGMLType.QK_K),
+    Q6_K(GGMLType.QK_K / 2 + GGMLType.QK_K / 4 + GGMLType.QK_K / 16 + Float16.BYTES, GGMLType.QK_K),
+    Q8_K(Integer.MAX_VALUE),
+    I8(Byte.BYTES),
+    I16(Short.BYTES),
+    I32(Integer.BYTES);
+
+    private static final GGMLType[] VALUES = values();
+
+    private final int typeSize;
+
+    private final int blockSize;
+
+    public int getTypeSize() {
+        return typeSize;
+    }
+
+    public int getBlockSize() {
+        return blockSize;
+    }
+
+    public static GGMLType fromId(int id) {
+        return VALUES[id];
+    }
+
+    GGMLType(int typeSize) {
+        this(typeSize, 1);
+    }
+
+    public long byteSizeFor(int numberOfElements) {
+        long t = numberOfElements * (long) getTypeSize();
+        assert t % getBlockSize() == 0;
+        return Math.toIntExact(t / getBlockSize());
+    }
+
+    public static final int QK_K = 256; // or 64?
+
+    GGMLType(int typeSize, int blockSize) {
+        assert blockSize > 0;
+        assert typeSize > 0;
+        assert isPowerOf2(blockSize);
+        this.typeSize = typeSize;
+        this.blockSize = blockSize;
+    }
+
+    private static boolean isPowerOf2(int n) {
+        return n > 0 && (n & (n - 1)) == 0;
+    }
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/Shape.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/Shape.java
@@ -45,7 +45,8 @@ public record Shape(long... dimensions) {
      * @return the total size of the shape as an int
      */
     public int getSize() {
-        return (int) Arrays.stream(dimensions).reduce(1, (a, b) -> a * b);
+        assert Arrays.stream(dimensions).allMatch(i -> i > 0);
+        return (int) Arrays.stream(dimensions).reduce(Math::multiplyExact).orElseThrow();
     }
 
     @Override

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/TensorQ8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/TensorQ8.java
@@ -1,56 +1,165 @@
+/*
+ * Copyright (c) 2013-2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package uk.ac.manchester.tornado.api.types.tensors;
 
-import sun.misc.Unsafe;
-import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
-import uk.ac.manchester.tornado.api.types.arrays.LongArray;
+import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
+import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.lang.reflect.Field;
 
 public class TensorQ8 extends Tensor {
-    private final DType dType;
+    private final boolean  DEBUG_TENSOR_Q8 = false;
+    private final ByteArray tensorStorage;
+    private final int numberOfElements;
     private final Shape shape;
+    private final DType dType;
 
-    private final HalfFloatArray tensorStorage;
+    private final int blockSize;
+    private final int bytesPerBlock;
 
-    private int numberOfElements;
-
+    private static final int HEADER_SIZE = (int) TornadoNativeArray.ARRAY_HEADER;
 
     public TensorQ8(Shape shape) {
-        super(DType.HALF_FLOAT, shape);
+        super(DType.QINT8, shape);
         this.shape = shape;
         this.numberOfElements = shape.getSize();
-        this.dType = DType.HALF_FLOAT;
-        this.tensorStorage = new HalfFloatArray(numberOfElements);
+        this.dType = DType.QINT8;
+        this.blockSize = GGMLType.Q8_0.getBlockSize();
+
+        // Each block contains:
+        // - 2 bytes for float16 scale
+        // - blockSize bytes for quantized values
+        this.bytesPerBlock = Float16.BYTES + blockSize;
+
+        // Calculate number of blocks needed to store all elements
+        int numBlocks = (numberOfElements + blockSize - 1) / blockSize;
+
+        // Calculate total storage size in bytes, including header
+        long dataSize = (long)numBlocks * bytesPerBlock;
+        long totalSize = dataSize + HEADER_SIZE;
+
+        if (DEBUG_TENSOR_Q8) {
+            System.out.println("Debug info:");
+            System.out.println("Number of elements: " + numberOfElements);
+            System.out.println("Block size: " + blockSize);
+            System.out.println("Bytes per block: " + bytesPerBlock);
+            System.out.println("Number of blocks: " + numBlocks);
+            System.out.println("Data size: " + dataSize);
+            System.out.println("Header size: " + HEADER_SIZE);
+            System.out.println("Total size with header: " + totalSize);
+        }
+
+        this.tensorStorage = new ByteArray(numberOfElements, totalSize);
     }
 
+    private float[] getBlockValues(int blockIndex) {
+        float[] values = new float[blockSize];
+        int blockOffset = blockIndex * bytesPerBlock;
 
-    public TensorQ8(int size, MemorySegment memorySegment) {
-        super(DType.HALF_FLOAT, new Shape(size));
-        this.dType = DType.HALF_FLOAT;
-        this.shape = new Shape(size);
-        this.numberOfElements = size;
-        this.tensorStorage = HalfFloatArray.fromSegment(memorySegment);
+        try {
+            float scale = Float.float16ToFloat(readShort(tensorStorage.getSegmentWithHeader(), HEADER_SIZE + blockOffset));
+            for (int i = 0; i < blockSize; i++) {
+                byte quant = readByte(tensorStorage.getSegmentWithHeader(), HEADER_SIZE + blockOffset + Float16.BYTES + i);
+                values[i] = quant * scale;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read block " + blockIndex +
+                    " at offset " + blockOffset + ": " + e.getMessage());
+        }
+        return values;
+    }
+
+    public float getFloat(int index) {
+        if (index < 0 || index >= numberOfElements) {
+            throw new IndexOutOfBoundsException("Index " + index + " out of bounds for length " + numberOfElements);
+        }
+
+        int blockIndex = index / blockSize;
+        int withinBlockIndex = index % blockSize;
+        int blockOffset = blockIndex * bytesPerBlock;
+
+        try {
+            float scale = Float.float16ToFloat(readShort(tensorStorage.getSegmentWithHeader(), HEADER_SIZE + blockOffset));
+            byte quant = readByte(tensorStorage.getSegmentWithHeader(), HEADER_SIZE + blockOffset + Float16.BYTES + withinBlockIndex);
+            return quant * scale;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get float at index " + index +
+                    " (block " + blockIndex + ", offset " + blockOffset + "): " + e.getMessage());
+        }
+    }
+
+    public void setFloat(int index, float value) {
+        if (index < 0 || index >= numberOfElements) {
+            throw new IndexOutOfBoundsException("Index " + index + " out of bounds for length " + numberOfElements);
+        }
+
+        int blockIndex = index / blockSize;
+        int withinBlockIndex = index % blockSize;
+
+        // Get current block values
+        float[] blockValues = getBlockValues(blockIndex);
+        blockValues[withinBlockIndex] = value;
+
+        // Compute optimal scale for block
+        float scale = computeOptimalScale(blockValues);
+
+        // Update block
+        int blockOffset = blockIndex * bytesPerBlock;
+
+        try {
+            // Write scale
+            writeShort(tensorStorage.getSegmentWithHeader(), HEADER_SIZE + blockOffset, Float.floatToFloat16(scale));
+
+            // Write quantized values
+            for (int i = 0; i < blockValues.length; i++) {
+                int quantized = Math.min(127, Math.max(-128, Math.round(blockValues[i] / scale)));
+                writeByte(tensorStorage.getSegmentWithHeader(), HEADER_SIZE + blockOffset + Float16.BYTES + i, (byte)quantized);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set float at index " + index +
+                    " (block " + blockIndex + ", offset " + blockOffset + "): " + e.getMessage());
+        }
+    }
+
+    private float computeOptimalScale(float[] values) {
+        float maxAbs = 1e-5f;
+        for (float value : values) {
+            maxAbs = Math.max(maxAbs, Math.abs(value));
+        }
+        return maxAbs / 127.0f;
     }
 
 
     static short readShort(MemorySegment memorySegment, long offset) {
-        return memorySegment.get(ValueLayout.JAVA_SHORT, memorySegment.address()+offset);
+        return memorySegment.get(ValueLayout.JAVA_SHORT, offset);
     }
 
     static byte readByte(MemorySegment memorySegment, long offset) {
-        return memorySegment.get(ValueLayout.JAVA_BYTE, memorySegment.address()+offset);
+        return memorySegment.get(ValueLayout.JAVA_BYTE, offset);
     }
 
-    public float getFloat(int index) {
-        assert 0 <= index && index < numberOfElements;
-        int blockIndex = index / GGMLType.Q8_0.getBlockSize();
-        int withinBlockIndex = index % GGMLType.Q8_0.getBlockSize();
-        int blockOffset = blockIndex * GGMLType.Q8_0.getTypeSize();
-        byte quant = readBy te(tensorStorage.getSegment(), blockOffset + Float16.BYTES + withinBlockIndex);
-        float scale = Float.float16ToFloat(readShort(tensorStorage.getSegment(), blockOffset));
-        return quant * scale;
+    static void writeShort(MemorySegment memorySegment, long offset, short value) {
+        memorySegment.set(ValueLayout.JAVA_SHORT, offset, value);
+    }
+
+    static void writeByte(MemorySegment memorySegment, long offset, byte value) {
+        memorySegment.set(ValueLayout.JAVA_BYTE, offset, value);
     }
 
     @Override
@@ -60,17 +169,17 @@ public class TensorQ8 extends Tensor {
 
     @Override
     public String getDTypeAsString() {
-        return "";
+        return dType.QINT8.toString();
     }
 
     @Override
     public DType getDType() {
-        return dType;
+        return DType.QINT8;
     }
 
     @Override
     public int getSize() {
-        return numberOfElements;
+        return shape.getSize();
     }
 
     @Override
@@ -100,6 +209,6 @@ public class TensorQ8 extends Tensor {
 
     @Override
     public int getElementSize() {
-        return numberOfElements;
+        return getSize();
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/TensorQ8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/TensorQ8.java
@@ -1,0 +1,105 @@
+package uk.ac.manchester.tornado.api.types.tensors;
+
+import sun.misc.Unsafe;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.LongArray;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.reflect.Field;
+
+public class TensorQ8 extends Tensor {
+    private final DType dType;
+    private final Shape shape;
+
+    private final HalfFloatArray tensorStorage;
+
+    private int numberOfElements;
+
+
+    public TensorQ8(Shape shape) {
+        super(DType.HALF_FLOAT, shape);
+        this.shape = shape;
+        this.numberOfElements = shape.getSize();
+        this.dType = DType.HALF_FLOAT;
+        this.tensorStorage = new HalfFloatArray(numberOfElements);
+    }
+
+
+    public TensorQ8(int size, MemorySegment memorySegment) {
+        super(DType.HALF_FLOAT, new Shape(size));
+        this.dType = DType.HALF_FLOAT;
+        this.shape = new Shape(size);
+        this.numberOfElements = size;
+        this.tensorStorage = HalfFloatArray.fromSegment(memorySegment);
+    }
+
+
+    static short readShort(MemorySegment memorySegment, long offset) {
+        return memorySegment.get(ValueLayout.JAVA_SHORT, memorySegment.address()+offset);
+    }
+
+    static byte readByte(MemorySegment memorySegment, long offset) {
+        return memorySegment.get(ValueLayout.JAVA_BYTE, memorySegment.address()+offset);
+    }
+
+    public float getFloat(int index) {
+        assert 0 <= index && index < numberOfElements;
+        int blockIndex = index / GGMLType.Q8_0.getBlockSize();
+        int withinBlockIndex = index % GGMLType.Q8_0.getBlockSize();
+        int blockOffset = blockIndex * GGMLType.Q8_0.getTypeSize();
+        byte quant = readByte(tensorStorage.getSegment(), blockOffset + Float16.BYTES + withinBlockIndex);
+        float scale = Float.float16ToFloat(readShort(tensorStorage.getSegment(), blockOffset));
+        return quant * scale;
+    }
+
+    @Override
+    public Shape getShape() {
+        return null;
+    }
+
+    @Override
+    public String getDTypeAsString() {
+        return "";
+    }
+
+    @Override
+    public DType getDType() {
+        return null;
+    }
+
+    @Override
+    public int getSize() {
+        return 0;
+    }
+
+    @Override
+    public MemorySegment getSegment() {
+        return null;
+    }
+
+    @Override
+    public MemorySegment getSegmentWithHeader() {
+        return null;
+    }
+
+    @Override
+    public long getNumBytesOfSegmentWithHeader() {
+        return 0;
+    }
+
+    @Override
+    public long getNumBytesOfSegment() {
+        return 0;
+    }
+
+    @Override
+    protected void clear() {
+
+    }
+
+    @Override
+    public int getElementSize() {
+        return 0;
+    }
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/TensorQ8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/TensorQ8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
  * The University of Manchester.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/TensorQ8.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors/TensorQ8.java
@@ -48,14 +48,14 @@ public class TensorQ8 extends Tensor {
         int blockIndex = index / GGMLType.Q8_0.getBlockSize();
         int withinBlockIndex = index % GGMLType.Q8_0.getBlockSize();
         int blockOffset = blockIndex * GGMLType.Q8_0.getTypeSize();
-        byte quant = readByte(tensorStorage.getSegment(), blockOffset + Float16.BYTES + withinBlockIndex);
+        byte quant = readBy te(tensorStorage.getSegment(), blockOffset + Float16.BYTES + withinBlockIndex);
         float scale = Float.float16ToFloat(readShort(tensorStorage.getSegment(), blockOffset));
         return quant * scale;
     }
 
     @Override
     public Shape getShape() {
-        return null;
+        return shape;
     }
 
     @Override
@@ -65,32 +65,32 @@ public class TensorQ8 extends Tensor {
 
     @Override
     public DType getDType() {
-        return null;
+        return dType;
     }
 
     @Override
     public int getSize() {
-        return 0;
+        return numberOfElements;
     }
 
     @Override
     public MemorySegment getSegment() {
-        return null;
+        return tensorStorage.getSegment();
     }
 
     @Override
     public MemorySegment getSegmentWithHeader() {
-        return null;
+        return tensorStorage.getSegmentWithHeader();
     }
 
     @Override
     public long getNumBytesOfSegmentWithHeader() {
-        return 0;
+        return tensorStorage.getNumBytesOfSegmentWithHeader();
     }
 
     @Override
     public long getNumBytesOfSegment() {
-        return 0;
+        return tensorStorage.getNumBytesOfSegment();
     }
 
     @Override
@@ -100,6 +100,6 @@ public class TensorQ8 extends Tensor {
 
     @Override
     public int getElementSize() {
-        return 0;
+        return numberOfElements;
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorQ8.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorQ8.java
@@ -1,0 +1,312 @@
+package uk.ac.manchester.tornado.unittests.tensors;
+
+import org.junit.Assert;
+import org.junit.Test;
+import uk.ac.manchester.tornado.api.types.tensors.GGMLType;
+import uk.ac.manchester.tornado.api.types.tensors.Shape;
+import uk.ac.manchester.tornado.api.types.tensors.TensorQ8;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+
+public class TestTensorQ8 extends TornadoTestBase {
+
+    @Test
+    public void testBasicQuantization() {
+        // Test with a simple 1D tensor
+        Shape shape = new Shape(1);
+        TensorQ8 tensor = new TensorQ8(shape);
+
+        // Test setting and getting a single value
+        float testValue = 1.5f;
+        tensor.setFloat(0, testValue);
+        float retrieved = tensor.getFloat(0);
+        System.out.println("Segment size for storing single value " + tensor.getSegment().byteSize());
+        Assert.assertEquals(testValue, retrieved, 0.1f);
+    }
+
+    @Test
+    public void testTensorQ8SetAndGetFloat() {
+        // Define the shape and create a tensor
+        Shape shape = new Shape(5); // 1D tensor with 128 elements
+        TensorQ8 tensorQ8 = new TensorQ8(shape);
+
+        // Set some values in the tensor using setFloat and then retrieve them with getFloat
+        float[] valuesToSet = {0.5f, -1.0f, 25.0f, -30.5f, 0.0f};
+        for (int i = 0; i < valuesToSet.length; i++) {
+            tensorQ8.setFloat(i, valuesToSet[i]);
+        }
+
+        // Check that each retrieved value matches the set value within tolerance
+        for (int i = 0; i < valuesToSet.length; i++) {
+            Assert.assertEquals(valuesToSet[i], tensorQ8.getFloat(i), 0.1f);
+        }
+    }
+
+    @Test
+    public void testTensorQ8SetAndGetFloatVerify() {
+        // Use a size that's aligned with Q8_0 block size (typically 32 elements)
+        int blockSize = GGMLType.Q8_0.getBlockSize();  // Should be 32
+        Shape shape = new Shape(blockSize);  // Use full block size
+        TensorQ8 tensorQ8 = new TensorQ8(shape);
+
+        // Create test values array matching the block size
+        float[] valuesToSet = new float[blockSize];
+        // Fill with repeating pattern
+        float[] pattern = {0.5f, -1.0f, 25.0f, -30.5f, 0.0f};
+        for (int i = 0; i < blockSize; i++) {
+            valuesToSet[i] = pattern[i % pattern.length];
+        }
+
+        // Print expected layout information
+        System.out.println("Total elements: " + shape.getSize());
+        System.out.println("Block size: " + blockSize);
+        System.out.println("Total allocated bytes: " + tensorQ8.getSegment().byteSize());
+
+        // Set values
+        for (int i = 0; i < valuesToSet.length; i++) {
+            tensorQ8.setFloat(i, valuesToSet[i]);
+            // Immediately verify each value after setting
+            float retrieved = tensorQ8.getFloat(i);
+            System.out.printf("Index %d: Set=%.2f Retrieved=%.2f%n",
+                    i, valuesToSet[i], retrieved);
+            Assert.assertEquals("Value mismatch at index " + i,
+                    valuesToSet[i], retrieved, 0.1f);
+        }
+
+        // Verify all values again
+        for (int i = 0; i < valuesToSet.length; i++) {
+            float retrieved = tensorQ8.getFloat(i);
+            Assert.assertEquals("Final verification failed at index " + i,
+                    valuesToSet[i], retrieved, 0.1f);
+        }
+    }
+
+    @Test
+    public void testMixedScaleValues() {
+        // Test handling of mixed scales within a block
+        Shape shape = new Shape(GGMLType.Q8_0.getBlockSize());
+        TensorQ8 tensorQ8 = new TensorQ8(shape);
+
+        // Set values with very different scales
+        tensorQ8.setFloat(0, 100.0f);
+        tensorQ8.setFloat(1, 0.001f);
+        tensorQ8.setFloat(2, -100.0f);
+        tensorQ8.setFloat(3, -0.001f);
+
+        // Verify large values maintain reasonable accuracy
+        Assert.assertEquals(100.0f, tensorQ8.getFloat(0), 1.0f);
+        Assert.assertEquals(-100.0f, tensorQ8.getFloat(2), 1.0f);
+
+        // Small values might have less precision but should maintain sign
+        float small1 = tensorQ8.getFloat(1);
+        float small2 = tensorQ8.getFloat(3);
+        Assert.assertTrue("Small positive value lost sign", small1 >= 0);
+        Assert.assertTrue("Small negative value lost sign", small2 <= 0);
+    }
+
+    @Test
+    public void testQuantizationRange() {
+        // Test extreme values and quantization handling
+        Shape shape = new Shape(GGMLType.Q8_0.getBlockSize());
+        TensorQ8 tensorQ8 = new TensorQ8(shape);
+
+        // Test values in separate blocks to maintain scale independence
+        float[] testValues = {
+                0.0f,              // Zero
+                1e-6f,            // Very small positive
+                -1e-6f,           // Very small negative
+                100.0f,           // Large positive
+                -100.0f,          // Large negative
+        };
+
+        for (int i = 0; i < testValues.length; i++) {
+            tensorQ8.setFloat(i, testValues[i]);
+            float retrieved = tensorQ8.getFloat(i);
+
+            // For very small values, check if they're close to zero
+            if (Math.abs(testValues[i]) < 1e-5f) {
+                Assert.assertTrue("Small value not close to zero",
+                        Math.abs(retrieved) < 1e-4f);
+            } else {
+                // For larger values, check relative error
+                float relativeError = Math.abs((retrieved - testValues[i]) / testValues[i]);
+                Assert.assertTrue("Large relative error at index " + i +
+                                ": expected=" + testValues[i] + ", got=" + retrieved,
+                        relativeError < 0.01f);
+            }
+        }
+    }
+
+    @Test
+    public void testInt8Range() {
+        // Test the full INT8 range in a dedicated test
+        Shape shape = new Shape(GGMLType.Q8_0.getBlockSize());
+        TensorQ8 tensorQ8 = new TensorQ8(shape);
+
+        // Set a few values at INT8 boundaries
+        float[] boundaryValues = {
+                -128.0f,   // Min INT8
+                -127.0f,
+                -64.0f,
+                0.0f,
+                63.0f,
+                126.0f,
+                127.0f     // Max INT8
+        };
+
+        // Set values one at a time to ensure same scale
+        for (int i = 0; i < boundaryValues.length; i++) {
+            tensorQ8.setFloat(i, boundaryValues[i]);
+            float retrieved = tensorQ8.getFloat(i);
+            System.out.printf("INT8 boundary test: Setting %.1f, got %.1f%n",
+                    boundaryValues[i], retrieved);
+            Assert.assertEquals("Value mismatch at INT8 boundary " + boundaryValues[i],
+                    boundaryValues[i], retrieved, 1.0f);  // Allow 1.0 tolerance for boundary values
+        }
+    }
+
+    @Test
+    public void testIndependentBlocks() {
+        // Test that blocks can handle different scales independently
+        int blockSize = GGMLType.Q8_0.getBlockSize();
+        Shape shape = new Shape(blockSize * 3);  // 3 blocks
+        TensorQ8 tensorQ8 = new TensorQ8(shape);
+
+        System.out.println("\nTesting independent blocks with different scales:");
+
+        // Block 1: Small values (0.1 to 1.0)
+        System.out.println("\nBlock 1 - Small values:");
+        for (int i = 0; i < blockSize; i++) {
+            float value = 0.1f + (0.9f * i / blockSize);
+            tensorQ8.setFloat(i, value);
+            float retrieved = tensorQ8.getFloat(i);
+            System.out.printf("Index %d: Set=%.6f Got=%.6f Diff=%.6f%n",
+                    i, value, retrieved, Math.abs(value - retrieved));
+        }
+
+        // Block 2: Medium values (10 to 20)
+        System.out.println("\nBlock 2 - Medium values:");
+        for (int i = 0; i < blockSize; i++) {
+            float value = 10.0f + (10.0f * i / blockSize);
+            tensorQ8.setFloat(blockSize + i, value);
+            float retrieved = tensorQ8.getFloat(blockSize + i);
+            System.out.printf("Index %d: Set=%.6f Got=%.6f Diff=%.6f%n",
+                    i, value, retrieved, Math.abs(value - retrieved));
+        }
+
+        // Block 3: Large values (100 to 200)
+        System.out.println("\nBlock 3 - Large values:");
+        for (int i = 0; i < blockSize; i++) {
+            float value = 100.0f + (100.0f * i / blockSize);
+            tensorQ8.setFloat(2 * blockSize + i, value);
+            float retrieved = tensorQ8.getFloat(2 * blockSize + i);
+            System.out.printf("Index %d: Set=%.6f Got=%.6f Diff=%.6f%n",
+                    i, value, retrieved, Math.abs(value - retrieved));
+        }
+
+        // Verify blocks maintain reasonable accuracy
+        System.out.println("\nVerifying accuracy for each block:");
+
+        // Helper function to check max absolute difference in a block
+        for (int block = 0; block < 3; block++) {
+            float maxDiff = 0.0f;
+            float maxRelErr = 0.0f;
+            float minVal = Float.MAX_VALUE;
+            float maxVal = Float.MIN_VALUE;
+
+            for (int i = 0; i < blockSize; i++) {
+                int idx = block * blockSize + i;
+                float original = (block == 0) ? (0.1f + (0.9f * i / blockSize)) :
+                        (block == 1) ? (10.0f + (10.0f * i / blockSize)) :
+                                (100.0f + (100.0f * i / blockSize));
+                float retrieved = tensorQ8.getFloat(idx);
+                float diff = Math.abs(original - retrieved);
+                float relErr = diff / Math.abs(original);
+
+                maxDiff = Math.max(maxDiff, diff);
+                maxRelErr = Math.max(maxRelErr, relErr);
+                minVal = Math.min(minVal, retrieved);
+                maxVal = Math.max(maxVal, retrieved);
+            }
+
+            System.out.printf("Block %d stats:%n", block);
+            System.out.printf("  Value range: %.6f to %.6f%n", minVal, maxVal);
+            System.out.printf("  Max absolute difference: %.6f%n", maxDiff);
+            System.out.printf("  Max relative error: %.6f%%%n", maxRelErr * 100);
+
+            // Verify block maintains reasonable range and accuracy
+            float expectedMaxErr;
+            if (block == 0) {  // Small values
+                expectedMaxErr = 0.5f;  // Larger relative error acceptable for small values
+            } else if (block == 1) {  // Medium values
+                expectedMaxErr = 0.2f;  // 20% error acceptable for medium values
+            } else {  // Large values
+                expectedMaxErr = 0.1f;  // 10% error acceptable for large values
+            }
+
+            Assert.assertTrue(
+                    String.format("Block %d error too large: %.2f%% > %.2f%%",
+                            block, maxRelErr * 100, expectedMaxErr * 100),
+                    maxRelErr < expectedMaxErr);
+        }
+    }
+
+    @Test
+    public void testConstantBlock() {
+        // Test how well we can represent a constant value
+        int blockSize = GGMLType.Q8_0.getBlockSize();
+        Shape shape = new Shape(blockSize);
+        TensorQ8 tensorQ8 = new TensorQ8(shape);
+
+        float testValue = 10.0f;
+        System.out.println("\nTesting constant value block:");
+
+        // Set all values in block to same value
+        for (int i = 0; i < blockSize; i++) {
+            tensorQ8.setFloat(i, testValue);
+        }
+
+        // Verify values
+        float maxDiff = 0.0f;
+        for (int i = 0; i < blockSize; i++) {
+            float retrieved = tensorQ8.getFloat(i);
+            float diff = Math.abs(retrieved - testValue);
+            maxDiff = Math.max(maxDiff, diff);
+            System.out.printf("Index %d: Expected=%.6f Got=%.6f Diff=%.6f%n",
+                    i, testValue, retrieved, diff);
+        }
+
+        float relativeError = maxDiff / Math.abs(testValue);
+        System.out.printf("Maximum relative error: %.6f%%%n", relativeError * 100);
+
+        Assert.assertTrue(
+                String.format("Relative error too large for constant block: %.2f%%",
+                        relativeError * 100),
+                relativeError < 0.1f);  // Expect very good accuracy for constant values
+    }
+
+    @Test
+    public void testSingleBlockPrecision() {
+        // Test precision within a single block using relative error metrics
+        Shape shape = new Shape(GGMLType.Q8_0.getBlockSize());
+        TensorQ8 tensorQ8 = new TensorQ8(shape);
+
+        float baseValue = 10.0f;  // Use a reasonable base value
+
+        System.out.println("\nTesting single block precision:");
+        for (int i = 0; i < shape.getSize(); i++) {
+            float value = baseValue * (i + 1) / shape.getSize();  // Spread values evenly
+            tensorQ8.setFloat(i, value);
+            float retrieved = tensorQ8.getFloat(i);
+            float relativeError = Math.abs((retrieved - value) / value);
+
+            System.out.printf("Index %d: Set=%.6f Got=%.6f RelError=%.6f%n",
+                    i, value, retrieved, relativeError);
+
+            Assert.assertTrue(String.format(
+                            "Relative error too large at index %d: expected=%.6f, got=%.6f, relative error=%.6f",
+                            i, value, retrieved, relativeError),
+                    relativeError < 0.1f);  // Allow 10% relative error
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorQ8.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorQ8.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package uk.ac.manchester.tornado.unittests.tensors;
 
 import org.junit.Assert;
@@ -7,7 +24,14 @@ import uk.ac.manchester.tornado.api.types.tensors.Shape;
 import uk.ac.manchester.tornado.api.types.tensors.TensorQ8;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
-
+/**
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.tensors.TestTensorQ8
+ * </code>
+ */
 public class TestTensorQ8 extends TornadoTestBase {
 
     @Test


### PR DESCRIPTION
#### Description
***NO CODE GEN SUPPORT***

This PR adds support for Q8 tensor quantization in TornadoVM. The implementation includes:

* A new TensorQ8 class that implements 8-bit quantization with float16 scales
* Block-based quantization where each block has its own scale factor
* Comprehensive test suite validating quantization accuracy and behavior
* Memory-efficient storage using native memory segments
* Support for both positive and negative values with proper scaling


The implementation shows good accuracy with relative errors typically below 1% for medium to large values and good preservation of small values.

#### Problem description
N/A - This is a feature addition to support 8-bit quantized tensors which are essential for efficient deep learning model deployment.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash 
tornado-test -V uk.ac.manchester.tornado.unittests.tensors.TestTensorQ8
``` 

Expected output: 

```bash 
Segment size for storing single value 34
Total elements: 32
Block size: 32
Total allocated bytes: 34
Index 0: Set=0.50 Retrieved=0.50
Index 1: Set=-1.00 Retrieved=-1.00
Index 2: Set=25.00 Retrieved=25.01
Index 3: Set=-30.50 Retrieved=-30.49
Index 4: Set=0.00 Retrieved=0.00
Index 5: Set=0.50 Retrieved=0.48
Index 6: Set=-1.00 Retrieved=-0.96
Index 7: Set=25.00 Retrieved=24.97
Index 8: Set=-30.50 Retrieved=-30.49
Index 9: Set=0.00 Retrieved=0.00
Index 10: Set=0.50 Retrieved=0.48
Index 11: Set=-1.00 Retrieved=-0.96
Index 12: Set=25.00 Retrieved=24.97
Index 13: Set=-30.50 Retrieved=-30.49
Index 14: Set=0.00 Retrieved=0.00
Index 15: Set=0.50 Retrieved=0.48
Index 16: Set=-1.00 Retrieved=-0.96
Index 17: Set=25.00 Retrieved=24.97
Index 18: Set=-30.50 Retrieved=-30.49
Index 19: Set=0.00 Retrieved=0.00
Index 20: Set=0.50 Retrieved=0.48
Index 21: Set=-1.00 Retrieved=-0.96
Index 22: Set=25.00 Retrieved=24.97
Index 23: Set=-30.50 Retrieved=-30.49
Index 24: Set=0.00 Retrieved=0.00
Index 25: Set=0.50 Retrieved=0.48
Index 26: Set=-1.00 Retrieved=-0.96
Index 27: Set=25.00 Retrieved=24.97
Index 28: Set=-30.50 Retrieved=-30.49
Index 29: Set=0.00 Retrieved=0.00
Index 30: Set=0.50 Retrieved=0.48
Index 31: Set=-1.00 Retrieved=-0.96
INT8 boundary test: Setting -128.0, got -128.0
INT8 boundary test: Setting -127.0, got -127.0
INT8 boundary test: Setting -64.0, got -64.5
INT8 boundary test: Setting 0.0, got 0.0
INT8 boundary test: Setting 63.0, got 63.5
INT8 boundary test: Setting 126.0, got 126.0
INT8 boundary test: Setting 127.0, got 127.0

Testing independent blocks with different scales:

Block 1 - Small values:
Index 0: Set=0.100000 Got=0.099982 Diff=0.000018
Index 1: Set=0.128125 Got=0.128141 Diff=0.000016
Index 2: Set=0.156250 Got=0.156240 Diff=0.000010
Index 3: Set=0.184375 Got=0.184340 Diff=0.000035
Index 4: Set=0.212500 Got=0.212560 Diff=0.000060
Index 5: Set=0.240625 Got=0.240659 Diff=0.000034
Index 6: Set=0.268750 Got=0.268637 Diff=0.000113
Index 7: Set=0.296875 Got=0.296978 Diff=0.000103
Index 8: Set=0.325000 Got=0.325077 Diff=0.000077
Index 9: Set=0.353125 Got=0.353176 Diff=0.000051
Index 10: Set=0.381250 Got=0.381275 Diff=0.000025
Index 11: Set=0.409375 Got=0.409374 Diff=0.000001
Index 12: Set=0.437500 Got=0.437473 Diff=0.000027
Index 13: Set=0.465625 Got=0.465572 Diff=0.000053
Index 14: Set=0.493750 Got=0.493671 Diff=0.000079
Index 15: Set=0.521875 Got=0.521770 Diff=0.000105
Index 16: Set=0.550000 Got=0.549870 Diff=0.000130
Index 17: Set=0.578125 Got=0.577969 Diff=0.000156
Index 18: Set=0.606250 Got=0.606068 Diff=0.000182
Index 19: Set=0.634375 Got=0.634167 Diff=0.000208
Index 20: Set=0.662500 Got=0.662266 Diff=0.000234
Index 21: Set=0.690625 Got=0.690849 Diff=0.000224
Index 22: Set=0.718750 Got=0.718948 Diff=0.000198
Index 23: Set=0.746875 Got=0.747047 Diff=0.000172
Index 24: Set=0.775000 Got=0.775146 Diff=0.000147
Index 25: Set=0.803125 Got=0.803246 Diff=0.000121
Index 26: Set=0.831250 Got=0.831345 Diff=0.000095
Index 27: Set=0.859375 Got=0.859444 Diff=0.000069
Index 28: Set=0.887500 Got=0.887543 Diff=0.000043
Index 29: Set=0.915625 Got=0.915642 Diff=0.000017
Index 30: Set=0.943750 Got=0.943741 Diff=0.000009
Index 31: Set=0.971875 Got=0.971840 Diff=0.000035

Block 2 - Medium values:
Index 0: Set=10.000000 Got=9.999390 Diff=0.000610
Index 1: Set=10.312500 Got=10.309448 Diff=0.003052
Index 2: Set=10.625000 Got=10.627258 Diff=0.002258
Index 3: Set=10.937500 Got=10.937317 Diff=0.000183
Index 4: Set=11.250000 Got=11.247375 Diff=0.002625
Index 5: Set=11.562500 Got=11.565186 Diff=0.002686
Index 6: Set=11.875000 Got=11.875244 Diff=0.000244
Index 7: Set=12.187500 Got=12.185303 Diff=0.002197
Index 8: Set=12.500000 Got=12.503113 Diff=0.003113
Index 9: Set=12.812500 Got=12.813171 Diff=0.000671
Index 10: Set=13.125000 Got=13.123230 Diff=0.001770
Index 11: Set=13.437500 Got=13.441040 Diff=0.003540
Index 12: Set=13.750000 Got=13.751099 Diff=0.001099
Index 13: Set=14.062500 Got=14.061157 Diff=0.001343
Index 14: Set=14.375000 Got=14.371216 Diff=0.003784
Index 15: Set=14.687500 Got=14.689026 Diff=0.001526
Index 16: Set=15.000000 Got=14.999084 Diff=0.000916
Index 17: Set=15.312500 Got=15.309143 Diff=0.003357
Index 18: Set=15.625000 Got=15.626953 Diff=0.001953
Index 19: Set=15.937500 Got=15.937012 Diff=0.000488
Index 20: Set=16.250000 Got=16.247070 Diff=0.002930
Index 21: Set=16.562500 Got=16.557129 Diff=0.005371
Index 22: Set=16.875000 Got=16.882690 Diff=0.007690
Index 23: Set=17.187500 Got=17.192749 Diff=0.005249
Index 24: Set=17.500000 Got=17.502808 Diff=0.002808
Index 25: Set=17.812500 Got=17.812866 Diff=0.000366
Index 26: Set=18.125000 Got=18.122925 Diff=0.002075
Index 27: Set=18.437500 Got=18.432983 Diff=0.004517
Index 28: Set=18.750000 Got=18.743042 Diff=0.006958
Index 29: Set=19.062500 Got=19.068604 Diff=0.006104
Index 30: Set=19.375000 Got=19.378662 Diff=0.003662
Index 31: Set=19.687500 Got=19.688721 Diff=0.001221

Block 3 - Large values:
Index 0: Set=100.000000 Got=100.024902 Diff=0.024902
Index 1: Set=103.125000 Got=103.125488 Diff=0.000488
Index 2: Set=106.250000 Got=106.226074 Diff=0.023926
Index 3: Set=109.375000 Got=109.388672 Diff=0.013672
Index 4: Set=112.500000 Got=112.489258 Diff=0.010742
Index 5: Set=115.625000 Got=115.651855 Diff=0.026855
Index 6: Set=118.750000 Got=118.752441 Diff=0.002441
Index 7: Set=121.875000 Got=121.853027 Diff=0.021973
Index 8: Set=125.000000 Got=125.015625 Diff=0.015625
Index 9: Set=128.125000 Got=128.116211 Diff=0.008789
Index 10: Set=131.250000 Got=131.216797 Diff=0.033203
Index 11: Set=134.375000 Got=134.317383 Diff=0.057617
Index 12: Set=137.500000 Got=137.541992 Diff=0.041992
Index 13: Set=140.625000 Got=140.642578 Diff=0.017578
Index 14: Set=143.750000 Got=143.743164 Diff=0.006836
Index 15: Set=146.875000 Got=146.843750 Diff=0.031250
Index 16: Set=150.000000 Got=149.944336 Diff=0.055664
Index 17: Set=153.125000 Got=153.168945 Diff=0.043945
Index 18: Set=156.250000 Got=156.269531 Diff=0.019531
Index 19: Set=159.375000 Got=159.370117 Diff=0.004883
Index 20: Set=162.500000 Got=162.470703 Diff=0.029297
Index 21: Set=165.625000 Got=165.571289 Diff=0.053711
Index 22: Set=168.750000 Got=168.795898 Diff=0.045898
Index 23: Set=171.875000 Got=171.896484 Diff=0.021484
Index 24: Set=175.000000 Got=174.997070 Diff=0.002930
Index 25: Set=178.125000 Got=178.097656 Diff=0.027344
Index 26: Set=181.250000 Got=181.198242 Diff=0.051758
Index 27: Set=184.375000 Got=184.422852 Diff=0.047852
Index 28: Set=187.500000 Got=187.523438 Diff=0.023438
Index 29: Set=190.625000 Got=190.624023 Diff=0.000977
Index 30: Set=193.750000 Got=193.724609 Diff=0.025391
Index 31: Set=196.875000 Got=196.825195 Diff=0.049805

Verifying accuracy for each block:
Block 0 stats:
  Value range: 0.107132 to 0.971840
  Max absolute difference: 0.011900
  Max relative error: 7.131957%
Block 1 stats:
  Value range: 10.231934 to 19.688721
  Max absolute difference: 0.377197
  Max relative error: 3.352865%
Block 2 stats:
  Value range: 102.287109 to 196.825195
  Max absolute difference: 2.743164
  Max relative error: 2.287109%

Testing constant value block:
Index 0: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 1: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 2: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 3: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 4: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 5: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 6: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 7: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 8: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 9: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 10: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 11: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 12: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 13: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 14: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 15: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 16: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 17: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 18: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 19: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 20: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 21: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 22: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 23: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 24: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 25: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 26: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 27: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 28: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 29: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 30: Expected=10.000000 Got=9.999390 Diff=0.000610
Index 31: Expected=10.000000 Got=9.999390 Diff=0.000610
Maximum relative error: 0.006104%

Testing single block precision:
Index 0: Set=0.312500 Got=0.312481 RelError=0.000061
Index 1: Set=0.625000 Got=0.624962 RelError=0.000061
Index 2: Set=0.937500 Got=0.937443 RelError=0.000061
Index 3: Set=1.250000 Got=1.249924 RelError=0.000061
Index 4: Set=1.562500 Got=1.562889 RelError=0.000249
Index 5: Set=1.875000 Got=1.874886 RelError=0.000061
Index 6: Set=2.187500 Got=2.187851 RelError=0.000160
Index 7: Set=2.500000 Got=2.499847 RelError=0.000061
Index 8: Set=2.812500 Got=2.811844 RelError=0.000233
Index 9: Set=3.125000 Got=3.125778 RelError=0.000249
Index 10: Set=3.437500 Got=3.437775 RelError=0.000080
Index 11: Set=3.750000 Got=3.749771 RelError=0.000061
Index 12: Set=4.062500 Got=4.061768 RelError=0.000180
Index 13: Set=4.375000 Got=4.375702 RelError=0.000160
Index 14: Set=4.687500 Got=4.685760 RelError=0.000371
Index 15: Set=5.000000 Got=4.999695 RelError=0.000061
Index 16: Set=5.312500 Got=5.313629 RelError=0.000213
Index 17: Set=5.625000 Got=5.623688 RelError=0.000233
Index 18: Set=5.937500 Got=5.937622 RelError=0.000021
Index 19: Set=6.250000 Got=6.251556 RelError=0.000249
Index 20: Set=6.562500 Got=6.561615 RelError=0.000135
Index 21: Set=6.875000 Got=6.875549 RelError=0.000080
Index 22: Set=7.187500 Got=7.185608 RelError=0.000263
Index 23: Set=7.500000 Got=7.499542 RelError=0.000061
Index 24: Set=7.812500 Got=7.813477 RelError=0.000125
Index 25: Set=8.125000 Got=8.123535 RelError=0.000180
Index 26: Set=8.437500 Got=8.441345 RelError=0.000456
Index 27: Set=8.750000 Got=8.751404 RelError=0.000160
Index 28: Set=9.062500 Got=9.061462 RelError=0.000114
Index 29: Set=9.375000 Got=9.371521 RelError=0.000371
Index 30: Set=9.687500 Got=9.689331 RelError=0.000189
Index 31: Set=10.000000 Got=9.999390 RelError=0.000061
Test: class uk.ac.manchester.tornado.unittests.tensors.TestTensorQ8
	Running test: testBasicQuantization      ................  [PASS] 
	Running test: testTensorQ8SetAndGetFloat ................  [PASS] 
	Running test: testTensorQ8SetAndGetFloatVerify ................  [PASS] 
	Running test: testMixedScaleValues       ................  [PASS] 
	Running test: testQuantizationRange      ................  [PASS] 
	Running test: testInt8Range              ................  [PASS] 
	Running test: testIndependentBlocks      ................  [PASS] 
	Running test: testConstantBlock          ................  [PASS] 
	Running test: testSingleBlockPrecision   ................  [PASS] 
Test ran: 9, Failed: 0, Unsupported: 0

``` 
----------------------------------------------------------------------------
