### PR TITLE
Enable colours in maven build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -298,7 +298,7 @@ def build_tornadovm(args, backend_profiles):
         else:
             isWinCmdOrBat = False
 
-        process = ["mvn", "-T1.5C"]
+        process = ["mvn", "-T1.5C", "-Dstyle.color=always"]
         if args.polyglot:
             process.append(f"-P{args.jdk},{backend_profiles},graalvm-polyglot")
         else:


### PR DESCRIPTION
#### Description

Enable colours in maven build

#### Problem description

Not sure why, but newer versions of Fedora colours were disabled. We can force this to be enabled.

![Screenshot From 2025-01-17 09-07-28](https://github.com/user-attachments/assets/6aaeceba-a549-4ba9-a162-ec3ff96ec477)

#### Backend/s tested

Mark the backends affected by this PR.


- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make
```