### PR TITLE
Fix subgraph executions using the GridScheduler

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/GridScheduler.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/GridScheduler.java
@@ -52,6 +52,7 @@ public class GridScheduler {
      * 
      * @param taskName
      * @param workerGrid
+     * @since v1.1.0
      */
     public void addWorkerGrid(String taskName, WorkerGrid workerGrid) {
         gridTaskMap.put(taskName, workerGrid);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/GridScheduler.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/GridScheduler.java
@@ -34,7 +34,7 @@ public class GridScheduler {
         gridTaskMap.put(taskName, workerGrid);
     }
 
-    public void setWorkerGrid(String taskName, WorkerGrid workerGrid) {
+    public void addWorkerGrid(String taskName, WorkerGrid workerGrid) {
         gridTaskMap.put(taskName, workerGrid);
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/GridScheduler.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/GridScheduler.java
@@ -21,31 +21,67 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Class to store the thread grid configuration for a specific task in a Task-Graph.
+ */
 public class GridScheduler {
 
     private final ConcurrentHashMap<String, WorkerGrid> gridTaskMap;
 
+    /**
+     * Creates a new GridScheduler object with an empty grid task map.
+     */
     public GridScheduler() {
         gridTaskMap = new ConcurrentHashMap<>();
     }
 
+    /**
+     * Creates a new GridScheduler with a specific task name and WorkerGrid. Task names must be unique
+     * for the whole execution plan that the grid scheduler will be attached to.
+     * 
+     * @param taskName
+     * @param workerGrid
+     */
     public GridScheduler(String taskName, WorkerGrid workerGrid) {
         gridTaskMap = new ConcurrentHashMap<>();
         gridTaskMap.put(taskName, workerGrid);
     }
 
+    /**
+     * Adds a new WorkerGrid object to the grid scheduler for a specific task.
+     * 
+     * @param taskName
+     * @param workerGrid
+     */
     public void addWorkerGrid(String taskName, WorkerGrid workerGrid) {
         gridTaskMap.put(taskName, workerGrid);
     }
 
+    /**
+     * Returns the WorkerGrid object associated with a given task name.
+     * 
+     * @param taskName
+     * @return
+     */
     public WorkerGrid get(String taskName) {
         return gridTaskMap.get(taskName);
     }
 
+    /**
+     * Checks if the grid scheduler contains a specific worker grid for a task.
+     *
+     * @param taskName
+     * @return boolean
+     */
     public boolean contains(String taskScheduleName, String taskName) {
         return gridTaskMap.containsKey(taskScheduleName + "." + taskName);
     }
 
+    /**
+     * It returns all task names associated with a grid scheduler.
+     * 
+     * @return
+     */
     public Set<String> keySet() {
         return gridTaskMap.keySet();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.api;
 
+import java.util.Collection;
+
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
-
-import java.util.Collection;
 
 /**
  * A {@link TaskGraph} is encapsulated in this class and all actions over a task

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -941,7 +941,6 @@ public class TaskGraph implements TaskGraphInterface {
         return taskGraphImpl.getCurrentDeviceMemoryUsage();
     }
 
-
     void mapOnDeviceMemoryRegion(Object destArray, Object srcArray, long offset, TornadoTaskGraphInterface taskGraphSrc) {
         taskGraphImpl.mapOnDeviceMemoryRegion(destArray, srcArray, offset, taskGraphSrc);
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -120,7 +120,8 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      * If the {@code TornadoExecutionPlan} consists of multiple task-graphs, this function
      * updates the access type of the input and output data of each task-graph, as necessary.
      *
-     * @param immutableTaskGraphs The list of the immutable task-graphs in the {@code TornadoExecutionPlan}
+     * @param immutableTaskGraphs
+     *     The list of the immutable task-graphs in the {@code TornadoExecutionPlan}
      */
     private void updateAccess(ImmutableTaskGraph... immutableTaskGraphs) {
         if (immutableTaskGraphs.length > 1) {
@@ -196,6 +197,9 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      */
     public TornadoExecutionPlan withGraph(int graphIndex) {
         tornadoExecutor.selectGraph(graphIndex);
+        if (executionFrame.getGridScheduler() != null) {
+            tornadoExecutor.withGridScheduler(executionFrame.getGridScheduler());
+        }
         return new WithGraph(this, graphIndex);
     }
 
@@ -343,6 +347,7 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      */
     public TornadoExecutionPlan withGridScheduler(GridScheduler gridScheduler) {
         tornadoExecutor.withGridScheduler(gridScheduler);
+        executionFrame.withGridScheduler(gridScheduler);
         return new WithGridScheduler(this, gridScheduler);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmTornado.java
@@ -79,7 +79,7 @@ public class SgemmTornado extends BenchmarkDriver {
             worker = new WorkerGrid2D(m, n);
             worker.setLocalWork(16, 16, 1);
             grid = new GridScheduler();
-            grid.setWorkerGrid("benchmark.sgemm", worker);
+            grid.addWorkerGrid("benchmark.sgemm", worker);
         }
 
         taskGraph = new TaskGraph("benchmark");

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/BlurFilter.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/BlurFilter.java
@@ -37,9 +37,9 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid2D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
-import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 
 /**
  * It applies a Blur filter to an input image. Algorithm taken from CUDA course CS344 in Udacity.
@@ -172,8 +172,8 @@ public class BlurFilter {
             long start = System.nanoTime();
             WorkerGrid workerGrid = new WorkerGrid2D(w, h);
             GridScheduler gridScheduler = new GridScheduler("blur.red", workerGrid);
-            gridScheduler.setWorkerGrid("blur.green", workerGrid);
-            gridScheduler.setWorkerGrid("blur.blue", workerGrid);
+            gridScheduler.addWorkerGrid("blur.green", workerGrid);
+            gridScheduler.addWorkerGrid("blur.blue", workerGrid);
             KernelContext context = new KernelContext();
             TaskGraph parallelFilter = new TaskGraph("blur") //
                     .transferToDevice(DataTransferMode.FIRST_EXECUTION, redChannel, greenChannel, blueChannel, filter) //

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsGlobalMemory.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsGlobalMemory.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,6 +17,8 @@
  */
 package uk.ac.manchester.tornado.examples.kernelcontext.reductions;
 
+import java.util.stream.IntStream;
+
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.KernelContext;
@@ -24,10 +26,8 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
-
-import java.util.stream.IntStream;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
  * <p>
@@ -83,7 +83,7 @@ public class ReductionsGlobalMemory {
 
         WorkerGrid worker = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s0.t0", worker);
+        gridScheduler.addWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s0") //

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsLocalMemory.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsLocalMemory.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,15 +26,15 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
-import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
  * <p>
  * How to run?
  * </p>
  * <code>
- *      $ tornado --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.reductions.ReductionsLocalMemory
+ * $ tornado --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.reductions.ReductionsLocalMemory
  * </code>
  */
 public class ReductionsLocalMemory {
@@ -85,7 +85,7 @@ public class ReductionsLocalMemory {
 
         WorkerGrid worker = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s0.t0", worker);
+        gridScheduler.addWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s0") //

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -653,8 +653,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     @Override
     public void updatePersistedObjectState(TornadoTaskGraphInterface taskGraphSrc) {
         TornadoTaskGraph graphSrc = (TornadoTaskGraph) taskGraphSrc;
-        List<Object> objectsToSync = executionContext.getPersistedTaskToObjectsMap()
-                .get(graphSrc.taskGraphName);
+        List<Object> objectsToSync = executionContext.getPersistedTaskToObjectsMap().get(graphSrc.taskGraphName);
 
         for (Object objectToSync : objectsToSync) {
             Access objectAccessSrc = graphSrc.getObjectAccess(objectToSync);
@@ -670,11 +669,12 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
             if (localStateDest == null) {
                 continue;
-//                throw new TornadoRuntimeException("[ERROR] Object " + objectsToSync + " is not a persistent object in the task graph " + taskGraphSrc.getTaskGraphName());
+                //                throw new TornadoRuntimeException("[ERROR] Object " + objectsToSync + " is not a persistent object in the task graph " + taskGraphSrc.getTaskGraphName());
             }
 
             if (!graphSrc.meta().getXPUDevice().equals(executionContext.meta().getXPUDevice())) {
-                throw new TornadoRuntimeException("[ERROR] Object " + objectsToSync + " is not on the same device pesisted and consumed: " + graphSrc.meta().getXPUDevice() + " " + " vs " + executionContext.meta().getXPUDevice());
+                throw new TornadoRuntimeException("[ERROR] Object " + objectsToSync + " is not on the same device pesisted and consumed: " + graphSrc.meta()
+                        .getXPUDevice() + " " + " vs " + executionContext.meta().getXPUDevice());
             }
 
             DataObjectState dataObjectStateDest = localStateDest.getDataObjectState();
@@ -1677,12 +1677,10 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     private void checkGridSchedulerNames() {
         Set<String> gridTaskNames = gridScheduler.keySet();
-        for (String gridName : gridTaskNames) {
-            if (!isTaskNamePresent(gridName)) {
-                throw new TornadoRuntimeException("[ERROR] Grid scheduler with name " + gridName + " not found in the Task-Graph");
-            }
+        boolean found = gridTaskNames.stream().anyMatch(this::isTaskNamePresent);
+        if (!found) {
+            throw new TornadoRuntimeException("[ERROR] Grid scheduler names: " + gridTaskNames + " -> not found in the Task-Graph");
         }
-
     }
 
     @SuppressWarnings("unchecked")

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestChainOfGridSchedulers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestChainOfGridSchedulers.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2025, APT Group, Department of Computer Science,
  * The University of Manchester.
@@ -20,10 +19,11 @@ package uk.ac.manchester.tornado.unittests.api;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Random;
+
 import org.junit.Test;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
-import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
@@ -75,58 +75,135 @@ public class TestChainOfGridSchedulers extends TornadoTestBase {
         FloatArray c2 = new FloatArray(size); // Output for TaskGraph 2
 
         // Initialize input arrays
+        Random r = new Random(71);
         for (int i = 0; i < size; i++) {
-            a.set(i, (float) i);
-            b.set(i, (float) i * 2);
+            a.set(i, r.nextFloat());
+            b.set(i, r.nextFloat());
         }
 
         KernelContext context = new KernelContext();
 
-        // formatter: off
-        TaskGraph tg1 = new TaskGraph("s0").transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b).task("vectorAdd", TestChainOfGridSchedulers::vectorAdd, context, a, b, c1).transferToHost(
-                DataTransferMode.EVERY_EXECUTION, c1);
+        TaskGraph tg1 = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("vectorAdd", TestChainOfGridSchedulers::vectorAdd, context, a, b, c1) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c1);
 
-        TaskGraph tg2 = new TaskGraph("s1").transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b).task("vectorMul", TestChainOfGridSchedulers::vectorMul, context, a, b, c2).transferToHost(
-                DataTransferMode.EVERY_EXECUTION, c2);
+        TaskGraph tg2 = new TaskGraph("s1") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("vectorMul", TestChainOfGridSchedulers::vectorMul, context, a, b, c2) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c2); //
 
-        // Create kernel context
-        // Task Graph 1: Vector Addition
+        // Create the worker grid for the task Graph 1: Vector Addition
         WorkerGrid worker1 = new WorkerGrid1D(size);
-        worker1.setGlobalWork(size, 1, 1);
         worker1.setLocalWork(256, 1, 1); // 256 threads per work-group
-        GridScheduler gridScheduler1 = new GridScheduler("s0.vectorAdd", worker1);
 
-        // Task Graph 2: Vector Multiplication
+        // Create the worker grid for the task Graph 2: Vector Multiplication
         WorkerGrid worker2 = new WorkerGrid1D(size);
-        worker2.setGlobalWork(size, 1, 1);
         worker2.setLocalWork(128, 1, 1); // 128 threads per work-group (different from TaskGraph 1)
-        GridScheduler gridScheduler2 = new GridScheduler("s1.vectorMul", worker2);
-        // formatter: on
 
-        // Create immutable task graphs
-        ImmutableTaskGraph itg1 = tg1.snapshot();
-        ImmutableTaskGraph itg2 = tg2.snapshot();
+        GridScheduler grid = new GridScheduler();
+        grid.addWorkerGrid("s0.vectorAdd", worker1);
+        grid.addWorkerGrid("s1.vectorMul", worker2);
 
-        // formatter: off
-        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(itg1, itg2)) {
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot())) {
 
-            executionPlan.withGraph(0).withGridScheduler(gridScheduler1).execute(); // Execute TaskGraph 1
-            executionPlan.withGraph(1).withGridScheduler(gridScheduler2).execute(); // Execute TaskGraph 2
+            // The order in which we specify the GridSchedulers and the graph selection should not matter.
+            // Using the witGridScheduler().withGraph(x) and the reverse withGraph(x).witGridScheduler()
+            // are equivalent.
+            // A Grid-scheduler must be shared across all graphs within an execution plan.
+
+            // Execute TaskGraph 0
+            executionPlan.withGridScheduler(grid).withGraph(0).execute();
+
+            // Execute TaskGraph 1
+            executionPlan.withGridScheduler(grid).withGraph(1).execute();
         }
-        // formatter: off
 
-        // Verify results for TaskGraph 1 (Vector Addition)
+        // Verify results 
         for (int i = 0; i < size; i++) {
             float expected = a.get(i) + b.get(i);
             float actual = c1.get(i);
-            assertEquals("Mismatch at index " + i + " for TaskGraph 1", expected, actual, 1e-6f);
+            assertEquals(expected, actual, 1e-6f);
+
+            expected = a.get(i) * b.get(i);
+            actual = c2.get(i);
+            assertEquals(expected, actual, 1e-6f);
         }
 
-        // Verify results for TaskGraph 2 (Vector Multiplication)
+    }
+
+    /**
+     * Same test as {@link #testMultipleTaskGraphs()} but with reverse order when selecting the graph and the grid scheduler.
+     * 
+     * @throws TornadoExecutionPlanException
+     */
+    @Test
+    public void testMultipleTaskGraphsSchedulerReverse() throws TornadoExecutionPlanException {
+        final int size = 1024;
+
+        // Allocate data arrays
+        FloatArray a = new FloatArray(size);
+        FloatArray b = new FloatArray(size);
+        FloatArray c1 = new FloatArray(size); // Output for TaskGraph 1
+        FloatArray c2 = new FloatArray(size); // Output for TaskGraph 2
+
+        c1.init(0.0f);
+        c2.init(0.0f);
+
+        // Initialize input arrays
+        Random r = new Random();
         for (int i = 0; i < size; i++) {
-            float expected = a.get(i) * b.get(i);
-            float actual = c2.get(i);
-            assertEquals("Mismatch at index " + i + " for TaskGraph 2", expected, actual, 1e-6f);
+            a.set(i, r.nextFloat());
+            b.set(i, r.nextFloat());
+        }
+
+        KernelContext context = new KernelContext();
+
+        TaskGraph tg1 = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("vectorAdd", TestChainOfGridSchedulers::vectorAdd, context, a, b, c1) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c1);
+
+        TaskGraph tg2 = new TaskGraph("s1") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("vectorMul", TestChainOfGridSchedulers::vectorMul, context, a, b, c2) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c2); //
+
+        // Create the worker grid for the task Graph 1: Vector Addition
+        WorkerGrid worker1 = new WorkerGrid1D(size);
+        worker1.setLocalWork(256, 1, 1); // 256 threads per work-group
+
+        // Create the worker grid for the task Graph 2: Vector Multiplication
+        WorkerGrid worker2 = new WorkerGrid1D(size);
+        worker2.setLocalWork(128, 1, 1); // 128 threads per work-group (different from TaskGraph 1)
+
+        GridScheduler grid = new GridScheduler();
+        grid.addWorkerGrid("s0.vectorAdd", worker1);
+        grid.addWorkerGrid("s1.vectorMul", worker2);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot())) {
+
+            // The order in which we specify the GridSchedulers and the graph selection should not matter.
+            // Using the witGridScheduler().withGraph(x) and the reverse withGraph(x).witGridScheduler()
+            // are equivalent.
+            // A Grid-scheduler must be shared across all graphs within an execution plan.
+
+            // Execute TaskGraph 0
+            executionPlan.withGraph(0).withGridScheduler(grid).execute();
+
+            // Execute TaskGraph 1
+            executionPlan.withGridScheduler(grid).withGraph(1).execute();
+        }
+
+        // Verify results 
+        for (int i = 0; i < size; i++) {
+            float expected = a.get(i) + b.get(i);
+            float actual = c1.get(i);
+            assertEquals(expected, actual, DELTA);
+
+            expected = a.get(i) * b.get(i);
+            actual = c2.get(i);
+            assertEquals(expected, actual, DELTA);
         }
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGrid.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/grid/TestGrid.java
@@ -199,7 +199,7 @@ public class TestGrid extends TornadoTestBase {
         // Set the Grid with 4096 threads
         WorkerGrid1D worker = new WorkerGrid1D(4096);
         GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
-        gridScheduler.setWorkerGrid("s0.t1", worker); // share the same worker
+        gridScheduler.addWorkerGrid("s0.t1", worker); // share the same worker
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph)) {
             executor.withGridScheduler(gridScheduler) //

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/KernelContextWorkGroupTests.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/KernelContextWorkGroupTests.java
@@ -74,7 +74,7 @@ public class KernelContextWorkGroupTests extends TornadoTestBase {
         KernelContext context = new KernelContext();
         GridScheduler grid = new GridScheduler();
         WorkerGrid worker = new WorkerGrid1D(16);
-        grid.setWorkerGrid("s0.t0", worker);
+        grid.addWorkerGrid("s0.t0", worker);
 
         IntArray data = new IntArray(16);
 
@@ -96,7 +96,7 @@ public class KernelContextWorkGroupTests extends TornadoTestBase {
         KernelContext context = new KernelContext();
         GridScheduler grid = new GridScheduler();
         WorkerGrid worker = new WorkerGrid2D(16, 8);
-        grid.setWorkerGrid("s0.t0", worker);
+        grid.addWorkerGrid("s0.t0", worker);
 
         IntArray data = new IntArray(16);
         TaskGraph taskGraph = new TaskGraph("s0") //
@@ -117,7 +117,7 @@ public class KernelContextWorkGroupTests extends TornadoTestBase {
         KernelContext context = new KernelContext();
         GridScheduler grid = new GridScheduler();
         WorkerGrid worker = new WorkerGrid3D(16, 8, 4);
-        grid.setWorkerGrid("s0.t0", worker);
+        grid.addWorkerGrid("s0.t0", worker);
 
         IntArray data = new IntArray(16);
         TaskGraph taskGraph = new TaskGraph("s0") //
@@ -137,7 +137,7 @@ public class KernelContextWorkGroupTests extends TornadoTestBase {
         GridScheduler grid = new GridScheduler();
         WorkerGrid worker = new WorkerGrid1D(1024);
         worker.setLocalWork(8, 1, 1);
-        grid.setWorkerGrid("s0.t0", worker);
+        grid.addWorkerGrid("s0.t0", worker);
 
         IntArray data = new IntArray(1024);
         TaskGraph taskGraph = new TaskGraph("s0") //
@@ -158,7 +158,7 @@ public class KernelContextWorkGroupTests extends TornadoTestBase {
         GridScheduler grid = new GridScheduler();
         WorkerGrid worker = new WorkerGrid2D(1024, 512);
         worker.setLocalWork(1, 8, 1);
-        grid.setWorkerGrid("s0.t0", worker);
+        grid.addWorkerGrid("s0.t0", worker);
 
         IntArray data = new IntArray(1024);
         TaskGraph taskGraph = new TaskGraph("s0") //
@@ -179,7 +179,7 @@ public class KernelContextWorkGroupTests extends TornadoTestBase {
         GridScheduler grid = new GridScheduler();
         WorkerGrid worker = new WorkerGrid3D(1, 1, 1024);
         worker.setLocalWork(1, 1, 8);
-        grid.setWorkerGrid("s0.t0", worker);
+        grid.addWorkerGrid("s0.t0", worker);
 
         IntArray data = new IntArray(1024);
         TaskGraph taskGraph = new TaskGraph("s0") //

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestCombinedTaskGraph.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestCombinedTaskGraph.java
@@ -220,9 +220,9 @@ public class TestCombinedTaskGraph extends TornadoTestBase {
 
         WorkerGrid worker = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s02.t0", worker);
-        gridScheduler.setWorkerGrid("s02.t1", worker);
-        gridScheduler.setWorkerGrid("s02.t2", worker);
+        gridScheduler.addWorkerGrid("s02.t0", worker);
+        gridScheduler.addWorkerGrid("s02.t1", worker);
+        gridScheduler.addWorkerGrid("s02.t2", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s02") //
@@ -265,8 +265,8 @@ public class TestCombinedTaskGraph extends TornadoTestBase {
 
         WorkerGrid worker = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s03.t1", worker);
-        gridScheduler.setWorkerGrid("s03.t2", worker);
+        gridScheduler.addWorkerGrid("s03.t1", worker);
+        gridScheduler.addWorkerGrid("s03.t2", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s03") //
@@ -309,8 +309,8 @@ public class TestCombinedTaskGraph extends TornadoTestBase {
 
         WorkerGrid worker = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s04.t0", worker);
-        gridScheduler.setWorkerGrid("s04.t1", worker);
+        gridScheduler.addWorkerGrid("s04.t0", worker);
+        gridScheduler.addWorkerGrid("s04.t1", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s04") //
@@ -354,8 +354,8 @@ public class TestCombinedTaskGraph extends TornadoTestBase {
         WorkerGrid workerT0 = new WorkerGrid1D(size);
         WorkerGrid workerT1 = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s05.t0", workerT0);
-        gridScheduler.setWorkerGrid("s05.t1", workerT1);
+        gridScheduler.addWorkerGrid("s05.t0", workerT0);
+        gridScheduler.addWorkerGrid("s05.t1", workerT1);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s05") //

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestVectorAdditionKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestVectorAdditionKernelContext.java
@@ -116,7 +116,7 @@ public class TestVectorAdditionKernelContext extends TornadoTestBase {
 
         WorkerGrid worker = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s0.t0", worker);
+        gridScheduler.addWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s0") //
@@ -150,7 +150,7 @@ public class TestVectorAdditionKernelContext extends TornadoTestBase {
 
         WorkerGrid worker = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s0.t0", worker);
+        gridScheduler.addWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s0") //
@@ -184,7 +184,7 @@ public class TestVectorAdditionKernelContext extends TornadoTestBase {
 
         WorkerGrid worker = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s0.t0", worker);
+        gridScheduler.addWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s0") //

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestMatrixMultiplicationKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestMatrixMultiplicationKernelContext.java
@@ -177,7 +177,7 @@ public class TestMatrixMultiplicationKernelContext extends TornadoTestBase {
 
         WorkerGrid worker = new WorkerGrid2D(size, size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s0.t0", worker);
+        gridScheduler.addWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s0") //
@@ -214,7 +214,7 @@ public class TestMatrixMultiplicationKernelContext extends TornadoTestBase {
 
         WorkerGrid worker = new WorkerGrid2D(size, size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("s0.t0", worker);
+        gridScheduler.addWorkerGrid("s0.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("s0") //

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsLongKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/reductions/TestReductionsLongKernelContext.java
@@ -246,7 +246,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
 
         WorkerGrid worker = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("taskGraph.t0", worker);
+        gridScheduler.addWorkerGrid("taskGraph.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("taskGraph") //
@@ -283,7 +283,7 @@ public class TestReductionsLongKernelContext extends TornadoTestBase {
 
         WorkerGrid worker = new WorkerGrid1D(size);
         GridScheduler gridScheduler = new GridScheduler();
-        gridScheduler.setWorkerGrid("taskGraph.t0", worker);
+        gridScheduler.addWorkerGrid("taskGraph.t0", worker);
         KernelContext context = new KernelContext();
 
         TaskGraph taskGraph = new TaskGraph("taskGraph") //


### PR DESCRIPTION
#### Description

This PR fixes the execution of sub-graphs (in a multi-execution graph plans) when having grid schedulers to define custom block of threads to launch on an accelerator.

#### Problem description

The problem was mainly due to a bad naming for the appending of grids in a grid-scheduler. By design in TornadoVM, a grid scheduler can be shared across multiple graphs in an execution plan. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-test -V --threadInfo uk.ac.manchester.tornado.unittests.api.TestChainOfGridSchedulers
```