### PR TITLE
[Feature] Select graph from a multi-graph execution plan to launch. 

### DIFF
--- a/tornado-api/src/main/java/module-info.java
+++ b/tornado-api/src/main/java/module-info.java
@@ -50,4 +50,6 @@ module tornado.api {
     opens uk.ac.manchester.tornado.api.types.tensors;
     opens uk.ac.manchester.tornado.api.types;
     opens uk.ac.manchester.tornado.api.runtime;
+    exports uk.ac.manchester.tornado.api.plan.types;
+    opens uk.ac.manchester.tornado.api.plan.types;
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionPlanType.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionPlanType.java
@@ -22,6 +22,7 @@ import uk.ac.manchester.tornado.api.plan.types.OffMemoryLimit;
 import uk.ac.manchester.tornado.api.plan.types.OffPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.OffProfiler;
 import uk.ac.manchester.tornado.api.plan.types.OffThreadInfo;
+import uk.ac.manchester.tornado.api.plan.types.WithAllGraphs;
 import uk.ac.manchester.tornado.api.plan.types.WithBatch;
 import uk.ac.manchester.tornado.api.plan.types.WithClearProfiles;
 import uk.ac.manchester.tornado.api.plan.types.WithCompilerFlags;
@@ -30,6 +31,7 @@ import uk.ac.manchester.tornado.api.plan.types.WithDefaultScheduler;
 import uk.ac.manchester.tornado.api.plan.types.WithDevice;
 import uk.ac.manchester.tornado.api.plan.types.WithDynamicReconfiguration;
 import uk.ac.manchester.tornado.api.plan.types.WithFreeDeviceMemory;
+import uk.ac.manchester.tornado.api.plan.types.WithGraph;
 import uk.ac.manchester.tornado.api.plan.types.WithGridScheduler;
 import uk.ac.manchester.tornado.api.plan.types.WithMemoryLimit;
 import uk.ac.manchester.tornado.api.plan.types.WithPrintKernel;
@@ -39,12 +41,11 @@ import uk.ac.manchester.tornado.api.plan.types.WithThreadInfo;
 import uk.ac.manchester.tornado.api.plan.types.WithWarmUp;
 
 public abstract sealed class ExecutionPlanType extends TornadoExecutionPlan //
-        permits OffConcurrentDevices, OffMemoryLimit, OffPrintKernel, //
-        OffProfiler, OffThreadInfo, WithWarmUp, WithBatch, WithClearProfiles,  //
-        WithCompilerFlags, WithConcurrentDevices, WithDefaultScheduler, //
-        WithDevice, WithDynamicReconfiguration, WithFreeDeviceMemory, //
-        WithGridScheduler, WithMemoryLimit, WithPrintKernel, WithProfiler, //
-        WithResetDevice, WithThreadInfo {
+        permits OffConcurrentDevices, OffMemoryLimit, OffPrintKernel, OffProfiler, //
+        OffThreadInfo, WithAllGraphs, WithBatch, WithClearProfiles, WithCompilerFlags,  //
+        WithConcurrentDevices, WithDefaultScheduler, WithDevice, WithDynamicReconfiguration, //
+        WithFreeDeviceMemory, WithGraph, WithGridScheduler, WithMemoryLimit, WithPrintKernel, //
+        WithProfiler, WithResetDevice, WithThreadInfo, WithWarmUp { //
 
     public ExecutionPlanType(TornadoExecutionPlan parentNode) {
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -17,9 +17,9 @@
  */
 package uk.ac.manchester.tornado.api;
 
-import java.util.Objects;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
@@ -32,6 +32,7 @@ import uk.ac.manchester.tornado.api.plan.types.OffMemoryLimit;
 import uk.ac.manchester.tornado.api.plan.types.OffPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.OffProfiler;
 import uk.ac.manchester.tornado.api.plan.types.OffThreadInfo;
+import uk.ac.manchester.tornado.api.plan.types.WithAllGraphs;
 import uk.ac.manchester.tornado.api.plan.types.WithBatch;
 import uk.ac.manchester.tornado.api.plan.types.WithClearProfiles;
 import uk.ac.manchester.tornado.api.plan.types.WithCompilerFlags;
@@ -40,6 +41,7 @@ import uk.ac.manchester.tornado.api.plan.types.WithDefaultScheduler;
 import uk.ac.manchester.tornado.api.plan.types.WithDevice;
 import uk.ac.manchester.tornado.api.plan.types.WithDynamicReconfiguration;
 import uk.ac.manchester.tornado.api.plan.types.WithFreeDeviceMemory;
+import uk.ac.manchester.tornado.api.plan.types.WithGraph;
 import uk.ac.manchester.tornado.api.plan.types.WithGridScheduler;
 import uk.ac.manchester.tornado.api.plan.types.WithMemoryLimit;
 import uk.ac.manchester.tornado.api.plan.types.WithPrintKernel;
@@ -163,6 +165,34 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
         TornadoExecutionResult executionResult = new TornadoExecutionResult(profilerResult);
         planResults.add(executionResult);
         return executionResult;
+    }
+
+    /**
+     * Select a graph from the {@link TornadoExecutionPlan} to execute.
+     * This method allows developers to select a specific graph from the
+     * execution plan to launch. Developers can choose which graph from
+     * the input list to use (passed in the constructor).
+     *
+     * 
+     * @since 1.0.9
+     * @param graphIndex
+     * @return {@link TornadoExecutionPlan}
+     */
+    public TornadoExecutionPlan withGraph(int graphIndex) {
+        tornadoExecutor.selectGraph(graphIndex);
+        return new WithGraph(this, graphIndex);
+    }
+
+    /**
+     * Select all graphs from the {@link TornadoExecutionPlan}. This method
+     * has an effect if the {@link #withGraph(int)} method was invoked.
+     *
+     * @since 1.0.9
+     * @return {@link TornadoExecutionPlan}
+     */
+    public TornadoExecutionPlan withAllGraphs() {
+        tornadoExecutor.selectAll();
+        return new WithAllGraphs(this);
     }
 
     /**
@@ -522,4 +552,5 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
         }
         return planResults.get(index);
     }
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -17,15 +17,15 @@
  */
 package uk.ac.manchester.tornado.api;
 
-import uk.ac.manchester.tornado.api.common.TornadoDevice;
-import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
-import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
-import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
 
 /**
  * Executor Class to dispatch Tornado Task-Graphs. An executor plan
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 class TornadoExecutor {
 
     private final List<ImmutableTaskGraph> immutableTaskGraphList;
+    private List<ImmutableTaskGraph> subgraphList;
 
     TornadoExecutor(ImmutableTaskGraph... immutableTaskGraphs) {
         immutableTaskGraphList = new ArrayList<>();
@@ -221,5 +222,23 @@ class TornadoExecutor {
 
     long getCurrentDeviceMemoryUsage() {
         return immutableTaskGraphList.stream().mapToLong(ImmutableTaskGraph::getCurrentDeviceMemoryUsage).sum();
+    }
+
+    void selectGraph(int graphIndex) {
+        if (subgraphList == null) {
+            subgraphList = new ArrayList<>();
+            immutableTaskGraphList.forEach(g -> Collections.addAll(subgraphList, g));
+        }
+        immutableTaskGraphList.clear();
+        Collections.addAll(immutableTaskGraphList, subgraphList.get(graphIndex));
+    }
+
+    void selectAll() {
+        if (subgraphList == null) {
+            return;
+        }
+        immutableTaskGraphList.clear();
+        subgraphList.forEach(g -> Collections.addAll(immutableTaskGraphList, g));
+        subgraphList = null;
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithAllGraphs.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithAllGraphs.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.plan.types;
+
+import uk.ac.manchester.tornado.api.ExecutionPlanType;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+
+public final class WithAllGraphs extends ExecutionPlanType {
+
+    public WithAllGraphs(TornadoExecutionPlan parent) {
+        super(parent);
+    }
+
+    @Override
+    public String toString() {
+        return parentLink.toString() + "\n -> withAllGraphs ";
+    }
+
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithGraph.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.plan.types;
+
+import uk.ac.manchester.tornado.api.ExecutionPlanType;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+
+public final class WithGraph extends ExecutionPlanType {
+
+    private final int graphIndexSelected;
+
+    public WithGraph(TornadoExecutionPlan parent, int graphIndexSelected) {
+        super(parent);
+        this.graphIndexSelected = graphIndexSelected;
+    }
+
+    @Override
+    public String toString() {
+        return parentLink.toString() + "\n -> withGraph(" + graphIndexSelected + ") ";
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
@@ -376,25 +376,26 @@ public class TestExecutor extends TornadoTestBase {
         }
 
         TaskGraph tg1 = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
                 .task("t0", TestHello::add, a, b, c) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
 
         // Set dependency from graph tg1 to tg2 
 
         TaskGraph tg2 = new TaskGraph("s1") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, c) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, c) //
                 .task("t1", TestHello::compute, c) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
 
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot())) {
 
+            // Select graph 0 (tg1) and run
             executionPlan.withGraph(0).execute();
             for (int i = 0; i < c.getSize(); i++) {
                 assertEquals(a.get(i) + b.get(i), c.get(i));
             }
 
-            // Select the graph 0 (tg1) to execute
+            // Select the graph 1 (tg2) and run
             executionPlan.withGraph(1).execute();
             for (int i = 0; i < c.getSize(); i++) {
                 assertEquals((a.get(i) + b.get(i)) * 2, c.get(i));

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
@@ -304,7 +304,9 @@ public class TestExecutor extends TornadoTestBase {
     }
 
     /**
-     * Test Multi-Graphs in an execution plan
+     * Test Multi-Graphs in an execution plan. An execution plan can hold and launch
+     * multiple immutable task graphs. This tests shows how to execute individual immutable
+     * task graphs in any order.
      * 
      * @throws TornadoExecutionPlanException
      */
@@ -331,6 +333,8 @@ public class TestExecutor extends TornadoTestBase {
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot())) {
 
             // Select graph 1 (tg2) to execute
+            // Once selected, every time we call the execute method,
+            // TornadoVM will launch the passed task-graph.
             executionPlan.withGraph(1).execute();
             for (int i = 0; i < c.getSize(); i++) {
                 assertEquals(a.get(i) + b.get(i), c.get(i));
@@ -343,6 +347,10 @@ public class TestExecutor extends TornadoTestBase {
             }
 
             // Select all graphs (tg1 and tg2) to execute.
+            // Since we selected individual task-graphs, we should be
+            // able to reverse this action and invoke all task-graph
+            // again. This is achieved with the `withAllGraphs` from the
+            // execution plan.
             executionPlan.withAllGraphs().execute();
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
@@ -357,7 +357,7 @@ public class TestExecutor extends TornadoTestBase {
     }
 
     /**
-     * Test Multi-Graphs in an execution plan. Based on the {@link #test06()}, this test checke
+     * Test Multi-Graphs in an execution plan. Based on the {@link #test06()}, this test checks
      * task-graphs with different tasks and data.
      *
      * @throws TornadoExecutionPlanException


### PR DESCRIPTION
#### Description

This PR extends the `TornadoExecutionPlan` API with a new method to select a graph to launch from a multi-graph execution plan configuration. This type of code is useful when we need to share context (e.g., command queues, cuda streams, code cache, etc) for the whole execution plan, but we only need to execute a task-graph at the time. 

The two methods added are as follows:

```java
try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot())) {

      // Select graph 1 (tg2) to execute
      // Once selected, every time we call the execute method,
      // TornadoVM will launch the passed task-graph.
      executionPlan.withGraph(1).execute();
  
      // Select the graph 0 (tg1) to execute
      executionPlan.withGraph(0).execute();

      // Select all graphs (tg1 and tg2) to execute.
      // Since we selected individual task-graphs, we should be
      // able to reverse this action and invoke all task-graph
      // again. This is achieved with the `withAllGraphs` from the
      // execution plan.
       executionPlan.withAllGraphs().execute();
 }
```

This allows the following pattern in TornadoVM:

```java
for (numIterations):
   executionPlan.withGraph(1).execute(); 
}

executionPlan.withGraph(2).execute();
...
```


#### Problem description

This path expands the capabilities of TornadoVM towards sharing state across different task-graph within a single execution plan. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-test --printKernel --threadInfo -V uk.ac.manchester.tornado.unittests.executor.TestExecutor#test06
```
