### PR TITLE
Device Filtering Fixed + New filters by device type and device names

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceMap.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceMap.java
@@ -176,5 +176,4 @@ public class TornadoDeviceMap {
         // Return an empty stream
         return Arrays.stream(new TornadoDevice[0]);
     }
-
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceMap.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceMap.java
@@ -105,7 +105,7 @@ public class TornadoDeviceMap {
      * @return
      *     Stream of devices that meet the criteria. Otherwise, an empty stream.
      */
-    public Stream<TornadoDevice> getDeviceByName(String deviceName) {
+    public Stream<TornadoDevice> getDevicesByName(String deviceName) {
         TornadoDeviceMap deviceMap = TornadoExecutionPlan.getTornadoDeviceMap();
         List<TornadoBackend> backendFilter = deviceMap.getBackendsWithPredicate(backend -> //
         backend.getAllDevices() //
@@ -150,7 +150,7 @@ public class TornadoDeviceMap {
      * @return
      *     Stream of devices that meet the criteria. Otherwise, an empty stream.
      */
-    public Stream<TornadoDevice> getDeviceByType(TornadoDeviceType deviceType) {
+    public Stream<TornadoDevice> getDevicesByType(TornadoDeviceType deviceType) {
         TornadoDeviceMap deviceMap = TornadoExecutionPlan.getTornadoDeviceMap();
         List<TornadoBackend> backendFilter = deviceMap.getBackendsWithPredicate(backend -> //
         backend.getAllDevices() //

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceMap.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceMap.java
@@ -87,6 +87,6 @@ public class TornadoDeviceMap {
      * @return {@link List< TornadoBackend >}
      */
     public List<TornadoBackend> getBackendsWithDevicePredicate(Predicate<? super TornadoDevice> predicate) {
-        return getAllBackends().stream().filter(backend -> backend.getAllDevices().stream().allMatch(predicate)).toList();
+        return getAllBackends().stream().filter(backend -> backend.getAllDevices().stream().anyMatch(predicate)).toList();
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceMap.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoDeviceMap.java
@@ -18,10 +18,13 @@
 package uk.ac.manchester.tornado.api;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 
 /**
@@ -89,4 +92,89 @@ public class TornadoDeviceMap {
     public List<TornadoBackend> getBackendsWithDevicePredicate(Predicate<? super TornadoDevice> predicate) {
         return getAllBackends().stream().filter(backend -> backend.getAllDevices().stream().anyMatch(predicate)).toList();
     }
+
+    /**
+     * Obtain a device object with a specific name. This function returns a Stream of all devices that meet the criteria.
+     * The device objects could be from different backends. For example, if we have multiple backends installed, and we
+     * request a device name with "NVIDIA" in it. In this case, this function can return a stream with multiple devices
+     * from different backends pointing to the same device (e.g., an NVIDIA GPU using the OpenCL backend, and an NVIDIA
+     * GPU using the PTX backend).
+     *
+     * @param deviceName
+     *     Name of the device.
+     * @return
+     *     Stream of devices that meet the criteria. Otherwise, an empty stream.
+     */
+    public Stream<TornadoDevice> getDeviceByName(String deviceName) {
+        TornadoDeviceMap deviceMap = TornadoExecutionPlan.getTornadoDeviceMap();
+        List<TornadoBackend> backendFilter = deviceMap.getBackendsWithPredicate(backend -> //
+        backend.getAllDevices() //
+                .stream() //
+                .anyMatch(device -> device //
+                        .getPhysicalDevice() //
+                        .getDeviceName() //
+                        .toLowerCase() //
+                        .contains(deviceName.toLowerCase())));
+
+        if (!backendFilter.isEmpty()) {
+            Stream<TornadoDevice> deviceStream = null;
+            for (TornadoBackend backend : backendFilter) {
+                Stream<TornadoDevice> deviceStreamI = backend //
+                        .getAllDevices() //
+                        .stream() //
+                        .filter(device -> device //
+                                .getPhysicalDevice()//
+                                .getDeviceName() //
+                                .toLowerCase() //
+                                .contains(deviceName.toLowerCase())); //
+
+                if (deviceStream == null) {
+                    deviceStream = deviceStreamI;
+                } else {
+                    deviceStream = Stream.concat(deviceStream, deviceStreamI);
+                }
+            }
+            return deviceStream;
+        }
+        // Return an empty stream
+        return Arrays.stream(new TornadoDevice[0]);
+    }
+
+    /**
+     * Obtain a device object from a specific type (GPU, Accelerator, CPU). This function returns a Stream of all devices that meet the criteria.
+     * The device objects could be from different backends. For example, if we have multiple backends installed, and we request any GPU device,
+     * this function will return all GPU devices (GPU-OpenCL, GPU-SPIR-V, GPU-PTX), even if they point to the exact same device.
+     * 
+     * @param deviceType
+     *     {@link TornadoDeviceType}
+     * @return
+     *     Stream of devices that meet the criteria. Otherwise, an empty stream.
+     */
+    public Stream<TornadoDevice> getDeviceByType(TornadoDeviceType deviceType) {
+        TornadoDeviceMap deviceMap = TornadoExecutionPlan.getTornadoDeviceMap();
+        List<TornadoBackend> backendFilter = deviceMap.getBackendsWithPredicate(backend -> //
+        backend.getAllDevices() //
+                .stream() //
+                .anyMatch(device -> device.getDeviceType() == deviceType));
+
+        if (!backendFilter.isEmpty()) {
+            Stream<TornadoDevice> deviceStream = null;
+            for (TornadoBackend backend : backendFilter) {
+                Stream<TornadoDevice> deviceStreamI = backend //
+                        .getAllDevices() //
+                        .stream() //
+                        .filter(device -> device.getDeviceType() == deviceType);
+
+                if (deviceStream == null) {
+                    deviceStream = deviceStreamI;
+                } else {
+                    deviceStream = Stream.concat(deviceStream, deviceStreamI);
+                }
+            }
+            return deviceStream;
+        }
+        // Return an empty stream
+        return Arrays.stream(new TornadoDevice[0]);
+    }
+
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDevices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDevices.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 
@@ -29,6 +30,7 @@ import uk.ac.manchester.tornado.api.TornadoBackend;
 import uk.ac.manchester.tornado.api.TornadoDeviceMap;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoBackendNotFound;
 import uk.ac.manchester.tornado.api.exceptions.TornadoDeviceNotFound;
@@ -135,7 +137,7 @@ public class TestDevices extends TornadoTestBase {
                 .toLowerCase()       //
                 .contains("nvidia"));
 
-        assertTrue(backendsWithNVIDIAAccess.size() >= 1);
+        assertTrue(!backendsWithNVIDIAAccess.isEmpty());
 
         // Another way to perform the previous query
         List<TornadoBackend> backendsWithNVIDIAAccess2 = tornadoDeviceMap //
@@ -148,7 +150,30 @@ public class TestDevices extends TornadoTestBase {
                                 .toLowerCase()      //
                                 .contains("nvidia")));
 
-        assertTrue(backendsWithNVIDIAAccess2.size() >= 1);
+        assertTrue(!backendsWithNVIDIAAccess2.isEmpty());
 
+    }
+
+    @Test
+    public void test05() {
+        TornadoDeviceMap deviceMap = new TornadoDeviceMap();
+        Stream<TornadoDevice> deviceStream = deviceMap.getDeviceByName("NVIDIA");
+
+        // Get the first that meets the criteria
+        TornadoDevice device = deviceStream.findFirst().get();
+        assertNotNull(device);
+        assertTrue(device.getPhysicalDevice().getDeviceName().toLowerCase().contains("nvidia"));
+    }
+
+    @Test
+    public void test06() {
+        TornadoDeviceType typeToFind = TornadoDeviceType.CPU;
+        TornadoDeviceMap deviceMap = new TornadoDeviceMap();
+        Stream<TornadoDevice> deviceStream = deviceMap.getDeviceByType(typeToFind);
+
+        // Get the first that meets the criteria
+        TornadoDevice device = deviceStream.findFirst().get();
+        assertNotNull(device);
+        assertTrue(device.getDeviceType() == typeToFind);
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDevices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDevices.java
@@ -157,7 +157,7 @@ public class TestDevices extends TornadoTestBase {
     @Test
     public void test05() {
         TornadoDeviceMap deviceMap = new TornadoDeviceMap();
-        Stream<TornadoDevice> deviceStream = deviceMap.getDeviceByName("NVIDIA");
+        Stream<TornadoDevice> deviceStream = deviceMap.getDevicesByName("NVIDIA");
 
         // Get the first that meets the criteria
         TornadoDevice device = deviceStream.findFirst().get();
@@ -169,11 +169,20 @@ public class TestDevices extends TornadoTestBase {
     public void test06() {
         TornadoDeviceType typeToFind = TornadoDeviceType.CPU;
         TornadoDeviceMap deviceMap = new TornadoDeviceMap();
-        Stream<TornadoDevice> deviceStream = deviceMap.getDeviceByType(typeToFind);
+        Stream<TornadoDevice> deviceStream = deviceMap.getDevicesByType(typeToFind);
 
         // Get the first that meets the criteria
         TornadoDevice device = deviceStream.findFirst().get();
         assertNotNull(device);
         assertTrue(device.getDeviceType() == typeToFind);
+    }
+
+    @Test
+    public void test07() {
+        TornadoDeviceMap deviceMap = new TornadoDeviceMap();
+
+        // Intentionally a random name to get an empty stream
+        Stream<TornadoDevice> deviceStream = deviceMap.getDevicesByName("foo");
+        assertTrue(deviceStream.findAny().isEmpty());
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDevices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDevices.java
@@ -122,23 +122,33 @@ public class TestDevices extends TornadoTestBase {
         // Obtain all backends with at least two devices associated to it
         List<TornadoBackend> multiDeviceBackends = tornadoDeviceMap.getBackendsWithPredicate(backend -> backend.getNumDevices() > 1);
 
+        // If the multi-backend list is not empty, then it found at least one backend with multiple devices
+        assertTrue(multiDeviceBackends.size() >= 1);
+
         // Obtain the backend that can support SPIR-V as default device
         List<TornadoBackend> spirvSupported = tornadoDeviceMap.getBackendsWithPredicate(backend -> backend.getDefaultDevice().isSPIRVSupported());
 
         // Return all backends that can access an NVIDIA GPU
         List<TornadoBackend> backendsWithNVIDIAAccess = tornadoDeviceMap.getBackendsWithDevicePredicate(device -> device //
-                .getDeviceName() //
-                .toLowerCase()//
+                .getPhysicalDevice() //
+                .getDeviceName()     //
+                .toLowerCase()       //
                 .contains("nvidia"));
+
+        assertTrue(backendsWithNVIDIAAccess.size() >= 1);
 
         // Another way to perform the previous query
         List<TornadoBackend> backendsWithNVIDIAAccess2 = tornadoDeviceMap //
                 .getBackendsWithPredicate(backend -> backend //
                         .getAllDevices()//
                         .stream()//
-                        .allMatch(device -> device//
-                                .getDeviceName()//
-                                .toLowerCase()//
+                        .anyMatch(device -> device//
+                                .getPhysicalDevice()//
+                                .getDeviceName()    //
+                                .toLowerCase()      //
                                 .contains("nvidia")));
+
+        assertTrue(backendsWithNVIDIAAccess2.size() >= 1);
+
     }
 }


### PR DESCRIPTION
#### Description

This PR fixes an issue with device filtering and the unittests associated with it. Besides, it adds new new functions to the `TornadoDeviceMap` API to easily query devices by a specific type, or a specific name. 

#### Problem description

Fix the filtering of backends and devices. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
tornado-test -V uk.ac.manchester.tornado.unittests.api.TestDevices
```

