### PR TITLE
[release] TornadoVM 1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TornadoVM
 
-![TornadoVM version](https://img.shields.io/badge/version-1.0.8-purple)  [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2) [![License: GPL v2](https://img.shields.io/badge/License-GPL%20V2%20Classpth%20Exeception-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+![TornadoVM version](https://img.shields.io/badge/version-1.0.9-purple)  [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2) [![License: GPL v2](https://img.shields.io/badge/License-GPL%20V2%20Classpth%20Exeception-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 
 <img align="left" width="250" height="250" src="etc/tornadoVM_Logo.jpg">
 
@@ -20,7 +20,7 @@ Developers can choose which backends to install and run.
 
 For a quick introduction please read the following [FAQ](https://tornadovm.readthedocs.io/en/latest/).
 
-**Latest Release:** TornadoVM 1.0.8 - 30/09/2024 :
+**Latest Release:** TornadoVM 1.0.9 - 20/12/2024 :
 See [CHANGELOG](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html).
 
 ----------------------
@@ -261,12 +261,12 @@ You can import the TornadoVM API by setting this the following dependency in the
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
 </dependency>
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-matrices</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
 </dependency>
 </dependencies>
 ```

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -36,7 +36,7 @@ import installer_config as config
 ## Configuration
 ## ################################################################
 __DIRECTORY_DEPENDENCIES__ = os.path.join("etc", "dependencies")
-__VERSION__ = "v1.0.9-dev"
+__VERSION__ = "v1.0.9"
 
 __SUPPORTED_JDKS__ = [
     config.__JDK21__,

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -5,6 +5,51 @@ TornadoVM Changelog
 
 This file summarizes the new features and major changes for each *TornadoVM* version.
 
+
+TornadoVM 1.0.9
+---------------
+20th December 2024
+
+Improvements
+~~~~~~~~~~~~
+
+- `#573 <https://github.com/beehive-lab/TornadoVM/pull/573>`_: Enhanced output of unit-tests with a summary  of pass-rates and fail-rates.
+- `#576 <https://github.com/beehive-lab/TornadoVM/pull/576>`_: Extended support for 3D matrices. 
+- `#580 <https://github.com/beehive-lab/TornadoVM/pull/580>`_: Extended debug information for execution plans. 
+- `#584 <https://github.com/beehive-lab/TornadoVM/pull/584>`_: Added helper menu for the ``tornado`` launcher script when no arguments are passed. 
+- `#589 <https://github.com/beehive-lab/TornadoVM/pull/589>`_: Enable partial loop unrolling for all backends. 
+- `#594 <https://github.com/beehive-lab/TornadoVM/pull/594>`_: Added RISC-V 64 CPU port support to run OpenCL with vector instructions RVV 1.0 (using the Codeplay OCK Toolkit). 
+- `#598 <https://github.com/beehive-lab/TornadoVM/pull/598>`_: OpenCL low-level buffers tagged as read, write and read/write based on the data dependency analysis. 
+- `#601 <https://github.com/beehive-lab/TornadoVM/pull/601>`_: Feature to select an immutable task graph to execute from a multi-task graph execution plan.
+
+
+Compatibility
+~~~~~~~~~~~~~
+
+- `#570 <https://github.com/beehive-lab/TornadoVM/pull/570>`_:  Extended timeout for all suite of unit-tests.
+- `#579 <https://github.com/beehive-lab/TornadoVM/pull/579>`_: Removed legacy JDK 8 and JDK11 build options from the TornadoVM installer. 
+- `#582 <https://github.com/beehive-lab/TornadoVM/pull/582>`_: Restored tornado runner scripts for IntellIJ. 
+- `#583 <https://github.com/beehive-lab/TornadoVM/pull/583>`_: Automatic generation of IDE IntelliJ configuration runner files from the TornadoVM command. 
+- `#597 <https://github.com/beehive-lab/TornadoVM/pull/597>`_: Updated white-list of unit-test and checkstyle improved.
+
+
+Bug Fixes
+~~~~~~~~~
+
+- `#571 <https://github.com/beehive-lab/TornadoVM/pull/571>`_: Fix issues with bracket closing for if/loops conditions. 
+- `#572 <https://github.com/beehive-lab/TornadoVM/pull/572>`_: Fix for printing default execution plans (execution plans with default parameters). 
+- `#575 <https://github.com/beehive-lab/TornadoVM/pull/575>`_: Fix the Level Zero version used for building the SPIR-V backend. 
+- `#577 <https://github.com/beehive-lab/TornadoVM/pull/577>`_: Fix checkstyle.
+- `#587 <https://github.com/beehive-lab/TornadoVM/pull/587>`_: Fix thread scheduler for new NVIDIA Drivers.
+- `#592 <https://github.com/beehive-lab/TornadoVM/pull/592>`_: Fix ``Float.POSITIVE_INFINITY`` and ``Float.NEGATIVE_INFINITIVE`` constants for the OpenCL, CUDA and SPIR-V backends. 
+- `#596 <https://github.com/beehive-lab/TornadoVM/pull/596>`_: Fix extra closing bracket during the code-generation for the FPGAs. 
+- Remove the intermediate CUDA pinned memory regions in the JNI code: `link <https://github.com/beehive-lab/TornadoVM/commit/9c3f8ce7eb917f30788710b390c07a072ecc49fb>`_
+- Fix bitwise negation operations for the PTX backend:  `link <https://github.com/beehive-lab/TornadoVM/commit/0db1cd3e7fd90accd737ca2bfd6d2450c40f3713>`_ 
+- ``GetBackendImpl::getAllDevices`` thread-safe: `link <https://github.com/beehive-lab/TornadoVM/commit/0d4425264ffe0633ea79c8aba91233591059d3fd>`_ 
+- Check size elements for memory segments: `link <https://github.com/beehive-lab/TornadoVM/commit/4360385156236bb2397debeea65fedea349c6bca>`_. 
+
+
+
 TornadoVM 1.0.8
 ---------------
 30th September 2024

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@ copyright = "2013-2024, APT Group, Department of Computer Science"
 author = "The University of Manchester"
 
 release = "v1.0.9"
-version = "v1.0.9-dev"
+version = "v1.0.9"
 
 # -- General configuration
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -560,13 +560,13 @@ To use the TornadoVM API in your projects, you can checkout our maven repository
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>1.0.8</version>
+         <version>1.0.9</version>
       </dependency>
 
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>1.0.8</version>
+         <version>1.0.9</version>
       </dependency>
    </dependencies>
 
@@ -577,7 +577,7 @@ Notice that, for running with TornadoVM, you will need either the docker images 
 Versions available
 ========================
 
-* 1.0.8
+* 1.0.9
 * 1.0.7
 * 1.0.6
 * 1.0.5

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>tornado</groupId>
     <artifactId>tornado</artifactId>
-    <version>1.0.9-dev</version>
+    <version>1.0.9</version>
     <packaging>pom</packaging>
     <name>tornado</name>
     <url>https://github.com/beehive-lab/tornadovm</url>

--- a/tornado-annotation/pom.xml
+++ b/tornado-annotation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
 
     <artifactId>tornado-annotation</artifactId>

--- a/tornado-api/pom.xml
+++ b/tornado-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
 
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.9-dev</version>
+    <version>1.0.9</version>
 
     <name>tornado-api</name>
     <url>https://tornadovm.org</url>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-assembly</artifactId>
     <packaging>pom</packaging>

--- a/tornado-benchmarks/pom.xml
+++ b/tornado-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
 
     <artifactId>tornado-benchmarks</artifactId>

--- a/tornado-drivers/drivers-common/pom.xml
+++ b/tornado-drivers/drivers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tornado-drivers/opencl-jni/pom.xml
+++ b/tornado-drivers/opencl-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-drivers-opencl-jni</artifactId>
     <name>tornado-drivers-opencl-jni</name>

--- a/tornado-drivers/opencl/pom.xml
+++ b/tornado-drivers/opencl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-drivers-opencl</artifactId>
     <name>tornado-drivers-opencl</name>

--- a/tornado-drivers/pom.xml
+++ b/tornado-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-drivers</artifactId>
     <name>tornado-drivers</name>

--- a/tornado-drivers/ptx-jni/pom.xml
+++ b/tornado-drivers/ptx-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-drivers-ptx-jni</artifactId>
     <name>tornado-drivers-ptx-jni</name>

--- a/tornado-drivers/ptx/pom.xml
+++ b/tornado-drivers/ptx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tornado-drivers</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-drivers-ptx</artifactId>
     <name>tornado-drivers-ptx</name>

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-drivers-spirv</artifactId>
     <name>tornado-drivers-spirv</name>

--- a/tornado-examples/pom.xml
+++ b/tornado-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-examples</artifactId>
     <name>tornado-examples</name>

--- a/tornado-matrices/pom.xml
+++ b/tornado-matrices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-matrices</artifactId>
     <name>tornado-matrices</name>

--- a/tornado-runtime/pom.xml
+++ b/tornado-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-runtime</artifactId>
     <name>tornado-runtime</name>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.9-dev</version>
+        <version>1.0.9</version>
     </parent>
     <artifactId>tornado-unittests</artifactId>
     <name>tornado-unittests</name>


### PR DESCRIPTION
Improvements
=============

- #573: Enhanced output of unit-tests with a summary  of pass-rates and fail-rates.
- #576: Extended support for 3D matrices.
- #580: Extended debug information for execution plans.
- #584: Added helper menu for the ``tornado`` launcher script when no arguments are passed.
- #589: Enable partial loop unrolling for all backends.
- #594: Added RISC-V 64 CPU port support to run OpenCL with vector instructions RVV 1.0 (using the Codeplay OCK Toolkit).
- #598: OpenCL low-level buffers tagged as read, write and read/write based on the data dependency analysis.
- #601: Feature to select an immutable task graph to execute from a multi-task graph execution plan.

Compatibility
=============

- #570:  Extended timeout for all suite of unit-tests.
- #579: Removed legacy JDK 8 and JDK11 build options from the TornadoVM installer.
- #582: Restored tornado runner scripts for IntellIJ.
- #583: Automatic generation of IDE IntelliJ configuration runner files from the TornadoVM command.
- #597: Updated white-list of unit-test and checkstyle improved.

Bug Fixes
=============

- #571: Fix issues with bracket closing for if/loops conditions.
- #572: Fix for printing default execution plans (execution plans with default parameters).
- #575: Fix the Level Zero version used for building the SPIR-V backend.
- #577: Fix checkstyle.
- #587: Fix thread scheduler for new NVIDIA Drivers.
- #592: Fix ``Float.POSITIVE_INFINITY`` and ``Float.NEGATIVE_INFINITIVE`` constants for the OpenCL, CUDA and SPIR-V backends.
- #596: Fix extra closing bracket during the code-generation for the FPGAs.
- Remove the intermediate CUDA pinned memory regions in the JNI code: [link](https://github.com/beehive-lab/TornadoVM/commit/9c3f8ce7eb917f30788710b390c07a072ecc49fb)
- Fix bitwise negation operations for the PTX backend:  [link](https://github.com/beehive-lab/TornadoVM/commit/0db1cd3e7fd90accd737ca2bfd6d2450c40f3713)
- `GetBackendImpl::getAllDevices` thread-safe: [link](https://github.com/beehive-lab/TornadoVM/commit/0d4425264ffe0633ea79c8aba91233591059d3fd)
- Check size elements for memory segments: [link](https://github.com/beehive-lab/TornadoVM/commit/4360385156236bb2397debeea65fedea349c6bca)

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [X] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

For all backends: 

```bash
make
make fast-tests
```
