### PR TITLE
[loging] Enhance deallocation logging to include materialization of action

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
@@ -44,12 +44,13 @@ class DebugInterpreter {
         appendLogBuilder(verbose, logBuilder);
     }
 
-    static void logDeallocObject(Object object, TornadoXPUDevice interpreterDevice, StringBuilder logBuilder) {
-        String verbose = String.format("bc: %s[0x%x] %s on %s", //
-                InterpreterUtilities.debugHighLightBC("DEALLOC"), //
+    static void logDeallocObject(Object object, TornadoXPUDevice interpreterDevice, StringBuilder logBuilder, boolean materializeDealloc) {
+        String verbose = String.format("bc: %s[0x%x] %s [Status: %s] on %s", //
+                materializeDealloc ? InterpreterUtilities.debugHighLightBC("DEALLOC") : InterpreterUtilities.debugHighLightNonExecBC("DEALLOC"), //
                 object.hashCode(), //
                 object, //
-                InterpreterUtilities.debugDeviceBC(interpreterDevice));
+                InterpreterUtilities.debugHighLightNonExecBC(materializeDealloc ? "Freed" : "Persisted"), //
+                InterpreterUtilities.debugDeviceBC(interpreterDevice)); //
         appendLogBuilder(verbose, logBuilder);
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -498,13 +498,13 @@ public class TornadoVMInterpreter {
     private int executeDeAlloc(StringBuilder tornadoVMBytecodeList, final int objectIndex) {
         Object object = objects.get(objectIndex);
 
-        if (TornadoOptions.PRINT_BYTECODES && isNotObjectAtomic(object)) {
-            DebugInterpreter.logDeallocObject(object, interpreterDevice, tornadoVMBytecodeList);
-        }
-
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
         long spaceDeallocated = interpreterDevice.deallocate(objectState);
         // Update current device area use
+        if (TornadoOptions.PRINT_BYTECODES && isNotObjectAtomic(object)) {
+            boolean materializeDealloc = spaceDeallocated == 0;
+            DebugInterpreter.logDeallocObject(object, interpreterDevice, tornadoVMBytecodeList, materializeDealloc);
+        }
         graphExecutionContext.setCurrentDeviceMemoryUsage(graphExecutionContext.getCurrentDeviceMemoryUsage() - spaceDeallocated);
         return -1;
     }


### PR DESCRIPTION
#### Description

This PR improves the logging for bytecode for deallocation. It now it includes information on status (free vs persisted).
This is needed to debug the actual action of the dealloc bytecode.


Dealloc that is actuall executed uses the same color with the other bytecodes.
Dealloc with empty action uses  differenct color. 
Also, status uses different color for readability.

![image](https://github.com/user-attachments/assets/da36c93e-9e7a-4e2a-b457-53c069d35a20)

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
tornado-test --printBytecodes -V uk.ac.manchester.tornado.unittests.api.TestSharedBuffers 
```
----------------------------------------------------------------------------
