### PR TITLE
Support Mixed Precision Matrix Multiplication  (FP16 to FP32)

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
@@ -109,6 +109,38 @@ public class OCLLIRStmt {
         }
     }
 
+    @Opcode("CONVERT_HALF")
+    public static class ConvertHalfToFloatStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<ConvertHalfToFloatStmt> TYPE = LIRInstructionClass.create(ConvertHalfToFloatStmt.class);
+
+        @Def
+        protected Value floatValue;
+        @Use
+        protected Value halfValue;
+
+        public ConvertHalfToFloatStmt(Value floatValue, Value halfValue) {
+            super(TYPE);
+            this.floatValue = floatValue;
+            this.halfValue = halfValue;
+        }
+
+        @Override
+        public void emitCode(OCLCompilationResultBuilder crb, OCLAssembler asm) {
+            asm.indent();
+            asm.emitValue(crb, floatValue);
+            asm.space();
+            asm.assign();
+            asm.space();
+            asm.emit("convert_float((float) ");
+            asm.emitValue(crb, halfValue);
+            asm.emit(")");
+            asm.delimiter();
+            asm.eol();
+        }
+
+    }
+
     @Opcode("VADD_HALF")
     public static class VectorAddHalfStmt extends AbstractInstruction {
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLConvertHalfToFloat.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLConvertHalfToFloat.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.opencl.graal.nodes;
+
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
+import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
+
+@NodeInfo
+public class OCLConvertHalfToFloat extends ValueNode implements LIRLowerable {
+
+    public static final NodeClass<OCLConvertHalfToFloat> TYPE = NodeClass.create(OCLConvertHalfToFloat.class);
+
+    @Input
+    private ValueNode halfValueNode;
+
+    public OCLConvertHalfToFloat(ValueNode halfValueNode) {
+        super(TYPE, StampFactory.forKind(JavaKind.Float));
+        this.halfValueNode = halfValueNode;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable floatValue = tool.newVariable(LIRKind.value(OCLKind.FLOAT));
+        Value halfValue = generator.operand(halfValueNode);
+        tool.append(new OCLLIRStmt.ConvertHalfToFloatStmt(floatValue, halfValue));
+        generator.setResult(this, floatValue);
+    }
+
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
@@ -405,6 +405,36 @@ public class PTXLIRStmt {
 
     }
 
+    @Opcode("CONVERT_HALF")
+    public static class ConvertHalfToFloatStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<ConvertHalfToFloatStmt> TYPE = LIRInstructionClass.create(ConvertHalfToFloatStmt.class);
+
+        @Def
+        protected Value floatValue;
+        @Use
+        protected Value halfValue;
+
+        public ConvertHalfToFloatStmt(Value floatValue, Value halfValue) {
+            super(TYPE);
+            this.floatValue = floatValue;
+            this.halfValue = halfValue;
+        }
+
+        @Override
+        public void emitCode(PTXCompilationResultBuilder crb, PTXAssembler asm) {
+            asm.emitSymbol(TAB);
+            asm.emit(CONVERT + DOT + "f32" + DOT + "f16");
+            asm.emitSymbol(SPACE);
+            asm.emitValue(floatValue);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(halfValue);
+            asm.delimiter();
+            asm.eol();
+        }
+
+    }
+
     @Opcode("LOCAL_MEMORY_ACCESS")
     public static class LocalMemoryAccessStmt extends AbstractInstruction {
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXConvertHalfToFloat.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXConvertHalfToFloat.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
+
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
+
+@NodeInfo
+public class PTXConvertHalfToFloat extends ValueNode implements LIRLowerable {
+
+    public static final NodeClass<PTXConvertHalfToFloat> TYPE = NodeClass.create(PTXConvertHalfToFloat.class);
+
+    @Input
+    private ValueNode halfValueNode;
+
+    public PTXConvertHalfToFloat(ValueNode halfValueNode) {
+        super(TYPE, StampFactory.forKind(JavaKind.Float));
+        this.halfValueNode = halfValueNode;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable floatValue = tool.newVariable(LIRKind.value(PTXKind.F32));
+        Value halfValue = generator.operand(halfValueNode);
+        tool.append(new PTXLIRStmt.ConvertHalfToFloatStmt(floatValue, halfValue));
+        generator.setResult(this, floatValue);
+    }
+
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
@@ -30,15 +30,19 @@ import jdk.vm.ci.meta.RawConstant;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.FixedGuardNode;
+import org.graalvm.compiler.nodes.FixedNode;
 import org.graalvm.compiler.nodes.GraphState;
 import org.graalvm.compiler.nodes.PiNode;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.ValuePhiNode;
 import org.graalvm.compiler.nodes.ValueProxyNode;
+import org.graalvm.compiler.nodes.calc.IsNullNode;
 import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.extended.JavaWriteNode;
 import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
+import org.graalvm.compiler.nodes.java.LoadFieldNode;
 import org.graalvm.compiler.nodes.java.NewInstanceNode;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.phases.BasePhase;
@@ -49,6 +53,7 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.AddHalfNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.HalfFloatConstantNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.MultHalfNode;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXConvertHalfToFloat;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXHalfFloatDivisionNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.ReadHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SubHalfNode;
@@ -160,6 +165,13 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
         replaceMultHalfFloatNodes(graph);
         replaceDivHalfFloatNodes(graph);
 
+        for (LoadFieldNode loadFieldNode : graph.getNodes().filter(LoadFieldNode.class)) {
+            // if the field loaded is from the HalfFloat class for the FP16->FP32 conversion, replace it
+            if (loadFieldNode.usages().filter(PTXConvertHalfToFloat.class).isNotEmpty()) {
+                replaceFieldAccess(loadFieldNode);
+            }
+        }
+
         // add after the loadindexedvector nodes the marker node to fix the offset of its read
 
         for (LoadIndexedVectorNode loadIndexedVectorNode : graph.getNodes().filter(LoadIndexedVectorNode.class)) {
@@ -196,6 +208,44 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
             }
         }
 
+    }
+
+    private static void replaceFieldAccess(LoadFieldNode loadFieldNode) {
+        // remove the FixGuardNode associated with the loading of the field
+        if (loadFieldNode.predecessor() instanceof FixedGuardNode) {
+            FixedGuardNode fixedGuardNode = (FixedGuardNode) loadFieldNode.predecessor();
+            deleteFixed(fixedGuardNode);
+        }
+        ArrayList<Node> nodesToBeDeleted = new ArrayList<>();
+        nodesToBeDeleted.add(loadFieldNode);
+        // iterate the inputs of the LoadFieldNode until you reach the node to replace it
+        Node replacement = identifyFieldReplacement(loadFieldNode.object(), nodesToBeDeleted);
+        loadFieldNode.replaceAtUsages(replacement);
+        //delete obsolete nodes
+        for (Node toBeDeleted : nodesToBeDeleted) {
+            if (toBeDeleted instanceof FixedNode) {
+                deleteFixed(toBeDeleted);
+            } else {
+                toBeDeleted.safeDelete();
+            }
+        }
+    }
+    private static Node identifyFieldReplacement(Node input, ArrayList<Node> nodesToBeDeleted) {
+        // the replacement is expected to be either the read node of a half value, or a phi node in case of accumulation
+        if (input instanceof ReadHalfFloatNode || input instanceof ValuePhiNode) {
+            return input;
+        }
+        if (input instanceof PiNode || input instanceof IsNullNode) {
+            nodesToBeDeleted.add(input);
+        }
+        Node replacement = null;
+        for (Node iterativeInputs : input.inputs()) {
+            replacement = identifyFieldReplacement(iterativeInputs, nodesToBeDeleted);
+            if (replacement != null) { // if the replacement node was found, stop the recursion
+                return replacement;
+            }
+        }
+        return replacement;
     }
 
     /**

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SPIRVConvertHalfToFloat.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SPIRVConvertHalfToFloat.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.spirv.graal.nodes;
+
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpConvertSToF;
+import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpConvertUToPtr;
+import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpFConvert;
+import uk.ac.manchester.tornado.drivers.spirv.graal.compiler.lir.SPIRVArithmeticTool;
+import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
+import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVLIRStmt;
+import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVUnary;
+
+@NodeInfo
+public class SPIRVConvertHalfToFloat extends ValueNode implements LIRLowerable {
+
+    public static final NodeClass<SPIRVConvertHalfToFloat> TYPE = NodeClass.create(SPIRVConvertHalfToFloat.class);
+
+    @Input
+    private ValueNode halfValueNode;
+
+    public SPIRVConvertHalfToFloat(ValueNode halfValueNode) {
+        super(TYPE, StampFactory.forKind(JavaKind.Float));
+        this.halfValueNode = halfValueNode;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable floatValue = tool.newVariable(LIRKind.value(SPIRVKind.OP_TYPE_FLOAT_32));
+        Value halfValue = generator.operand(halfValueNode);
+        LIRKind lirKind = LIRKind.value(SPIRVKind.OP_TYPE_FLOAT_32);
+        SPIRVUnary.CastOperations cast = new SPIRVUnary.CastFloatDouble(lirKind, floatValue, halfValue, SPIRVKind.OP_TYPE_FLOAT_32);
+        tool.append(new SPIRVLIRStmt.AssignStmt(floatValue, cast));
+        generator.setResult(this, floatValue);
+    }
+
+}

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoHalfFloatReplacement.java
@@ -33,15 +33,19 @@ import jdk.vm.ci.meta.RawConstant;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.FixedGuardNode;
+import org.graalvm.compiler.nodes.FixedNode;
 import org.graalvm.compiler.nodes.GraphState;
 import org.graalvm.compiler.nodes.PiNode;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.ValuePhiNode;
 import org.graalvm.compiler.nodes.ValueProxyNode;
+import org.graalvm.compiler.nodes.calc.IsNullNode;
 import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.extended.JavaWriteNode;
 import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
+import org.graalvm.compiler.nodes.java.LoadFieldNode;
 import org.graalvm.compiler.nodes.java.NewInstanceNode;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.phases.BasePhase;
@@ -54,6 +58,7 @@ import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.AddHalfNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.MultHalfNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.ReadHalfFloatNode;
+import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SPIRVConvertHalfToFloat;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SubHalfNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.WriteHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.vector.LoadIndexedVectorNode;
@@ -163,6 +168,13 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
         replaceMultHalfFloatNodes(graph);
         replaceDivHalfFloatNodes(graph);
 
+        for (LoadFieldNode loadFieldNode : graph.getNodes().filter(LoadFieldNode.class)) {
+            // if the field loaded is from the HalfFloat class for the FP16->FP32 conversion, replace it
+            if (loadFieldNode.usages().filter(SPIRVConvertHalfToFloat.class).isNotEmpty()) {
+                replaceFieldAccess(loadFieldNode);
+            }
+        }
+
         // add after the loadindexedvector nodes the marker node to fix the offset of its read
 
         for (LoadIndexedVectorNode loadIndexedVectorNode : graph.getNodes().filter(LoadIndexedVectorNode.class)) {
@@ -199,6 +211,44 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
             }
         }
 
+    }
+
+    private static void replaceFieldAccess(LoadFieldNode loadFieldNode) {
+        // remove the FixGuardNode associated with the loading of the field
+        if (loadFieldNode.predecessor() instanceof FixedGuardNode) {
+            FixedGuardNode fixedGuardNode = (FixedGuardNode) loadFieldNode.predecessor();
+            deleteFixed(fixedGuardNode);
+        }
+        ArrayList<Node> nodesToBeDeleted = new ArrayList<>();
+        nodesToBeDeleted.add(loadFieldNode);
+        // iterate the inputs of the LoadFieldNode until you reach the node to replace it
+        Node replacement = identifyFieldReplacement(loadFieldNode.object(), nodesToBeDeleted);
+        loadFieldNode.replaceAtUsages(replacement);
+        //delete obsolete nodes
+        for (Node toBeDeleted : nodesToBeDeleted) {
+            if (toBeDeleted instanceof FixedNode) {
+                deleteFixed(toBeDeleted);
+            } else {
+                toBeDeleted.safeDelete();
+            }
+        }
+    }
+    private static Node identifyFieldReplacement(Node input, ArrayList<Node> nodesToBeDeleted) {
+        // the replacement is expected to be either the read node of a half value, or a phi node in case of accumulation
+        if (input instanceof ReadHalfFloatNode || input instanceof ValuePhiNode) {
+            return input;
+        }
+        if (input instanceof PiNode || input instanceof IsNullNode) {
+            nodesToBeDeleted.add(input);
+        }
+        Node replacement = null;
+        for (Node iterativeInputs : input.inputs()) {
+            replacement = identifyFieldReplacement(iterativeInputs, nodesToBeDeleted);
+            if (replacement != null) { // if the replacement node was found, stop the recursion
+                return replacement;
+            }
+        }
+        return replacement;
     }
 
     /**

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/ComputeTests.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compute/ComputeTests.java
@@ -419,6 +419,18 @@ public class ComputeTests extends TornadoTestBase {
         }
     }
 
+    private static void matrixMultiplicationHalfFloatToFloat2(final HalfFloatArray A, final HalfFloatArray B, final FloatArray C, final int size) {
+        for (@Parallel int i = 0; i < size; i++) {
+            for (@Parallel int j = 0; j < size; j++) {
+                float sum = 0.0f;
+                for (int k = 0; k < size; k++) {
+                    float mult = A.get((i * size) + k).getFloat32() * B.get((k * size) + j).getFloat32();
+                    sum += mult;
+                }
+                C.set((i * size) + j, sum);
+            }
+        }
+    }
 
     @Test
     public void testNBody() throws TornadoExecutionPlanException {
@@ -1009,6 +1021,36 @@ public class ComputeTests extends TornadoTestBase {
         }
 
         matrixMultiplicationHalfFloatToFloat(matrixA, matrixB, matrixCSeq, N);
+
+        for (int i = 0; i < N * N; i++) {
+            assertEquals(matrixCSeq.get(i), matrixC.get(i), DELTA);
+        }
+    }
+
+    @Test
+    public void testHalfFloatToFloatMatrixMultiplication2() throws TornadoExecutionPlanException {
+        int N = 256;
+        HalfFloatArray matrixA = new HalfFloatArray(N * N);
+        HalfFloatArray matrixB = new HalfFloatArray(N * N);
+        FloatArray matrixCSeq = new FloatArray(N * N);
+        FloatArray matrixC = new FloatArray(N * N);
+
+        IntStream.range(0, N * N).parallel().forEach(idx -> {
+            matrixA.set(idx, new HalfFloat(2.5f));
+            matrixB.set(idx, new HalfFloat(3.5f));
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB) //
+                .task("t0", ComputeTests::matrixMultiplicationHalfFloatToFloat2, matrixA, matrixB, matrixC, N) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executor.execute();
+        }
+
+        matrixMultiplicationHalfFloatToFloat2(matrixA, matrixB, matrixCSeq, N);
 
         for (int i = 0; i < N * N; i++) {
             assertEquals(matrixCSeq.get(i), matrixC.get(i), DELTA);


### PR DESCRIPTION
#### Description

This PR enables mixed precision matrix multiplication, where the input matrices contain half float values and the results are stored in an FP32 matrix. 

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Run `tornado-test -V uk.ac.manchester.tornado.unittests.compute.ComputeTests#testHalfFloatToFloatMatrixMultiplication`
and 
`tornado-test -V uk.ac.manchester.tornado.unittests.compute.ComputeTests#testHalfFloatToFloatMatrixMultiplication2`

