### PR TITLE
Update Accesses of UNDER_DEMAND Objects

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -74,6 +74,10 @@ public class ImmutableTaskGraph {
         taskGraph.syncRuntimeTransferToHost(object, offset, partialCopySize);
     }
 
+    public TaskGraph getTaskGraph() {
+        return taskGraph;
+    }
+
     long getTotalTime() {
         return taskGraph.getTotalTime();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -909,4 +909,8 @@ public class TaskGraph implements TaskGraphInterface {
     void mapOnDeviceMemoryRegion(Object destArray, Object srcArray, long offset, TornadoTaskGraphInterface taskGraphSrc) {
         taskGraphImpl.mapOnDeviceMemoryRegion(destArray, srcArray, offset, taskGraphSrc);
     }
+
+    public TornadoTaskGraphInterface getTaskGraphImpl() {
+        return taskGraphImpl;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -111,6 +111,13 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
         tornadoExecutor = new TornadoExecutor(immutableTaskGraphs);
         final long id = globalExecutionPlanCounter.incrementAndGet();
         executionFrame = new ExecutorFrame(id);
+        if (immutableTaskGraphs.length > 1) {
+            for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphs) {
+                TaskGraph taskGraph = immutableTaskGraph.getTaskGraph();
+                TornadoTaskGraphInterface taskGraphImpl = taskGraph.getTaskGraphImpl();
+                taskGraphImpl.updateAccessForUnderDemandPolicy();
+            }
+        }
         rootNode = this;
         planResults = new ArrayList<>();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -127,4 +127,6 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
     void withCompilerFlags(TornadoVMBackendType backendType, String compilerFlags);
 
     void mapOnDeviceMemoryRegion(Object destArray, Object srcArray, long offset, TornadoTaskGraphInterface taskGraphSrc);
+
+    void updateAccessForUnderDemandPolicy();
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -530,6 +530,42 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
+    public void updateAccessForUnderDemandPolicy() {
+        // iterate over stream-in and stream-out objects and, if the mode is UNDER_DEMAND, update their Access to READ-WRITE
+        HashMap<Object, Access> objectAccesses = executionContext.getObjectsAccesses();
+
+        for (StreamingObject inputStreamObject : inputModesObjects) {
+            if (inputStreamObject.getMode() == DataTransferMode.UNDER_DEMAND) {
+                Object streamInObject = inputStreamObject.getObject();
+                Access currentAccess = objectAccesses.get(streamInObject);
+                if (currentAccess != Access.READ_WRITE) {
+                    objectAccesses.replace(streamInObject, currentAccess, Access.READ_WRITE);
+                }
+            }
+        }
+
+        for (StreamingObject outputStreamObject : outputModeObjects) {
+            if (outputStreamObject.getMode() == DataTransferMode.UNDER_DEMAND) {
+                Object streamOutObject = outputStreamObject.getObject();
+                Access currentAccess = objectAccesses.get(streamOutObject);
+                if (currentAccess != Access.READ_WRITE) {
+                    objectAccesses.replace(streamOutObject, currentAccess, Access.READ_WRITE);
+                }
+            }
+        }
+
+        for (StreamingObject outputStreamObject : outputModeObjects) {
+            if (outputStreamObject.getMode() == DataTransferMode.UNDER_DEMAND) {
+                Object streamOutObject = outputStreamObject.getObject();
+                Access currentAccess = objectAccesses.get(streamOutObject);
+                if (currentAccess != Access.READ_WRITE) {
+                    objectAccesses.replace(streamOutObject, currentAccess, Access.READ_WRITE);
+                }
+            }
+        }
+    }
+
+    @Override
     public long getTotalBytesTransferred() {
         return getProfilerValue(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES) + getProfilerValue(TOTAL_COPY_OUT_SIZE_BYTES);
     }
@@ -2468,6 +2504,15 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     @Override
     public long getDeviceKernelTime() {
         return getProfilerValue(TOTAL_KERNEL_TIME);
+    }
+
+
+    public List<StreamingObject> getInputModeObjects () {
+        return inputModesObjects;
+    }
+
+    public List<StreamingObject> getOutputModeObjects () {
+        return outputModeObjects;
     }
 
     private long getProfilerValueFromReduceTaskGraph(ProfilerType profilerType) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -2506,15 +2506,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         return getProfilerValue(TOTAL_KERNEL_TIME);
     }
 
-
-    public List<StreamingObject> getInputModeObjects () {
-        return inputModesObjects;
-    }
-
-    public List<StreamingObject> getOutputModeObjects () {
-        return outputModeObjects;
-    }
-
     private long getProfilerValueFromReduceTaskGraph(ProfilerType profilerType) {
         return switch (profilerType) {
             case TOTAL_KERNEL_TIME -> reduceTaskGraph.getExecutionResult().getProfilerResult().getDeviceKernelTime();


### PR DESCRIPTION
#### Description
This PR is applied for `TornadoExecutionPlans` that contain multiple `Task Graphs`.  Specifically, this PR iterates over the objects of each `Task Graph` and, if their data transfer mode is `UNDER_DEMAND`, it ensures that their access type is `READ_WRITE`. 

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

