### PR TITLE
[release] v1.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TornadoVM
 
-![TornadoVM version](https://img.shields.io/badge/version-1.0.9-purple)  [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2) [![License: GPL v2](https://img.shields.io/badge/License-GPL%20V2%20Classpth%20Exeception-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+![TornadoVM version](https://img.shields.io/badge/version-1.0.10-purple)  [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2) [![License: GPL v2](https://img.shields.io/badge/License-GPL%20V2%20Classpth%20Exeception-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 
 <img align="left" width="250" height="250" src="etc/tornadoVM_Logo.jpg">
 
@@ -20,7 +20,7 @@ Developers can choose which backends to install and run.
 
 For a quick introduction please read the following [FAQ](https://tornadovm.readthedocs.io/en/latest/).
 
-**Latest Release:** TornadoVM 1.0.9 - 20/12/2024 :
+**Latest Release:** TornadoVM 1.0.10 - 31/01/2025 :
 See [CHANGELOG](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html).
 
 ----------------------
@@ -261,12 +261,12 @@ You can import the TornadoVM API by setting this the following dependency in the
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
 </dependency>
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-matrices</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
 </dependency>
 </dependencies>
 ```

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -36,7 +36,7 @@ import installer_config as config
 ## Configuration
 ## ################################################################
 __DIRECTORY_DEPENDENCIES__ = os.path.join("etc", "dependencies")
-__VERSION__ = "v1.0.9"
+__VERSION__ = "v1.0.10"
 
 __SUPPORTED_JDKS__ = [
     config.__JDK21__,

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -5,6 +5,33 @@ TornadoVM Changelog
 
 This file summarizes the new features and major changes for each *TornadoVM* version.
 
+TornadoVM 1.0.10
+---------------
+31/01/25
+
+Improvements
+~~~~~~~~~~~~
+
+- `#608 <https://github.com/beehive-lab/TornadoVM/pull/608>`_: Selective execution with multiple SPIR-V runtimes (either OpenCL, Intel Level Zero, or both) to unlock execution on RISC-V systems. 
+- `#611 <https://github.com/beehive-lab/TornadoVM/pull/611>`_: Support of ``HalfFloat`` for Matrix Types (``FP16`` -> ``FP16``).
+
+Compatibility
+~~~~~~~~~~~~
+
+- `#607 <https://github.com/beehive-lab/TornadoVM/pull/607>`_: WSL installation and configuration updated for WSL Ubuntu 24 LTS and Windows 11.
+- `#609 <https://github.com/beehive-lab/TornadoVM/pull/609>`_: Documentation and patch for RISC-V64 updated.
+- `#610 <https://github.com/beehive-lab/TornadoVM/pull/610>`_: Maven dependency updated
+- `#612 <https://github.com/beehive-lab/TornadoVM/pull/612>`_: Re-enable colours in maven builds on Linux. 
+
+Bug Fixes 
+~~~~~~~~~~~~
+
+- `#606 <https://github.com/beehive-lab/TornadoVM/pull/606>`_: Fix data sizes in benchmark suite.
+- `#613 <https://github.com/beehive-lab/TornadoVM/pull/613>`_: Fix code formatter.
+- `#614 <https://github.com/beehive-lab/TornadoVM/pull/614>`_: Fix flags for the benchmark pipeline in Jenkins. 
+- `#615 <https://github.com/beehive-lab/TornadoVM/pull/615>`_: Fix code style based on the formatter. 
+- `#616 <https://github.com/beehive-lab/TornadoVM/pull/616>`_: Fix atomics for the Kernel API and the OpenCL backend.
+
 
 TornadoVM 1.0.9
 ---------------
@@ -47,7 +74,6 @@ Bug Fixes
 - Fix bitwise negation operations for the PTX backend:  `link <https://github.com/beehive-lab/TornadoVM/commit/0db1cd3e7fd90accd737ca2bfd6d2450c40f3713>`_ 
 - ``GetBackendImpl::getAllDevices`` thread-safe: `link <https://github.com/beehive-lab/TornadoVM/commit/0d4425264ffe0633ea79c8aba91233591059d3fd>`_ 
 - Check size elements for memory segments: `link <https://github.com/beehive-lab/TornadoVM/commit/4360385156236bb2397debeea65fedea349c6bca>`_. 
-
 
 
 TornadoVM 1.0.8

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,8 +6,8 @@ project = "TornadoVM"
 copyright = "2013-2024, APT Group, Department of Computer Science"
 author = "The University of Manchester"
 
-release = "v1.0.9"
-version = "v1.0.9"
+release = "v1.0.10"
+version = "v1.0.10"
 
 # -- General configuration
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -737,13 +737,13 @@ To use the TornadoVM API in your projects, you can checkout our maven repository
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>1.0.9</version>
+         <version>1.0.10</version>
       </dependency>
 
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>1.0.9</version>
+         <version>1.0.10</version>
       </dependency>
    </dependencies>
 
@@ -754,6 +754,7 @@ Notice that, for running with TornadoVM, you will need either the docker images 
 Versions available
 ==================
 
+* 1.0.10
 * 1.0.9
 * 1.0.7
 * 1.0.6
@@ -763,21 +764,3 @@ Versions available
 * 1.0.2
 * 1.0.1
 * 1.0
-* 0.15.2
-* 0.15.1
-* 0.15
-* 0.14.1
-* 0.14
-* 0.13
-* 0.12
-* 0.11
-* 0.10
-* 0.9
-* 0.8
-* 0.7
-* 0.6
-* 0.5
-* 0.4
-* 0.3
-* 0.2
-* 0.1.0

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>tornado</groupId>
     <artifactId>tornado</artifactId>
-    <version>1.0.10-dev </version>
+    <version>1.0.10</version>
     <packaging>pom</packaging>
     <name>tornado</name>
     <url>https://github.com/beehive-lab/tornadovm</url>

--- a/tornado-annotation/pom.xml
+++ b/tornado-annotation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
 
     <artifactId>tornado-annotation</artifactId>

--- a/tornado-api/pom.xml
+++ b/tornado-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
 
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.10-dev </version>
+    <version>1.0.10</version>
 
     <name>tornado-api</name>
     <url>https://tornadovm.org</url>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-assembly</artifactId>
     <packaging>pom</packaging>

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -352,7 +352,7 @@ else:
 
 ENABLE_ASSERTIONS = "-ea "
 
-__VERSION__ = "1.0.9-dev"
+__VERSION__ = "1.0.10"
 
 try:
     javaHome = os.environ["JAVA_HOME"]

--- a/tornado-benchmarks/pom.xml
+++ b/tornado-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
 
     <artifactId>tornado-benchmarks</artifactId>

--- a/tornado-drivers/drivers-common/pom.xml
+++ b/tornado-drivers/drivers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.10-dev</version>
+        <version>1.0.10</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tornado-drivers/opencl-jni/pom.xml
+++ b/tornado-drivers/opencl-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-drivers-opencl-jni</artifactId>
     <name>tornado-drivers-opencl-jni</name>

--- a/tornado-drivers/opencl/pom.xml
+++ b/tornado-drivers/opencl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-drivers-opencl</artifactId>
     <name>tornado-drivers-opencl</name>

--- a/tornado-drivers/pom.xml
+++ b/tornado-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-drivers</artifactId>
     <name>tornado-drivers</name>

--- a/tornado-drivers/ptx-jni/pom.xml
+++ b/tornado-drivers/ptx-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-drivers-ptx-jni</artifactId>
     <name>tornado-drivers-ptx-jni</name>

--- a/tornado-drivers/ptx/pom.xml
+++ b/tornado-drivers/ptx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tornado-drivers</artifactId>
         <groupId>tornado</groupId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-drivers-ptx</artifactId>
     <name>tornado-drivers-ptx</name>

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-drivers-spirv</artifactId>
     <name>tornado-drivers-spirv</name>

--- a/tornado-examples/pom.xml
+++ b/tornado-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-examples</artifactId>
     <name>tornado-examples</name>

--- a/tornado-matrices/pom.xml
+++ b/tornado-matrices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-matrices</artifactId>
     <name>tornado-matrices</name>

--- a/tornado-runtime/pom.xml
+++ b/tornado-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.10-dev</version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-runtime</artifactId>
     <name>tornado-runtime</name>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.0.10-dev </version>
+        <version>1.0.10</version>
     </parent>
     <artifactId>tornado-unittests</artifactId>
     <name>tornado-unittests</name>


### PR DESCRIPTION
## Improvements

- #608: Selective execution with multiple SPIR-V runtimes (either OpenCL, Intel Level Zero, or both) to unlock execution on RISC-V systems. 
- #611: Support of ``HalfFloat`` for Matrix Types (``FP16`` -> ``FP16``).

## Compatibility

- #607: WSL installation and configuration updated for WSL Ubuntu 24 LTS and Windows 11.
- #609: Documentation and patch for RISC-V64 updated.
- #610: Maven dependency updated
- #612: Re-enable colours in maven builds on Linux. 

## Bug Fixes 

- #606: Fix data sizes in benchmark suite.
- #613: Fix code formatter.
- #614: Fix flags for the benchmark pipeline in Jenkins. 
- #615: Fix code style based on the formatter. 
- #616: Fix atomics for the Kernel API and the OpenCL backend.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make 
make tests
```
