### PR TITLE
[hotfix] Object repetition with shared buffers on ON_DEVICE bytecodes

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
@@ -89,7 +89,7 @@ public class TornadoVMBytecodeBuilder {
         if (node instanceof AllocateMultipleBuffersNode allocateMultipleBuffersNode) {
             bitcodeASM.allocate(allocateMultipleBuffersNode.getValues(), batchSize);
         } else if (node instanceof OnDeviceObjectNode onDeviceObjectNode) {
-            bitcodeASM.onDevice(onDeviceObjectNode.getIndex(), dependencyBC, offset, batchSize); 
+            bitcodeASM.onDevice(onDeviceObjectNode.getValue().getIndex(), dependencyBC, offset, batchSize);
         } else if (node instanceof CopyInNode copyInNode) {
             bitcodeASM.transferToDeviceOnce(copyInNode.getValue().getIndex(), dependencyBC, offset, batchSize);
         } else if (node instanceof AllocateNode allocateNode) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/nodes/OnDeviceObjectNode.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/nodes/OnDeviceObjectNode.java
@@ -12,7 +12,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -28,23 +28,27 @@ import java.util.Collections;
 import java.util.List;
 
 public class OnDeviceObjectNode extends ContextOpNode {
-    public OnDeviceObjectNode(ContextNode context) {
-        super(context);
-    }
-
     private ObjectNode value;
 
-    public void setValue(ObjectNode object) {
-        value = object;
+    public OnDeviceObjectNode(ContextNode context) {
+        super(context);
     }
 
     public ObjectNode getValue() {
         return value;
     }
 
+    public void setValue(ObjectNode object) {
+        value = object;
+    }
+
     @Override
     public String toString() {
-        return String.format("[%d]: on-device object %d", id,  value.getIndex());
+        if (value == null) {
+            return String.format("[%d]: on-device object (value not set)", id);
+        } else {
+            return String.format("[%d]: on-device object %d", id, value.getIndex());
+        }
     }
 
     @Override


### PR DESCRIPTION
#### Description

Fix incorrect object index in onDevice bytecode generation. The system was using the OnDeviceObjectNode's ID instead of the wrapped ObjectNode's index, causing multiple objects to be processed with the same index. This resulted in redundant operations on the first object while subsequent objects were ignored.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
tornado-test --printBytecodes -V uk.ac.manchester.tornado.unittests.api.TestSharedBuffers#testMultipleSharedObjects

```

Expected output:

```bash 
Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@6aa3a905 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x3a0baae5] uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0, offset=0 [event list=-1]
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x4f25b795] uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0, offset=0 [event list=-1]
bc:  LAUNCH  task s0.t0 - add on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  DEALLOC [0x6aa3a905] uk.ac.manchester.tornado.api.types.arrays.IntArray@6aa3a905 [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  BARRIER  event-list 3
bc:  END
 

Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ON_DEVICE_BUFFER [0x3a0baae5] uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  ON_DEVICE_BUFFER [0x4f25b795] uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  LAUNCH  task s1.t1 - add on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x59b38691] uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, sizeBatch=0, offset=0 [event list=1]
bc:  DEALLOC [0x3a0baae5] uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x4f25b795] uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x59b38691] uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  END

```
----------------------------------------------------------------------------
