### PR TITLE
Build with maven in single-threaded mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ graal-jdk-21:
 polyglot:
 	bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --polyglot
 
+mvn-single-threaded-jdk21:
+	bin/compile --jdk jdk21 --backend $(BACKEND) --mvn_single_threaded
+
+mvn-single-threaded-graal-jdk-21:
+	bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded
+
 ptx:
 	bin/compile --jdk jdk21 --backend ptx,opencl
 

--- a/Makefile.mak
+++ b/Makefile.mak
@@ -16,6 +16,12 @@ graal-jdk-21:
 polyglot:
 	python bin\compile --jdk graal-jdk-21 --backend $(BACKEND) --polyglot
 
+mvn-single-threaded-jdk21:
+	python bin/compile --jdk jdk21 --backend $(BACKEND) --mvn_single_threaded
+
+mvn-single-threaded-graal-jdk-21:
+	python bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded
+
 ptx:
 	python bin\compile --jdk graal-jdk-21 --backend ptx,opencl
 

--- a/bin/compile
+++ b/bin/compile
@@ -160,7 +160,7 @@ def build_levelzero_jni_lib(rebuild=False):
     if (rebuild or build):
 
         os.chdir(levelzero_jni)
-        
+
         ## Switch branch to the tagged version
         subprocess.run(
             [
@@ -298,7 +298,10 @@ def build_tornadovm(args, backend_profiles):
         else:
             isWinCmdOrBat = False
 
-        process = ["mvn", "-T1.5C", "-Dstyle.color=always"]
+        if args.mavenSingleThreaded:
+            process = ["mvn", "-T1", "-Dstyle.color=always"]
+        else:
+            process = ["mvn", "-T1.5C", "-Dstyle.color=always"]
         if args.polyglot:
             process.append(f"-P{args.jdk},{backend_profiles},graalvm-polyglot")
         else:
@@ -392,6 +395,13 @@ def parse_args():
         help="To enable interoperability with Truffle Programming Languages."
     )
     parser.add_argument(
+        "--mvn_single_threaded",
+        action="store_true",
+        dest="mavenSingleThreaded",
+        default=False,
+        help="To build with maven while using one thread."
+    )
+    parser.add_argument(
         "--rebuild",
         action="store_true",
         dest="rebuild",
@@ -406,7 +416,7 @@ def parse_args():
 def check_tornadoSDK():
     """
     Check if TORNADO_SDK env variable is loaded. It exits the compilation if it is not
-    declared. 
+    declared.
     """
     print("Checking TORNADO_SDK env variable ................ ",  end='')
     try:

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -256,7 +256,7 @@ class TornadoInstaller:
                     command = "nmake /f Makefile.mak " + mavenSingleThreadedOption
         else:
             if all(s == "" for s in [polyglotOption, mavenSingleThreadedOption]):
-                        command = "make " + makeJDK + " " + backend
+                command = "make " + makeJDK + " " + backend
             else:
                 if polyglotOption:
                     command = "make " + polyglotOption

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -253,7 +253,7 @@ class TornadoInstaller:
                 if polyglotOption:
                     command = "nmake /f Makefile.mak " + polyglotOption
                 if mavenSingleThreadedOption:
-                    command = "nmake /f Makefile.mak " + mavenSingleThreadedOption
+                    command = "nmake /f Makefile.mak " + mavenSingleThreadedOption + " " + backend 
         else:
             if all(s == "" for s in [polyglotOption, mavenSingleThreadedOption]):
                 command = "make " + makeJDK + " " + backend
@@ -261,7 +261,7 @@ class TornadoInstaller:
                 if polyglotOption:
                     command = "make " + polyglotOption
                 if mavenSingleThreadedOption:
-                    command = "make " + mavenSingleThreadedOption
+                    command = "make " + mavenSingleThreadedOption + " " + backend
         os.system(command)
 
     def createSourceFile(self):

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -247,10 +247,21 @@ class TornadoInstaller:
 
     def compileTornadoVM(self, makeJDK, backend, polyglotOption, mavenSingleThreadedOption):
         if os.name == 'nt':
-            command = "nmake /f Makefile.mak " + makeJDK + " " + backend + " " + polyglotOption + mavenSingleThreadedOption
+            if all(s == "" for s in [polyglotOption, mavenSingleThreadedOption]):
+                command = "nmake /f Makefile.mak " + makeJDK + " " + backend
+            else:
+                if polyglotOption:
+                    command = "nmake /f Makefile.mak " + polyglotOption
+                if mavenSingleThreadedOption:
+                    command = "nmake /f Makefile.mak " + mavenSingleThreadedOption
         else:
-            command = "make " + makeJDK + " " + backend + " " + polyglotOption + mavenSingleThreadedOption
-        print(command)
+            if all(s == "" for s in [polyglotOption, mavenSingleThreadedOption]):
+                        command = "make " + makeJDK + " " + backend
+            else:
+                if polyglotOption:
+                    command = "make " + polyglotOption
+                if mavenSingleThreadedOption:
+                    command = "make " + mavenSingleThreadedOption
         os.system(command)
 
     def createSourceFile(self):
@@ -330,7 +341,6 @@ class TornadoInstaller:
             mavenSingleThreadedOption = "mvn-single-threaded-" + makeJDK
         else:
             mavenSingleThreadedOption = ""
-        print(mavenSingleThreadedOption)
         return mavenSingleThreadedOption
 
     def check_or_install_python_modules(self):

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -245,11 +245,12 @@ class TornadoInstaller:
         ## 3. TORNADO_SDK
         os.environ["TORNADO_SDK"] = self.env["TORNADO_SDK"]
 
-    def compileTornadoVM(self, makeJDK, backend, polyglotOption):
+    def compileTornadoVM(self, makeJDK, backend, polyglotOption, mavenSingleThreadedOption):
         if os.name == 'nt':
-            command = "nmake /f Makefile.mak " + makeJDK + " " + backend + " " + polyglotOption
+            command = "nmake /f Makefile.mak " + makeJDK + " " + backend + " " + polyglotOption + mavenSingleThreadedOption
         else:
-            command = "make " + makeJDK + " " + backend + " " + polyglotOption
+            command = "make " + makeJDK + " " + backend + " " + polyglotOption + mavenSingleThreadedOption
+        print(command)
         os.system(command)
 
     def createSourceFile(self):
@@ -324,6 +325,14 @@ class TornadoInstaller:
             polyglotOption = ""
         return polyglotOption
 
+    def composeMavenSingleThreadedOption(self, args, makeJDK):
+        if args.mavenSingleThreaded:
+            mavenSingleThreadedOption = "mvn-single-threaded-" + makeJDK
+        else:
+            mavenSingleThreadedOption = ""
+        print(mavenSingleThreadedOption)
+        return mavenSingleThreadedOption
+
     def check_or_install_python_modules(self):
         command = "pip3 install -r bin/tornadoDepModules.txt"
         os.system(command)
@@ -347,6 +356,7 @@ class TornadoInstaller:
             makeJDK = "graal-jdk-21"
             polyglotOption = self.composePolyglotOption(args)
 
+        mavenSingleThreadedOption = self.composeMavenSingleThreadedOption(args, makeJDK)
         if args.javaHome != None:
             directoryPostfix = args.javaHome.split(os.sep)[-1]
         else:
@@ -365,7 +375,7 @@ class TornadoInstaller:
             self.env["JAVA_HOME"] = args.javaHome
 
         self.setEnvironmentVariables()
-        self.compileTornadoVM(makeJDK, backend, polyglotOption)
+        self.compileTornadoVM(makeJDK, backend, polyglotOption, mavenSingleThreadedOption)
         self.createSourceFile()
 
 
@@ -441,6 +451,13 @@ def parseArguments():
         dest="polyglot",
         default=None,
         help="To enable interoperability with Truffle Programming Languages.",
+    )
+    parser.add_argument(
+        "--mvn_single_threaded",
+        action="store_true",
+        dest="mavenSingleThreaded",
+        default=None,
+        help="To build with maven while using one thread.",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
#### Description

This PR adds a new rule in the Makefile for forcing maven to run with one thread. Additionally, it exposes a user parameter in the `compile` script and the `tornadovm-installer` script to trigger this rule.

See here the help menu:
```bash
./bin/tornadovm-installer                                                          
usage: tornadovm-installer [-h] [--version] [--jdk JDK] [--backend BACKEND] [--listJDKs] [--javaHome JAVAHOME] [--polyglot] [--mvn_single_threaded]

TornadoVM Installer Tool. It will install all software dependencies except the GPU/FPGA drivers

options:
  -h, --help            show this help message and exit
  --version             Print version of TornadoVM
  --jdk JDK             Select one of the supported JDKs. Use --listJDKs option to see all supported ones.
  --backend BACKEND     Select the backend to install: { opencl, ptx, spirv }
  --listJDKs            List all JDK supported versions
  --javaHome JAVAHOME   Use a JDK from a user directory
  --polyglot            To enable interoperability with Truffle Programming Languages.
  --mvn_single_threaded
                        To build with maven while using one thread.
```

#### Problem description

There seems to be an issue in some local PCs with Ubuntu OS, and also in the docker containers when we try to build with Maven in parallel. By default we use the `-T1.5C` option.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [x] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

In Linux OS and macOS, you can try:
```bash
./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl --mvn_single_threaded
```

In Windows OS, you can try:
```bash
python bin\tornadovm-installer --jdk graal-jdk-21 --backend opencl --mvn_single_threaded
```

----------------------------------------------------------------------------
