### PR TITLE
RISC-V 64 Port Enabled

### DIFF
--- a/bin/installer_config.py
+++ b/bin/installer_config.py
@@ -19,51 +19,59 @@
 
 import platform
 
-__X86_64__ = "x86_64"
-__ARM__ = "arm64"
+__X86_64__   = "x86_64"
+__ARM__      = "arm64"
+__RISCV_64__ = "riscv64" 
 
-__LINUX__ = "linux"
-__APPLE__ = "darwin"
+__LINUX__   = "linux"
+__APPLE__   = "darwin"
 __WINDOWS__ = "windows"
 
-__JDK21__ = "jdk21"
-__GRAALVM21__ = "graal-jdk-21"
-__MANDREL21__ = "mandrel-jdk-21"
-__CORRETTO21__ = "corretto-jdk-21"
-__MICROSOFT21__ = "microsoft-jdk-21"
-__ZULU21__ = "zulu-jdk-21"
-__TEMURIN21__ = "temurin-jdk-21"
+__JDK21__        = "jdk21"
+__GRAALVM21__    = "graal-jdk-21"
+__MANDREL21__    = "mandrel-jdk-21"
+__CORRETTO21__   = "corretto-jdk-21"
+__MICROSOFT21__  = "microsoft-jdk-21"
+__ZULU21__       = "zulu-jdk-21"
+__TEMURIN21__    = "temurin-jdk-21"
 __SAPMACHINE21__ = "sapmachine-jdk-21"
+__LIBERICA21__   = "liberica-jdk-21"
 
 ## cmake
 CMAKE = {
     __LINUX__: {
-        __X86_64__: "https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-x86_64.tar.gz",
-        __ARM__: "https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-aarch64.tar.gz",
+        __X86_64__   : "https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-x86_64.tar.gz",
+        __ARM__      : "https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-aarch64.tar.gz",
+        __RISCV_64__ : None,
     },
     __APPLE__: {
         __X86_64__: "https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-macos-universal.tar.gz",
         __ARM__: "https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-macos-universal.tar.gz",
+        __RISCV_64__ : None,
     },
     __WINDOWS__: {
         __X86_64__: "https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3-windows-x86_64.zip",
         __ARM__: None,
+        __RISCV_64__ : None,
     },
 }
 
 ## Maven
 MAVEN = {
     __LINUX__: {
-        __X86_64__: "https://archive.apache.org/dist/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz",
-        __ARM__: "https://archive.apache.org/dist/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz",
+        __X86_64__  : "https://archive.apache.org/dist/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz",
+        __ARM__     : "https://archive.apache.org/dist/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz",
+        __RISCV_64__: "https://archive.apache.org/dist/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz",
     },
     __APPLE__: {
         __X86_64__: "https://archive.apache.org/dist/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz",
-        __ARM__: "https://archive.apache.org/dist/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz",
+        __ARM__   : "https://archive.apache.org/dist/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.tar.gz",
+        __RISCV_64__ : None,
     },
     __WINDOWS__: {
         __X86_64__: "https://archive.apache.org/dist/maven/maven-3/3.9.3/binaries/apache-maven-3.9.3-bin.zip",
         __ARM__: None,
+        __RISCV_64__ : None,
     },
 }
 
@@ -73,112 +81,154 @@ JDK = {
         __LINUX__: {
             __X86_64__: "https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.tar.gz",
             __ARM__: "https://download.oracle.com/java/21/latest/jdk-21_linux-aarch64_bin.tar.gz",
+           __RISCV_64__: None,
         },
         __APPLE__: {
             __X86_64__: "https://download.oracle.com/java/21/latest/jdk-21_macos-x64_bin.tar.gz",
             __ARM__: "https://download.oracle.com/java/21/latest/jdk-21_macos-aarch64_bin.tar.gz",
+           __RISCV_64__: None,
         },
         __WINDOWS__: {
             __X86_64__: "https://download.oracle.com/java/21/archive/jdk-21.0.1_windows-x64_bin.zip",
             __ARM__: None,
+           __RISCV_64__: None,
         },
     },
     __GRAALVM21__: {
         __LINUX__: {
             __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-x64_bin.tar.gz",
             __ARM__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-aarch64_bin.tar.gz",
+           __RISCV_64__: None,
         },
         __APPLE__: {
             __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_macos-x64_bin.tar.gz",
             __ARM__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_macos-aarch64_bin.tar.gz",
+           __RISCV_64__: None,
         },
         __WINDOWS__: {
             __X86_64__: "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_windows-x64_bin.zip",
             __ARM__: None,
+           __RISCV_64__: None,
         },
     },
     __CORRETTO21__: {
         __LINUX__: {
             __X86_64__: "https://corretto.aws/downloads/latest/amazon-corretto-21-x64-linux-jdk.tar.gz",
             __ARM__: "https://corretto.aws/downloads/latest/amazon-corretto-21-aarch64-linux-jdk.tar.gz",
+           __RISCV_64__: None,
         },
         __APPLE__: {
             __X86_64__: "https://corretto.aws/downloads/latest/amazon-corretto-21-x64-macos-jdk.tar.gz",
             __ARM__: "https://corretto.aws/downloads/latest/amazon-corretto-21-aarch64-macos-jdk.tar.gz",
+           __RISCV_64__: None,
         },
         __WINDOWS__: {
             __X86_64__: None,
             __ARM__: None,
+           __RISCV_64__: None,
         },
     },
     __MANDREL21__: {
         __LINUX__: {
             __X86_64__: "https://github.com/graalvm/mandrel/releases/download/mandrel-23.1.0.0-Final/mandrel-java21-linux-amd64-23.1.0.0-Final.tar.gz",
             __ARM__: "https://github.com/graalvm/mandrel/releases/download/mandrel-23.1.0.0-Final/mandrel-java21-linux-aarch64-23.1.0.0-Final.tar.gz",
+           __RISCV_64__: None,
         },
         __APPLE__: {
             __X86_64__: None,
             __ARM__: None,
+           __RISCV_64__: None,
         },
         __WINDOWS__: {
             __X86_64__: None,
             __ARM__: None,
+           __RISCV_64__: None,
         },
     },
     __MICROSOFT21__: {
         __LINUX__: {
             __X86_64__: "https://aka.ms/download-jdk/microsoft-jdk-21.0.3-linux-x64.tar.gz",
             __ARM__: "https://aka.ms/download-jdk/microsoft-jdk-21.0.3-linux-aarch64.tar.gz",
+           __RISCV_64__: None,
         },
         __APPLE__: {
             __X86_64__: "https://aka.ms/download-jdk/microsoft-jdk-21.0.3-macos-x64.tar.gz",
             __ARM__: "https://aka.ms/download-jdk/microsoft-jdk-21.0.3-macos-aarch64.tar.gz",
+           __RISCV_64__: None,
         },
         __WINDOWS__: {
             __X86_64__: "https://aka.ms/download-jdk/microsoft-jdk-21.0.3-windows-x64.zip",
             __ARM__: "https://aka.ms/download-jdk/microsoft-jdk-21.0.3-windows-aarch64.zip",
+           __RISCV_64__: None,
         },
     },
     __ZULU21__: {
         __LINUX__: {
             __X86_64__: "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-linux_x64.tar.gz",
             __ARM__: "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-linux_aarch64.tar.gz",
+           __RISCV_64__: None,
         },
         __APPLE__: {
             __X86_64__: "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-macosx_x64.tar.gz",
             __ARM__: "https://cdn.azul.com/zulu/bin/zulu21.28.85-ca-jdk21.0.0-macosx_aarch64.tar.gz",
+           __RISCV_64__: None,
         },
         __WINDOWS__: {
             __X86_64__: None,
             __ARM__: None,
+           __RISCV_64__: None,
         },
     },
     __TEMURIN21__: {
         __LINUX__: {
             __X86_64__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz",
             __ARM__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz",
+           __RISCV_64__: None,
         },
         __APPLE__: {
             __X86_64__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz",
             __ARM__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.1_12.tar.gz",
+           __RISCV_64__: None,
         },
         __WINDOWS__: {
             __X86_64__: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_x64_windows_hotspot_21.0.3_9.zip",
             __ARM__: None,
+           __RISCV_64__: None,
         },
     },
     __SAPMACHINE21__: {
         __LINUX__: {
             __X86_64__: "https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.3/sapmachine-jdk-21.0.3_linux-x64_bin.tar.gz",
             __ARM__: "https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.3/sapmachine-jdk-21.0.3_linux-aarch64_bin.tar.gz",
+           __RISCV_64__: None,
         },
         __APPLE__: {
             __X86_64__: "https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.3/sapmachine-jdk-21.0.3_macos-x64_bin.tar.gz",
             __ARM__: "https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.3/sapmachine-jdk-21.0.3_macos-aarch64_bin.tar.gz",
+           __RISCV_64__: None,
         },
         __WINDOWS__: {
             __X86_64__: "https://github.com/SAP/SapMachine/releases/download/sapmachine-21.0.3/sapmachine-jdk-21.0.3_windows-x64_bin.zip",
             __ARM__: None,
+           __RISCV_64__: None,
         },
+    },
+
+    __LIBERICA21__ : {
+        __LINUX__: {
+            __X86_64__  : "https://download.bell-sw.com/java/21.0.5+11/bellsoft-jdk21.0.5+11-linux-amd64.tar.gz",
+            __ARM__     : "https://download.bell-sw.com/java/21.0.5+11/bellsoft-jdk21.0.5+11-linux-aarch64.tar.gz",
+            __RISCV_64__: "https://download.bell-sw.com/java/21.0.5+11/bellsoft-jdk21.0.5+11-linux-riscv64.tar.gz",
+       },
+        __APPLE__ : {
+            __X86_64__:  "https://download.bell-sw.com/java/21.0.5+11/bellsoft-jdk21.0.5+11-macos-amd64.tar.gz",
+            __ARM__   : "https://download.bell-sw.com/java/21.0.5+11/bellsoft-jdk21.0.5+11-macos-aarch64.tar.gz",
+           __RISCV_64__: None,
+       },
+       __WINDOWS__: {
+           __X86_64__: "https://download.bell-sw.com/java/21.0.5+11/bellsoft-jdk21.0.5+11-windows-amd64.zip",
+           __ARM__   : "https://download.bell-sw.com/java/21.0.5+11/bellsoft-jdk21.0.5+11-windows-aarch64.zip",
+           __RISCV_64__: None,
+      },
     },
 }

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -36,7 +36,7 @@ import installer_config as config
 ## Configuration
 ## ################################################################
 __DIRECTORY_DEPENDENCIES__ = os.path.join("etc", "dependencies")
-__VERSION__ = "v1.0.7-dev"
+__VERSION__ = "v1.0.9-dev"
 
 __SUPPORTED_JDKS__ = [
     config.__JDK21__,
@@ -47,6 +47,7 @@ __SUPPORTED_JDKS__ = [
     config.__ZULU21__,
     config.__TEMURIN21__,
     config.__SAPMACHINE21__,
+    config.__LIBERICA21__,
 ]
 
 __SUPPORTED_BACKENDS__ = ["opencl", "spirv", "ptx"]
@@ -71,7 +72,8 @@ class TornadoInstaller:
             "x86_64"  : "x86_64",
             "amd64"   : "x86_64",
             "arm64"   : "arm64",
-            "aarch64" : "arm64"
+            "aarch64" : "arm64",
+            "riscv64" : "riscv64"
         }
         machine = platform.machine().lower()
         return compatibleMachineTypes[machine]
@@ -96,8 +98,13 @@ class TornadoInstaller:
     def downloadCMake(self):
         url = config.CMAKE[self.osPlatform][self.hardware]
         if url == None:
-            print("CMake not configured for this OS/ machine configuration: {self.osPlatform}/ {self.hardware}")
-            sys.exit(0)
+            ## When using the RISC-V installer, CMAKE will be None
+            ## Only for this case, we can use the system cmake instead.
+            if (self.hardware == "riscv64"):
+                return
+            else:
+                print("CMake not configured for this OS/ machine configuration: {self.osPlatform}/ {self.hardware}")
+                sys.exit(0)
 
         fileName = self.processFileName(url)
         print("\nChecking dependency: " + fileName)
@@ -375,6 +382,7 @@ def listSupportedJDKs():
     zulu-jdk-21       : Install TornadoVM with Azul Zulu JDK 21
     temurin-jdk-21    : Install TornadoVM with Eclipse Temurin JDK 21
     sapmachine-jdk-21 : Install TornadoVM with SapMachine OpenJDK 21
+    liberica-jdk-21   : Install TornadoVM with Liberica OpenJDK 21 (Only option for RISC-V 64)
 
     Usage:
       $ ./bin/tornadovm-installer  --jdk <JDK_VERSION> --backend <BACKEND>

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -466,7 +466,7 @@ The RISC-V port is experimental, but users can try it on real RISC-V hardware.
 The following instructions have been tested on Linux Bianbu OS 1.0.15 on a Bananapi F3 SBC. 
 
 
-The installation requires a patch for RISC-V. This patch disable `cmake-maven` pkugin for the native OpenCL part due to unsupported port for RISC-V. 
+The installation requires a patch that disables the `cmake-maven` plugin for the native OpenCL part due to unsupported port for RISC-V. 
 
 We have pushed a script that automatically applies the patch and builds TornadoVM to run on RISC-V. 
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -456,6 +456,57 @@ Then the following package should be installed:
    $ apt-get install ocl-icd-opencl-dev
 
 
+
+.. _installation_riscv:
+
+Installation for RISC-V RVV 1.0 on Linux
+========================================
+
+The RISC-V port is experimental, but users can try on real RISC-V hardware. 
+The following instructions have been tested on Linux Bianbu OS 1.0.15 on a Bananapi F3 SBC. 
+
+
+The installation requires a patch for RISC-V. This patch disable `cmake-maven` pkugin for the native OpenCL part due to unsupported port for RISC-V. 
+
+We have pushed a script that automatically applies the patch and builds TornadoVM to run on RISC-V. 
+
+
+First, install the dependencies:
+
+.. code:: bash
+
+   sudo apt-get install python3-psutil cmake 
+
+
+Then, download the script to apply the patch:
+
+
+.. code:: bash
+
+   wget https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/d79af888a9873f8a3b44e4cc35a8ae382684cdb2/apply-riscv-patch.sh 
+   bash apply-riscv-patch.sh 
+
+
+Run TornadoVM:
+
+.. code:: bash
+
+   source setvars.sh
+   tornado --devices 
+
+   Number of Tornado drivers: 1
+   Driver: OpenCL
+      Total number of OpenCL devices  : 1
+      Tornado device=0:0  (DEFAULT)
+        OPENCL --  [ComputeAorta] -- RefSi G1 RV64
+                Global Memory Size: 2.0 GB
+                Local Memory Size: 256.0 KB
+                Workgroup Dimensions: 3
+                Total Number of Block Threads: [1024]
+                Max WorkGroup Configuration: [1024, 1024, 1024]
+                Device OpenCL C version: OpenCL C 1.2 Clang 19.1.5
+
+
 IDE Code Formatter
 ====================
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -462,7 +462,7 @@ Then the following package should be installed:
 Installation for RISC-V RVV 1.0 on Linux
 ========================================
 
-The RISC-V port is experimental, but users can try on real RISC-V hardware. 
+The RISC-V port is experimental, but users can try it on real RISC-V hardware. 
 The following instructions have been tested on Linux Bianbu OS 1.0.15 on a Bananapi F3 SBC. 
 
 


### PR DESCRIPTION
#### Description

This partially enables the installation for RISC-V 64 on Linux systems. This patch can be combined with a new patch to be able to compile and run on RISC-V. The patch removes the dependency to `cmake-maven` due to unsupported RISC-V architecture. 

Once the plugin supports RISC-V, we can drop the external patch. 

This patch also includes a new JDK installation for Liberica JDK 21. This JDK includes a port for RISC-V 64. 

```bash
./bin/tornadovm-installer --jdk liberica-jdk-21 --backend=opencl
```

#### Problem description

n. a

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

On a RISC-V platform:

```bash
wget https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/d79af888a9873f8a3b44e4cc35a8ae382684cdb2/apply-riscv-patch.sh
bash apply-riscv-patch.sh
```

Then:

```bash
source setvars.sh
Number of Tornado drivers: 1
Driver: OpenCL
  Total number of OpenCL devices  : 1
  Tornado device=0:0  (DEFAULT)
        OPENCL --  [ComputeAorta] -- RefSi G1 RV64
                Global Memory Size: 2.0 GB
                Local Memory Size: 256.0 KB
                Workgroup Dimensions: 3
                Total Number of Block Threads: [1024]
                Max WorkGroup Configuration: [1024, 1024, 1024]
                Device OpenCL C version: OpenCL C 1.2 Clang 19.1.5
```


