### PR TITLE
Fields memory duplication fixed

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/SchedulableTask.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/SchedulableTask.java
@@ -69,4 +69,6 @@ public interface SchedulableTask {
 
     boolean isGridSchedulerEnabled();
 
+    boolean isStatic();
+
 }

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -238,6 +238,14 @@ __TEST_THE_WORLD__ = [
                   "-Dtornado.feature.extraction=True",
                   "-Dtornado.features.dump.dir=" + os.environ["TORNADO_SDK"] + "/virtualFeaturesOut.out"]),
 
+    ## Test stress memory fields
+    TestEntry(testName="uk.ac.manchester.tornado.unittests.fields.TestStressFields",
+              testParameters=[
+                  "-Dtornado.device.memory=2GB",
+                  "-Xmx14g", 
+                  "-Dtornado.profiler=True",
+                  "-Dtornado.log.profiler=True" ]),
+
     ## Tests for Multi-Thread and Memory
     TestEntry(testName="uk.ac.manchester.tornado.unittests.multithreaded.TestMultiThreadedExecutionPlans",
               testParameters=["-Dtornado.device.memory=4GB"]),

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -186,11 +186,16 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
         // Parameters
         for (int i = 0, argIndex = 0; i < kernelArgs.getCallArguments().size(); i++) {
             KernelStackFrame.CallArgument arg = kernelArgs.getCallArguments().get(i);
+
             if (arg.getValue() instanceof KernelStackFrame.KernelContextArgument) {
                 // We do not set any kernel context argument. This is only for the Java side.
                 continue;
             }
-            if (isBoxedPrimitive(arg.getValue()) || arg.getValue().getClass().isPrimitive()) {
+            if (arg.getValue() instanceof KernelStackFrame.ThisMethodArgument) {
+                buffer.clear();
+                buffer.putLong(kernelArgs.toThisAddress());
+                kernel.setArg(index + argIndex, buffer);
+            } else if (isBoxedPrimitive(arg.getValue()) || arg.getValue().getClass().isPrimitive()) {
                 buffer.clear();
                 PrimitiveSerialiser.put(buffer, arg.getValue());
                 kernel.setArg(index + argIndex, buffer);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLByteBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLByteBuffer.java
@@ -285,6 +285,10 @@ public class OCLByteBuffer {
         return deviceContext.getMemoryManager().toConstantAddress();
     }
 
+    public long toThisAddress() {
+        return deviceContext.getMemoryManager().toThisAddress();
+    }
+
     public long toAtomicAddress() {
         return deviceContext.getMemoryManager().toAtomicAddress();
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemoryManager.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemoryManager.java
@@ -43,6 +43,7 @@ public class OCLMemoryManager implements TornadoMemoryProvider {
     private final OCLDeviceContext deviceContext;
     private Map<Long, OCLKernelStackFrame> oclKernelStackFrame = new ConcurrentHashMap<>();
     private long constantPointer;
+    private long thisAddress;
     private long atomicsRegion = -1;
 
     public OCLMemoryManager(final OCLDeviceContext deviceContext) {
@@ -79,6 +80,7 @@ public class OCLMemoryManager implements TornadoMemoryProvider {
      */
     public void allocateDeviceMemoryRegions() {
         this.constantPointer = createBuffer(4, OCLMemFlags.CL_MEM_READ_ONLY | OCLMemFlags.CL_MEM_ALLOC_HOST_PTR).getBuffer();
+        this.thisAddress = createBuffer(4, OCLMemFlags.CL_MEM_READ_ONLY | OCLMemFlags.CL_MEM_ALLOC_HOST_PTR).getBuffer();
         allocateAtomicRegion();
     }
 
@@ -92,6 +94,10 @@ public class OCLMemoryManager implements TornadoMemoryProvider {
 
     long toConstantAddress() {
         return constantPointer;
+    }
+
+    long toThisAddress() {
+        return thisAddress;
     }
 
     long toAtomicAddress() {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -313,17 +313,17 @@ public class PTXDeviceContext implements TornadoDeviceContext {
             KernelStackFrame.CallArgument arg = ptxKernelArgs.getCallArguments().get(argIndex);
             if (arg.getValue() instanceof KernelStackFrame.KernelContextArgument) {
                 args.putLong(address);
-                continue;
+            } else if (arg.getValue() instanceof KernelStackFrame.ThisMethodArgument) {
+                args.putLong(address);
             } else if (isBoxedPrimitive(arg.getValue()) || arg.getValue().getClass().isPrimitive()) {
-                if (arg.getValue() instanceof HalfFloat) {
-                    short halfFloat = ((HalfFloat) arg.getValue()).getHalfFloatValue();
-                    args.putLong(((Number) halfFloat).longValue());
-                } else if (arg.getValue() instanceof Number) {
-                    args.putLong(((Number) arg.getValue()).longValue());
-                } else if (arg.getValue() instanceof Character) {
-                    args.putLong((char) arg.getValue());
-                } else {
-                    shouldNotReachHere();
+                switch (arg.getValue()) {
+                    case HalfFloat aFloat -> {
+                        short halfFloat = aFloat.getHalfFloatValue();
+                        args.putLong(((Number) halfFloat).longValue());
+                    }
+                    case Number number -> args.putLong(number.longValue());
+                    case Character c -> args.putLong((char) arg.getValue());
+                    case null, default -> shouldNotReachHere();
                 }
             } else {
                 shouldNotReachHere();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -158,23 +158,23 @@ public class TaskUtils {
          * Method.
          */
         final ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getVMBackend().getMetaAccess().lookupJavaMethod(entryPoint);
-        final ConstantPool cp = resolvedMethod.getConstantPool();
-        final byte[] bc = resolvedMethod.getCode();
+        final ConstantPool constantPool = resolvedMethod.getConstantPool();
+        final byte[] code = resolvedMethod.getCode();
 
-        for (int i = 0; i < bc.length; i++) {
-            if (bc[i] == (byte) Bytecodes.INVOKESTATIC) {
-                cp.loadReferencedType(bc[i + 2], Bytecodes.INVOKESTATIC);
-                JavaMethod jm = cp.lookupMethod(bc[i + 2], Bytecodes.INVOKESTATIC);
+        for (int i = 0; i < code.length; i++) {
+            if (code[i] == (byte) Bytecodes.INVOKESTATIC) {
+                constantPool.loadReferencedType(code[i + 2], Bytecodes.INVOKESTATIC);
+                JavaMethod method = constantPool.lookupMethod(code[i + 2], Bytecodes.INVOKESTATIC);
 
                 if (useToJavaMethod) {
-                    return callToJava(jm);
+                    return callToJava(method);
                 } else {
-                    return callGetMethod(jm);
+                    return callGetMethod(method);
                 }
-            } else if (bc[i] == (byte) Bytecodes.INVOKEVIRTUAL) {
-                cp.loadReferencedType(bc[i + 2], Bytecodes.INVOKEVIRTUAL);
-                JavaMethod jm = cp.lookupMethod(bc[i + 2], Bytecodes.INVOKEVIRTUAL);
-                switch (jm.getName()) {
+            } else if (code[i] == (byte) Bytecodes.INVOKEVIRTUAL) {
+                constantPool.loadReferencedType(code[i + 2], Bytecodes.INVOKEVIRTUAL);
+                JavaMethod method = constantPool.lookupMethod(code[i + 2], Bytecodes.INVOKEVIRTUAL);
+                switch (method.getName()) {
                     case "booleanValue":
                     case "byteValue":
                     case "charValue":
@@ -187,9 +187,9 @@ public class TaskUtils {
                 }
 
                 if (useToJavaMethod) {
-                    return callToJava(jm);
+                    return callToJava(method);
                 } else {
-                    return callGetMethod(jm);
+                    return callGetMethod(method);
                 }
             }
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/KernelStackFrame.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/KernelStackFrame.java
@@ -32,6 +32,11 @@ public interface KernelStackFrame {
     class KernelContextArgument {
     }
 
+    // Mark an argument with this
+    class ThisMethodArgument {
+
+    }
+
     class CallArgument {
         private final Object value;
         private final boolean isReferenceType;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -106,7 +106,7 @@ public class TornadoExecutionContext {
         persistedObjects = new ArrayList<>();
         objectsAccesses = new HashMap<>();
         objectState = new ArrayList<>();
-        persistedTaskToObjectsMap =  new HashMap<>();
+        persistedTaskToObjectsMap = new HashMap<>();
         devices = new ArrayList<>(INITIAL_DEVICE_CAPACITY);
         kernelStackFrame = new KernelStackFrame[MAX_TASKS];
         taskToDeviceMapTable = new TornadoXPUDevice[MAX_TASKS];
@@ -689,7 +689,6 @@ public class TornadoExecutionContext {
     public void setCurrentDeviceMemoryUsage(long currentDeviceMemoryUsage) {
         this.currentDeviceMemoryUsage = currentDeviceMemoryUsage;
     }
-
 
     public void addPersistedObject(String taskgraphUniqueName, Object value) {
         persistedTaskToObjectsMap.computeIfAbsent(taskgraphUniqueName, k -> new ArrayList<>()).add(value);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoGraphBuilder.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoGraphBuilder.java
@@ -81,7 +81,6 @@ public class TornadoGraphBuilder {
         graph.add(thisNode);
         context.addUse(thisNode);
         args[argIndex] = thisNode;
-        //persistNode.addValue((ObjectNode) arg);
     }
 
     private static void createOnDeviceNode(ContextNode context, TornadoGraph graph, AbstractNode arg, AbstractNode[] args, int argIndex, AllocateMultipleBuffersNode persistNode) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodes.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodes.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -193,7 +193,6 @@ public enum TornadoVMBytecodes {
      */
     DEALLOC((byte) 24),
 
-
     /**
      * Reuse of a buffer from a device.
      * <p>
@@ -203,8 +202,9 @@ public enum TornadoVMBytecodes {
      * ON_DEVICE(obj,dest)
      * </code>
      */
-    ON_DEVICE((byte) 25);
+    ON_DEVICE((byte) 25),
 
+    PUSH_REFERENCE_THIS((byte) 26);
 
     final byte value;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodes.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodes.java
@@ -204,6 +204,16 @@ public enum TornadoVMBytecodes {
      */
     ON_DEVICE((byte) 25),
 
+    /**
+     * Add a reference to this (as in Java `this`) to be used as an argument in a kernel.
+     *
+     * <p>
+     * Format:
+     * <code>
+     * PUSH_REFERENCE_THIS(obj)
+     * </code>
+     * </p>
+     */
     PUSH_REFERENCE_THIS((byte) 26);
 
     final byte value;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/nodes/ThisNode.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/nodes/ThisNode.java
@@ -1,3 +1,26 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
 package uk.ac.manchester.tornado.runtime.graph.nodes;
 
 import java.util.ArrayList;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/nodes/ThisNode.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/nodes/ThisNode.java
@@ -1,0 +1,43 @@
+package uk.ac.manchester.tornado.runtime.graph.nodes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ThisNode extends ContextOpNode {
+
+    public ThisNode(ContextNode context) {
+        super(context);
+    }
+
+    private ObjectNode value;
+
+    public void setValue(ObjectNode object) {
+        value = object;
+    }
+
+    public ObjectNode getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[%d]: this object %d", id, value.getIndex());
+    }
+
+    @Override
+    public boolean hasInputs() {
+        return value != null;
+    }
+
+    @Override
+    public List<AbstractNode> getInputs() {
+        if (!hasInputs()) {
+            return Collections.emptyList();
+        }
+
+        final List<AbstractNode> result = new ArrayList<AbstractNode>();
+        result.add(value);
+        return result;
+    }
+}

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/Sketch.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/Sketch.java
@@ -31,6 +31,8 @@ public class Sketch {
 
     private final Graph graph;
 
+    private final boolean isStatic;
+
     private boolean batchWriteThreadIndex;
 
     /**
@@ -39,10 +41,11 @@ public class Sketch {
      */
     private final Access[] argumentsAccess;
 
-    Sketch(Graph graph, Access[] argumentAccesses, boolean batchWriteThreadIndex) {
+    Sketch(Graph graph, Access[] argumentAccesses, boolean batchWriteThreadIndex, boolean isStatic) {
         this.graph = graph;
         this.argumentsAccess = argumentAccesses;
         this.batchWriteThreadIndex = batchWriteThreadIndex;
+        this.isStatic = isStatic;
     }
 
     public Graph getGraph() {
@@ -55,6 +58,10 @@ public class Sketch {
 
     public boolean getBatchWriteThreadIndex() {
         return this.batchWriteThreadIndex;
+    }
+
+    public boolean isStatic() {
+        return this.isStatic;
     }
 
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
@@ -184,7 +184,7 @@ public class TornadoSketcher {
 
             methodAccesses = highTierAccesses;
 
-            return new Sketch(graph.copy(TornadoCoreRuntime.getDebugContext()), methodAccesses, highTierContext.getBatchWriteThreadIndex());
+            return new Sketch(graph.copy(TornadoCoreRuntime.getDebugContext()), methodAccesses, highTierContext.getBatchWriteThreadIndex(), resolvedMethod.isStatic());
 
         } catch (Throwable e) {
             logger.fatal("unable to build sketch for method: %s (%s)", resolvedMethod.getName(), e.getMessage());

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/CompilableTask.java
@@ -26,11 +26,13 @@ package uk.ac.manchester.tornado.runtime.tasks;
 import java.lang.reflect.Method;
 import java.util.Objects;
 
+import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
+import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
@@ -203,6 +205,12 @@ public class CompilableTask implements SchedulableTask {
     @Override
     public boolean isGridSchedulerEnabled() {
         return meta.isGridSchedulerEnabled();
+    }
+
+    @Override
+    public boolean isStatic() {
+        ResolvedJavaMethod resolveJavaMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(method);
+        return resolveJavaMethod.isStatic();
     }
 
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
@@ -216,6 +216,11 @@ public class PrebuiltTask implements SchedulableTask {
         return meta.isGridSchedulerEnabled();
     }
 
+    @Override
+    public boolean isStatic() {
+        return false;
+    }
+
     public int[] getAtomics() {
         return atomics;
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoGraphBitcodes.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoGraphBitcodes.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -32,7 +32,8 @@ public enum TornadoGraphBitcodes {
     LOAD_PRIM((byte)2),
     LAUNCH   ((byte)3),
     ARG_LIST ((byte)4),
-    CONTEXT  ((byte)5);
+    CONTEXT  ((byte)5),
+    THIS     ((byte)6);
     // @formatter:on
 
     byte index;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -669,7 +669,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
             if (localStateDest == null) {
                 continue;
-                //                throw new TornadoRuntimeException("[ERROR] Object " + objectsToSync + " is not a persistent object in the task graph " + taskGraphSrc.getTaskGraphName());
             }
 
             if (!graphSrc.meta().getXPUDevice().equals(executionContext.meta().getXPUDevice())) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/common/TornadoTestBase.java
@@ -33,6 +33,8 @@ public abstract class TornadoTestBase {
     public static final float DELTA_05 = 0.5f;
     protected static boolean wasDeviceInspected = false;
 
+    public static final int SIZE_OF_512MB = 512 * 1024 * 1024;
+
     public static TornadoRuntime getTornadoRuntime() {
         return TornadoRuntimeProvider.getTornadoRuntime();
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fields/TestStressFields.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fields/TestStressFields.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.fields;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * <p>
+ * How to test?
+ * </p>
+ * <code>
+ * tornado-test -pbc -V --enableProfiler silent --fast --jvm="-Dtornado.device.memory=2GB" uk.ac.manchester.tornado.unittests.fields.TestStressFields
+ * </code>
+ */
+public class TestStressFields extends TornadoTestBase {
+
+    FloatArray arrayA;
+    FloatArray arrayB;
+    FloatArray arrayC;
+
+    private void testStressFields(FloatArray a, FloatArray b, FloatArray c) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            c.set(i, a.get(i) * b.get(i) * b.get(i));
+        }
+    }
+
+    @Test
+    public void testStressMemoryFields() {
+        int size = SIZE_OF_512MB / 4;
+        arrayA = new FloatArray(size);
+        arrayB = new FloatArray(size);
+        arrayC = new FloatArray(size);
+
+        arrayA.init(0.1f);
+        arrayB.init(0.2f);
+
+        TaskGraph taskGraph = new TaskGraph("testStressMemoryFields") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, arrayA, arrayB) //
+                .task("fields", this::testStressFields, arrayA, arrayB, arrayC) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, arrayC); //
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            for (int i = 0; i < 100; i++) {
+                TornadoExecutionResult execute = executionPlan.execute();
+                long totalDeviceMemoryUsage = execute.getProfilerResult().getTotalDeviceMemoryUsage();
+                assertEquals(1610612808, totalDeviceMemoryUsage);
+            }
+
+            for (int i = 0; i < arrayC.getSize(); i++) {
+                assertEquals(arrayA.get(i) * arrayB.get(i) * arrayB.get(i), arrayC.get(i), 0.001f);
+            }
+
+        } catch (TornadoExecutionPlanException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testStressMemoryLocalArrays() {
+        int size = SIZE_OF_512MB / 4;
+        FloatArray a = new FloatArray(size);
+        FloatArray b = new FloatArray(size);
+        FloatArray c = new FloatArray(size);
+
+        a.init(0.1f);
+        b.init(0.2f);
+        c.init(0.0f);
+
+        TaskGraph taskGraph = new TaskGraph("testStressMemoryLocalArrays") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("local", this::testStressFields, a, b, c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c); //
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            for (int i = 0; i < 100; i++) {
+                TornadoExecutionResult execute = executionPlan.execute();
+                long totalDeviceMemoryUsage = execute.getProfilerResult().getTotalDeviceMemoryUsage();
+                assertEquals(1610612808, totalDeviceMemoryUsage);
+            }
+            for (int i = 0; i < a.getSize(); i++) {
+                assertEquals(a.get(i) * b.get(i) * b.get(i), c.get(i), 0.001f);
+            }
+
+        } catch (TornadoExecutionPlanException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
#### Description

This PR fixes the field memory claim/reclaim by inserting a new bytecode in the TornadoVM list of bytecodes to represent the `this` in Java. 

#### Problem description

There was a problem duplicating buffer size for all field buffer arrays. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```
make
tornado-test -V --enableProfiler silent --fast --jvm="-Dtornado.device.memory=2GB"  uk.ac.manchester.tornado.unittests.fields.TestStressFields
```
