### PR TITLE
[hotfix] Fix to prevent issue with shared buffer allocation when not all buffers are present in args

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -190,7 +190,8 @@ class TornadoExecutor {
         immutableTaskGraphList.forEach(ImmutableTaskGraph::withThreadInfo);
     }
 
-    List<Object> getOutputs() { List<Object> outputs = new ArrayList<>();
+    List<Object> getOutputs() {
+        List<Object> outputs = new ArrayList<>();
         immutableTaskGraphList.forEach(immutableTaskGraph -> outputs.addAll(immutableTaskGraph.getOutputs()));
         return outputs;
     }
@@ -236,20 +237,17 @@ class TornadoExecutor {
     /**
      * Processes the persistent states of a specified subgraph.
      *
-     * @param graphIndex The index of the subgraph to process.
+     * @param graphIndex
+     *     The index of the subgraph to process.
      */
     private void processPersistentStates(int graphIndex) {
         // Validate that the graphIndex is within bounds of subgraphList
         if (graphIndex < 0 || graphIndex >= subgraphList.size()) {
-             throw new TornadoRuntimeException("Error: graphIndex out of bounds: " + graphIndex);
+            throw new TornadoRuntimeException("Error: graphIndex out of bounds: " + graphIndex);
         }
 
         // Retrieve the list of persisted task names from the specified subgraph
-        List<String> namesList = new ArrayList<>(subgraphList.get(graphIndex)
-                .getTaskGraph()
-                .taskGraphImpl
-                .getPersistedTaskToObjectsMap()
-                .keySet());
+        List<String> namesList = new ArrayList<>(subgraphList.get(graphIndex).getTaskGraph().taskGraphImpl.getPersistedTaskToObjectsMap().keySet());
 
         // Determine the safe iteration limit to avoid IndexOutOfBoundsException
         int limit = Math.min(graphIndex, namesList.size());
@@ -260,7 +258,6 @@ class TornadoExecutor {
             subgraphList.get(graphIndex).updatePersistedObjectState(getGraphByName(key));
         }
     }
-
 
     private ImmutableTaskGraph getGraph(int graphIndex) {
         if (graphIndex < immutableTaskGraphList.size()) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -978,23 +978,11 @@ public class TornadoVMInterpreter {
      * Container class that holds information about object allocation counts.
      * Used to track the number of persistent objects and the number of objects
      * that need to be allocated.
+     *
+     * @param persistentObjectCount Number of persistent objects that don't need allocation
+     * @param objectsToAlloc Number of objects that need to be allocated
      */
-    private static class ObjectAllocationInfo {
-        final int persistentObjectCount;
-        final int objectsToAlloc;
-
-        /**
-         * Creates a new object allocation information container.
-         *
-         * @param persistentObjectCount
-         *     Number of persistent objects that don't need allocation
-         * @param objectsToAlloc
-         *     Number of objects that need to be allocated
-         */
-        ObjectAllocationInfo(int persistentObjectCount, int objectsToAlloc) {
-            this.persistentObjectCount = persistentObjectCount;
-            this.objectsToAlloc = objectsToAlloc;
-        }
+    public record ObjectAllocationInfo(int persistentObjectCount, int objectsToAlloc) {
     }
 
     private static class XPUExecutionFrame {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -2632,12 +2632,12 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         return profilerMode;
     }
 
+    public record Tuple2(int threadWinnerIndex, Thread join) {
+    }
+
     // Timer implementation within the Task Schedule
     private interface Timer {
         long time();
-    }
-
-    public record Tuple2(int threadWinnerIndex, Thread join) {
     }
 
     private static class MilliSecTimer implements Timer {


### PR DESCRIPTION
#### Description

There was an issue with the shared buffer functionalty that it was taking into account that shared buffers might not be present in all tasks of taskgraph. This is it was causing negative allocation for some tests. Also, it adds tests to force  buffers to be copied out but adding intermediate dummy tasks. 


#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash 
 tornado-test   -V uk.ac.manchester.tornado.unittests.api.TestSharedBuffers
```
----------------------------------------------------------------------------
