### PR TITLE
[test] Update whitelisted unit-tests with the new atomic tests

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -272,6 +272,12 @@ __TORNADO_TESTS_WHITE_LIST__ = [
     ## Atomics are only available for OpenCL
     "uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic12",
     "uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic15",
+    "uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic13_getAndDecrement",
+    "uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic13_decrementAndGet",
+    "uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic17_getAndIncrement_kernel_api",
+    "uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic17_getAndIncrement_parallel_api",
+    "uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic17_incrementAndGet_kernel_api",
+    "uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic17_incrementAndGet_parallel_api",
 
     ## Precision errors
     "uk.ac.manchester.tornado.unittests.compute.ComputeTests#testNBodyBigNoWorker",


### PR DESCRIPTION
This PR does not have any change in the production code. It only registers six unit-tests from the Atomics test suite in the white list. Theses tests are failing in some devices (Integrated Graphics), but pass on other devices. The kernels are correct, so the issue is attributed to precision errors, or driver issues.

The problem is observed in the Jenkins pipeline.