### PR TITLE
[hotfix] FPGA kernels generate an extra bracket

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompilationResultBuilder.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLCompilationResultBuilder.java
@@ -344,6 +344,10 @@ public class OCLCompilationResultBuilder extends CompilationResultBuilder {
                 breakInst = op;
                 continue;
             } else if ((shouldRemoveLoop() && loops == 0) && isLoopDependencyNode(op)) {
+                /**
+                 * Apply the Loop Flattening optimization for FPGAs,
+                 * which omits the outermost for loop along with every data dependency associated with it.
+                 */
                 if (op instanceof OCLControlFlow.LoopPostOp) {
                     loops++;
                 }


### PR DESCRIPTION
#### Description

This PR fixes issue #590.

#### Problem description

After close inspection the problem was that for FPGAs, we apply a compiler optimization for loop flattening of the outermost for loop. In this case, the `OCLBlockVisitor.java` class did not account for the flattened loop and was emitting the closing bracket.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [x] Yes
- [ ] No

#### How to test the new patch?

```bash
make && make fast-tests
tornado-test -V uk.ac.manchester.tornado.unittests.branching.TestLoopConditions
```

In my case the FPGA device is device `0:4`. To test on FPGAs kernels, run: 
```bash
rm -rf fpga-source-comp/ && tornado --igv --jvm "-Ds0.t0.device=0:4 -Xmx20g -Xms20g" --printKernel --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.dynamic.DFTMT --params="256 default 1"

rm -rf fpga-source-comp/ && tornado --igv --jvm "-Ds0.t0.device=0:4 -Xmx20g -Xms20g" --printKernel --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.dynamic.BlackScholesMT --params="256 default 1"

rm -rf fpga-source-comp/ && tornado --igv --jvm "-Ds0.t0.device=0:4 -Xmx20g -Xms20g" --printKernel --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.dynamic.MontecarloMT --params="256 default 1"

rm -rf fpga-source-comp/ && tornado --igv --jvm "-Ds0.t0.device=0:4 -Xmx20g -Xms20g" --printKernel --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.dynamic.NBodyMT --params="256 default 1"

rm -rf fpga-source-comp/ && tornado --igv --jvm "-Ds0.t0.device=0:4 -Xmx20g -Xms20g" --printKernel --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.dynamic.SaxpyMT --params="256 default 1"
```
----------------------------------------------------------------------------
