### PR TITLE
[hotfix] Update inner node for local memory allocation to be ValueNode instead of ConstantNode

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
@@ -314,8 +314,7 @@ public class OCLGraphBuilderPlugins {
         r.register(new InvocationPlugin("allocateIntLocalArray", Receiver.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
-                ConstantNode constantNode = new ConstantNode(size.asConstant(), StampFactory.forKind(JavaKind.Int));
-                LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, constantNode);
+                LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, size);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -326,8 +325,7 @@ public class OCLGraphBuilderPlugins {
         r.register(new InvocationPlugin("allocateLongLocalArray", Receiver.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
-                ConstantNode constantNode = new ConstantNode(size.asConstant(), StampFactory.forKind(JavaKind.Int));
-                LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, constantNode);
+                LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, size);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -338,8 +336,7 @@ public class OCLGraphBuilderPlugins {
         r.register(new InvocationPlugin("allocateFloatLocalArray", Receiver.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
-                ConstantNode constantNode = new ConstantNode(size.asConstant(), StampFactory.forKind(JavaKind.Int));
-                LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, constantNode);
+                LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, size);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -350,8 +347,7 @@ public class OCLGraphBuilderPlugins {
         r.register(new InvocationPlugin("allocateDoubleLocalArray", Receiver.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
-                ConstantNode constantNode = new ConstantNode(size.asConstant(), StampFactory.forKind(JavaKind.Int));
-                LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, constantNode);
+                LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, size);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/LocalArrayNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/LocalArrayNode.java
@@ -29,8 +29,8 @@ import org.graalvm.compiler.core.common.type.TypeReference;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.FixedNode;
+import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.memory.MemoryKill;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
@@ -51,12 +51,12 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
     public static final NodeClass<LocalArrayNode> TYPE = NodeClass.create(LocalArrayNode.class);
 
     @Input
-    protected ConstantNode length;
+    protected ValueNode length;
     protected OCLArchitecture.OCLMemoryBase memoryRegister;
     protected OCLAssembler.OCLBinaryTemplate arrayTemplate;
     private OCLKind kind;
 
-    public LocalArrayNode(OCLArchitecture.OCLMemoryBase memoryRegister, ResolvedJavaType elementType, ConstantNode length) {
+    public LocalArrayNode(OCLArchitecture.OCLMemoryBase memoryRegister, ResolvedJavaType elementType, ValueNode length) {
         super(TYPE, StampFactory.objectNonNull(TypeReference.createTrustedWithoutAssumptions(elementType.getArrayClass())));
         this.memoryRegister = memoryRegister;
         this.length = length;
@@ -64,7 +64,7 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
         this.arrayTemplate = OCLKind.resolveTemplateType(elementType);
     }
 
-    public LocalArrayNode(OCLArchitecture.OCLMemoryBase memoryRegister, JavaKind elementKind, ConstantNode length) {
+    public LocalArrayNode(OCLArchitecture.OCLMemoryBase memoryRegister, JavaKind elementKind, ValueNode length) {
         super(TYPE, StampFactory.forKind(JavaKind.Object));
         this.memoryRegister = memoryRegister;
         this.length = length;
@@ -76,7 +76,7 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
         return memoryRegister;
     }
 
-    public ConstantNode getLength() {
+    public ValueNode getLength() {
         return length;
     }
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
@@ -267,8 +267,7 @@ public class PTXGraphBuilderPlugins {
         r.register(new InvocationPlugin("allocateIntLocalArray", InvocationPlugin.Receiver.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
-                ConstantNode constantNode = new ConstantNode(size.asConstant(), StampFactory.forKind(JavaKind.Int));
-                LocalArrayNode localArrayNode = new LocalArrayNode(PTXArchitecture.sharedSpace, elementType, constantNode);
+                LocalArrayNode localArrayNode = new LocalArrayNode(PTXArchitecture.sharedSpace, elementType, size);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -279,8 +278,7 @@ public class PTXGraphBuilderPlugins {
         r.register(new InvocationPlugin("allocateLongLocalArray", InvocationPlugin.Receiver.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
-                ConstantNode constantNode = new ConstantNode(size.asConstant(), StampFactory.forKind(JavaKind.Int));
-                LocalArrayNode localArrayNode = new LocalArrayNode(PTXArchitecture.sharedSpace, elementType, constantNode);
+                LocalArrayNode localArrayNode = new LocalArrayNode(PTXArchitecture.sharedSpace, elementType, size);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -291,8 +289,7 @@ public class PTXGraphBuilderPlugins {
         r.register(new InvocationPlugin("allocateFloatLocalArray", InvocationPlugin.Receiver.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
-                ConstantNode constantNode = new ConstantNode(size.asConstant(), StampFactory.forKind(JavaKind.Int));
-                LocalArrayNode localArrayNode = new LocalArrayNode(PTXArchitecture.sharedSpace, elementType, constantNode);
+                LocalArrayNode localArrayNode = new LocalArrayNode(PTXArchitecture.sharedSpace, elementType, size);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -303,8 +300,7 @@ public class PTXGraphBuilderPlugins {
         r.register(new InvocationPlugin("allocateDoubleLocalArray", InvocationPlugin.Receiver.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
-                ConstantNode constantNode = new ConstantNode(size.asConstant(), StampFactory.forKind(JavaKind.Int));
-                LocalArrayNode localArrayNode = new LocalArrayNode(PTXArchitecture.sharedSpace, elementType, constantNode);
+                LocalArrayNode localArrayNode = new LocalArrayNode(PTXArchitecture.sharedSpace, elementType, size);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/LocalArrayNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/LocalArrayNode.java
@@ -31,8 +31,8 @@ import org.graalvm.compiler.core.common.type.TypeReference;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.FixedNode;
+import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.memory.MemoryKill;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
@@ -57,13 +57,13 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
     public static final NodeClass<LocalArrayNode> TYPE = NodeClass.create(LocalArrayNode.class);
 
     @Input
-    protected ConstantNode length;
+    protected ValueNode length;
 
     protected PTXMemoryBase memoryRegister;
     protected PTXBinaryTemplate arrayTemplate;
     private PTXKind kind;
 
-    public LocalArrayNode(PTXMemoryBase memoryRegister, ResolvedJavaType elementType, ConstantNode length) {
+    public LocalArrayNode(PTXMemoryBase memoryRegister, ResolvedJavaType elementType, ValueNode length) {
         super(TYPE, StampFactory.objectNonNull(TypeReference.createTrustedWithoutAssumptions(elementType.getArrayClass())));
         this.memoryRegister = memoryRegister;
         this.length = length;
@@ -71,7 +71,7 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
         this.arrayTemplate = PTXKind.resolveTemplateType(elementType);
     }
 
-    public LocalArrayNode(PTXMemoryBase memoryRegister, JavaKind elementKind, ConstantNode length) {
+    public LocalArrayNode(PTXMemoryBase memoryRegister, JavaKind elementKind, ValueNode length) {
         super(TYPE, StampFactory.forKind(JavaKind.Object));
         this.memoryRegister = memoryRegister;
         this.length = length;
@@ -83,7 +83,7 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
         return memoryRegister;
     }
 
-    public ConstantNode getLength() {
+    public ValueNode getLength() {
         return length;
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVGraphBuilderPlugins.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVGraphBuilderPlugins.java
@@ -190,8 +190,7 @@ public class SPIRVGraphBuilderPlugins {
         r.register(new InvocationPlugin(method, InvocationPlugin.Receiver.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
-                ConstantNode constantNode = new ConstantNode(size.asConstant(), StampFactory.forKind(JavaKind.Int));
-                LocalArrayNode localArrayNode = new LocalArrayNode(SPIRVArchitecture.localSpace, elementType, constantNode);
+                LocalArrayNode localArrayNode = new LocalArrayNode(SPIRVArchitecture.localSpace, elementType, size);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/LocalArrayNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/LocalArrayNode.java
@@ -30,8 +30,8 @@ import org.graalvm.compiler.core.common.type.TypeReference;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.FixedNode;
+import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.memory.MemoryKill;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
@@ -56,19 +56,19 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
     public static final NodeClass<LocalArrayNode> TYPE = NodeClass.create(LocalArrayNode.class);
 
     @Input
-    protected ConstantNode length;
+    protected ValueNode length;
 
     protected SPIRVArchitecture.SPIRVMemoryBase memoryBase;
     protected SPIRVKind elementKind;
 
-    public LocalArrayNode(SPIRVArchitecture.SPIRVMemoryBase memoryBase, ResolvedJavaType elementType, ConstantNode length) {
+    public LocalArrayNode(SPIRVArchitecture.SPIRVMemoryBase memoryBase, ResolvedJavaType elementType, ValueNode length) {
         super(TYPE, StampFactory.objectNonNull(TypeReference.createTrustedWithoutAssumptions(elementType.getArrayClass())));
         this.memoryBase = memoryBase;
         this.length = length;
         this.elementKind = SPIRVKind.fromJavaKind(elementType.getJavaKind());
     }
 
-    public LocalArrayNode(SPIRVArchitecture.SPIRVMemoryBase memoryBase, JavaKind elementType, ConstantNode length) {
+    public LocalArrayNode(SPIRVArchitecture.SPIRVMemoryBase memoryBase, JavaKind elementType, ValueNode length) {
         super(TYPE, StampFactory.forKind(JavaKind.Object));
         this.memoryBase = memoryBase;
         this.length = length;
@@ -79,7 +79,7 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
         return memoryBase;
     }
 
-    public ConstantNode getLength() {
+    public ValueNode getLength() {
         return length;
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsLongKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsLongKernelContext.java
@@ -92,6 +92,25 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         }
     }
 
+    public static void longReductionAddLocalMemory(KernelContext context, LongArray a, LongArray b, int blockDim) {
+        int globalIdx = context.globalIdx;
+        int localIdx = context.localIdx;
+        int localGroupSize = context.localGroupSizeX;
+        int groupID = context.groupIdx; // Expose Group ID
+
+        long[] localA = context.allocateLongLocalArray(blockDim);
+        localA[localIdx] = a.get(globalIdx);
+        for (int stride = (localGroupSize / 2); stride > 0; stride /= 2) {
+            context.localBarrier();
+            if (localIdx < stride) {
+                localA[localIdx] += localA[localIdx + stride];
+            }
+        }
+        if (localIdx == 0) {
+            b.set(groupID, localA[0]);
+        }
+    }
+
     public static long computeMaxSequential(LongArray input) {
         long acc = 0;
         for (int i = 0; i < input.getSize(); i++) {
@@ -217,7 +236,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
     }
 
     @Test
-    public void testLongReductionsAddLocalMemory() throws TornadoExecutionPlanException {
+    public void testLongReductionsAddLocalMemory01() throws TornadoExecutionPlanException {
         final int size = 1024;
         final int localSize = 256;
         LongArray input = new LongArray(size);
@@ -233,6 +252,43 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
         TaskGraph taskGraph = new TaskGraph("taskGraph") //
                 .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
                 .task("t0", TestReductionsLongKernelContext::longReductionAddLocalMemory, context, input, reduce) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, reduce);
+        // Change the Grid
+        worker.setGlobalWork(size, 1, 1);
+        worker.setLocalWork(localSize, 1, 1);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler) //
+                    .execute();
+        }
+
+        // Final SUM
+        long finalSum = 0;
+        for (int i = 0; i < reduce.getSize(); i++) {
+            finalSum += reduce.get(i);
+        }
+
+        assertEquals(sequential, finalSum, 0);
+    }
+
+    @Test
+    public void testLongReductionsAddLocalMemory02() throws TornadoExecutionPlanException {
+        final int size = 1024;
+        final int localSize = 256;
+        LongArray input = new LongArray(size);
+        LongArray reduce = new LongArray(size / localSize);
+        IntStream.range(0, input.getSize()).sequential().forEach(i -> input.set(i, i));
+        long sequential = computeAddSequential(input);
+
+        WorkerGrid worker = new WorkerGrid1D(size);
+        GridScheduler gridScheduler = new GridScheduler();
+        gridScheduler.setWorkerGrid("taskGraph.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("taskGraph") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("t0", TestReductionsLongKernelContext::longReductionAddLocalMemory, context, input, reduce, localSize) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, reduce);
         // Change the Grid
         worker.setGlobalWork(size, 1, 1);


### PR DESCRIPTION
#### Description

This PR provides a hotfix regarding the allocation of local memory in the 3 backends (OpenCL, PTX, SPIR-V). The issue is described in #634.

I have added several uni-tests to test the update in the compiler plugins for various data types.

**Note:** In OpenCL, the dynamic data size for the definition of a local memory array, is not supported. Therefore, as a workaround we pass the size as argument in the method.

#### Problem description

The issue was that the compiler plugins were requiring the input size to be a constant.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Note that for SPIR-V, some unit-tests are classified as unsupported due to FP64 not been supported for the Integrated Graphics.

In OpenCL:
```bash
make BACKEND=opencl
tornado-test --printKernel -V uk.ac.manchester.tornado.unittests.codegen.CodeGenTest#test06
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsIntegersKernelContext
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsLongKernelContext
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsFloatsKernelContext
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsDoublesKernelContext
```

In PTX:
```bash
make BACKEND=ptx
tornado-test --printKernel -V uk.ac.manchester.tornado.unittests.codegen.CodeGenTest#test06
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsIntegersKernelContext
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsLongKernelContext
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsFloatsKernelContext
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsDoublesKernelContext
```

In SPIR-V:
```bash
make BACKEND=spirv
tornado-test --printKernel -V uk.ac.manchester.tornado.unittests.codegen.CodeGenTest#test06
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsIntegersKernelContext
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsLongKernelContext
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsFloatsKernelContext
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsDoublesKernelContext
```

In SPIR-V:
```bash
make BACKEND=spirv
tornado-test --printKernel -V --jvm="-Dtornado.unittests.device=0:1" uk.ac.manchester.tornado.unittests.codegen.CodeGenTest#test06
tornado-test -V --jvm="-Dtornado.unittests.device=0:1" uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsIntegersKernelContext
tornado-test -V --jvm="-Dtornado.unittests.device=0:1" uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsLongKernelContext
tornado-test -V --jvm="-Dtornado.unittests.device=0:1" uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsFloatsKernelContext
tornado-test -V --jvm="-Dtornado.unittests.device=0:1" uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsDoublesKernelContext
```
----------------------------------------------------------------------------
