### PR TITLE
[rt] Memory dealloc by default when closing an execution plan resource

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -76,7 +76,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompilationResu
 import uk.ac.manchester.tornado.drivers.opencl.graal.compiler.OCLCompiler;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.TornadoAtomicIntegerNode;
-import uk.ac.manchester.tornado.drivers.opencl.mm.AtomicsBuffer;
+import uk.ac.manchester.tornado.drivers.opencl.mm.OCLAtomicsBuffer;
 import uk.ac.manchester.tornado.drivers.opencl.mm.OCLByteArrayWrapper;
 import uk.ac.manchester.tornado.drivers.opencl.mm.OCLCharArrayWrapper;
 import uk.ac.manchester.tornado.drivers.opencl.mm.OCLDoubleArrayWrapper;
@@ -111,7 +111,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     private final int deviceIndex;
     private final int platformIndex;
     private final String platformName;
-    private XPUBuffer reuseBuffer;
+    private XPUBuffer atomicsBuffer;
     private ConcurrentHashMap<Object, Integer> mappingAtomics;
     private TornadoLogger logger = new TornadoLogger(this.getClass());
 
@@ -233,11 +233,11 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public XPUBuffer createOrReuseAtomicsBuffer(int[] array, Access access) {
-        if (reuseBuffer == null) {
-            reuseBuffer = getDeviceContext().getMemoryManager().createAtomicsBuffer(array, access);
+        if (atomicsBuffer == null) {
+            atomicsBuffer = getDeviceContext().getMemoryManager().createAtomicsBuffer(array, access);
         }
-        reuseBuffer.setIntBuffer(array);
-        return reuseBuffer;
+        atomicsBuffer.setIntBuffer(array);
+        return atomicsBuffer;
     }
 
     private boolean isOpenCLPreLoadBinary(long executionPlanId, OCLDeviceContextInterface deviceContext, String deviceInfo) {
@@ -406,10 +406,10 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public int[] checkAtomicsForTask(SchedulableTask task, int[] array, int paramIndex, Object value) {
-        if (value instanceof AtomicInteger) {
-            AtomicInteger ai = (AtomicInteger) value;
-            if (TornadoAtomicIntegerNode.globalAtomicsParameters.containsKey(task.meta().getCompiledResolvedJavaMethod())) {
-                HashMap<Integer, Integer> values = TornadoAtomicIntegerNode.globalAtomicsParameters.get(task.meta().getCompiledResolvedJavaMethod());
+        if (value instanceof AtomicInteger ai) {
+            Object compiledResolvedJavaMethod = task.meta().getCompiledResolvedJavaMethod();
+            if (TornadoAtomicIntegerNode.globalAtomicsParameters.containsKey(compiledResolvedJavaMethod)) {
+                HashMap<Integer, Integer> values = TornadoAtomicIntegerNode.globalAtomicsParameters.get(compiledResolvedJavaMethod);
                 int index = values.get(paramIndex);
                 array[index] = ai.get();
             }
@@ -418,13 +418,13 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     }
 
     @Override
-    public int[] updateAtomicRegionAndObjectState(SchedulableTask task, int[] array, int paramIndex, Object value, XPUDeviceBufferState objectState) {
+    public int[] updateAtomicRegionAndObjectState(SchedulableTask task, int[] array, int paramIndex, Object value, XPUDeviceBufferState atomicState) {
         int[] atomicsArray = checkAtomicsForTask(task, array, paramIndex, value);
         mappingAtomics.put(value, getAtomicsGlobalIndexForTask(task, paramIndex));
-        XPUBuffer bufferAtomics = objectState.getXPUBuffer();
-        bufferAtomics.setIntBuffer(atomicsArray);
-        setAtomicRegion(bufferAtomics);
-        objectState.setAtomicRegion(bufferAtomics);
+        XPUBuffer xpuBufferForAtomic = atomicState.getXPUBuffer();
+        xpuBufferForAtomic.setIntBuffer(atomicsArray);
+        this.atomicsBuffer = xpuBufferForAtomic;
+        atomicState.setAtomicRegion(xpuBufferForAtomic);
         return atomicsArray;
     }
 
@@ -532,7 +532,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
             }
         } else if (!type.isPrimitive()) {
             if (object instanceof AtomicInteger) {
-                result = new AtomicsBuffer(new int[] {}, deviceContext, access);
+                result = new OCLAtomicsBuffer(new int[] {}, deviceContext, access);
             } else if (object.getClass().getAnnotation(Vector.class) != null) {
                 result = new OCLVectorWrapper(deviceContext, object, batchSize, access);
             } else if (object instanceof MemorySegment) {
@@ -614,7 +614,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
             buffer = newDeviceBufferAllocation(object, batchSize, state, access);
         }
 
-        if (buffer.getClass() == AtomicsBuffer.class) {
+        if (buffer.getClass() == OCLAtomicsBuffer.class) {
             state.setAtomicRegion();
         }
         return state.getXPUBuffer().size();
@@ -627,7 +627,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
             return deallocatedSpace;
         }
         deviceBufferState.getXPUBuffer().markAsFreeBuffer();
-        if (!TornadoOptions.isReusedBuffersEnabled()) {
+        if (TornadoOptions.isDeallocateBufferEnabled()) {
             deallocatedSpace = deviceBufferState.getXPUBuffer().deallocate();
         }
         deviceBufferState.setContents(false);
@@ -792,7 +792,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public XPUBuffer getAtomic() {
-        return reuseBuffer;
+        return atomicsBuffer;
     }
 
     @Override
@@ -807,7 +807,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
 
     @Override
     public void setAtomicRegion(XPUBuffer bufferAtomics) {
-        reuseBuffer = bufferAtomics;
+        atomicsBuffer = bufferAtomics;
     }
 
     @Override
@@ -826,19 +826,16 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         }
 
         Matcher matcher = NAME_PATTERN.matcher(version);
-        int major = 0;
-        int minor = 0;
+        int majorVersion = 0;
+        int minorVersion = 0;
         if (matcher.find()) {
-            major = Integer.parseInt(matcher.group(1));
-            minor = Integer.parseInt(matcher.group(2));
+            majorVersion = Integer.parseInt(matcher.group(1));
+            minorVersion = Integer.parseInt(matcher.group(2));
         }
-        if (major > 2) {
+        if (majorVersion > 2) {
             return true;
         }
-        if (major == 2 && minor >= 1) {
-            return true;
-        }
-        return false;
+        return majorVersion == 2 && minorVersion >= 1;
     }
 
     @Override

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -328,7 +328,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
         }
 
         deviceBufferState.getXPUBuffer().markAsFreeBuffer();
-        if (!TornadoOptions.isReusedBuffersEnabled()) {
+        if (TornadoOptions.isDeallocateBufferEnabled()) {
             deallocatedSpace = deviceBufferState.getXPUBuffer().deallocate();
         }
         deviceBufferState.setContents(false);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -50,7 +50,7 @@ import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.api.types.tensors.Tensor;
 import uk.ac.manchester.tornado.drivers.common.TornadoBufferProvider;
-import uk.ac.manchester.tornado.drivers.opencl.mm.AtomicsBuffer;
+import uk.ac.manchester.tornado.drivers.opencl.mm.OCLAtomicsBuffer;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVBackend;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVBackendImpl;
 import uk.ac.manchester.tornado.drivers.spirv.SPIRVDevice;
@@ -347,7 +347,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
             buffer = createNewBufferAllocation(object, batchSize, state, access);
         }
 
-        if (buffer.getClass() == AtomicsBuffer.class) {
+        if (buffer.getClass() == OCLAtomicsBuffer.class) {
             state.setAtomicRegion();
         }
         return state.getXPUBuffer().size();
@@ -361,7 +361,7 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
         }
 
         deviceBufferState.getXPUBuffer().markAsFreeBuffer();
-        if (!TornadoOptions.isReusedBuffersEnabled()) {
+        if (TornadoOptions.isDeallocateBufferEnabled()) {
             deallocatedSpace = deviceBufferState.getXPUBuffer().deallocate();
         }
         deviceBufferState.setContents(false);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -224,10 +224,10 @@ public class TornadoOptions {
      *
      * <p>
      * <ul>
-     *   <il>Use <code>-Dtornado.spirv.runtimes=opencl</code> for OpenCL only.
-     *   <il>Use <code>-Dtornado.spirv.runtimes=levelzero</code> for LevelZero only.
-     *   <il>Use <code>-Dtornado.spirv.runtimes=opencl,levelzero</code> for both OpenCL and Level Zero runtimes, being
-     *   OpenCL the first in the list (default).
+     * <il>Use <code>-Dtornado.spirv.runtimes=opencl</code> for OpenCL only.
+     * <il>Use <code>-Dtornado.spirv.runtimes=levelzero</code> for LevelZero only.
+     * <il>Use <code>-Dtornado.spirv.runtimes=opencl,levelzero</code> for both OpenCL and Level Zero runtimes, being
+     * OpenCL the first in the list (default).
      * *</ul>
      * </p>
      */
@@ -353,6 +353,15 @@ public class TornadoOptions {
     }
 
     /**
+     * Option to deallocate after the execution plan finishes. It frees all
+     * resources consumed by the execution plan, which can involved multiple
+     * task graphs.
+     */
+    public static boolean isDeallocateBufferEnabled() {
+        return getBooleanValue("tornado.deallocate.buffers", TRUE);
+    }
+
+    /**
      * Option to enable profiler. It can be disabled at any point during runtime.
      *
      * @return boolean.
@@ -458,5 +467,9 @@ public class TornadoOptions {
         String contextEmulatorIntelFPGA = System.getenv("CL_CONTEXT_EMULATOR_DEVICE_INTELFPGA");
         String contextEmulatorXilinxFPGA = System.getenv("XCL_EMULATION_MODE");
         return (contextEmulatorIntelFPGA != null && (contextEmulatorIntelFPGA.equals("1"))) || (contextEmulatorXilinxFPGA != null && (contextEmulatorXilinxFPGA.equals("sw_emu")));
+    }
+
+    public static boolean cleanUpAtomicsSpace() {
+        return getBooleanValue("tornado.clean.atomics.space", FALSE);
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -469,6 +469,14 @@ public class TornadoOptions {
         return (contextEmulatorIntelFPGA != null && (contextEmulatorIntelFPGA.equals("1"))) || (contextEmulatorXilinxFPGA != null && (contextEmulatorXilinxFPGA.equals("sw_emu")));
     }
 
+    /**
+     * Flag to signal to clean up the atomics area (as in accelerator's global memory) when the Execution Plan
+     * resource is closed. This is False by default, since this area is global for all kernels. In near future,
+     * we will change this to use a unique area per execution plan, and have the option to turn on and off
+     * this flag as needed.
+     * 
+     * @return boolean
+     */
     public static boolean cleanUpAtomicsSpace() {
         return getBooleanValue("tornado.clean.atomics.space", FALSE);
     }


### PR DESCRIPTION
#### Description

It forces to clean up all resources (e.g., all GPU memory used) when the `ExecutionPlan` resource is closed. 
The only exception is when using constant memory (as in CUDA constant) and atomics, which in TornadoVM, these
are separated memory regions handler by the device memory manager. 

In future versions of TornadoVM, we should improve these handler by taking into account the execution plan IDs, we memory management can be further improved. 

#### Problem description

When running with large data sets with multiple execution plans, TornadoVM tends to lock memory to reuse as much as possible. However, when a resource (execution plan) is closed, we can free all resources associated to an execution plan, and make more space for new execution plans. 

This is needed to run GAIA code under the AERO EU project. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make
make tests
tornado-test --fast -V uk.ac.manchester.tornado.unittests.atomics.TestAtomics
```
