### PR TITLE
[Fix] Replace Invalid OpenCL Representation of Infinity Constants for `Float.POSITIVE_INFINITY` and `Float.NEGATIVE_INFINITY`

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -198,6 +198,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.codegen.CodeGenTest"),
     TestEntry("uk.ac.manchester.tornado.unittests.atomics.TestAtomics"),
     TestEntry("uk.ac.manchester.tornado.unittests.compute.ComputeTests"),
+    TestEntry("uk.ac.manchester.tornado.unittests.compute.MMwithBytes"),
     TestEntry("uk.ac.manchester.tornado.unittests.dynamic.TestDynamic"),
     TestEntry("uk.ac.manchester.tornado.unittests.vector.api.TestVectorAPI"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestConcat"),

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLowTier.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLowTier.java
@@ -40,6 +40,7 @@ import uk.ac.manchester.tornado.api.TornadoDeviceContext;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.analysis.TornadoFeatureExtraction;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoopCanonicalization;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.utils.DumpLowTierGraph;
+import uk.ac.manchester.tornado.drivers.opencl.graal.phases.InfinityReplacementPhase;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.InverseSquareRootPhase;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.OCLFMAPhase;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.OCLFP16SupportPhase;
@@ -99,6 +100,8 @@ public class OCLLowTier extends TornadoLowTier {
         if (TornadoOptions.MATH_OPTIMIZATIONS) {
             appendPhase(new InverseSquareRootPhase());
         }
+
+        appendPhase(new InfinityReplacementPhase());
 
         appendPhase(new TornadoAtomicsParametersPhase());
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/InfinityReplacementPhase.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/InfinityReplacementPhase.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.opencl.graal.phases;
 
 import jdk.vm.ci.meta.JavaConstant;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/InfinityReplacementPhase.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/InfinityReplacementPhase.java
@@ -21,7 +21,7 @@
 package uk.ac.manchester.tornado.drivers.opencl.graal.phases;
 
 import jdk.vm.ci.meta.JavaConstant;
-]import org.graalvm.compiler.nodes.GraphState;
+import org.graalvm.compiler.nodes.GraphState;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.phases.Phase;
 
@@ -40,42 +40,28 @@ public class InfinityReplacementPhase  extends Phase {
     @Override
     protected void run(StructuredGraph graph) {
         graph.getNodes().filter(ConstantNode.class).forEach(constantNode -> {
-
-
-            String resultValue = constantNode.getValue().toValueString(); // Get the result of the division
+            String resultValue = constantNode.getValue().toValueString();
             if (resultValue.equals("Infinity") || resultValue.equals("-Infinity")) {
-
-                if (resultValue.equals("Infinity")) {
-                    ConstantNode constantOne = ConstantNode.forConstant(JavaConstant.forFloat(1.0f), null, graph);
-                    ConstantNode constantZero = ConstantNode.forConstant(JavaConstant.forFloat(0.0f), null, graph);
-
-                    // Step 2: Create the division node (1.0f / 0.0f)
-                    FloatDivNode divisionNode = new FloatDivNode(constantOne, constantZero);
-
-                    // Add the division node to the graph
-                    graph.addOrUnique(divisionNode);
-
-                    constantNode.replaceAtUsages(divisionNode);
-                    if (constantNode.hasNoUsages()) {
-                        constantNode.safeDelete();
-                    }
-
-                } else if (resultValue.equals("-Infinity")) {
-                    ConstantNode constantMinusOne = ConstantNode.forConstant(JavaConstant.forFloat(-1.0f), null, graph);
-                    ConstantNode constantZero = ConstantNode.forConstant(JavaConstant.forFloat(0.0f), null, graph);
-
-                    // Step 2: Create the division node (1.0f / 0.0f)
-                    FloatDivNode divisionNode = new FloatDivNode(constantMinusOne, constantZero);
-
-                    // Add the division node to the graph
-                    graph.addOrUnique(divisionNode);
-
-                    constantNode.replaceAtUsages(divisionNode);
-                    if (constantNode.hasNoUsages()) {
-                        constantNode.safeDelete();
-                    }
-                }
+                float constantValue = resultValue.equals("Infinity") ? 1.0f : -1.0f;
+                replaceWithDivisionNode(constantValue, graph, constantNode);
             }
         });
     }
+
+    private void replaceWithDivisionNode(float constantValue, StructuredGraph graph, ConstantNode constantNode) {
+        ConstantNode constant = ConstantNode.forConstant(JavaConstant.forFloat(constantValue), null, graph);
+        ConstantNode constantZero = ConstantNode.forConstant(JavaConstant.forFloat(0.0f), null, graph);
+
+        // Create the division node (constantValue / 0.0f)
+        FloatDivNode divisionNode = new FloatDivNode(constant, constantZero);
+
+        // Add the division node to the graph
+        graph.addOrUnique(divisionNode);
+
+        constantNode.replaceAtUsages(divisionNode);
+        if (constantNode.hasNoUsages()) {
+            constantNode.safeDelete();
+        }
+    }
+
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/InfinityReplacementPhase.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/InfinityReplacementPhase.java
@@ -1,0 +1,61 @@
+package uk.ac.manchester.tornado.drivers.opencl.graal.phases;
+
+import jdk.vm.ci.meta.JavaConstant;
+]import org.graalvm.compiler.nodes.GraphState;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.phases.Phase;
+
+import java.util.Optional;
+
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.calc.FloatDivNode;
+
+
+public class InfinityReplacementPhase  extends Phase {
+    @Override
+    public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
+        return ALWAYS_APPLICABLE;
+    }
+
+    @Override
+    protected void run(StructuredGraph graph) {
+        graph.getNodes().filter(ConstantNode.class).forEach(constantNode -> {
+
+
+            String resultValue = constantNode.getValue().toValueString(); // Get the result of the division
+            if (resultValue.equals("Infinity") || resultValue.equals("-Infinity")) {
+
+                if (resultValue.equals("Infinity")) {
+                    ConstantNode constantOne = ConstantNode.forConstant(JavaConstant.forFloat(1.0f), null, graph);
+                    ConstantNode constantZero = ConstantNode.forConstant(JavaConstant.forFloat(0.0f), null, graph);
+
+                    // Step 2: Create the division node (1.0f / 0.0f)
+                    FloatDivNode divisionNode = new FloatDivNode(constantOne, constantZero);
+
+                    // Add the division node to the graph
+                    graph.addOrUnique(divisionNode);
+
+                    constantNode.replaceAtUsages(divisionNode);
+                    if (constantNode.hasNoUsages()) {
+                        constantNode.safeDelete();
+                    }
+
+                } else if (resultValue.equals("-Infinity")) {
+                    ConstantNode constantMinusOne = ConstantNode.forConstant(JavaConstant.forFloat(-1.0f), null, graph);
+                    ConstantNode constantZero = ConstantNode.forConstant(JavaConstant.forFloat(0.0f), null, graph);
+
+                    // Step 2: Create the division node (1.0f / 0.0f)
+                    FloatDivNode divisionNode = new FloatDivNode(constantMinusOne, constantZero);
+
+                    // Add the division node to the graph
+                    graph.addOrUnique(divisionNode);
+
+                    constantNode.replaceAtUsages(divisionNode);
+                    if (constantNode.hasNoUsages()) {
+                        constantNode.safeDelete();
+                    }
+                }
+            }
+        });
+    }
+}

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/InfinityReplacementPhase.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/InfinityReplacementPhase.java
@@ -30,13 +30,27 @@ import java.util.Optional;
 import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.calc.FloatDivNode;
 
-
+/**
+ * The {@link InfinityReplacementPhase} class is responsible for identifying and replacing instances
+ * of positive and negative infinity constants in the graph with division operations.
+ * <p>
+ * Specifically, this phase looks for constant nodes whose values are "Infinity" or "-Infinity" and replaces
+ * them with a division node that represents the result of dividing either 1.0f or -1.0f by 0.0f,
+ * depending on whether the original value was "Infinity" or "-Infinity".
+ */
 public class InfinityReplacementPhase  extends Phase {
     @Override
     public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
         return ALWAYS_APPLICABLE;
     }
 
+    /**
+     * Runs the transformation on the provided graph by searching for constant nodes
+     * with values of "Infinity" or "-Infinity" and replacing them with division nodes
+     * representing {@code 1.0f / 0.0f} or {@code -1.0f / 0.0f}, respectively.
+     *
+     * @param graph the {@link StructuredGraph} to process
+     */
     @Override
     protected void run(StructuredGraph graph) {
         graph.getNodes().filter(ConstantNode.class).forEach(constantNode -> {
@@ -48,6 +62,15 @@ public class InfinityReplacementPhase  extends Phase {
         });
     }
 
+    /**
+     * Replaces the given constant node with a division node that divides a constant value by zero.
+     * This division represents either {@code 1.0f / 0.0f} or {@code -1.0f / 0.0f} depending on the
+     * {@code constantValue} passed in.
+     *
+     * @param constantValue the constant value (either 1.0f or -1.0f) to use in the division
+     * @param graph the {@link StructuredGraph} that contains the nodes
+     * @param constantNode the original constant node to be replaced
+     */
     private void replaceWithDivisionNode(float constantValue, StructuredGraph graph, ConstantNode constantNode) {
         ConstantNode constant = ConstantNode.forConstant(JavaConstant.forFloat(constantValue), null, graph);
         ConstantNode constantZero = ConstantNode.forConstant(JavaConstant.forFloat(0.0f), null, graph);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXLowTier.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXLowTier.java
@@ -41,6 +41,7 @@ import uk.ac.manchester.tornado.drivers.common.compiler.phases.analysis.TornadoF
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.loops.TornadoLoopCanonicalization;
 import uk.ac.manchester.tornado.drivers.common.compiler.phases.utils.DumpLowTierGraph;
 import uk.ac.manchester.tornado.drivers.ptx.graal.phases.InverseSquareRootPhase;
+import uk.ac.manchester.tornado.drivers.ptx.graal.phases.InfinityReplacementPhase;
 import uk.ac.manchester.tornado.drivers.ptx.graal.phases.PTXFMAPhase;
 import uk.ac.manchester.tornado.drivers.ptx.graal.phases.TornadoFixedArrayCopyPhase;
 import uk.ac.manchester.tornado.drivers.ptx.graal.phases.TornadoHalfFloatVectorOffset;
@@ -84,6 +85,9 @@ public class PTXLowTier extends TornadoLowTier {
         if (TornadoOptions.MATH_OPTIMIZATIONS) {
             appendPhase(new InverseSquareRootPhase());
         }
+
+        appendPhase(new InfinityReplacementPhase());
+
 
         appendPhase(new SchedulePhase(SchedulePhase.SchedulingStrategy.LATEST_OUT_OF_LOOPS));
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/InfinityReplacementPhase.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/InfinityReplacementPhase.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.opencl.graal.phases;
+
+import jdk.vm.ci.meta.JavaConstant;
+import org.graalvm.compiler.nodes.GraphState;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.phases.Phase;
+
+import java.util.Optional;
+
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.calc.FloatDivNode;
+
+/**
+ * The {@link InfinityReplacementPhase} class is responsible for identifying and replacing instances
+ * of positive and negative infinity constants in the graph with division operations.
+ * <p>
+ * Specifically, this phase looks for constant nodes whose values are "Infinity" or "-Infinity" and replaces
+ * them with a division node that represents the result of dividing either 1.0f or -1.0f by 0.0f,
+ * depending on whether the original value was "Infinity" or "-Infinity".
+ */
+public class InfinityReplacementPhase  extends Phase {
+    @Override
+    public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
+        return ALWAYS_APPLICABLE;
+    }
+
+    /**
+     * Runs the transformation on the provided graph by searching for constant nodes
+     * with values of "Infinity" or "-Infinity" and replacing them with division nodes
+     * representing {@code 1.0f / 0.0f} or {@code -1.0f / 0.0f}, respectively.
+     *
+     * @param graph the {@link StructuredGraph} to process
+     */
+    @Override
+    protected void run(StructuredGraph graph) {
+        graph.getNodes().filter(ConstantNode.class).forEach(constantNode -> {
+            String resultValue = constantNode.getValue().toValueString();
+            if (resultValue.equals("Infinity") || resultValue.equals("-Infinity")) {
+                float constantValue = resultValue.equals("Infinity") ? 1.0f : -1.0f;
+                replaceWithDivisionNode(constantValue, graph, constantNode);
+            }
+        });
+    }
+
+    /**
+     * Replaces the given constant node with a division node that divides a constant value by zero.
+     * This division represents either {@code 1.0f / 0.0f} or {@code -1.0f / 0.0f} depending on the
+     * {@code constantValue} passed in.
+     *
+     * @param constantValue the constant value (either 1.0f or -1.0f) to use in the division
+     * @param graph the {@link StructuredGraph} that contains the nodes
+     * @param constantNode the original constant node to be replaced
+     */
+    private void replaceWithDivisionNode(float constantValue, StructuredGraph graph, ConstantNode constantNode) {
+        ConstantNode constant = ConstantNode.forConstant(JavaConstant.forFloat(constantValue), null, graph);
+        ConstantNode constantZero = ConstantNode.forConstant(JavaConstant.forFloat(0.0f), null, graph);
+
+        // Create the division node (constantValue / 0.0f)
+        FloatDivNode divisionNode = new FloatDivNode(constant, constantZero);
+
+        // Add the division node to the graph
+        graph.addOrUnique(divisionNode);
+
+        constantNode.replaceAtUsages(divisionNode);
+        if (constantNode.hasNoUsages()) {
+            constantNode.safeDelete();
+        }
+    }
+
+}

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLowTier.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/SPIRVLowTier.java
@@ -44,6 +44,7 @@ import uk.ac.manchester.tornado.drivers.common.compiler.phases.utils.DumpLowTier
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.OCLFPGAPragmaPhase;
 import uk.ac.manchester.tornado.drivers.opencl.graal.phases.OCLFPGAThreadScheduler;
 import uk.ac.manchester.tornado.drivers.spirv.graal.phases.InverseSquareRootPhase;
+import uk.ac.manchester.tornado.drivers.spirv.graal.phases.InfinityReplacementPhase;
 import uk.ac.manchester.tornado.drivers.spirv.graal.phases.PartialLoopUnrollPhase;
 import uk.ac.manchester.tornado.drivers.spirv.graal.phases.SPIRVFMAPhase;
 import uk.ac.manchester.tornado.drivers.spirv.graal.phases.SPIRVFP64SupportPhase;
@@ -96,6 +97,8 @@ public class SPIRVLowTier extends TornadoLowTier {
         if (TornadoOptions.MATH_OPTIMIZATIONS) {
             appendPhase(new InverseSquareRootPhase());
         }
+
+        appendPhase(new InfinityReplacementPhase());
 
         // TODO Atomics Phase for SPIRV (this is the last thing to support)
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/InfinityReplacementPhase.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/InfinityReplacementPhase.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.spirv.graal.phases;
+
+import jdk.vm.ci.meta.JavaConstant;
+import org.graalvm.compiler.nodes.GraphState;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.phases.Phase;
+
+import java.util.Optional;
+
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.calc.FloatDivNode;
+
+/**
+ * The {@link InfinityReplacementPhase} class is responsible for identifying and replacing instances
+ * of positive and negative infinity constants in the graph with division operations.
+ * <p>
+ * Specifically, this phase looks for constant nodes whose values are "Infinity" or "-Infinity" and replaces
+ * them with a division node that represents the result of dividing either 1.0f or -1.0f by 0.0f,
+ * depending on whether the original value was "Infinity" or "-Infinity".
+ */
+public class InfinityReplacementPhase extends Phase {
+    @Override
+    public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
+        return ALWAYS_APPLICABLE;
+    }
+
+    /**
+     * Runs the transformation on the provided graph by searching for constant nodes
+     * with values of "Infinity" or "-Infinity" and replacing them with division nodes
+     * representing {@code 1.0f / 0.0f} or {@code -1.0f / 0.0f}, respectively.
+     *
+     * @param graph the {@link StructuredGraph} to process
+     */
+    @Override
+    protected void run(StructuredGraph graph) {
+        graph.getNodes().filter(ConstantNode.class).forEach(constantNode -> {
+            String resultValue = constantNode.getValue().toValueString();
+            if (resultValue.equals("Infinity") || resultValue.equals("-Infinity")) {
+                float constantValue = resultValue.equals("Infinity") ? 1.0f : -1.0f;
+                replaceWithDivisionNode(constantValue, graph, constantNode);
+            }
+        });
+    }
+
+    /**
+     * Replaces the given constant node with a division node that divides a constant value by zero.
+     * This division represents either {@code 1.0f / 0.0f} or {@code -1.0f / 0.0f} depending on the
+     * {@code constantValue} passed in.
+     *
+     * @param constantValue the constant value (either 1.0f or -1.0f) to use in the division
+     * @param graph the {@link StructuredGraph} that contains the nodes
+     * @param constantNode the original constant node to be replaced
+     */
+    private void replaceWithDivisionNode(float constantValue, StructuredGraph graph, ConstantNode constantNode) {
+        ConstantNode constant = ConstantNode.forConstant(JavaConstant.forFloat(constantValue), null, graph);
+        ConstantNode constantZero = ConstantNode.forConstant(JavaConstant.forFloat(0.0f), null, graph);
+
+        // Create the division node (constantValue / 0.0f)
+        FloatDivNode divisionNode = new FloatDivNode(constant, constantZero);
+
+        // Add the division node to the graph
+        graph.addOrUnique(divisionNode);
+
+        constantNode.replaceAtUsages(divisionNode);
+        if (constantNode.hasNoUsages()) {
+            constantNode.safeDelete();
+        }
+    }
+
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/MMwithBytes.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/MMwithBytes.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.unittests.compute;
 
 import org.junit.Test;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/MMwithBytes.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/MMwithBytes.java
@@ -1,0 +1,142 @@
+package uk.ac.manchester.tornado.unittests.compute;
+
+import org.junit.Test;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+import static org.junit.Assert.assertFalse;
+
+public class MMwithBytes extends TornadoTestBase {
+
+    @Test
+    public void testMatrixMultiplicationWithBytes() throws TornadoExecutionPlanException {
+
+        // Define matrix/vector dimensions
+        final int dim = 128;  // example dimension, adjust as necessary
+        final int numRows = 1024; // example number of rows for ByteArray
+
+        // Initialize input data
+        ByteArray byteArrayWeights = new ByteArray(numRows * (2 + 32)); // dim + 2 bytes for scale per row
+        FloatArray inputVector = new FloatArray(dim);
+        FloatArray outputVector = new FloatArray(numRows);
+
+        // Populate the ByteArray with dummy quantized weights and scales
+        for (int i = 0; i < numRows; i++) {
+            int offset = i * (2 + 32);
+            byteArrayWeights.set(offset, (byte) 0);          // scale byte 1
+            byteArrayWeights.set(offset + 1, (byte) 0);      // scale byte 2
+            for (int j = 2; j < 2 + 32; j++) {
+                byteArrayWeights.set(offset + j, (byte) (Math.random() * 255 - 128)); // random quantized values
+            }
+        }
+
+        // Populate the input vector with random floats
+        for (int i = 0; i < dim; i++) {
+            inputVector.set(i, (float) Math.random());
+        }
+
+        // Expected output should be initialized to zero
+        outputVector.init(0.0f);
+
+        // Create the execution plan
+        WorkerGrid workerGrid = new WorkerGrid1D(numRows);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
+        workerGrid.setGlobalWork(numRows, 1, 1);
+        workerGrid.setLocalWork(32, 1, 1);
+
+        // Define the TaskGraph for matrix multiplication
+        TaskGraph taskGraph = new TaskGraph("s0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, byteArrayWeights, inputVector)
+                .task("t0", MMwithBytes::matmulTornado, new KernelContext(), byteArrayWeights, inputVector, outputVector, dim)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, outputVector);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        // Validation: Manually check output values or use precomputed expected output
+        // For simplicity, check that no NaNs or Infinity are in the result
+        for (int i = 0; i < numRows; i++) {
+            float result = outputVector.get(i);
+            assertFalse("Output contains NaN at index " + i, Float.isNaN(result));
+            assertFalse("Output contains Infinity at index " + i, Float.isInfinite(result));
+        }
+
+        // Optionally, add further checks against a precomputed result array if available
+    }
+
+    public static void matmulTornado(KernelContext context, ByteArray thisx, FloatArray that, FloatArray out, int dim1) {
+        final int BLOCK_SIZE = 32; // Assuming this is the block size used in quantization
+        final int BYTES_PER_BLOCK = 2 + BLOCK_SIZE; // 2 bytes for scale + block_size bytes for values
+
+        int idx = context.globalIdx;
+
+        float result = 0f;
+        int thisOffset = idx * dim1;
+
+        for (int j = 0; j < dim1; j++) {
+            int index = thisOffset + j;
+            // Calculate block position
+            int blockIndex = index / BLOCK_SIZE;
+            int withinBlockIndex = index % BLOCK_SIZE;
+            int blockOffset = blockIndex * BYTES_PER_BLOCK;
+
+            // Read scale (float16) for this block
+            int scaleByte1 = thisx.get(blockOffset) & 0xFF;
+            int scaleByte2 = thisx.get(blockOffset + 1) & 0xFF;
+            short scaleFloat16 = (short)((scaleByte2 << 8) | scaleByte1);
+            float scale = decodeFloat16(scaleFloat16);
+
+            // Read quantized value
+            byte quantized = thisx.get(blockOffset + 2 + withinBlockIndex);
+
+            // Dequantize and multiply
+            result += (quantized * scale) * that.get(j);
+        }
+
+        out.set(idx, result);
+
+    }
+
+    private static float decodeFloat16(short value) {
+        int sign = (value & 0x8000) >>> 15;
+        int exp = (value & 0x7C00) >>> 10;
+        int frac = value & 0x03FF;
+
+        // Handle special cases
+        if (exp == 0x1F) return sign == 0 ? Float.POSITIVE_INFINITY : Float.NEGATIVE_INFINITY;
+        if (exp == 0) {
+            if (frac == 0) return sign == 0 ? 0.0f : -0.0f;
+            float result = frac * pow2(-24);
+            return sign == 0 ? result : -result;
+        }
+
+        float result = 1.0f + (frac / 1024.0f);
+        result *= pow2(exp - 15);
+        return sign == 0 ? result : -result;
+    }
+
+    private static float pow2(int n) {
+        if (n >= 0) {
+            if (n < 31) {
+                return (float)(1 << n);
+            }
+            return Float.POSITIVE_INFINITY;
+        }
+        if (n > -150) {
+            return 1.0f / (1 << -n);
+        }
+        return 0.0f;
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/MMwithBytes.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/MMwithBytes.java
@@ -69,7 +69,7 @@ public class MMwithBytes extends TornadoTestBase {
             byteArrayWeights.set(offset, (byte) 0);          // scale byte 1
             byteArrayWeights.set(offset + 1, (byte) 0);      // scale byte 2
             for (int j = 2; j < 2 + 32; j++) {
-                byteArrayWeights.set(offset + j, (byte) (Math.random() * 255 - 128)); // random quantized values
+                byteArrayWeights.set(offset + j, (byte) ((i*3f) * 255 - 128)); // random quantized values
             }
         }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/MMwithBytes.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/MMwithBytes.java
@@ -37,6 +37,18 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 import static org.junit.Assert.assertFalse;
 
+/**
+ * Test to check the infinity values are properly replaced for code gen.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ *
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.compute.MMwithBytes
+ * </code>
+ *
+ */
 public class MMwithBytes extends TornadoTestBase {
 
     @Test
@@ -93,8 +105,6 @@ public class MMwithBytes extends TornadoTestBase {
             assertFalse("Output contains NaN at index " + i, Float.isNaN(result));
             assertFalse("Output contains Infinity at index " + i, Float.isInfinite(result));
         }
-
-        // Optionally, add further checks against a precomputed result array if available
     }
 
     public static void matmulTornado(KernelContext context, ByteArray thisx, FloatArray that, FloatArray out, int dim1) {


### PR DESCRIPTION
#### Description

There was a bug when generating code for the constant values `Float.POSITIVE_INFINITY` and `Float.NEGATIVE_INFINITY` from the Float class. Using these values caused the compiler to generate OpenCL code with Infinity and -Infinity constants, which are not valid OpenCL intrinsics.

This fix replaces Float.POSITIVE_INFINITY and Float.NEGATIVE_INFINITY with `1.0f / 0.0f` and `-1.0f / 0.0f` respectively, which are the proper representations of positive and negative infinity in OpenCL.


#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
make jdk21 
tornado-test  -V uk.ac.manchester.tornado.unittests.compute.MMwithBytes
```
----------------------------------------------------------------------------
