### PR TITLE
Add Unit Test for Executing Multiple Task Graphs with Different Grid Schedulers

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -205,6 +205,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestSlice"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestBuildFromByteBuffers"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestSharedBuffers"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestChainOfGridSchedulers"),
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleFunctions"),
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleTasksMultipleDevices"),
     TestEntry("uk.ac.manchester.tornado.unittests.vm.concurrency.TestConcurrentBackends"),

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestChainOfGridSchedulers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestChainOfGridSchedulers.java
@@ -115,8 +115,8 @@ public class TestChainOfGridSchedulers extends TornadoTestBase {
         // formatter: off
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(itg1, itg2)) {
 
-            executionPlan.withGridScheduler(gridScheduler1).withGraph(0).execute(); // Execute TaskGraph 1
-            executionPlan.withGridScheduler(gridScheduler2).withGraph(1).execute(); // Execute TaskGraph 2
+            executionPlan.withGraph(0).withGridScheduler(gridScheduler1).execute(); // Execute TaskGraph 1
+            executionPlan.withGraph(1).withGridScheduler(gridScheduler2).execute(); // Execute TaskGraph 2
         }
         // formatter: off
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestChainOfGridSchedulers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestChainOfGridSchedulers.java
@@ -1,0 +1,138 @@
+
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import org.junit.Test;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * How to run?
+ *
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.api.TestChainOfGridSchedulers
+ * </code>
+ * </p>
+ */
+public class TestChainOfGridSchedulers extends TornadoTestBase {
+    /**
+     * Task 1: Simple vector addition
+     */
+    public static void vectorAdd(KernelContext context, FloatArray a, FloatArray b, FloatArray c) {
+        int idx = context.globalIdx;
+        if (idx < c.getSize()) {
+            c.set(idx, a.get(idx) + b.get(idx));
+        }
+    }
+
+    /**
+     * Task 2: Simple vector multiplication
+     */
+    public static void vectorMul(KernelContext context, FloatArray a, FloatArray b, FloatArray c) {
+        int idx = context.globalIdx;
+        if (idx < c.getSize()) {
+            c.set(idx, a.get(idx) * b.get(idx));
+        }
+    }
+
+    @Test
+    public void testMultipleTaskGraphs() throws TornadoExecutionPlanException {
+        final int size = 1024;
+
+        // Allocate data arrays
+        FloatArray a = new FloatArray(size);
+        FloatArray b = new FloatArray(size);
+        FloatArray c1 = new FloatArray(size); // Output for TaskGraph 1
+        FloatArray c2 = new FloatArray(size); // Output for TaskGraph 2
+
+        // Initialize input arrays
+        for (int i = 0; i < size; i++) {
+            a.set(i, (float) i);
+            b.set(i, (float) i * 2);
+        }
+
+        KernelContext context = new KernelContext();
+
+        // formatter: off
+        TaskGraph tg1 = new TaskGraph("s0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b)
+                .task("vectorAdd", TestChainOfGridSchedulers::vectorAdd, context, a, b, c1)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c1);
+
+
+        TaskGraph tg2 = new TaskGraph("s1")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b)
+                .task("vectorMul", TestChainOfGridSchedulers::vectorMul, context, a, b, c2)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c2);
+
+        // Create kernel context
+        // Task Graph 1: Vector Addition
+        WorkerGrid worker1 = new WorkerGrid1D(size);
+        worker1.setGlobalWork(size, 1, 1);
+        worker1.setLocalWork(256, 1, 1); // 256 threads per work-group
+        GridScheduler gridScheduler1 = new GridScheduler("s0.vectorAdd", worker1);
+
+        // Task Graph 2: Vector Multiplication
+        WorkerGrid worker2 = new WorkerGrid1D(size);
+        worker2.setGlobalWork(size, 1, 1);
+        worker2.setLocalWork(128, 1, 1); // 128 threads per work-group (different from TaskGraph 1)
+        GridScheduler gridScheduler2 = new GridScheduler("s1.vectorMul", worker2);
+        // formatter: on
+
+
+        // Create immutable task graphs
+        ImmutableTaskGraph itg1 = tg1.snapshot();
+        ImmutableTaskGraph itg2 = tg2.snapshot();
+
+        // formatter: off
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(itg1, itg2)) {
+
+            executionPlan.withGridScheduler(gridScheduler1).withGraph(0).execute(); // Execute TaskGraph 1
+            executionPlan.withGridScheduler(gridScheduler2).withGraph(1).execute(); // Execute TaskGraph 2
+        }
+        // formatter: off
+
+
+        // Verify results for TaskGraph 1 (Vector Addition)
+        for (int i = 0; i < size; i++) {
+            float expected = a.get(i) + b.get(i);
+            float actual = c1.get(i);
+            assertEquals("Mismatch at index " + i + " for TaskGraph 1", expected, actual, 1e-6f);
+        }
+
+        // Verify results for TaskGraph 2 (Vector Multiplication)
+        for (int i = 0; i < size; i++) {
+            float expected = a.get(i) * b.get(i);
+            float actual = c2.get(i);
+            assertEquals("Mismatch at index " + i + " for TaskGraph 2", expected, actual, 1e-6f);
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestChainOfGridSchedulers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestChainOfGridSchedulers.java
@@ -18,7 +18,10 @@
  */
 package uk.ac.manchester.tornado.unittests.api;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
+
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.KernelContext;
@@ -30,8 +33,6 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * How to run?
@@ -82,16 +83,11 @@ public class TestChainOfGridSchedulers extends TornadoTestBase {
         KernelContext context = new KernelContext();
 
         // formatter: off
-        TaskGraph tg1 = new TaskGraph("s0")
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b)
-                .task("vectorAdd", TestChainOfGridSchedulers::vectorAdd, context, a, b, c1)
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, c1);
+        TaskGraph tg1 = new TaskGraph("s0").transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b).task("vectorAdd", TestChainOfGridSchedulers::vectorAdd, context, a, b, c1).transferToHost(
+                DataTransferMode.EVERY_EXECUTION, c1);
 
-
-        TaskGraph tg2 = new TaskGraph("s1")
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b)
-                .task("vectorMul", TestChainOfGridSchedulers::vectorMul, context, a, b, c2)
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, c2);
+        TaskGraph tg2 = new TaskGraph("s1").transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b).task("vectorMul", TestChainOfGridSchedulers::vectorMul, context, a, b, c2).transferToHost(
+                DataTransferMode.EVERY_EXECUTION, c2);
 
         // Create kernel context
         // Task Graph 1: Vector Addition
@@ -107,7 +103,6 @@ public class TestChainOfGridSchedulers extends TornadoTestBase {
         GridScheduler gridScheduler2 = new GridScheduler("s1.vectorMul", worker2);
         // formatter: on
 
-
         // Create immutable task graphs
         ImmutableTaskGraph itg1 = tg1.snapshot();
         ImmutableTaskGraph itg2 = tg2.snapshot();
@@ -119,7 +114,6 @@ public class TestChainOfGridSchedulers extends TornadoTestBase {
             executionPlan.withGraph(1).withGridScheduler(gridScheduler2).execute(); // Execute TaskGraph 2
         }
         // formatter: off
-
 
         // Verify results for TaskGraph 1 (Vector Addition)
         for (int i = 0; i < size; i++) {


### PR DESCRIPTION
#### Description

This patch adds a new unit test, `TestChainOfGridSchedulers`, which verifies the execution of multiple task graphs using different `GridScheduler` configurations within a single `TornadoExecutionPlan`. The test ensures that distinct task graphs can be scheduled and executed correctly with separate work-group configurations.

#### Problem description

The order in which methods are chained when configuring and executing task graphs within a `TornadoExecutionPlan` is crucial. The correct sequence should be choosing the task graph first, then applying the `GridScheduler`.

The following approach is **incorrect** because it first sets the GridScheduler and then selects the task graph:
```java
executionPlan.withGridScheduler(gridScheduler1).withGraph(0).execute(); // Execute TaskGraph 1  
executionPlan.withGridScheduler(gridScheduler2).withGraph(1).execute(); // Execute TaskGraph 2  
```

Instead, the **correct** approach is to first select the task graph and then assign the corresponding `GridScheduler`:

```java
executionPlan.withGraph(0).withGridScheduler(gridScheduler1).execute(); // Execute TaskGraph 1  
executionPlan.withGraph(1).withGridScheduler(gridScheduler2).execute(); // Execute TaskGraph 2  
```



#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
tornado-test -V uk.ac.manchester.tornado.unittests.api.TestChainOfGridSchedulers
```
----------------------------------------------------------------------------
