### PR TITLE
[fix] Atomic operations in OpenCL with the Kernel API

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
@@ -80,6 +80,7 @@ import uk.ac.manchester.tornado.api.exceptions.Debug;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLArchitecture;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLUnary;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.AtomicAddNodeTemplate;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.DecAtomicNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.GetAtomicNode;
@@ -147,7 +148,7 @@ public class OCLGraphBuilderPlugins {
         r.register(new InvocationPlugin("incrementAndGet", Receiver.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
-                b.addPush(returnedJavaKind, b.append(new IncAtomicNode(receiver.get(), true)));
+                b.addPush(returnedJavaKind, b.append(new IncAtomicNode(receiver.get(), OCLUnary.AtomicOperator.INCREMENT_AND_GET)));
                 return true;
             }
         });
@@ -155,7 +156,7 @@ public class OCLGraphBuilderPlugins {
         r.register(new InvocationPlugin("getAndIncrement", Receiver.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
-                b.addPush(returnedJavaKind, b.append(new IncAtomicNode(receiver.get())));
+                b.addPush(returnedJavaKind, b.append(new IncAtomicNode(receiver.get(), OCLUnary.AtomicOperator.GET_AND_INCREMENT)));
                 return true;
             }
         });
@@ -163,7 +164,7 @@ public class OCLGraphBuilderPlugins {
         r.register(new InvocationPlugin("decrementAndGet", Receiver.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
-                b.addPush(returnedJavaKind, b.append(new DecAtomicNode(receiver.get(), true)));
+                b.addPush(returnedJavaKind, b.append(new DecAtomicNode(receiver.get(), OCLUnary.AtomicOperator.DECREMENT_AND_GET)));
                 return true;
             }
         });
@@ -171,7 +172,7 @@ public class OCLGraphBuilderPlugins {
         r.register(new InvocationPlugin("getAndDecrement", Receiver.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
-                b.addPush(returnedJavaKind, b.append(new DecAtomicNode(receiver.get())));
+                b.addPush(returnedJavaKind, b.append(new DecAtomicNode(receiver.get(), OCLUnary.AtomicOperator.GET_AND_DECREMENT)));
                 return true;
             }
         });

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLUnary.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLUnary.java
@@ -120,18 +120,18 @@ public class OCLUnary {
 
         private static final String arrayName = OCLArchitecture.atomicSpace.getName();
         private int index;
-        private boolean incrementsFirst;
+        private boolean operatorFirst;
 
         public IntrinsicAtomicInc(OCLUnaryOp opcode, LIRKind lirKind, Value value, int index) {
             super(opcode, lirKind, value);
             this.index = index;
-            this.incrementsFirst = false;
+            this.operatorFirst = false;
         }
 
-        public IntrinsicAtomicInc(OCLUnaryOp opcode, LIRKind lirKind, Value value, int index, boolean incrementsFirst) {
+        public IntrinsicAtomicInc(OCLUnaryOp opcode, LIRKind lirKind, Value value, int index, boolean operatorFirst) {
             super(opcode, lirKind, value);
             this.index = index;
-            this.incrementsFirst = incrementsFirst;
+            this.operatorFirst = operatorFirst;
         }
 
         @Override
@@ -141,11 +141,14 @@ public class OCLUnary {
 
         @Override
         public String toString() {
-            if (incrementsFirst) {
-                return String.format("%s(&%s[%s]) + %d", opcode.toString(), arrayName, index, 1);
-            } else {
-                return String.format("%s(&%s[%s])", opcode.toString(), arrayName, index);
+            if (operatorFirst) {
+                if (opcode.toString().equals("atomic_inc")) {
+                    return String.format("%s(&%s[%s]) + %d", opcode.toString(), arrayName, index, 1);
+                } else if (opcode.toString().equals("atomic_dec")) {
+                    return String.format("%s(&%s[%s]) - %d", opcode.toString(), arrayName, index, 1);
+                }
             }
+            return String.format("%s(&%s[%s])", opcode.toString(), arrayName, index);
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLUnary.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLUnary.java
@@ -116,22 +116,20 @@ public class OCLUnary {
         }
     }
 
-    public static class IntrinsicAtomicInc extends UnaryConsumer {
+    public enum AtomicOperator {
+        INCREMENT_AND_GET, GET_AND_INCREMENT, DECREMENT_AND_GET, GET_AND_DECREMENT
+    }
+
+    public static class IntrinsicAtomicOperator extends UnaryConsumer {
 
         private static final String arrayName = OCLArchitecture.atomicSpace.getName();
         private int index;
-        private boolean operatorFirst;
+        private final AtomicOperator atomicOperator;
 
-        public IntrinsicAtomicInc(OCLUnaryOp opcode, LIRKind lirKind, Value value, int index) {
+        public IntrinsicAtomicOperator(OCLUnaryOp opcode, LIRKind lirKind, Value value, int index, AtomicOperator atomicOperator) {
             super(opcode, lirKind, value);
             this.index = index;
-            this.operatorFirst = false;
-        }
-
-        public IntrinsicAtomicInc(OCLUnaryOp opcode, LIRKind lirKind, Value value, int index, boolean operatorFirst) {
-            super(opcode, lirKind, value);
-            this.index = index;
-            this.operatorFirst = operatorFirst;
+            this.atomicOperator = atomicOperator;
         }
 
         @Override
@@ -141,14 +139,21 @@ public class OCLUnary {
 
         @Override
         public String toString() {
-            if (operatorFirst) {
-                if (opcode.toString().equals("atomic_inc")) {
+            switch (atomicOperator) {
+                case INCREMENT_AND_GET -> {
                     return String.format("%s(&%s[%s]) + %d", opcode.toString(), arrayName, index, 1);
-                } else if (opcode.toString().equals("atomic_dec")) {
+                }
+                case DECREMENT_AND_GET -> {
                     return String.format("%s(&%s[%s]) - %d", opcode.toString(), arrayName, index, 1);
                 }
+                case GET_AND_INCREMENT -> {
+                    return String.format("%s(&%s[%s])", opcode.toString(), arrayName, index);
+                }
+                case GET_AND_DECREMENT -> {
+                    return String.format("%s(&%s[%s])", opcode.toString(), arrayName, index);
+                }
             }
-            return String.format("%s(&%s[%s])", opcode.toString(), arrayName, index);
+            return "";
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLUnary.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLUnary.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2013-2022, 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2022, 2024-2025, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -120,10 +120,18 @@ public class OCLUnary {
 
         private static final String arrayName = OCLArchitecture.atomicSpace.getName();
         private int index;
+        private boolean incrementsFirst;
 
         public IntrinsicAtomicInc(OCLUnaryOp opcode, LIRKind lirKind, Value value, int index) {
             super(opcode, lirKind, value);
             this.index = index;
+            this.incrementsFirst = false;
+        }
+
+        public IntrinsicAtomicInc(OCLUnaryOp opcode, LIRKind lirKind, Value value, int index, boolean incrementsFirst) {
+            super(opcode, lirKind, value);
+            this.index = index;
+            this.incrementsFirst = incrementsFirst;
         }
 
         @Override
@@ -133,7 +141,11 @@ public class OCLUnary {
 
         @Override
         public String toString() {
-            return String.format("%s(&%s[%s])", opcode.toString(), arrayName, index);
+            if (incrementsFirst) {
+                return String.format("%s(&%s[%s]) + %d", opcode.toString(), arrayName, index, 1);
+            } else {
+                return String.format("%s(&%s[%s])", opcode.toString(), arrayName, index);
+            }
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/DecAtomicNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/DecAtomicNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2020, 2025, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -10,7 +10,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -44,10 +44,18 @@ public class DecAtomicNode extends NodeAtomic implements LIRLowerable {
 
     @Input
     ValueNode atomicNode;
+    boolean decrementsFirst;
+
+    public DecAtomicNode(ValueNode atomicValue, boolean decrementsFirst) {
+        super(TYPE, StampFactory.forKind(JavaKind.Int));
+        this.atomicNode = atomicValue;
+        this.decrementsFirst = decrementsFirst;
+    }
 
     public DecAtomicNode(ValueNode atomicValue) {
         super(TYPE, StampFactory.forKind(JavaKind.Int));
         this.atomicNode = atomicValue;
+        this.decrementsFirst = false;
     }
 
     private void generateExpressionForOpenCL2_0(NodeLIRBuilderTool generator) {
@@ -77,7 +85,8 @@ public class DecAtomicNode extends NodeAtomic implements LIRLowerable {
                     OCLAssembler.OCLUnaryIntrinsic.ATOMIC_DEC, //
                     tool.getLIRKind(stamp), //
                     generator.operand(atomicNode), //
-                    indexFromGlobal);
+                    indexFromGlobal, //
+                    decrementsFirst);
 
             OCLLIRStmt.AssignStmt assignStmt = new OCLLIRStmt.AssignStmt(result, intrinsicAtomicAdd);
             tool.append(assignStmt);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/DecAtomicNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/DecAtomicNode.java
@@ -44,18 +44,12 @@ public class DecAtomicNode extends NodeAtomic implements LIRLowerable {
 
     @Input
     ValueNode atomicNode;
-    boolean decrementsFirst;
+    OCLUnary.AtomicOperator atomicOperator;
 
-    public DecAtomicNode(ValueNode atomicValue, boolean decrementsFirst) {
+    public DecAtomicNode(ValueNode atomicValue, OCLUnary.AtomicOperator atomicOperator) {
         super(TYPE, StampFactory.forKind(JavaKind.Int));
         this.atomicNode = atomicValue;
-        this.decrementsFirst = decrementsFirst;
-    }
-
-    public DecAtomicNode(ValueNode atomicValue) {
-        super(TYPE, StampFactory.forKind(JavaKind.Int));
-        this.atomicNode = atomicValue;
-        this.decrementsFirst = false;
+        this.atomicOperator = atomicOperator;
     }
 
     private void generateExpressionForOpenCL2_0(NodeLIRBuilderTool generator) {
@@ -81,12 +75,12 @@ public class DecAtomicNode extends NodeAtomic implements LIRLowerable {
 
             int indexFromGlobal = atomicIntegerNode.getIndexFromGlobalMemory();
 
-            OCLUnary.IntrinsicAtomicInc intrinsicAtomicAdd = new OCLUnary.IntrinsicAtomicInc( //
+            OCLUnary.IntrinsicAtomicOperator intrinsicAtomicAdd = new OCLUnary.IntrinsicAtomicOperator( //
                     OCLAssembler.OCLUnaryIntrinsic.ATOMIC_DEC, //
                     tool.getLIRKind(stamp), //
                     generator.operand(atomicNode), //
                     indexFromGlobal, //
-                    decrementsFirst);
+                    atomicOperator);
 
             OCLLIRStmt.AssignStmt assignStmt = new OCLLIRStmt.AssignStmt(result, intrinsicAtomicAdd);
             tool.append(assignStmt);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/IncAtomicNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/IncAtomicNode.java
@@ -44,18 +44,12 @@ public class IncAtomicNode extends NodeAtomic implements LIRLowerable {
 
     @Input
     ValueNode atomicNode;
-    boolean incrementsFirst;
+    OCLUnary.AtomicOperator atomicOperator;
 
-    public IncAtomicNode(ValueNode atomicValue, boolean incrementsFirst) {
+    public IncAtomicNode(ValueNode atomicValue, OCLUnary.AtomicOperator atomicOperator) {
         super(TYPE, StampFactory.forKind(JavaKind.Int));
         this.atomicNode = atomicValue;
-        this.incrementsFirst = incrementsFirst;
-    }
-
-    public IncAtomicNode(ValueNode atomicValue) {
-        super(TYPE, StampFactory.forKind(JavaKind.Int));
-        this.atomicNode = atomicValue;
-        this.incrementsFirst = false;
+        this.atomicOperator = atomicOperator;
     }
 
     @Override
@@ -86,12 +80,12 @@ public class IncAtomicNode extends NodeAtomic implements LIRLowerable {
 
             int indexFromGlobal = atomicIntegerNode.getIndexFromGlobalMemory();
 
-            OCLUnary.IntrinsicAtomicInc intrinsicAtomicAdd = new OCLUnary.IntrinsicAtomicInc( //
+            OCLUnary.IntrinsicAtomicOperator intrinsicAtomicAdd = new OCLUnary.IntrinsicAtomicOperator( //
                     OCLAssembler.OCLUnaryIntrinsic.ATOMIC_INC, //
                     tool.getLIRKind(stamp), //
                     generator.operand(atomicNode), //
                     indexFromGlobal, //
-                    incrementsFirst);
+                    atomicOperator);
 
             OCLLIRStmt.AssignStmt assignStmt = new OCLLIRStmt.AssignStmt(result, intrinsicAtomicAdd);
             tool.append(assignStmt);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/IncAtomicNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/IncAtomicNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, APT Group, Department of Computer Science,
+ * Copyright (c) 2020, 2025, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -10,7 +10,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -44,10 +44,18 @@ public class IncAtomicNode extends NodeAtomic implements LIRLowerable {
 
     @Input
     ValueNode atomicNode;
+    boolean incrementsFirst;
+
+    public IncAtomicNode(ValueNode atomicValue, boolean incrementsFirst) {
+        super(TYPE, StampFactory.forKind(JavaKind.Int));
+        this.atomicNode = atomicValue;
+        this.incrementsFirst = incrementsFirst;
+    }
 
     public IncAtomicNode(ValueNode atomicValue) {
         super(TYPE, StampFactory.forKind(JavaKind.Int));
         this.atomicNode = atomicValue;
+        this.incrementsFirst = false;
     }
 
     @Override
@@ -82,7 +90,8 @@ public class IncAtomicNode extends NodeAtomic implements LIRLowerable {
                     OCLAssembler.OCLUnaryIntrinsic.ATOMIC_INC, //
                     tool.getLIRKind(stamp), //
                     generator.operand(atomicNode), //
-                    indexFromGlobal);
+                    indexFromGlobal, //
+                    incrementsFirst);
 
             OCLLIRStmt.AssignStmt assignStmt = new OCLLIRStmt.AssignStmt(result, intrinsicAtomicAdd);
             tool.append(assignStmt);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoAtomicsScheduling.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoAtomicsScheduling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * Copyright (c) 2023, 2025, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009-2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -10,7 +10,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -28,7 +28,7 @@ import java.util.Optional;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.graph.iterators.NodeIterable;
-import org.graalvm.compiler.nodes.EndNode;
+import org.graalvm.compiler.nodes.FixedNode;
 import org.graalvm.compiler.nodes.FixedWithNextNode;
 import org.graalvm.compiler.nodes.GraphState;
 import org.graalvm.compiler.nodes.StartNode;
@@ -77,7 +77,7 @@ public class TornadoAtomicsScheduling extends Phase {
 
         if (first != null && !(first instanceof StartNode)) {
             first.replaceAtPredecessor(startNode);
-            startNode.setNext((EndNode) first);
+            startNode.setNext((FixedNode) first);
         }
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/atomics/TestAtomics.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/atomics/TestAtomics.java
@@ -568,12 +568,19 @@ public class TestAtomics extends TornadoTestBase {
         assertNotBackend(TornadoVMBackendType.PTX);
         assertNotBackend(TornadoVMBackendType.SPIRV);
 
+        Random random = new Random();
         final int size = 32;
         IntArray a = new IntArray(size);
-        a.init(1);
+        IntArray dataSequential = new IntArray(size);
+        for (int i = 0; i < size; i++) {
+            int intRandomValue = random.nextInt();
+            a.set(i, intRandomValue);
+            dataSequential.set(i, intRandomValue);
+        }
 
         final int initialValueA = 311;
         AtomicInteger ai = new AtomicInteger(initialValueA);
+        AtomicInteger jai = new AtomicInteger(initialValueA);
 
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.EVERY_EXECUTION, a) //
@@ -584,11 +591,13 @@ public class TestAtomics extends TornadoTestBase {
             executionPlan.execute();
         }
 
-        boolean repeated = isValueRepeated(a);
+        atomic13DecrementAndGet(dataSequential, jai);
 
+        boolean repeated = isValueRepeated(a);
         int lastValue = ai.get();
         assertFalse(repeated);
         assertEquals(initialValueA - size, lastValue);
+        assertArrayEquals(dataSequential.toHeapArray(), a.toHeapArray());
     }
 
     @Test
@@ -600,12 +609,16 @@ public class TestAtomics extends TornadoTestBase {
         Random random = new Random();
         final int size = 32;
         IntArray a = new IntArray(size);
+        IntArray dataSequential = new IntArray(size);
         for (int i = 0; i < size; i++) {
-            a.set(i, random.nextInt());
+            int intRandomValue = random.nextInt();
+            a.set(i, intRandomValue);
+            dataSequential.set(i, intRandomValue);
         }
 
         final int initialValueA = 311;
         AtomicInteger ai = new AtomicInteger(initialValueA);
+        AtomicInteger jai = new AtomicInteger(initialValueA);
 
         TaskGraph taskGraph = new TaskGraph("s0") //
                 .transferToDevice(DataTransferMode.EVERY_EXECUTION, a) //
@@ -616,11 +629,13 @@ public class TestAtomics extends TornadoTestBase {
             executionPlan.execute();
         }
 
-        boolean repeated = isValueRepeated(a);
+        atomic13GetAndDecrement(dataSequential, jai);
 
+        boolean repeated = isValueRepeated(a);
         int lastValue = ai.get();
         assertFalse(repeated);
         assertEquals(initialValueA - size, lastValue);
+        assertArrayEquals(dataSequential.toHeapArray(), a.toHeapArray());
     }
 
     @Test
@@ -722,8 +737,9 @@ public class TestAtomics extends TornadoTestBase {
         IntArray dataTornadoVM = new IntArray(size);
         IntArray dataSequential = new IntArray(size);
         for (int i = 0; i < size; i++) {
-            dataTornadoVM.set(i, random.nextInt());
-            dataSequential.set(i, random.nextInt());
+            int intRandomValue = random.nextInt();
+            dataTornadoVM.set(i, intRandomValue);
+            dataSequential.set(i, intRandomValue);
         }
 
         KernelContext context = new KernelContext();
@@ -762,8 +778,9 @@ public class TestAtomics extends TornadoTestBase {
         IntArray dataTornadoVM = new IntArray(size);
         IntArray dataSequential = new IntArray(size);
         for (int i = 0; i < size; i++) {
-            dataTornadoVM.set(i, random.nextInt());
-            dataSequential.set(i, random.nextInt());
+            int intRandomValue = random.nextInt();
+            dataTornadoVM.set(i, intRandomValue);
+            dataSequential.set(i, intRandomValue);
         }
 
         KernelContext context = new KernelContext();


### PR DESCRIPTION
#### Description

This PR provides one fix and one extension:
- It fixes the `incrementAndGet` functionality in OpenCL because the OpenCL implementation of the `atomic_inc` function returns the [old value](https://manpages.debian.org/buster/opencl-1.2-man-doc/atom_inc.3clc.en.html) and not the incremented result.
- It adds two plugins for `getAndIncrement` and `getAndDecrement` functions along with the respective tests.
- It enables the functions that use the `Kernel API` for expressing parallelism, to also use the `AtomicInteger` object. However, this is allowed, only if it is passed as an argument to the method. This is according to the design that is currently applicable at the methods that use the `Loop Parallel` API.
- It adds in total five new unit-tests that assess the `incrementAndGet` , `getAndIncrement` and `getAndDecrement` operations with the `Loop Parallel API` and the `Kernel API`.

#### Problem description

The first problem is that the unit-tests that were invoking the `incrementAndGet` method they were getting the old values and not the incremented ones. The final result may have been correct, however if the result from `atomic_inc` was stored in an array, that value would be the old value.

The second problem is that the compiler was throwing an exception whenever the `AtomicInteger` object was used within a method that uses the `KernelContext` (i.e., `Kernel API`).

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
make BACKEND=opencl
tornado-test -V uk.ac.manchester.tornado.unittests.atomics.TestAtomics
```
----------------------------------------------------------------------------
