### PR TITLE
[feat] Individual selection of Level Zero and/or OpenCL runtimes for SPIR-V 

### DIFF
--- a/docs/source/spirv-backend.rst
+++ b/docs/source/spirv-backend.rst
@@ -69,7 +69,9 @@ TornadoVM/Java Options for SPIR-V:
 
 - ``-Dtornado.spirv.version=1.2``: Modify the minimum version supported. By default is 1.2. However, developers can change this value. Note that the generated code might not work, as TornadoVM requires at least 1.2.
 
-- ``-Dtornado.spirv.dispatcher=opencl``: It sets the runtime to dispatch SPIR-V kernels. Allowed values are: ``opencl`` and ``levelzero``.
+- ``-Dtornado.spirv.default.dispatcher=opencl``: It sets the runtime to dispatch SPIR-V kernels. Allowed values are: ``opencl`` and ``levelzero``.
+
+- ``-Dtornado.spirv.runtimes=opencl,levelzero``: It sets the list of supported runtimes to dispatch SPIR-V. Allowed values are: ``opencl`` and ``levelzero``.
 
 - ``-Dtornado.spirv.levelzero.extended.memory=True``: It uses Level Zero extended memory mode. It is set to ``true`` by default.
 

--- a/docs/source/spirv-backend.rst
+++ b/docs/source/spirv-backend.rst
@@ -1,4 +1,4 @@
-SPIR-V Devices
+\SPIR-V Devices
 ====================================
 
 SPIR-V makes use of the `Intel Level Zero API <https://spec.oneapi.io/level-zero/latest/index.html>`__.
@@ -69,9 +69,7 @@ TornadoVM/Java Options for SPIR-V:
 
 - ``-Dtornado.spirv.version=1.2``: Modify the minimum version supported. By default is 1.2. However, developers can change this value. Note that the generated code might not work, as TornadoVM requires at least 1.2.
 
-- ``-Dtornado.spirv.default.dispatcher=opencl``: It sets the runtime to dispatch SPIR-V kernels. Allowed values are: ``opencl`` and ``levelzero``.
-
-- ``-Dtornado.spirv.runtimes=opencl,levelzero``: It sets the list of supported runtimes to dispatch SPIR-V. Allowed values are: ``opencl`` and ``levelzero``.
+- ``-Dtornado.spirv.runtimes=opencl,levelzero``: It sets the list of supported runtimes to dispatch SPIR-V. Allowed values are: ``opencl`` and ``levelzero``. They are sepated by a comma, and the first in the list is taken as deafult. 
 
 - ``-Dtornado.spirv.levelzero.extended.memory=True``: It uses Level Zero extended memory mode. It is set to ``true`` by default.
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLPragmaUnroll.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLPragmaUnroll.java
@@ -9,15 +9,15 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResu
 @Opcode("Unroll")
 public class OCLPragmaUnroll extends OCLLIROp {
 
-    private int unroll;
+    private final int unrollFactor;
 
-    public OCLPragmaUnroll(int unroll) {
+    public OCLPragmaUnroll(int unrollFactor) {
         super(LIRKind.Illegal);
-        this.unroll = unroll;
+        this.unrollFactor = unrollFactor;
     }
 
     @Override
     public void emit(OCLCompilationResultBuilder crb, OCLAssembler asm) {
-        asm.emitLine("#pragma unroll " + unroll);
+        asm.emitLine("#pragma unroll " + unrollFactor);
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVBackendImpl.java
@@ -75,7 +75,7 @@ public final class SPIRVBackendImpl implements TornadoAcceleratorBackend {
         logger.info("[SPIR-V] Found %d platforms", numPlatforms);
 
         if (numPlatforms < 1) {
-            throw new TornadoBailoutRuntimeException("[Warning] No SPIR-V platforms found. Deoptimizing to sequential execution");
+            throw new TornadoBailoutRuntimeException("[ERROR] No SPIR-V platforms found. Deoptimizing to sequential execution");
         }
         platforms = new ArrayList<>();
         spirvBackends = new SPIRVBackend[numPlatforms][];

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOpenCLPlatform.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVOpenCLPlatform.java
@@ -31,9 +31,9 @@ import uk.ac.manchester.tornado.drivers.opencl.TornadoPlatformInterface;
 
 public class SPIRVOpenCLPlatform implements SPIRVPlatform {
 
-    private TornadoPlatformInterface oclPlatform;
+    private final TornadoPlatformInterface oclPlatform;
     private OCLContextInterface context;
-    private List<SPIRVDevice> spirvDevices;
+    private final List<SPIRVDevice> spirvDevices;
 
     public SPIRVOpenCLPlatform(int platformIndex, TornadoPlatformInterface oclPlatform) {
         this.oclPlatform = oclPlatform;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
@@ -43,8 +43,6 @@ import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
  */
 public class SPIRVRuntimeImpl {
 
-    private final String ERROR_PLATFORM_NOT_IMPLEMENTED = "SPIR-V Runtime Implementation not supported: " + TornadoOptions.SPIRV_DEFAULT_RUNTIME + " \nUse \"opencl\" or \"levelzero\"";
-
     private List<SPIRVPlatform> platforms;
     private static SPIRVRuntimeImpl instance;
 
@@ -59,29 +57,28 @@ public class SPIRVRuntimeImpl {
         init();
     }
 
+    private String printErrorPlatformNotImplemented(String spirvPlatform) {
+        return "SPIR-V Runtime Implementation not supported: " + spirvPlatform + " \nUse \"opencl\" or \"levelzero\"";
+    }
+
     private SPIRVDispatcher instantiateDispatcher(String runtimeName) {
         if (runtimeName.equalsIgnoreCase("opencl")) {
             return new SPIRVOpenCLDriver();
         } else if (runtimeName.equalsIgnoreCase("levelzero")) {
             return new SPIRVLevelZeroDriver();
         } else {
-            throw new TornadoRuntimeException(ERROR_PLATFORM_NOT_IMPLEMENTED);
+            throw new TornadoRuntimeException(printErrorPlatformNotImplemented(runtimeName));
         }
     }
 
     private synchronized void init() {
         if (platforms == null) {
             List<SPIRVDispatcher> dispatchers = new ArrayList<>();
-            dispatchers.add(instantiateDispatcher(TornadoOptions.SPIRV_DEFAULT_RUNTIME));
-
             String[] listOfRuntimes = TornadoOptions.SPIRV_INSTALLED_RUNTIMES.split(",");
-            if (listOfRuntimes.length > 1) {
-                // We need to install the second runtime
-                for (String runtime : listOfRuntimes) {
-                    if (!runtime.equals(TornadoOptions.SPIRV_DEFAULT_RUNTIME)) {
-                        dispatchers.add( instantiateDispatcher(runtime));
-                    }
-                }
+
+            // We need to install the second runtime
+            for (String runtime : listOfRuntimes) {
+                dispatchers.add(instantiateDispatcher(runtime));
             }
 
             platforms = new ArrayList<>();

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2021, 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2021, 2024-2025 APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
@@ -60,16 +60,13 @@ public class SPIRVRuntimeImpl {
     }
 
     private SPIRVDispatcher instantiateDispatcher(String runtimeName) {
-        SPIRVDispatcher dispatcher;
-        System.out.println("Creating Dispatcher for " + runtimeName);
         if (runtimeName.equalsIgnoreCase("opencl")) {
-            dispatcher = new SPIRVOpenCLDriver();
+            return new SPIRVOpenCLDriver();
         } else if (runtimeName.equalsIgnoreCase("levelzero")) {
-            dispatcher = new SPIRVLevelZeroDriver();
+            return new SPIRVLevelZeroDriver();
         } else {
             throw new TornadoRuntimeException(ERROR_PLATFORM_NOT_IMPLEMENTED);
         }
-        return dispatcher;
     }
 
     private synchronized void init() {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/SPIRVRuntimeImpl.java
@@ -24,7 +24,9 @@
 package uk.ac.manchester.tornado.drivers.spirv;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
@@ -73,13 +75,8 @@ public class SPIRVRuntimeImpl {
 
     private synchronized void init() {
         if (platforms == null) {
-            List<SPIRVDispatcher> dispatchers = new ArrayList<>();
             String[] listOfRuntimes = TornadoOptions.SPIRV_INSTALLED_RUNTIMES.split(",");
-
-            // We need to install the second runtime
-            for (String runtime : listOfRuntimes) {
-                dispatchers.add(instantiateDispatcher(runtime));
-            }
+            List<SPIRVDispatcher> dispatchers = Arrays.stream(listOfRuntimes).map(this::instantiateDispatcher).toList();
 
             platforms = new ArrayList<>();
             for (SPIRVDispatcher dispatcher : dispatchers) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -220,7 +220,7 @@ public class TornadoOptions {
     /**
      * Use Level Zero or OpenCL as the SPIR-V Code runtime and code dispatcher. Allowed values: "opencl", "levelzero". The default option is "opencl".
      */
-    public static final String SPIRV_DEFAULT_RUNTIME = getProperty("tornado.spirv.dispatcher", "opencl");
+    public static final String SPIRV_DEFAULT_RUNTIME = getProperty("tornado.spirv.default.dispatcher", "opencl");
 
     /**
      * List of installed SPIR-V runtimes. Allowed values : "opencl,levelzero".

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -217,19 +217,17 @@ public class TornadoOptions {
      * It enables inlining during Java bytecode parsing. Default is False.
      */
     public static final boolean INLINE_DURING_BYTECODE_PARSING = getBooleanValue("tornado.compiler.bytecodeInlining", FALSE);
-    /**
-     * Use Level Zero or OpenCL as the SPIR-V Code runtime and code dispatcher. Allowed values: "opencl", "levelzero". The default option is "opencl".
-     */
-    public static final String SPIRV_DEFAULT_RUNTIME = getProperty("tornado.spirv.default.dispatcher", "opencl");
 
     /**
-     * List of installed SPIR-V runtimes. Allowed values : "opencl,levelzero".
+     * List of installed SPIR-V runtimes. Allowed values : "opencl,levelzero". The first in the list is set to the
+     * default one.
      *
      * <p>
      * <ul>
      *   <il>Use <code>-Dtornado.spirv.runtimes=opencl</code> for OpenCL only.
      *   <il>Use <code>-Dtornado.spirv.runtimes=levelzero</code> for LevelZero only.
-     *   <il>Use <code>-Dtornado.spirv.runtimes=opencl,levelzero</code> for both OpenCL and Level Zero runtimes.
+     *   <il>Use <code>-Dtornado.spirv.runtimes=opencl,levelzero</code> for both OpenCL and Level Zero runtimes, being
+     *   OpenCL the first in the list (default).
      * *</ul>
      * </p>
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2013-2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2025, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -218,9 +218,23 @@ public class TornadoOptions {
      */
     public static final boolean INLINE_DURING_BYTECODE_PARSING = getBooleanValue("tornado.compiler.bytecodeInlining", FALSE);
     /**
-     * Use Level Zero or OpenCL as the SPIR-V Code Dispatcher and Runtime. Allowed values: "opencl", "levelzero". The default option is "opencl".
+     * Use Level Zero or OpenCL as the SPIR-V Code runtime and code dispatcher. Allowed values: "opencl", "levelzero". The default option is "opencl".
      */
-    public static final String SPIRV_DISPATCHER = getProperty("tornado.spirv.dispatcher", "opencl");
+    public static final String SPIRV_DEFAULT_RUNTIME = getProperty("tornado.spirv.dispatcher", "opencl");
+
+    /**
+     * List of installed SPIR-V runtimes. Allowed values : "opencl,levelzero".
+     *
+     * <p>
+     * <ul>
+     *   <il>Use <code>-Dtornado.spirv.runtimes=opencl</code> for OpenCL only.
+     *   <il>Use <code>-Dtornado.spirv.runtimes=levelzero</code> for LevelZero only.
+     *   <il>Use <code>-Dtornado.spirv.runtimes=opencl,levelzero</code> for both OpenCL and Level Zero runtimes.
+     * *</ul>
+     * </p>
+     */
+    public static final String SPIRV_INSTALLED_RUNTIMES = getProperty("tornado.spirv.runtimes", "opencl,levelzero");
+
     /**
      * Check I/O parameters for every task within a task-graph.
      */


### PR DESCRIPTION
#### Description

**Updated** See discussions below.

This PR extends TornadoVM to select individual runtimes for dispatching and managing SPIR-V. To do so, this PR introduces new option (`-Dtornado.spirv.runtimes`) 

To select **only** the level zero port with SPIR-V.

```bash
tornado <flags> --jvm="-Dtornado.spirv.runtimes=levelzero " <program>
```

To select **only** the OpenCL port with SPIR-V:

```bash
tornado <flags> --jvm="-Dtornado.spirv.runtimes=opencl " <program>
```

To select both OpenCL and SPIR-V. The default one is the first in the list. 

```bash
tornado <flags> --jvm="-Dtornado.spirv.runtimes=opencl,levelzero " <program>
```

Developers can select either `opencl` or `levelzero` as a default dispatcher.


#### Problem description

The main obstacle was that TornadoVM required both Level Zero and OpenCL runtimes to work with SPIR-V. This PR solves this and introduces a custom selection for the dispatch runtimes to be enabled. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?


Select only OpenCL:

```bash
tornado --jvm="-Dtornado.spirv.runtimes=opencl" --devices
WARNING: Using incubator modules: jdk.incubator.vector

Number of Tornado drivers: 1
Driver: SPIR-V
  Total number of SPIR-V devices  : 1
  Tornado device=0:0  (DEFAULT)
	SPIRV -- SPIRV OCL - Intel(R) UHD Graphics 770
		Global Memory Size: 28.8 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [512]
		Max WorkGroup Configuration: [512, 512, 512]
		Device OpenCL C version: OpenCL C 1.2


```

Select Level Zero:

```bash
tornado --jvm="-Dtornado.spirv.runtimes=levelzero" --devices
WARNING: Using incubator modules: jdk.incubator.vector

Number of Tornado drivers: 1
Driver: SPIR-V
  Total number of SPIR-V devices  : 1
  Tornado device=0:0  (DEFAULT)
	SPIRV -- SPIRV LevelZero - Intel(R) UHD Graphics 770
		Global Memory Size: 28.8 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [512]
		Max WorkGroup Configuration: [512, 512, 512]
		Device OpenCL C version:  (LEVEL ZERO) 1.5

```

Select both runtimes with Level Zero as default:


```bash
tornado --jvm="-Dtornado.spirv.runtimes=levelzero,opencl" --devices
WARNING: Using incubator modules: jdk.incubator.vector

Number of Tornado drivers: 1
Driver: SPIR-V
  Total number of SPIR-V devices  : 2
  Tornado device=0:0  (DEFAULT)
	SPIRV -- SPIRV LevelZero - Intel(R) UHD Graphics 770
		Global Memory Size: 28.8 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [512]
		Max WorkGroup Configuration: [512, 512, 512]
		Device OpenCL C version:  (LEVEL ZERO) 1.5

  Tornado device=0:1
	SPIRV -- SPIRV OCL - Intel(R) UHD Graphics 770
		Global Memory Size: 28.8 GB
		Local Memory Size: 64.0 KB
		Workgroup Dimensions: 3
		Total Number of Block Threads: [512]
		Max WorkGroup Configuration: [512, 512, 512]
		Device OpenCL C version: OpenCL C 1.2
```

