### PR TITLE
Fix UNDER_DEMAND batch processing for READ-WRITE buffers 

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -595,7 +595,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
 
     private XPUBuffer newDeviceBufferAllocation(Object object, long batchSize, DeviceBufferState deviceObjectState, Access access) {
         final XPUBuffer buffer;
-        TornadoInternalError.guarantee(deviceObjectState.isAtomicRegionPresent() || !deviceObjectState.hasObjectBuffer(), "A device memory leak might be occurring.");
+        TornadoInternalError.guarantee(deviceObjectState.isAtomicRegionPresent() || !deviceObjectState.hasObjectBuffer() || batchSize != 0, "A device memory leak might be occurring.");
         buffer = createDeviceBuffer(object.getClass(), object, (OCLDeviceContext) getDeviceContext(), batchSize, access);
         deviceObjectState.setXPUBuffer(buffer);
         buffer.allocate(object, batchSize, access);


### PR DESCRIPTION
#### Description
This PR solves a corner case that was demonstrated by the unittest `uk.ac.manchester.tornado.unittests.batches.TestBatches#test512MBLazy`. 
For batch processing, if a buffer is READ-WRITE (both stream-in and stream-out) and the `UNDER_DEMAND` mode is used, for example: 
```
TaskGraph taskGraph = new TaskGraph("s0") //
                .transferToDevice(DataTransferMode.FIRST_EXECUTION, arrayA) //
                .task("t0", TestBatches::compute, arrayA) //
                .transferToHost(DataTransferMode.UNDER_DEMAND, arrayA);
```
then an exception is thrown during the creation of a new buffer for the second batch, indicating a memory leak.  

Before allocating the new buffer, there is guarantee that examines the device buffer state, and if it's not clean (unbuffered) then throws the exception. 
However, because for `UNDER_DEMAND` buffers, there is no deallocation before each batch allocation, the state is not clean and so the runtime assumes a memory leak.  To take this case into account,  the condition is expanded to examine whether batch processing takes place. 

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Run `tornado-test -V uk.ac.manchester.tornado.unittests.batches.TestBatches`

