### PR TITLE
Compiler Plugins for `acosh` and `asinh` math functions 

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -347,7 +347,7 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      */
     public TornadoExecutionPlan withGridScheduler(GridScheduler gridScheduler) {
         tornadoExecutor.withGridScheduler(gridScheduler);
-        executionFrame.withGridScheduler(gridScheduler);
+        executionFrame.setGridScheduler(gridScheduler);
         return new WithGridScheduler(this, gridScheduler);
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/math/TornadoMath.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/math/TornadoMath.java
@@ -432,6 +432,14 @@ public class TornadoMath {
         return (float) Math.acos(a);
     }
 
+    public static float acosh(float x) {
+        return (float) Math.log(x + Math.sqrt(x * x - 1));
+    }
+
+    public static double acosh(double x) {
+        return Math.log(x + Math.sqrt(x * x - 1));
+    }
+
     public static double acos(double a) {
         return Math.acos(a);
     }
@@ -442,6 +450,14 @@ public class TornadoMath {
 
     public static double asin(double a) {
         return Math.asin(a);
+    }
+
+    public static float asinh(float x) {
+        return (float) Math.log(x + Math.sqrt(x * x + 1));
+    }
+
+    public static double asinh(double x) {
+        return Math.log(x + Math.sqrt(x * x + 1));
     }
 
     public static float cos(float angle) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/asm/OCLAssembler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/asm/OCLAssembler.java
@@ -724,7 +724,9 @@ public final class OCLAssembler extends Assembler {
         public static final OCLUnaryIntrinsic TANH = new OCLUnaryIntrinsic("tanh");
         public static final OCLUnaryIntrinsic ATAN = new OCLUnaryIntrinsic("atan");
         public static final OCLUnaryIntrinsic ASIN = new OCLUnaryIntrinsic("asin");
+        public static final OCLUnaryIntrinsic ASINH = new OCLUnaryIntrinsic("asinh");
         public static final OCLUnaryIntrinsic ACOS = new OCLUnaryIntrinsic("acos");
+        public static final OCLUnaryIntrinsic ACOSH = new OCLUnaryIntrinsic("acosh");
         public static final OCLUnaryIntrinsic SINPI = new OCLUnaryIntrinsic("sinpi");
         public static final OCLUnaryIntrinsic COSPI = new OCLUnaryIntrinsic("cospi");
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
@@ -45,7 +45,7 @@ import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLIntBinaryIn
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLIntUnaryIntrinsicNode.Operation.POPCOUNT;
 
 import java.lang.foreign.MemorySegment;
-import jdk.vm.ci.meta.RawConstant;
+
 import org.graalvm.compiler.core.common.memory.BarrierType;
 import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.type.StampFactory;
@@ -77,6 +77,7 @@ import org.graalvm.word.LocationIdentity;
 
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.RawConstant;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TornadoVMIntrinsics;
@@ -115,7 +116,6 @@ public class OCLGraphBuilderPlugins {
 
         registerFP16ConversionPlugins(plugins);
         registerTornadoVMIntrinsicsPlugins(plugins);
-        registerOpenCLBuiltinPlugins(plugins);
 
         // Register Atomics
         registerTornadoVMAtomicsPlugins(plugins);
@@ -123,6 +123,7 @@ public class OCLGraphBuilderPlugins {
         registerKernelContextPlugins(plugins);
 
         OCLMathPlugins.registerTornadoMathPlugins(plugins);
+        registerOpenCLBuiltinPlugins(plugins);
         OCLVectorPlugins.registerPlugins(ps, plugins);
 
         // Register TornadoAtomicInteger
@@ -515,7 +516,7 @@ public class OCLGraphBuilderPlugins {
     private static void registerOpenCLBuiltinPlugins(InvocationPlugins plugins) {
 
         Registration r = new Registration(plugins, java.lang.Math.class);
-        // We have to overwrite some of standard math plugins
+        // We have to overwrite some of the standard math plugins
         r.setAllowOverwrite(true);
         registerOpenCLOverridesForType(r, Float.TYPE, JavaKind.Float);
         registerOpenCLOverridesForType(r, Double.TYPE, JavaKind.Double);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLMathPlugins.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLMathPlugins.java
@@ -28,7 +28,9 @@ import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPBinaryInt
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPBinaryIntrinsicNode.Operation.FMIN;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPBinaryIntrinsicNode.Operation.POW;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.ACOS;
+import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.ACOSH;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.ASIN;
+import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.ASINH;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.ATAN;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.CEIL;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPUnaryIntrinsicNode.Operation.COS;
@@ -94,6 +96,7 @@ public class OCLMathPlugins {
     }
 
     private static void registerFloatMath1Plugins(Registration r, Class<?> type, JavaKind kind) {
+
         r.register(new InvocationPlugin("sqrt", type) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
@@ -145,6 +148,23 @@ public class OCLMathPlugins {
     }
 
     private static void registerTrigonometric1Plugins(Registration r, Class<?> type, JavaKind kind) {
+
+        r.register(new InvocationPlugin("acosh", type) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(kind, b.append(OCLFPUnaryIntrinsicNode.create(value, ACOSH, kind)));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("asinh", type) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(kind, b.append(OCLFPUnaryIntrinsicNode.create(value, ASINH, kind)));
+                return true;
+            }
+        });
+
         r.register(new InvocationPlugin("atan2", type, type) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode x, ValueNode y) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLBuiltinTool.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLBuiltinTool.java
@@ -35,7 +35,9 @@ import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCL
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLTernaryIntrinsic.CLAMP;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.ABS;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.ACOS;
+import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.ACOSH;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.ASIN;
+import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.ASINH;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.ATAN;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.CEIL;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLUnaryIntrinsic.COS;
@@ -74,8 +76,8 @@ public class OCLBuiltinTool {
     }
 
     public Value genFloatACosh(Value input) {
-        unimplemented();
-        return null;
+        Logger.traceBuildLIR(Logger.BACKEND.OpenCL, "genAcosh: acosh(%s)", input);
+        return new OCLUnary.Intrinsic(ACOSH, LIRKind.value(input.getPlatformKind()), input);
     }
 
     public Value genFloatACospi(Value input) {
@@ -89,8 +91,8 @@ public class OCLBuiltinTool {
     }
 
     public Value genFloatASinh(Value input) {
-        unimplemented();
-        return null;
+        Logger.traceBuildLIR(Logger.BACKEND.OpenCL, "genAsinh: asinh(%s)", input);
+        return new OCLUnary.Intrinsic(ASINH, LIRKind.value(input.getPlatformKind()), input);
     }
 
     public Value genFloatASinpi(Value input) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFPUnaryIntrinsicNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLFPUnaryIntrinsicNode.java
@@ -84,10 +84,28 @@ public class OCLFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
         return result;
     }
 
+    private static double computeAcosh(double value) {
+        return Math.log(value + Math.sqrt(value * value - 1));
+    }
+
+    private static float computeAcosh(float value) {
+        return (float) Math.log(value + Math.sqrt(value * value - 1));
+    }
+
+    private static double computeAsinh(double value) {
+        return Math.log(value + Math.sqrt(value * value + 1));
+    }
+
+    private static float computeAsinh(float value) {
+        return (float) Math.log(value + Math.sqrt(value * value + 1));
+    }
+
     private static double doCompute(double value, Operation op) {
         return switch (op) {
             case ASIN -> Math.asin(value);
+            case ASINH -> computeAsinh(value);
             case ACOS -> Math.acos(value);
+            case ACOSH -> computeAcosh(value);
             case FABS -> Math.abs(value);
             case EXP -> Math.exp(value);
             case SQRT -> Math.sqrt(value);
@@ -101,7 +119,9 @@ public class OCLFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
     private static float doCompute(float value, Operation op) {
         return switch (op) {
             case ASIN -> (float) Math.asin(value);
+            case ASINH -> computeAsinh(value);
             case ACOS -> (float) Math.acos(value);
+            case ACOSH -> computeAcosh(value);
             case FABS -> Math.abs(value);
             case EXP -> (float) Math.exp(value);
             case SQRT -> (float) Math.sqrt(value);
@@ -138,7 +158,9 @@ public class OCLFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
         OCLBuiltinTool gen = ((OCLArithmeticTool) lirGen).getGen().getOCLBuiltinTool();
         Value input = builder.operand(getValue());
         Value result = switch (operation()) {
+            case ACOSH -> gen.genFloatACosh(input);
             case ASIN -> gen.genFloatASin(input);
+            case ASINH -> gen.genFloatASinh(input);
             case ACOS -> gen.genFloatACos(input);
             case ATAN -> gen.genFloatATan(input);
             case CEIL -> gen.genFloatCeil(input);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVMathPlugins.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVMathPlugins.java
@@ -73,6 +73,22 @@ public class SPIRVMathPlugins {
 
     private static void registerFloatMath1Plugins(InvocationPlugins.Registration r, Class<?> type, JavaKind kind) {
 
+        r.register(new InvocationPlugin("acosh", type) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(kind, b.append(SPIRVFPUnaryIntrinsicNode.create(value, SPIRVUnaryOperation.ACOSH, kind)));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("asinh", type) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(kind, b.append(SPIRVFPUnaryIntrinsicNode.create(value, SPIRVUnaryOperation.ASINH, kind)));
+                return true;
+            }
+        });
+
         r.register(new InvocationPlugin("sqrt", type) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/lir/SPIRVBuiltinTool.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/lir/SPIRVBuiltinTool.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -61,7 +61,7 @@ public class SPIRVBuiltinTool {
 
     public Value genFloatASinh(Value input) {
         Logger.traceBuildLIR(Logger.BACKEND.SPIRV, "gen: asinh(%s)", input);
-        return new SPIRVUnary.Intrinsic(SPIRVUnary.Intrinsic.OpenCLExtendedIntrinsic.ASIN, LIRKind.value(input.getPlatformKind()), input);
+        return new SPIRVUnary.Intrinsic(SPIRVUnary.Intrinsic.OpenCLExtendedIntrinsic.ASINH, LIRKind.value(input.getPlatformKind()), input);
     }
 
     public Value genFloatASinpi(Value input) {
@@ -112,7 +112,6 @@ public class SPIRVBuiltinTool {
         Logger.traceBuildLIR(Logger.BACKEND.SPIRV, "gen: cosh(%s)", input);
         return new SPIRVUnary.Intrinsic(SPIRVUnary.Intrinsic.OpenCLExtendedIntrinsic.COSH, LIRKind.value(input.getPlatformKind()), input);
     }
-
 
     public Value genFloatErfc(Value input) {
         unimplemented();

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SPIRVFPUnaryIntrinsicNode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SPIRVFPUnaryIntrinsicNode.java
@@ -59,7 +59,6 @@ public class SPIRVFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLI
         assert value.stamp(NodeView.DEFAULT) instanceof FloatStamp && PrimitiveStamp.getBits(value.stamp(NodeView.DEFAULT)) == kind.getBitCount();
         this.operation = op;
     }
-    // @formatter:on
 
     public static ValueNode create(ValueNode value, SPIRVUnaryOperation op, JavaKind kind) {
         ValueNode c = tryConstantFold(value, op, kind);
@@ -84,10 +83,28 @@ public class SPIRVFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLI
         return result;
     }
 
+    private static double computeAcosh(double value) {
+        return Math.log(value + Math.sqrt(value * value - 1));
+    }
+
+    private static float computeAcosh(float value) {
+        return (float) Math.log(value + Math.sqrt(value * value - 1));
+    }
+
+    private static double computeAsinh(double value) {
+        return Math.log(value + Math.sqrt(value * value + 1));
+    }
+
+    private static float computeAsinh(float value) {
+        return (float) Math.log(value + Math.sqrt(value * value + 1));
+    }
+
     private static double doCompute(double value, SPIRVUnaryOperation op) {
         return switch (op) {
-            case ASIN -> Math.asin(value);
             case ACOS -> Math.acos(value);
+            case ACOSH -> computeAcosh(value);
+            case ASIN -> Math.asin(value);
+            case ASINH -> computeAsinh(value);
             case FABS -> Math.abs(value);
             case EXP -> Math.exp(value);
             case SQRT -> Math.sqrt(value);
@@ -102,8 +119,10 @@ public class SPIRVFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLI
 
     private static float doCompute(float value, SPIRVUnaryOperation op) {
         return switch (op) {
-            case ASIN -> (float) Math.asin(value);
             case ACOS -> (float) Math.acos(value);
+            case ACOSH -> computeAcosh(value);
+            case ASIN -> (float) Math.asin(value);
+            case ASINH -> computeAsinh(value);
             case FABS -> Math.abs(value);
             case EXP -> (float) Math.exp(value);
             case SQRT -> (float) Math.sqrt(value);
@@ -140,12 +159,13 @@ public class SPIRVFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLI
 
     @Override
     public void generate(NodeLIRBuilderTool builder, ArithmeticLIRGeneratorTool lirGen) {
-
         SPIRVBuiltinTool gen = ((SPIRVArithmeticTool) lirGen).getGen().getSpirvBuiltinTool();
         Value input = builder.operand(getValue());
         Value result = switch (operation()) {
-            case ASIN -> gen.genFloatASin(input);
             case ACOS -> gen.genFloatACos(input);
+            case ACOSH -> gen.genFloatACosh(input);
+            case ASIN -> gen.genFloatASin(input);
+            case ASINH -> gen.genFloatASinh(input);
             case CEIL -> gen.genFloatCeil(input);
             case FABS -> gen.genFloatAbs(input);
             case EXP -> gen.genFloatExp(input);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
@@ -52,6 +52,12 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         }
     }
 
+    public static void testTornadoAcosh(FloatArray a) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            a.set(i, TornadoMath.acosh(a.get(i)));
+        }
+    }
+
     public static void testTornadoSignum(FloatArray a) {
         for (@Parallel int i = 0; i < a.getSize(); i++) {
             a.set(i, TornadoMath.signum(a.get(i)));
@@ -103,6 +109,12 @@ public class TestTornadoMathCollection extends TornadoTestBase {
     public static void testTornadoAsin(FloatArray a) {
         for (@Parallel int i = 0; i < a.getSize(); i++) {
             a.set(i, (TornadoMath.asin(a.get(i))));
+        }
+    }
+
+    public static void testTornadoAsinh(FloatArray a) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            a.set(i, (TornadoMath.asinh(a.get(i))));
         }
     }
 
@@ -268,6 +280,35 @@ public class TestTornadoMathCollection extends TornadoTestBase {
         }
 
         testTornadoCos(seq);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(data.get(i), seq.get(i), 0.01f);
+        }
+
+    }
+
+    @Test
+    public void testTornadoMathAcosh() throws TornadoExecutionPlanException {
+        final int size = 128;
+        FloatArray data = new FloatArray(size);
+        FloatArray seq = new FloatArray(size);
+
+        IntStream.range(0, size).parallel().forEach(i -> {
+            data.set(i, (float) Math.random());
+            seq.set(i, data.get(i));
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, data) //
+                .task("t0", TestTornadoMathCollection::testTornadoAcosh, data) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        testTornadoAcosh(seq);
 
         for (int i = 0; i < size; i++) {
             assertEquals(data.get(i), seq.get(i), 0.01f);
@@ -1265,6 +1306,34 @@ public class TestTornadoMathCollection extends TornadoTestBase {
             executionPlan.execute();
         }
         testTornadoAsin(seqA);
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(a.get(i), seqA.get(i), 0.01f);
+        }
+    }
+
+    @Test
+    public void testMathASinh() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.PTX);
+
+        final int size = 128;
+        FloatArray a = new FloatArray(size);
+        FloatArray seqA = new FloatArray(size);
+
+        IntStream.range(0, size).parallel().forEach(i -> {
+            a.set(i, (float) Math.random());
+            seqA.set(i, a.get(i));
+        });
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a) //
+                .task("t0", TestTornadoMathCollection::testTornadoAsinh, a) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a);
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+        testTornadoAsinh(seqA);
 
         for (int i = 0; i < size; i++) {
             assertEquals(a.get(i), seqA.get(i), 0.01f);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestTornadoMathCollection.java
@@ -1314,8 +1314,6 @@ public class TestTornadoMathCollection extends TornadoTestBase {
 
     @Test
     public void testMathASinh() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.PTX);
-
         final int size = 128;
         FloatArray a = new FloatArray(size);
         FloatArray seqA = new FloatArray(size);


### PR DESCRIPTION
#### Description

Expand the TornadoVM Math function with `asinh` and `acosh` for the OpenCL and SPIR-V backends. 

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make
tornado-test -pk -V uk.ac.manchester.tornado.unittests.math.TestTornadoMathCollection#testTornadoMathCosh
tornado-test -pk -V uk.ac.manchester.tornado.unittests.math.TestTornadoMathCollection#testMathASinh
```



