### PR TITLE
Hotfix for the whitelist of some test-devices unittests

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -319,6 +319,12 @@ __TORNADO_TESTS_WHITE_LIST__ = [
     ## SPIR-V with Level Zero
     'uk.ac.manchester.tornado.unittests.pointers.TestCopyDevicePointers#testCopyDevicePointersMatrix',
 
+    ## Test Devices: provided filters depend on the actual hardware installed.
+    ## The fact that these tests fail, does not mean the API is wrong.
+    'uk.ac.manchester.tornado.unittests.api.TestDevices#test04',
+    'uk.ac.manchester.tornado.unittests.api.TestDevices#test05',
+    'uk.ac.manchester.tornado.unittests.api.TestDevices#test06',
+
 ]
 
 ## List of tests to be excluded when running with the quick pass argument as they cause delays

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDevices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDevices.java
@@ -19,6 +19,7 @@ package uk.ac.manchester.tornado.unittests.api;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -110,6 +111,8 @@ public class TestDevices extends TornadoTestBase {
     @Test
     public void test04() {
 
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+
         TornadoDeviceMap tornadoDeviceMap = TornadoExecutionPlan.getTornadoDeviceMap();
 
         // Query the number of backends
@@ -137,7 +140,7 @@ public class TestDevices extends TornadoTestBase {
                 .toLowerCase()       //
                 .contains("nvidia"));
 
-        assertTrue(!backendsWithNVIDIAAccess.isEmpty());
+        assertFalse(backendsWithNVIDIAAccess.isEmpty());
 
         // Another way to perform the previous query
         List<TornadoBackend> backendsWithNVIDIAAccess2 = tornadoDeviceMap //
@@ -150,12 +153,14 @@ public class TestDevices extends TornadoTestBase {
                                 .toLowerCase()      //
                                 .contains("nvidia")));
 
-        assertTrue(!backendsWithNVIDIAAccess2.isEmpty());
+        assertFalse(backendsWithNVIDIAAccess2.isEmpty());
 
     }
 
     @Test
     public void test05() {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+
         TornadoDeviceMap deviceMap = new TornadoDeviceMap();
         Stream<TornadoDevice> deviceStream = deviceMap.getDevicesByName("NVIDIA");
 
@@ -167,6 +172,8 @@ public class TestDevices extends TornadoTestBase {
 
     @Test
     public void test06() {
+        assertNotBackend(TornadoVMBackendType.PTX);
+
         TornadoDeviceType typeToFind = TornadoDeviceType.CPU;
         TornadoDeviceMap deviceMap = new TornadoDeviceMap();
         Stream<TornadoDevice> deviceStream = deviceMap.getDevicesByType(typeToFind);
@@ -174,7 +181,7 @@ public class TestDevices extends TornadoTestBase {
         // Get the first that meets the criteria
         TornadoDevice device = deviceStream.findFirst().get();
         assertNotNull(device);
-        assertTrue(device.getDeviceType() == typeToFind);
+        assertSame(typeToFind, device.getDeviceType());
     }
 
     @Test


### PR DESCRIPTION
#### Description

This PR includes in the whitelist the unit-tests that filter devices. This is ok if they fail, since it queries specific devices. 

#### Problem description

Fix Jenkins pipeline test regression.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-test -V uk.ac.manchester.tornado.unittests.api.TestDevices
```
