### PR TITLE
Support Multiplication of Half Float Matrices

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/HalfFloatStamp.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/HalfFloatStamp.java
@@ -1,0 +1,88 @@
+package uk.ac.manchester.tornado.drivers.opencl.graal;
+
+import jdk.vm.ci.meta.Constant;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.MemoryAccessProvider;
+import jdk.vm.ci.meta.MetaAccessProvider;
+import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.spi.LIRKindTool;
+import org.graalvm.compiler.core.common.type.Stamp;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
+
+public class HalfFloatStamp extends Stamp {
+    @Override
+    public ResolvedJavaType javaType(MetaAccessProvider metaAccess) {
+        return metaAccess.lookupJavaType(java.lang.Short.TYPE);
+    }
+
+    @Override
+    public JavaKind getStackKind() {
+        return JavaKind.Short;
+    }
+
+    @Override
+    public LIRKind getLIRKind(LIRKindTool tool) {
+        return LIRKind.value(OCLKind.HALF);
+    }
+
+    @Override
+    public Stamp meet(Stamp other) {
+        return this;
+    }
+
+    @Override
+    public Stamp join(Stamp other) {
+        return this;
+    }
+
+    @Override
+    public Stamp unrestricted() {
+        return this;
+    }
+
+    @Override
+    public Stamp empty() {
+        return this;
+    }
+
+    @Override
+    public Stamp constant(Constant c, MetaAccessProvider meta) {
+        return null;
+    }
+
+    @Override
+    public boolean isCompatible(Stamp other) {
+        return true;
+    }
+
+    @Override
+    public boolean isCompatible(Constant constant) {
+        return true;
+    }
+
+    @Override
+    public boolean hasValues() {
+        return true;
+    }
+
+    @Override
+    public Constant readConstant(MemoryAccessProvider provider, Constant base, long displacement) {
+        return null;
+    }
+
+    @Override
+    public Stamp improveWith(Stamp other) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "half";
+    }
+
+    @Override
+    public void accept(Visitor v) {
+
+    }
+}

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/HalfFloatStamp.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/HalfFloatStamp.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2018-2022 APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.opencl.graal;
 
 import jdk.vm.ci.meta.Constant;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/HalfFloatStamp.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/HalfFloatStamp.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2018-2022 APT Group, Department of Computer Science,
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
@@ -156,6 +156,43 @@ public class OCLLIRStmt {
 
     }
 
+    @Opcode("ADD_HALF")
+    public static class AddHalfStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<AddHalfStmt> TYPE = LIRInstructionClass.create(AddHalfStmt.class);
+
+        @Def
+        protected Value result;
+        @Use
+        protected Value x;
+        @Use
+        protected Value y;
+
+        public AddHalfStmt(Value result, Value x, Value y) {
+            super(TYPE);
+            this.result = result;
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public void emitCode(OCLCompilationResultBuilder crb, OCLAssembler asm) {
+            asm.indent();
+            asm.emitValue(crb, result);
+            asm.space();
+            asm.assign();
+            asm.space();
+            asm.emitValue(crb, x);
+            asm.space();
+            asm.emitSymbol("+");
+            asm.space();
+            asm.emitValue(crb, y);
+            asm.delimiter();
+            asm.eol();
+        }
+
+    }
+
     @Opcode("VSUB_HALF")
     public static class VectorSubHalfStmt extends AbstractInstruction {
 
@@ -197,6 +234,43 @@ public class OCLLIRStmt {
             } else {
                 asm.emitValue(crb, y);
             }
+            asm.delimiter();
+            asm.eol();
+        }
+
+    }
+
+    @Opcode("MULT_HALF")
+    public static class MultHalfStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<MultHalfStmt> TYPE = LIRInstructionClass.create(MultHalfStmt.class);
+
+        @Def
+        protected Value result;
+        @Use
+        protected Value x;
+        @Use
+        protected Value y;
+
+        public MultHalfStmt(Value result, Value x, Value y) {
+            super(TYPE);
+            this.result = result;
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public void emitCode(OCLCompilationResultBuilder crb, OCLAssembler asm) {
+            asm.indent();
+            asm.emitValue(crb, result);
+            asm.space();
+            asm.assign();
+            asm.space();
+            asm.emitValue(crb, x);
+            asm.space();
+            asm.emitSymbol("*");
+            asm.space();
+            asm.emitValue(crb, y);
             asm.delimiter();
             asm.eol();
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020-2022, 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2018, 2020-2022, 2024, 2025, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
@@ -193,6 +193,43 @@ public class OCLLIRStmt {
 
     }
 
+    @Opcode("SUB_HALF")
+    public static class SubHalfStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<SubHalfStmt> TYPE = LIRInstructionClass.create(SubHalfStmt.class);
+
+        @Def
+        protected Value result;
+        @Use
+        protected Value x;
+        @Use
+        protected Value y;
+
+        public SubHalfStmt(Value result, Value x, Value y) {
+            super(TYPE);
+            this.result = result;
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public void emitCode(OCLCompilationResultBuilder crb, OCLAssembler asm) {
+            asm.indent();
+            asm.emitValue(crb, result);
+            asm.space();
+            asm.assign();
+            asm.space();
+            asm.emitValue(crb, x);
+            asm.space();
+            asm.emitSymbol("-");
+            asm.space();
+            asm.emitValue(crb, y);
+            asm.delimiter();
+            asm.eol();
+        }
+
+    }
+
     @Opcode("VSUB_HALF")
     public static class VectorSubHalfStmt extends AbstractInstruction {
 
@@ -318,6 +355,43 @@ public class OCLLIRStmt {
             } else {
                 asm.emitValue(crb, y);
             }
+            asm.delimiter();
+            asm.eol();
+        }
+
+    }
+
+    @Opcode("DIV_HALF")
+    public static class DivHalfStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<DivHalfStmt> TYPE = LIRInstructionClass.create(DivHalfStmt.class);
+
+        @Def
+        protected Value result;
+        @Use
+        protected Value x;
+        @Use
+        protected Value y;
+
+        public DivHalfStmt(Value result, Value x, Value y) {
+            super(TYPE);
+            this.result = result;
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public void emitCode(OCLCompilationResultBuilder crb, OCLAssembler asm) {
+            asm.indent();
+            asm.emitValue(crb, result);
+            asm.space();
+            asm.assign();
+            asm.space();
+            asm.emitValue(crb, x);
+            asm.space();
+            asm.emitSymbol("/");
+            asm.space();
+            asm.emitValue(crb, y);
             asm.delimiter();
             asm.eol();
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/AddHalfNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/AddHalfNode.java
@@ -1,0 +1,40 @@
+package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
+
+@NodeInfo
+public class AddHalfNode extends ValueNode implements LIRLowerable {
+    public static final NodeClass<AddHalfNode> TYPE = NodeClass.create(AddHalfNode.class);
+
+    @Input
+    private ValueNode x;
+
+    @Input
+    private ValueNode y;
+
+    public AddHalfNode(ValueNode x, ValueNode y) {
+        super(TYPE, new HalfFloatStamp());
+        this.x = x;
+        this.y = y;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable result = tool.newVariable(LIRKind.value(OCLKind.HALF));
+        Value inputX = generator.operand(x);
+        Value inputY = generator.operand(y);
+        tool.append(new OCLLIRStmt.AddHalfStmt(result, inputX, inputY));
+        generator.setResult(this, result);
+    }
+}

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/AddHalfNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/AddHalfNode.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
 
 import jdk.vm.ci.meta.Value;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/DivHalfNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/DivHalfNode.java
@@ -1,0 +1,40 @@
+package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
+
+@NodeInfo
+public class DivHalfNode extends ValueNode implements LIRLowerable {
+    public static final NodeClass<DivHalfNode> TYPE = NodeClass.create(DivHalfNode.class);
+
+    @Input
+    private ValueNode x;
+
+    @Input
+    private ValueNode y;
+
+    public DivHalfNode(ValueNode x, ValueNode y) {
+        super(TYPE, new HalfFloatStamp());
+        this.x = x;
+        this.y = y;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable result = tool.newVariable(LIRKind.value(OCLKind.HALF));
+        Value inputX = generator.operand(x);
+        Value inputY = generator.operand(y);
+        tool.append(new OCLLIRStmt.DivHalfStmt(result, inputX, inputY));
+        generator.setResult(this, result);
+    }
+}

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/DivHalfNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/DivHalfNode.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
 
 import jdk.vm.ci.meta.Value;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/HalfFloatConstantNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/HalfFloatConstantNode.java
@@ -1,0 +1,33 @@
+package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
+
+import jdk.vm.ci.meta.Constant;
+import jdk.vm.ci.meta.JavaKind;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.ConstantValue;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.calc.FloatingNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
+
+@NodeInfo
+public class HalfFloatConstantNode extends FloatingNode implements LIRLowerable {
+
+    public static final NodeClass<HalfFloatConstantNode> TYPE = NodeClass.create(HalfFloatConstantNode.class);
+
+    private Constant halfFloatValue;
+
+    public HalfFloatConstantNode(Constant halfFloatValue) {
+        super(TYPE, new HalfFloatStamp());
+        this.halfFloatValue = halfFloatValue;
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool generator) {
+        generator.setResult(this, new ConstantValue(LIRKind.value(OCLKind.HALF), halfFloatValue));
+    }
+}

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/HalfFloatConstantNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/HalfFloatConstantNode.java
@@ -1,9 +1,27 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
 
-import jdk.vm.ci.meta.Constant;
-import jdk.vm.ci.meta.JavaKind;
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.ConstantValue;
 import org.graalvm.compiler.nodeinfo.NodeInfo;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/HalfFloatConstantNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/HalfFloatConstantNode.java
@@ -19,15 +19,16 @@ public class HalfFloatConstantNode extends FloatingNode implements LIRLowerable 
 
     public static final NodeClass<HalfFloatConstantNode> TYPE = NodeClass.create(HalfFloatConstantNode.class);
 
-    private Constant halfFloatValue;
+    @Input
+    private ConstantNode halfFloatValue;
 
-    public HalfFloatConstantNode(Constant halfFloatValue) {
+    public HalfFloatConstantNode(ConstantNode halfFloatValue) {
         super(TYPE, new HalfFloatStamp());
         this.halfFloatValue = halfFloatValue;
     }
 
     @Override
     public void generate(NodeLIRBuilderTool generator) {
-        generator.setResult(this, new ConstantValue(LIRKind.value(OCLKind.HALF), halfFloatValue));
+        generator.setResult(this, new ConstantValue(LIRKind.value(OCLKind.HALF), halfFloatValue.asConstant()));
     }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/MultHalfNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/MultHalfNode.java
@@ -1,9 +1,28 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
 
-import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/MultHalfNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/MultHalfNode.java
@@ -1,0 +1,42 @@
+package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
+
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
+
+@NodeInfo
+public class MultHalfNode extends ValueNode implements LIRLowerable {
+    public static final NodeClass<MultHalfNode> TYPE = NodeClass.create(MultHalfNode.class);
+
+    @Input
+    private ValueNode x;
+
+    @Input
+    private ValueNode y;
+
+    public MultHalfNode(ValueNode x, ValueNode y) {
+        super(TYPE, new HalfFloatStamp());
+        this.x = x;
+        this.y = y;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable result = tool.newVariable(LIRKind.value(OCLKind.HALF));
+        Value inputX = generator.operand(x);
+        Value inputY = generator.operand(y);
+        tool.append(new OCLLIRStmt.MultHalfStmt(result, inputX, inputY));
+        generator.setResult(this, result);
+    }
+}

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/ReadHalfFloatNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/ReadHalfFloatNode.java
@@ -34,6 +34,7 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLArchitecture;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
@@ -48,7 +49,7 @@ public class ReadHalfFloatNode extends FixedWithNextNode implements LIRLowerable
     private AddressNode addressNode;
 
     public ReadHalfFloatNode(AddressNode addressNode) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.addressNode = addressNode;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/ReadHalfFloatNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/ReadHalfFloatNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/SubHalfNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/SubHalfNode.java
@@ -1,0 +1,40 @@
+package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
+
+@NodeInfo
+public class SubHalfNode extends ValueNode implements LIRLowerable {
+    public static final NodeClass<SubHalfNode> TYPE = NodeClass.create(SubHalfNode.class);
+
+    @Input
+    private ValueNode x;
+
+    @Input
+    private ValueNode y;
+
+    public SubHalfNode(ValueNode x, ValueNode y) {
+        super(TYPE, new HalfFloatStamp());
+        this.x = x;
+        this.y = y;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable result = tool.newVariable(LIRKind.value(OCLKind.HALF));
+        Value inputX = generator.operand(x);
+        Value inputY = generator.operand(y);
+        tool.append(new OCLLIRStmt.SubHalfStmt(result, inputX, inputY));
+        generator.setResult(this, result);
+    }
+}

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/SubHalfNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/SubHalfNode.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
 
 import jdk.vm.ci.meta.Value;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/WriteHalfFloatNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/WriteHalfFloatNode.java
@@ -34,6 +34,7 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLArchitecture;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
@@ -51,7 +52,7 @@ public class WriteHalfFloatNode extends FixedWithNextNode implements LIRLowerabl
     private ValueNode valueNode;
 
     public WriteHalfFloatNode(AddressNode addressNode, ValueNode valueNode) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.addressNode = addressNode;
         this.valueNode = valueNode;
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/WriteHalfFloatNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/WriteHalfFloatNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -22,7 +22,6 @@
 package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
 
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
@@ -32,7 +31,6 @@ import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
-import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLArchitecture;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/vector/VectorSubHalfNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/vector/VectorSubHalfNode.java
@@ -32,6 +32,7 @@ import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
 
@@ -47,7 +48,7 @@ public class VectorSubHalfNode extends ValueNode implements LIRLowerable {
     private ValueNode y;
 
     public VectorSubHalfNode(ValueNode x, ValueNode y) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.x = x;
         this.y = y;
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/vector/VectorSubHalfNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/vector/VectorSubHalfNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -21,10 +21,8 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.graal.nodes.vector;
 
-import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoHalfFloatReplacement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -115,7 +115,7 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
             if (newInstanceNode.instanceClass().getAnnotation(HalfType.class) != null) {
                 if (newInstanceNode.successors().first() instanceof NewHalfFloatInstance) {
                     NewHalfFloatInstance newHalfFloatInstance = (NewHalfFloatInstance) newInstanceNode.successors().first();
-                    ValueNode valueInput = getHalfFloatValue(newHalfFloatInstance.getValue(), graph); //newHalfFloatInstance.getValue();
+                    ValueNode valueInput = getHalfFloatValue(newHalfFloatInstance.getValue(), graph);
                     newInstanceNode.replaceAtUsages(valueInput);
                     deleteFixed(newInstanceNode);
                     deleteFixed(newHalfFloatInstance);
@@ -198,6 +198,14 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
 
     }
 
+    /**
+     * This function receives a half float value and, if it is a constant, it encapsulates it in a {@code HalfFloatConstantNode}.
+     * Otherwise, the input value is returned.
+     *
+     * @param halfFloatValue The half float value.
+     * @param graph The Structured Graph.
+     * @return The half float value, either as is, or in the form of the {@code HalfFloatConstantNode}.
+     */
     private static ValueNode getHalfFloatValue(ValueNode halfFloatValue, StructuredGraph graph) {
         if (halfFloatValue instanceof ConstantNode) {
             ConstantNode floatValue = (ConstantNode) halfFloatValue;
@@ -311,6 +319,17 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
         }
     }
 
+    /**
+     * Since the compiler treats half float values as Objects by default,
+     * this function examines if the stamp of a {@code ValuePhiNode} is an Object stamp,
+     * and if it is, it replaces the node with a new {@code ValuePhiNode} with a {@code HalfFloatStamp}.
+     * It is safe to assume that the Object stamp corresponds to a half value and not another
+     * Object type, because the functions that invoke it are operating only on half float related nodes.
+     *
+     * @param phiNode The {@code ValuePhiNode} to be examined.
+     * @param graph The Structured Graph.
+     * @return The {@code ValuePhiNode} with the {@code HalfFloatStamp}, or the existing {@code ValuePhiNode}.
+     */
     private static ValuePhiNode replacePhi(ValuePhiNode phiNode, StructuredGraph graph) {
         if (phiNode.getStackKind().isObject()) {
             ValueNode[] values = new ValueNode[phiNode.valueCount()];

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoHalfFloatReplacement.java
@@ -36,10 +36,6 @@ import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.ValuePhiNode;
 import org.graalvm.compiler.nodes.ValueProxyNode;
-import org.graalvm.compiler.nodes.calc.AddNode;
-import org.graalvm.compiler.nodes.calc.FloatDivNode;
-import org.graalvm.compiler.nodes.calc.MulNode;
-import org.graalvm.compiler.nodes.calc.SubNode;
 import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.extended.JavaWriteNode;
 import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
@@ -50,9 +46,11 @@ import org.graalvm.compiler.phases.BasePhase;
 import uk.ac.manchester.tornado.api.internal.annotations.HalfType;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.AddHalfNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.DivHalfNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.HalfFloatConstantNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.MultHalfNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.ReadHalfFloatNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.SubHalfNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.WriteHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.vector.LoadIndexedVectorNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.vector.VectorAddHalfNode;
@@ -203,11 +201,8 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
     private static ValueNode getHalfFloatValue(ValueNode halfFloatValue, StructuredGraph graph) {
         if (halfFloatValue instanceof ConstantNode) {
             ConstantNode floatValue = (ConstantNode) halfFloatValue;
-            Constant half = new RawConstant(floatValue.asJavaConstant().asInt());
-            HalfFloatConstantNode halfFloatConstantNode = new HalfFloatConstantNode(half);
+            HalfFloatConstantNode halfFloatConstantNode = new HalfFloatConstantNode(floatValue);
             graph.addWithoutUnique(halfFloatConstantNode);
-            floatValue.replaceAtUsages(halfFloatConstantNode);
-            floatValue.safeDelete();
             return halfFloatConstantNode;
         } else {
             return halfFloatValue;
@@ -259,7 +254,7 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
             subNode = new VectorSubHalfNode(subX, subY);
             graph.addWithoutUnique(subNode);
         } else {
-            subNode = new SubNode(subX, subY);
+            subNode = new SubHalfNode(subX, subY);
             graph.addWithoutUnique(subNode);
         }
 
@@ -302,7 +297,7 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
         ValueNode divX = getHalfOperand(divHalfFloatNode.getX(), graph);
         ValueNode divY = getHalfOperand(divHalfFloatNode.getY(), graph);
 
-        FloatDivNode divNode = new FloatDivNode(divX, divY);
+        DivHalfNode divNode = new DivHalfNode(divX, divY);
         graph.addWithoutUnique(divNode);
 
         divHalfFloatNode.replaceAtUsages(divNode);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/HalfFloatStamp.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/HalfFloatStamp.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.ptx.graal;
 
 import jdk.vm.ci.meta.Constant;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/HalfFloatStamp.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/HalfFloatStamp.java
@@ -1,0 +1,88 @@
+package uk.ac.manchester.tornado.drivers.ptx.graal;
+
+import jdk.vm.ci.meta.Constant;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.MemoryAccessProvider;
+import jdk.vm.ci.meta.MetaAccessProvider;
+import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.spi.LIRKindTool;
+import org.graalvm.compiler.core.common.type.Stamp;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+
+public class HalfFloatStamp extends Stamp {
+    @Override
+    public ResolvedJavaType javaType(MetaAccessProvider metaAccess) {
+        return metaAccess.lookupJavaType(java.lang.Short.TYPE);
+    }
+
+    @Override
+    public JavaKind getStackKind() {
+        return JavaKind.Short;
+    }
+
+    @Override
+    public LIRKind getLIRKind(LIRKindTool tool) {
+        return LIRKind.value(PTXKind.F16);
+    }
+
+    @Override
+    public Stamp meet(Stamp other) {
+        return this;
+    }
+
+    @Override
+    public Stamp join(Stamp other) {
+        return this;
+    }
+
+    @Override
+    public Stamp unrestricted() {
+        return this;
+    }
+
+    @Override
+    public Stamp empty() {
+        return this;
+    }
+
+    @Override
+    public Stamp constant(Constant c, MetaAccessProvider meta) {
+        return null;
+    }
+
+    @Override
+    public boolean isCompatible(Stamp other) {
+        return true;
+    }
+
+    @Override
+    public boolean isCompatible(Constant constant) {
+        return true;
+    }
+
+    @Override
+    public boolean hasValues() {
+        return true;
+    }
+
+    @Override
+    public Constant readConstant(MemoryAccessProvider provider, Constant base, long displacement) {
+        return null;
+    }
+
+    @Override
+    public Stamp improveWith(Stamp other) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "half";
+    }
+
+    @Override
+    public void accept(Visitor v) {
+
+    }
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
@@ -230,6 +230,41 @@ public class PTXLIRStmt {
 
     }
 
+    @Opcode("ADD_HALF")
+    public static class AddHalfStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<AddHalfStmt> TYPE = LIRInstructionClass.create(AddHalfStmt.class);
+
+        @Def
+        protected Value result;
+        @Use
+        protected Value x;
+        @Use
+        protected Value y;
+
+        public AddHalfStmt(Value result, Value x, Value y) {
+            super(TYPE);
+            this.result = result;
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public void emitCode(PTXCompilationResultBuilder crb, PTXAssembler asm) {
+            asm.emitSymbol(TAB);
+            asm.emit(ADD + DOT + "rn.f16");
+            asm.emitSymbol(SPACE);
+            asm.emitValue(result);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(x);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(y);
+            asm.delimiter();
+            asm.eol();
+        }
+
+    }
+
     @Opcode("VSUB_HALF")
     public static class VectorSubHalfStmt extends AbstractInstruction {
 
@@ -278,6 +313,41 @@ public class PTXLIRStmt {
         protected Value y;
 
         public VectorMultHalfStmt(Value result, Value x, Value y) {
+            super(TYPE);
+            this.result = result;
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public void emitCode(PTXCompilationResultBuilder crb, PTXAssembler asm) {
+            asm.emitSymbol(TAB);
+            asm.emit(MUL + DOT + "rn.f16");
+            asm.emitSymbol(SPACE);
+            asm.emitValue(result);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(x);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(y);
+            asm.delimiter();
+            asm.eol();
+        }
+
+    }
+
+    @Opcode("MULT_HALF")
+    public static class MultHalfStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<MultHalfStmt> TYPE = LIRInstructionClass.create(MultHalfStmt.class);
+
+        @Def
+        protected Value result;
+        @Use
+        protected Value x;
+        @Use
+        protected Value y;
+
+        public MultHalfStmt(Value result, Value x, Value y) {
             super(TYPE);
             this.result = result;
             this.x = x;
@@ -417,7 +487,12 @@ public class PTXLIRStmt {
             } else {
                 asm.emitSymbol(TAB);
                 if (shouldEmitMove(lhsKind, rhsKind)) {
-                    asm.emit(MOVE + DOT + lhsKind.toString());
+                    if (lhsKind.isF16()) {
+                        // here
+                        asm.emit(MOVE + DOT + "b16");
+                    } else {
+                        asm.emit(MOVE + DOT + lhsKind.toString());
+                    }
                 } else {
                     asm.emit(CONVERT + DOT);
                     if ((lhsKind.isFloating() || rhsKind.isFloating()) && getFPURoundingMode(lhsKind, rhsKind) != null) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
@@ -265,6 +265,41 @@ public class PTXLIRStmt {
 
     }
 
+    @Opcode("SUB_HALF")
+    public static class SubHalfStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<SubHalfStmt> TYPE = LIRInstructionClass.create(SubHalfStmt.class);
+
+        @Def
+        protected Value result;
+        @Use
+        protected Value x;
+        @Use
+        protected Value y;
+
+        public SubHalfStmt(Value result, Value x, Value y) {
+            super(TYPE);
+            this.result = result;
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public void emitCode(PTXCompilationResultBuilder crb, PTXAssembler asm) {
+            asm.emitSymbol(TAB);
+            asm.emit(SUB + DOT + "rn.f16");
+            asm.emitSymbol(SPACE);
+            asm.emitValue(result);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(x);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(y);
+            asm.delimiter();
+            asm.eol();
+        }
+
+    }
+
     @Opcode("VSUB_HALF")
     public static class VectorSubHalfStmt extends AbstractInstruction {
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2020, 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2020, 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/AddHalfNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/AddHalfNode.java
@@ -1,0 +1,40 @@
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
+
+@NodeInfo
+public class AddHalfNode extends ValueNode implements LIRLowerable {
+    public static final NodeClass<AddHalfNode> TYPE = NodeClass.create(AddHalfNode.class);
+
+    @Input
+    private ValueNode x;
+
+    @Input
+    private ValueNode y;
+
+    public AddHalfNode(ValueNode x, ValueNode y) {
+        super(TYPE, new HalfFloatStamp());
+        this.x = x;
+        this.y = y;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable result = tool.newVariable(LIRKind.value(PTXKind.F16));
+        Value inputX = generator.operand(x);
+        Value inputY = generator.operand(y);
+        tool.append(new PTXLIRStmt.AddHalfStmt(result, inputX, inputY));
+        generator.setResult(this, result);
+    }
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/AddHalfNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/AddHalfNode.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
 import jdk.vm.ci.meta.Value;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/HalfFloatConstantNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/HalfFloatConstantNode.java
@@ -1,10 +1,29 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
-import jdk.vm.ci.meta.Constant;
 import jdk.vm.ci.meta.Value;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.graph.NodeClass;
-import org.graalvm.compiler.lir.ConstantValue;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodeinfo.NodeInfo;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/HalfFloatConstantNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/HalfFloatConstantNode.java
@@ -1,0 +1,30 @@
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
+
+import jdk.vm.ci.meta.Constant;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.ConstantValue;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.calc.FloatingNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+
+@NodeInfo
+public class HalfFloatConstantNode extends FloatingNode implements LIRLowerable {
+
+    public static final NodeClass<HalfFloatConstantNode> TYPE = NodeClass.create(HalfFloatConstantNode.class);
+
+    private Constant halfFloatValue;
+
+    public HalfFloatConstantNode(Constant halfFloatValue) {
+        super(TYPE, new HalfFloatStamp());
+        this.halfFloatValue = halfFloatValue;
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool generator) {
+        generator.setResult(this, new ConstantValue(LIRKind.value(PTXKind.F16), halfFloatValue));
+    }
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/MultHalfNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/MultHalfNode.java
@@ -1,0 +1,40 @@
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
+
+@NodeInfo
+public class MultHalfNode extends ValueNode implements LIRLowerable {
+    public static final NodeClass<MultHalfNode> TYPE = NodeClass.create(MultHalfNode.class);
+
+    @Input
+    private ValueNode x;
+
+    @Input
+    private ValueNode y;
+
+    public MultHalfNode(ValueNode x, ValueNode y) {
+        super(TYPE, new HalfFloatStamp());
+        this.x = x;
+        this.y = y;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable result = tool.newVariable(LIRKind.value(PTXKind.F16));
+        Value inputX = generator.operand(x);
+        Value inputY = generator.operand(y);
+        tool.append(new PTXLIRStmt.MultHalfStmt(result, inputX, inputY));
+        generator.setResult(this, result);
+    }
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/MultHalfNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/MultHalfNode.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
 import jdk.vm.ci.meta.Value;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXHalfFloatDivisionNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXHalfFloatDivisionNode.java
@@ -33,6 +33,7 @@ import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.FloatingNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 
@@ -47,7 +48,7 @@ public class PTXHalfFloatDivisionNode extends FloatingNode implements LIRLowerab
     private ValueNode divisor;
 
     public PTXHalfFloatDivisionNode(ValueNode dividend, ValueNode divisor) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.dividend = dividend;
         this.divisor = divisor;
     }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXHalfFloatDivisionNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXHalfFloatDivisionNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -21,10 +21,8 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
-import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/ReadHalfFloatNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/ReadHalfFloatNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/ReadHalfFloatNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/ReadHalfFloatNode.java
@@ -34,6 +34,7 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
+import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
@@ -48,7 +49,7 @@ public class ReadHalfFloatNode extends FixedWithNextNode implements LIRLowerable
     private AddressNode addressNode;
 
     public ReadHalfFloatNode(AddressNode addressNode) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.addressNode = addressNode;
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SubHalfNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SubHalfNode.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
 import jdk.vm.ci.meta.Value;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SubHalfNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SubHalfNode.java
@@ -1,15 +1,12 @@
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
-import jdk.vm.ci.meta.Constant;
 import jdk.vm.ci.meta.Value;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.graph.NodeClass;
-import org.graalvm.compiler.lir.ConstantValue;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.ConstantNode;
-import org.graalvm.compiler.nodes.calc.FloatingNode;
+import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
@@ -17,27 +14,27 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 
 @NodeInfo
-public class HalfFloatConstantNode extends FloatingNode implements LIRLowerable {
-
-    public static final NodeClass<HalfFloatConstantNode> TYPE = NodeClass.create(HalfFloatConstantNode.class);
+public class SubHalfNode extends ValueNode implements LIRLowerable {
+    public static final NodeClass<SubHalfNode> TYPE = NodeClass.create(SubHalfNode.class);
 
     @Input
-    private ConstantNode halfFloatValue;
+    private ValueNode x;
 
-    public HalfFloatConstantNode(ConstantNode halfFloatValue) {
+    @Input
+    private ValueNode y;
+
+    public SubHalfNode(ValueNode x, ValueNode y) {
         super(TYPE, new HalfFloatStamp());
-        this.halfFloatValue = halfFloatValue;
+        this.x = x;
+        this.y = y;
     }
 
-    @Override
     public void generate(NodeLIRBuilderTool generator) {
-        // the value to be written is in float format, so the bytecodes to convert
-        // to half float need to be generated
         LIRGeneratorTool tool = generator.getLIRGeneratorTool();
-        Value value = generator.operand(halfFloatValue);
-        Variable intermediate = tool.newVariable(LIRKind.value(PTXKind.F32));
         Variable result = tool.newVariable(LIRKind.value(PTXKind.F16));
-        tool.append(new PTXLIRStmt.ConvertHalfFloatStmt(result, value, intermediate));
+        Value inputX = generator.operand(x);
+        Value inputY = generator.operand(y);
+        tool.append(new PTXLIRStmt.SubHalfStmt(result, inputX, inputY));
         generator.setResult(this, result);
     }
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/WriteHalfFloatNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/WriteHalfFloatNode.java
@@ -36,6 +36,7 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
+import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.ptx.graal.compiler.PTXLIRGenerationResult;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
@@ -54,7 +55,7 @@ public class WriteHalfFloatNode extends FixedWithNextNode implements LIRLowerabl
     private ValueNode valueNode;
 
     public WriteHalfFloatNode(AddressNode addressNode, ValueNode valueNode) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.addressNode = addressNode;
         this.valueNode = valueNode;
     }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/WriteHalfFloatNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/WriteHalfFloatNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -22,7 +22,6 @@
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
@@ -34,14 +33,11 @@ import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
-import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
-import uk.ac.manchester.tornado.drivers.ptx.graal.compiler.PTXLIRGenerationResult;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXUnary;
-import uk.ac.manchester.tornado.runtime.graph.nodes.ConstantNode;
 
 @NodeInfo
 public class WriteHalfFloatNode extends FixedWithNextNode implements LIRLowerable {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
@@ -34,6 +34,8 @@ import org.graalvm.compiler.nodes.GraphState;
 import org.graalvm.compiler.nodes.PiNode;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.ValuePhiNode;
+import org.graalvm.compiler.nodes.ValueProxyNode;
 import org.graalvm.compiler.nodes.calc.AddNode;
 import org.graalvm.compiler.nodes.calc.MulNode;
 import org.graalvm.compiler.nodes.calc.SubNode;
@@ -45,7 +47,11 @@ import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.phases.BasePhase;
 
 import uk.ac.manchester.tornado.api.internal.annotations.HalfType;
+import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.AddHalfNode;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.HalfFloatConstantNode;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.MultHalfNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXHalfFloatDivisionNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.ReadHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.WriteHalfFloatNode;
@@ -111,7 +117,7 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
             if (newInstanceNode.instanceClass().getAnnotation(HalfType.class) != null) {
                 if (newInstanceNode.successors().first() instanceof NewHalfFloatInstance) {
                     NewHalfFloatInstance newHalfFloatInstance = (NewHalfFloatInstance) newInstanceNode.successors().first();
-                    ValueNode valueInput = newHalfFloatInstance.getValue();
+                    ValueNode valueInput = getHalfFloatValue(newHalfFloatInstance.getValue(), graph);
                     newInstanceNode.replaceAtUsages(valueInput);
                     deleteFixed(newInstanceNode);
                     deleteFixed(newHalfFloatInstance);
@@ -194,6 +200,20 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
 
     }
 
+    private static ValueNode getHalfFloatValue(ValueNode halfFloatValue, StructuredGraph graph) {
+        if (halfFloatValue instanceof ConstantNode) {
+            ConstantNode floatValue = (ConstantNode) halfFloatValue;
+            Constant half = new RawConstant(floatValue.asJavaConstant().asInt());
+            HalfFloatConstantNode halfFloatConstantNode = new HalfFloatConstantNode(half);
+            graph.addWithoutUnique(halfFloatConstantNode);
+            floatValue.replaceAtUsages(halfFloatConstantNode);
+            floatValue.safeDelete();
+            return halfFloatConstantNode;
+        } else {
+            return halfFloatValue;
+        }
+    }
+
     private static ValueNode replaceAdd(AddHalfFloatNode addHalfFloatNode, StructuredGraph graph) {
         ValueNode addNode;
         ValueNode addX = getHalfOperand(addHalfFloatNode.getX(), graph);
@@ -202,7 +222,7 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
             addNode = new VectorAddHalfNode(addX, addY);
             graph.addWithoutUnique(addNode);
         } else {
-            addNode = new AddNode(addX, addY);
+            addNode = new AddHalfNode(addX, addY);
             graph.addWithoutUnique(addNode);
         }
 
@@ -262,7 +282,7 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
             multNode = new VectorMultHalfNode(multX, multY);
             graph.addWithoutUnique(multNode);
         } else {
-            multNode = new MulNode(multX, multY);
+            multNode = new MultHalfNode(multX, multY);
             graph.addWithoutUnique(multNode);
         }
         multHalfFloatNode.replaceAtUsages(multNode);
@@ -294,6 +314,25 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
         }
     }
 
+    private static ValuePhiNode replacePhi(ValuePhiNode phiNode, StructuredGraph graph) {
+        if (phiNode.getStackKind().isObject()) {
+            ValueNode[] values = new ValueNode[phiNode.valueCount()];
+            phiNode.values().toArray(values);
+            ValuePhiNode halfPhiNode = new ValuePhiNode(new HalfFloatStamp(), phiNode.merge(), values);
+            graph.addWithoutUnique(halfPhiNode);
+            if (phiNode.usages().filter(ValueProxyNode.class).isNotEmpty()) {
+                ValueProxyNode proxy = phiNode.usages().filter(ValueProxyNode.class).first();
+                proxy.replaceAtUsages(phiNode);
+                proxy.safeDelete();
+            }
+            phiNode.replaceAtUsages(halfPhiNode);
+            phiNode.safeDelete();
+            return halfPhiNode;
+        } else {
+            return phiNode;
+        }
+    }
+
     private static ValueNode getHalfOperand(ValueNode operand, StructuredGraph graph) {
         ValueNode halfOperand;
         if (operand instanceof VectorLoadElementNode) {
@@ -312,6 +351,8 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
             halfOperand = replaceSub((SubHalfFloatNode) operand, graph);
         } else if (operand instanceof DivHalfFloatNode) {
             halfOperand = replaceDiv((DivHalfFloatNode) operand, graph);
+        } else if (operand instanceof ValuePhiNode) {
+            halfOperand = replacePhi((ValuePhiNode) operand, graph);
         } else {
             halfOperand = operand;
         }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -198,6 +198,14 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
 
     }
 
+    /**
+     * This function receives a half float value and, if it is a constant, it encapsulates it in a {@code HalfFloatConstantNode}.
+     * Otherwise, the input value is returned.
+     *
+     * @param halfFloatValue The half float value.
+     * @param graph The Structured Graph.
+     * @return The half float value, either as is, or in the form of the {@code HalfFloatConstantNode}.
+     */
     private static ValueNode getHalfFloatValue(ValueNode halfFloatValue, StructuredGraph graph) {
         if (halfFloatValue instanceof ConstantNode) {
             ConstantNode floatValue = (ConstantNode) halfFloatValue;
@@ -309,6 +317,17 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
         }
     }
 
+    /**
+     * Since the compiler treats half float values as Objects by default,
+     * this function examines if the stamp of a {@code ValuePhiNode} is an Object stamp,
+     * and if it is, it replaces the node with a new {@code ValuePhiNode} with a {@code HalfFloatStamp}.
+     * It is safe to assume that the Object stamp corresponds to a half value and not another
+     * Object type, because the functions that invoke it are operating only on half float related nodes.
+     *
+     * @param phiNode The {@code ValuePhiNode} to be examined.
+     * @param graph The Structured Graph.
+     * @return The {@code ValuePhiNode} with the {@code HalfFloatStamp}, or the existing {@code ValuePhiNode}.
+     */
     private static ValuePhiNode replacePhi(ValuePhiNode phiNode, StructuredGraph graph) {
         if (phiNode.getStackKind().isObject()) {
             ValueNode[] values = new ValueNode[phiNode.valueCount()];

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
@@ -36,9 +36,6 @@ import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.ValuePhiNode;
 import org.graalvm.compiler.nodes.ValueProxyNode;
-import org.graalvm.compiler.nodes.calc.AddNode;
-import org.graalvm.compiler.nodes.calc.MulNode;
-import org.graalvm.compiler.nodes.calc.SubNode;
 import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.extended.JavaWriteNode;
 import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
@@ -54,6 +51,7 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.HalfFloatConstantNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.MultHalfNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXHalfFloatDivisionNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.ReadHalfFloatNode;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SubHalfNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.WriteHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector.LoadIndexedVectorNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector.VectorAddHalfNode;
@@ -203,11 +201,8 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
     private static ValueNode getHalfFloatValue(ValueNode halfFloatValue, StructuredGraph graph) {
         if (halfFloatValue instanceof ConstantNode) {
             ConstantNode floatValue = (ConstantNode) halfFloatValue;
-            Constant half = new RawConstant(floatValue.asJavaConstant().asInt());
-            HalfFloatConstantNode halfFloatConstantNode = new HalfFloatConstantNode(half);
+            HalfFloatConstantNode halfFloatConstantNode = new HalfFloatConstantNode(floatValue);
             graph.addWithoutUnique(halfFloatConstantNode);
-            floatValue.replaceAtUsages(halfFloatConstantNode);
-            floatValue.safeDelete();
             return halfFloatConstantNode;
         } else {
             return halfFloatValue;
@@ -259,7 +254,7 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
             subNode = new VectorSubHalfNode(subX, subY);
             graph.addWithoutUnique(subNode);
         } else {
-            subNode = new SubNode(subX, subY);
+            subNode = new SubHalfNode(subX, subY);
             graph.addWithoutUnique(subNode);
         }
         subHalfFloatNode.replaceAtUsages(subNode);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/HalfFloatStamp.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/HalfFloatStamp.java
@@ -1,3 +1,26 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.spirv.graal;
 
 import jdk.vm.ci.meta.Constant;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/HalfFloatStamp.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/HalfFloatStamp.java
@@ -1,0 +1,88 @@
+package uk.ac.manchester.tornado.drivers.spirv.graal;
+
+import jdk.vm.ci.meta.Constant;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.MemoryAccessProvider;
+import jdk.vm.ci.meta.MetaAccessProvider;
+import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.spi.LIRKindTool;
+import org.graalvm.compiler.core.common.type.Stamp;
+import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
+
+public class HalfFloatStamp extends Stamp {
+    @Override
+    public ResolvedJavaType javaType(MetaAccessProvider metaAccess) {
+        return metaAccess.lookupJavaType(java.lang.Short.TYPE);
+    }
+
+    @Override
+    public JavaKind getStackKind() {
+        return JavaKind.Short;
+    }
+
+    @Override
+    public LIRKind getLIRKind(LIRKindTool tool) {
+        return LIRKind.value(SPIRVKind.OP_TYPE_FLOAT_16);
+    }
+
+    @Override
+    public Stamp meet(Stamp other) {
+        return this;
+    }
+
+    @Override
+    public Stamp join(Stamp other) {
+        return this;
+    }
+
+    @Override
+    public Stamp unrestricted() {
+        return this;
+    }
+
+    @Override
+    public Stamp empty() {
+        return this;
+    }
+
+    @Override
+    public Stamp constant(Constant c, MetaAccessProvider meta) {
+        return null;
+    }
+
+    @Override
+    public boolean isCompatible(Stamp other) {
+        return true;
+    }
+
+    @Override
+    public boolean isCompatible(Constant constant) {
+        return true;
+    }
+
+    @Override
+    public boolean hasValues() {
+        return true;
+    }
+
+    @Override
+    public Constant readConstant(MemoryAccessProvider provider, Constant base, long displacement) {
+        return null;
+    }
+
+    @Override
+    public Stamp improveWith(Stamp other) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "half";
+    }
+
+    @Override
+    public void accept(Visitor v) {
+
+    }
+}

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/AddHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/AddHalfNode.java
@@ -31,6 +31,6 @@ public class AddHalfNode extends ValueNode implements ArithmeticLIRLowerable {
         Value inputY = builder.operand(y);
 
         SPIRVArithmeticTool spirvArithmeticTool = (SPIRVArithmeticTool) generator;
-        builder.setResult(this, spirvArithmeticTool.emitAnd(inputX, inputY));
+        builder.setResult(this, spirvArithmeticTool.emitAdd(inputX, inputY, false));
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/AddHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/AddHalfNode.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
 
 import jdk.vm.ci.meta.Value;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/AddHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/AddHalfNode.java
@@ -1,0 +1,36 @@
+package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.gen.ArithmeticLIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.ArithmeticLIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.lir.SPIRVArithmeticTool;
+
+@NodeInfo
+public class AddHalfNode extends ValueNode implements ArithmeticLIRLowerable {
+    public static final NodeClass<AddHalfNode> TYPE = NodeClass.create(AddHalfNode.class);
+
+    @Input
+    private ValueNode x;
+
+    @Input
+    private ValueNode y;
+
+    public AddHalfNode(ValueNode x, ValueNode y) {
+        super(TYPE, new HalfFloatStamp());
+        this.x = x;
+        this.y = y;
+    }
+
+    public void generate(NodeLIRBuilderTool builder, ArithmeticLIRGeneratorTool generator) {
+        Value inputX = builder.operand(x);
+        Value inputY = builder.operand(y);
+
+        SPIRVArithmeticTool spirvArithmeticTool = (SPIRVArithmeticTool) generator;
+        builder.setResult(this, spirvArithmeticTool.emitAnd(inputX, inputY));
+    }
+}

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/DivHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/DivHalfNode.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
 
 import jdk.vm.ci.meta.Value;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/DivHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/DivHalfNode.java
@@ -1,0 +1,36 @@
+package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.gen.ArithmeticLIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.ArithmeticLIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.lir.SPIRVArithmeticTool;
+
+@NodeInfo
+public class DivHalfNode extends ValueNode implements ArithmeticLIRLowerable {
+    public static final NodeClass<DivHalfNode> TYPE = NodeClass.create(DivHalfNode.class);
+
+    @Input
+    private ValueNode x;
+
+    @Input
+    private ValueNode y;
+
+    public DivHalfNode(ValueNode x, ValueNode y) {
+        super(TYPE, new HalfFloatStamp());
+        this.x = x;
+        this.y = y;
+    }
+
+    public void generate(NodeLIRBuilderTool builder, ArithmeticLIRGeneratorTool generator) {
+        Value inputX = builder.operand(x);
+        Value inputY = builder.operand(y);
+
+        SPIRVArithmeticTool spirvArithmeticTool = (SPIRVArithmeticTool) generator;
+        builder.setResult(this, spirvArithmeticTool.emitDiv(inputX, inputY, null));
+    }
+}

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/HalfFloatConstantNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/HalfFloatConstantNode.java
@@ -1,0 +1,30 @@
+package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
+
+import jdk.vm.ci.meta.Constant;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.ConstantValue;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.calc.FloatingNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.spirv.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
+
+@NodeInfo
+public class HalfFloatConstantNode extends FloatingNode implements LIRLowerable {
+
+    public static final NodeClass<HalfFloatConstantNode> TYPE = NodeClass.create(HalfFloatConstantNode.class);
+
+    private Constant halfFloatValue;
+
+    public HalfFloatConstantNode(Constant halfFloatValue) {
+        super(TYPE, new HalfFloatStamp());
+        this.halfFloatValue = halfFloatValue;
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool generator) {
+        generator.setResult(this, new ConstantValue(LIRKind.value(SPIRVKind.OP_TYPE_FLOAT_16), halfFloatValue));
+    }
+}

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/HalfFloatConstantNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/HalfFloatConstantNode.java
@@ -5,6 +5,7 @@ import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.ConstantValue;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.calc.FloatingNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
@@ -16,15 +17,16 @@ public class HalfFloatConstantNode extends FloatingNode implements LIRLowerable 
 
     public static final NodeClass<HalfFloatConstantNode> TYPE = NodeClass.create(HalfFloatConstantNode.class);
 
-    private Constant halfFloatValue;
+    @Input
+    private ConstantNode halfFloatValue;
 
-    public HalfFloatConstantNode(Constant halfFloatValue) {
+    public HalfFloatConstantNode(ConstantNode halfFloatValue) {
         super(TYPE, new HalfFloatStamp());
         this.halfFloatValue = halfFloatValue;
     }
 
     @Override
     public void generate(NodeLIRBuilderTool generator) {
-        generator.setResult(this, new ConstantValue(LIRKind.value(SPIRVKind.OP_TYPE_FLOAT_16), halfFloatValue));
+        generator.setResult(this, new ConstantValue(LIRKind.value(SPIRVKind.OP_TYPE_FLOAT_16), halfFloatValue.asConstant()));
     }
 }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/HalfFloatConstantNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/HalfFloatConstantNode.java
@@ -1,6 +1,29 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
 
-import jdk.vm.ci.meta.Constant;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.ConstantValue;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/MultHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/MultHalfNode.java
@@ -1,0 +1,36 @@
+package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.gen.ArithmeticLIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.ArithmeticLIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.lir.SPIRVArithmeticTool;
+
+@NodeInfo
+public class MultHalfNode extends ValueNode implements ArithmeticLIRLowerable {
+    public static final NodeClass<MultHalfNode> TYPE = NodeClass.create(MultHalfNode.class);
+
+    @Input
+    private ValueNode x;
+
+    @Input
+    private ValueNode y;
+
+    public MultHalfNode(ValueNode x, ValueNode y) {
+        super(TYPE, new HalfFloatStamp());
+        this.x = x;
+        this.y = y;
+    }
+
+    public void generate(NodeLIRBuilderTool builder, ArithmeticLIRGeneratorTool generator) {
+        Value inputX = builder.operand(x);
+        Value inputY = builder.operand(y);
+
+        SPIRVArithmeticTool spirvArithmeticTool = (SPIRVArithmeticTool) generator;
+        builder.setResult(this, spirvArithmeticTool.emitMul(inputX, inputY, false));
+    }
+}

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/MultHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/MultHalfNode.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
 
 import jdk.vm.ci.meta.Value;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/ReadHalfFloatNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/ReadHalfFloatNode.java
@@ -37,6 +37,7 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.spirv.graal.SPIRVArchitecture;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVLIRStmt;
@@ -51,7 +52,7 @@ public class ReadHalfFloatNode extends FixedWithNextNode implements LIRLowerable
     private AddressNode addressNode;
 
     public ReadHalfFloatNode(AddressNode addressNode) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.addressNode = addressNode;
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/ReadHalfFloatNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/ReadHalfFloatNode.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SubHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SubHalfNode.java
@@ -1,0 +1,36 @@
+package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.gen.ArithmeticLIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.ArithmeticLIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.lir.SPIRVArithmeticTool;
+
+@NodeInfo
+public class SubHalfNode extends ValueNode implements ArithmeticLIRLowerable {
+    public static final NodeClass<SubHalfNode> TYPE = NodeClass.create(SubHalfNode.class);
+
+    @Input
+    private ValueNode x;
+
+    @Input
+    private ValueNode y;
+
+    public SubHalfNode(ValueNode x, ValueNode y) {
+        super(TYPE, new HalfFloatStamp());
+        this.x = x;
+        this.y = y;
+    }
+
+    public void generate(NodeLIRBuilderTool builder, ArithmeticLIRGeneratorTool generator) {
+        Value inputX = builder.operand(x);
+        Value inputY = builder.operand(y);
+
+        SPIRVArithmeticTool spirvArithmeticTool = (SPIRVArithmeticTool) generator;
+        builder.setResult(this, spirvArithmeticTool.emitSub(inputX, inputY, false));
+    }
+}

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SubHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SubHalfNode.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
 
 import jdk.vm.ci.meta.Value;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/WriteHalfFloatNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/WriteHalfFloatNode.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -25,7 +25,6 @@
 package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
 
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
@@ -35,7 +34,6 @@ import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
-import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/WriteHalfFloatNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/WriteHalfFloatNode.java
@@ -37,6 +37,7 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
+import uk.ac.manchester.tornado.drivers.opencl.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVLIRStmt;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVUnary;
@@ -55,7 +56,7 @@ public class WriteHalfFloatNode extends FixedWithNextNode implements LIRLowerabl
     private ValueNode valueNode;
 
     public WriteHalfFloatNode(AddressNode addressNode, ValueNode valueNode) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.addressNode = addressNode;
         this.valueNode = valueNode;
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorAddHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorAddHalfNode.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -24,22 +24,17 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv.graal.nodes.vector;
 
-import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
-import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
-import uk.ac.manchester.tornado.drivers.common.logging.Logger;
 import uk.ac.manchester.tornado.drivers.spirv.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.spirv.graal.asm.SPIRVAssembler;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVBinary;
-import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVLIROp;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVLIRStmt;
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorAddHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorAddHalfNode.java
@@ -36,6 +36,7 @@ import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.common.logging.Logger;
+import uk.ac.manchester.tornado.drivers.spirv.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.spirv.graal.asm.SPIRVAssembler;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVBinary;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
@@ -54,7 +55,7 @@ public class VectorAddHalfNode extends ValueNode implements LIRLowerable {
     private ValueNode y;
 
     public VectorAddHalfNode(ValueNode x, ValueNode y) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.x = x;
         this.y = y;
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorMultHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorMultHalfNode.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -24,23 +24,17 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv.graal.nodes.vector;
 
-import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.ConstantNode;
-import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
-import uk.ac.manchester.tornado.drivers.common.logging.Logger;
 import uk.ac.manchester.tornado.drivers.spirv.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.spirv.graal.asm.SPIRVAssembler;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVBinary;
-import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVLIROp;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVLIRStmt;
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorMultHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorMultHalfNode.java
@@ -37,6 +37,7 @@ import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.common.logging.Logger;
+import uk.ac.manchester.tornado.drivers.spirv.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.spirv.graal.asm.SPIRVAssembler;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVBinary;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
@@ -55,7 +56,7 @@ public class VectorMultHalfNode extends ValueNode implements LIRLowerable {
     private ValueNode y;
 
     public VectorMultHalfNode(ValueNode x, ValueNode y) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.x = x;
         this.y = y;
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorSubHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorSubHalfNode.java
@@ -34,6 +34,7 @@ import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.spirv.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.spirv.graal.asm.SPIRVAssembler;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVBinary;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVLIROp;
@@ -50,7 +51,7 @@ public class VectorSubHalfNode extends ValueNode implements LIRLowerable {
     private ValueNode y;
 
     public VectorSubHalfNode(ValueNode x, ValueNode y) {
-        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        super(TYPE, new HalfFloatStamp());
         this.x = x;
         this.y = y;
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorSubHalfNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/vector/VectorSubHalfNode.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -24,10 +24,8 @@
  */
 package uk.ac.manchester.tornado.drivers.spirv.graal.nodes.vector;
 
-import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.nodeinfo.NodeInfo;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoHalfFloatReplacement.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2024, 2025, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -39,7 +39,6 @@ import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.ValuePhiNode;
 import org.graalvm.compiler.nodes.ValueProxyNode;
-import org.graalvm.compiler.nodes.calc.FloatDivNode;
 import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.extended.JavaWriteNode;
 import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
@@ -202,6 +201,14 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
 
     }
 
+    /**
+     * This function receives a half float value and, if it is a constant, it encapsulates it in a {@code HalfFloatConstantNode}.
+     * Otherwise, the input value is returned.
+     *
+     * @param halfFloatValue The half float value.
+     * @param graph The Structured Graph.
+     * @return The half float value, either as is, or in the form of the {@code HalfFloatConstantNode}.
+     */
     private static ValueNode getHalfFloatValue(ValueNode halfFloatValue, StructuredGraph graph) {
         if (halfFloatValue instanceof ConstantNode) {
             ConstantNode floatValue = (ConstantNode) halfFloatValue;
@@ -325,6 +332,17 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
         }
     }
 
+    /**
+     * Since the compiler treats half float values as Objects by default,
+     * this function examines if the stamp of a {@code ValuePhiNode} is an Object stamp,
+     * and if it is, it replaces the node with a new {@code ValuePhiNode} with a {@code HalfFloatStamp}.
+     * It is safe to assume that the Object stamp corresponds to a half value and not another
+     * Object type, because the functions that invoke it are operating only on half float related nodes.
+     *
+     * @param phiNode The {@code ValuePhiNode} to be examined.
+     * @param graph The Structured Graph.
+     * @return The {@code ValuePhiNode} with the {@code HalfFloatStamp}, or the existing {@code ValuePhiNode}.
+     */
     private static ValuePhiNode replacePhi(ValuePhiNode phiNode, StructuredGraph graph) {
         if (phiNode.getStackKind().isObject()) {
             ValueNode[] values = new ValueNode[phiNode.valueCount()];

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoHalfFloatReplacement.java
@@ -205,11 +205,8 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
     private static ValueNode getHalfFloatValue(ValueNode halfFloatValue, StructuredGraph graph) {
         if (halfFloatValue instanceof ConstantNode) {
             ConstantNode floatValue = (ConstantNode) halfFloatValue;
-            Constant half = new RawConstant(floatValue.asJavaConstant().asInt());
-            HalfFloatConstantNode halfFloatConstantNode = new HalfFloatConstantNode(half);
+            HalfFloatConstantNode halfFloatConstantNode = new HalfFloatConstantNode(floatValue);
             graph.addWithoutUnique(halfFloatConstantNode);
-            floatValue.replaceAtUsages(halfFloatConstantNode);
-            floatValue.safeDelete();
             return halfFloatConstantNode;
         } else {
             return halfFloatValue;

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoHalfFloatReplacement.java
@@ -39,10 +39,7 @@ import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.ValuePhiNode;
 import org.graalvm.compiler.nodes.ValueProxyNode;
-import org.graalvm.compiler.nodes.calc.AddNode;
 import org.graalvm.compiler.nodes.calc.FloatDivNode;
-import org.graalvm.compiler.nodes.calc.MulNode;
-import org.graalvm.compiler.nodes.calc.SubNode;
 import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.extended.JavaWriteNode;
 import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
@@ -52,11 +49,13 @@ import org.graalvm.compiler.phases.BasePhase;
 
 import uk.ac.manchester.tornado.api.internal.annotations.HalfType;
 import uk.ac.manchester.tornado.drivers.spirv.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.DivHalfNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.HalfFloatConstantNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.AddHalfNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.MultHalfNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.ReadHalfFloatNode;
+import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SubHalfNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.WriteHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.vector.LoadIndexedVectorNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.vector.SPIRVVectorValueNode;
@@ -264,7 +263,7 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
             subNode = new VectorSubHalfNode(subX, subY);
             graph.addWithoutUnique(subNode);
         } else {
-            subNode = new SubNode(subX, subY);
+            subNode = new SubHalfNode(subX, subY);
             graph.addWithoutUnique(subNode);
         }
         subHalfFloatNode.replaceAtUsages(subNode);
@@ -315,7 +314,7 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
         ValueNode divX = getHalfOperand(divHalfFloatNode.getX(), graph, isVectorOperation);
         ValueNode divY = getHalfOperand(divHalfFloatNode.getY(), graph, isVectorOperation);
 
-        FloatDivNode divNode = new FloatDivNode(divX, divY);
+        DivHalfNode divNode = new DivHalfNode(divX, divY);
         graph.addWithoutUnique(divNode);
 
         divHalfFloatNode.replaceAtUsages(divNode);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
@@ -34,8 +34,6 @@ import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
-import uk.ac.manchester.tornado.api.types.HalfFloat;
-import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020, 2022, 2025, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2020, 2022, APT Group, Department of Computer Science,
  * The University of Manchester.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,6 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
-import uk.ac.manchester.tornado.unittests.vectortypes.TestHalfFloats;
 
 /**
  * <p>
@@ -172,19 +171,6 @@ public class TestMatrices extends TornadoTestBase {
         for (@Parallel int i = 0; i < first.length; i++) {
             for (@Parallel int j = 0; j < first.length; j++) {
                 first[i][j] = first[i][j] + second[i][j];
-            }
-        }
-    }
-
-    private static void matrixMultiplicationHalfFloats(final HalfFloatArray A, final HalfFloatArray B, final HalfFloatArray C, final int size) {
-        for (@Parallel int i = 0; i < size; i++) {
-            for (@Parallel int j = 0; j < size; j++) {
-                HalfFloat sum = new HalfFloat(0.0f);
-                for (int k = 0; k < size; k++) {
-                    HalfFloat mult = HalfFloat.mult(A.get((i * size) + k), B.get((k * size) + j));
-                    sum = HalfFloat.add(sum, mult);
-                }
-                C.set((i * size) + j, sum);
             }
         }
     }
@@ -797,36 +783,6 @@ public class TestMatrices extends TornadoTestBase {
 
         for (int i = 0; i < firstMatrix.length; i++) {
             Assert.assertArrayEquals(firstMatrixSeq[i], firstMatrix[i], 0.01f);
-        }
-    }
-
-    @Test
-    public void testHalfFloatMatrixMultiplication() throws TornadoExecutionPlanException {
-        int N = 256;
-        HalfFloatArray matrixA = new HalfFloatArray(N * N);
-        HalfFloatArray matrixB = new HalfFloatArray(N * N);
-        HalfFloatArray matrixCSeq = new HalfFloatArray(N * N);
-        HalfFloatArray matrixC = new HalfFloatArray(N * N);
-
-        IntStream.range(0, N * N).parallel().forEach(idx -> {
-            matrixA.set(idx, new HalfFloat(2.5f));
-            matrixB.set(idx, new HalfFloat(3.5f));
-        });
-
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB) //
-                .task("t0", TestMatrices::matrixMultiplicationHalfFloats, matrixA, matrixB, matrixC, N) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
-
-        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        try (TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executor.execute();
-        }
-
-        matrixMultiplicationHalfFloats(matrixA, matrixB, matrixCSeq, N);
-
-        for (int i = 0; i < N * N; i++) {
-            assertEquals(matrixCSeq.get(i).getFloat32(), matrixC.get(i).getFloat32(), DELTA);
         }
     }
     // CHECKSTYLE:ON

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalfFloats.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalfFloats.java
@@ -20,6 +20,7 @@ package uk.ac.manchester.tornado.unittests.vectortypes;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Random;
+import java.util.stream.IntStream;
 
 import org.junit.Test;
 
@@ -245,6 +246,19 @@ public class TestHalfFloats extends TornadoTestBase {
             half2.setX(HalfFloat.add(value.get(i).getS0(), value.get(i).getS1()));
             half2.setY(value.get(i).getS1());
             output.set(i, half2);
+        }
+    }
+
+    private static void matrixMultiplication(final HalfFloatArray A, final HalfFloatArray B, final HalfFloatArray C, final int size) {
+        for (@Parallel int i = 0; i < size; i++) {
+            for (@Parallel int j = 0; j < size; j++) {
+                HalfFloat sum = new HalfFloat(0.0f);
+                for (int k = 0; k < size; k++) {
+                    HalfFloat mult = HalfFloat.mult(A.get((i * size) + k), B.get((k * size) + j));
+                    sum = HalfFloat.add(sum, mult);
+                }
+                C.set((i * size) + j, sum);
+            }
         }
     }
 
@@ -926,6 +940,37 @@ public class TestHalfFloats extends TornadoTestBase {
             assertEquals(sequentialOutput.get(i).getY().getFloat32(), tornadoOutput.get(i).getY().getFloat32(), DELTA);
         }
     }
+
+    @Test
+    public void testMatrixMultiplication() throws TornadoExecutionPlanException {
+        int N = 256;
+        HalfFloatArray matrixA = new HalfFloatArray(N * N);
+        HalfFloatArray matrixB = new HalfFloatArray(N * N);
+        HalfFloatArray matrixCSeq = new HalfFloatArray(N * N);
+        HalfFloatArray matrixC = new HalfFloatArray(N * N);
+
+        IntStream.range(0, N * N).parallel().forEach(idx -> {
+            matrixA.set(idx, new HalfFloat(2.5f));
+            matrixB.set(idx, new HalfFloat(3.5f));
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB) //
+                .task("t0", TestHalfFloats::matrixMultiplication, matrixA, matrixB, matrixC, N) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executor.execute();
+        }
+
+        matrixMultiplication(matrixA, matrixB, matrixCSeq, N);
+
+        for (int i = 0; i < N * N; i++) {
+            assertEquals(matrixCSeq.get(i).getFloat32(), matrixC.get(i).getFloat32(), DELTA);
+        }
+    }
+
 
     @Test(timeout = 1000) //timeout of 1sec
     public void testAllocationIssue() {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalfFloats.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalfFloats.java
@@ -20,7 +20,6 @@ package uk.ac.manchester.tornado.unittests.vectortypes;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Random;
-import java.util.stream.IntStream;
 
 import org.junit.Test;
 


### PR DESCRIPTION
#### Description

This PR extends TornadoVM with the necessary functionality to support multiplication of matrices that consist of half float values. In this PR it is assumed that the results of the multiplication do not overflow,  so the output matrix consists also of half float values.

#### Problem description

The changes in this PR take place on the compilation and code generation fronts. Regarding compilation, the key change is regarding the `ValuePhiNode`, which accumulates the dot products of the multiplication to perform the addition. Since Java does not have a half float type by default (this type was introduced by TornadoVM), the half float values are treated as Java Objects by default. To avoid compilation errors due to that fact, a new `HalfFloatStamp` is introduced and used in the `ValuePhiNode` instead. This stamp is also now used in all half float related nodes, which before were represented as shorts. To this extend, new nodes for the operations between half float values are also introduced, since the `HalfFloatStamp` is an illegal stamp for the default add/sub/div/mult nodes of graal. Finally, a node to represent half float constants has been included for the same purposes.  These new operator nodes generate the code that their operators indicate. 

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
tornado-test -V uk.ac.manchester.tornado.unittests.compute.ComputeTests#testHalfFloatMatrixMultiplication
```