### PR TITLE
[ptx] Memory region mapping with offsets fixed

### DIFF
--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -601,8 +601,8 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         return streamTable.get(executionPlanId).get(device);
     }
 
-    public long mapOnDeviceMemoryRegion(long executionPlanId, long destDevicePtr, long srcDevicePtr, long offset) {
+    public long mapOnDeviceMemoryRegion(long executionPlanId, long destDevicePtr, long srcDevicePtr, long offset, int sizeOfType) {
         PTXStream ptxStream = getStream(executionPlanId);
-        return ptxStream.mapOnDeviceMemoryRegion(destDevicePtr, srcDevicePtr, offset);
+        return ptxStream.mapOnDeviceMemoryRegion(destDevicePtr, srcDevicePtr, offset, sizeOfType);
     }
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXStream.java
@@ -367,8 +367,7 @@ public class PTXStream {
         return isDestroy;
     }
 
-    public long mapOnDeviceMemoryRegion(long destDevicePtr, long srcDevicePtr, long offset) {
-        final int sizeofType = 4;
+    public long mapOnDeviceMemoryRegion(long destDevicePtr, long srcDevicePtr, long offset, int sizeofType) {
         return NativePTXStream.mapOnDeviceMemoryRegion(destDevicePtr, srcDevicePtr, offset, sizeofType);
     }
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/mm/PTXMemorySegmentWrapper.java
@@ -239,10 +239,10 @@ public class PTXMemorySegmentWrapper implements XPUBuffer {
 
     @Override
     public void mapOnDeviceMemoryRegion(long executionPlanId, XPUBuffer srcPointer, long offset) {
-        if (!(srcPointer instanceof PTXMemorySegmentWrapper oclMemorySegmentWrapper)) {
-            throw new TornadoRuntimeException("[ERROR] copy pointer must be an instance of OCLMemorySegmentWrapper: " + srcPointer);
+        if (!(srcPointer instanceof PTXMemorySegmentWrapper ptxMemorySegmentWrapper)) {
+            throw new TornadoRuntimeException("[ERROR] copy pointer must be an instance of PTXMemorySegmentWrapper: " + srcPointer);
         }
-        this.bufferId = deviceContext.mapOnDeviceMemoryRegion(executionPlanId, this.bufferId, oclMemorySegmentWrapper.bufferId, offset);
+        this.bufferId = deviceContext.mapOnDeviceMemoryRegion(executionPlanId, this.bufferId, ptxMemorySegmentWrapper.bufferId, offset, sizeOfType);
     }
 
     @Override


### PR DESCRIPTION
#### Description

Memory region mapping with offsets fixed

#### Problem description

PTX assumes offset of 4 bytes, which was a leftover from the original PoC. 

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [X] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make BACKEND=ptx
tornado-test -pbc --threadInfo -V uk.ac.manchester.tornado.unittests.pointers.TestCopyDevicePointers
```
