### PR TITLE
[release] TornadoVM 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TornadoVM
 
-![TornadoVM version](https://img.shields.io/badge/version-1.0.10-purple)  [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2) [![License: GPL v2](https://img.shields.io/badge/License-GPL%20V2%20Classpth%20Exeception-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
+![TornadoVM version](https://img.shields.io/badge/version-1.1.0-purple)  [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)  [![License: Apache 2](https://img.shields.io/badge/License-Apache%202.0-red.svg)](https://github.com/beehive-lab/TornadoVM/blob/master/LICENSE_APACHE2) [![License: GPL v2](https://img.shields.io/badge/License-GPL%20V2%20Classpth%20Exeception-blue.svg)](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html)
 
 <img align="left" width="250" height="250" src="etc/tornadoVM_Logo.jpg">
 
@@ -20,7 +20,7 @@ Developers can choose which backends to install and run.
 
 For a quick introduction please read the following [FAQ](https://tornadovm.readthedocs.io/en/latest/).
 
-**Latest Release:** TornadoVM 1.0.10 - 31/01/2025 :
+**Latest Release:** TornadoVM 1.1.0 - 31/03/2025 :
 See [CHANGELOG](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html).
 
 ----------------------
@@ -261,12 +261,12 @@ You can import the TornadoVM API by setting this the following dependency in the
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.0.10</version>
+    <version>1.1.0</version>
 </dependency>
 <dependency>
     <groupId>tornado</groupId>
     <artifactId>tornado-matrices</artifactId>
-    <version>1.0.10</version>
+    <version>1.1.0</version>
 </dependency>
 </dependencies>
 ```

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -36,7 +36,7 @@ import installer_config as config
 ## Configuration
 ## ################################################################
 __DIRECTORY_DEPENDENCIES__ = os.path.join("etc", "dependencies")
-__VERSION__ = "v1.1.0-dev"
+__VERSION__ = "v1.1.0"
 
 __SUPPORTED_JDKS__ = [
     config.__JDK21__,

--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -5,6 +5,50 @@ TornadoVM Changelog
 
 This file summarizes the new features and major changes for each *TornadoVM* version.
 
+
+TornadoVM 1.1.0
+---------------
+31/03/25
+
+Improvements
+~~~~~~~~~~~~
+
+- `#620 <https://github.com/beehive-lab/TornadoVM/pull/620>`_: Support of computation with mixed precision ``FP16`` to  ``FP32`` for matrix operations.
+- `#622 <https://github.com/beehive-lab/TornadoVM/pull/622>`_: New API to allow buffer mapping between two different buffers on the hardware accelerator.
+- `#624 <https://github.com/beehive-lab/TornadoVM/pull/624>`_: Enhanced TornadoVM profiler with correct information for the ``UNDER_DEMAND`` transfer to host data. 
+- `#627 <https://github.com/beehive-lab/TornadoVM/pull/627>`_: New feature to persist data on the hardware accelerator, and consume data already allocated on the hardware accelerator.
+- `#630 <https://github.com/beehive-lab/TornadoVM/pull/630>`_: Support for atomics using the kernel API for OpenCL and PTX backends. 
+- `#636 <https://github.com/beehive-lab/TornadoVM/pull/636>`_: TornadoVM bytecode logging improved. 
+- `#642 <https://github.com/beehive-lab/TornadoVM/pull/642>`_: Math functions extended: ``acosh`` and ``asinh`` supported for OpenCL and SPIR-V.
+- `#645 <https://github.com/beehive-lab/TornadoVM/pull/645>`_: Memory deallocations improved. Action by default when closing the ``TornadoExecutionPlan`` resource.
+
+
+Compatibility
+~~~~~~~~~~~~
+
+- `#625 <https://github.com/beehive-lab/TornadoVM/pull/625>`_: Documentation to build on RISC-V updated.
+- `#632 <https://github.com/beehive-lab/TornadoVM/pull/632>`_: Add maven build with Single thread.
+- `#633 <https://github.com/beehive-lab/TornadoVM/pull/633>`_: Add tests for running multiple task graphs with different grid schedulers. 
+- `#638 <https://github.com/beehive-lab/TornadoVM/pull/638>`_: Add tests to check force copy in buffers and persist buffers on the hardware accelerator.
+- `#640 <https://github.com/beehive-lab/TornadoVM/pull/640>`_: Rename XPUFuffer to FieldBuffer for all backends.
+- `#649 <https://github.com/beehive-lab/TornadoVM/pull/649>`_: Update the fast mode to live mode for testing.
+- `#654 <https://github.com/beehive-lab/TornadoVM/pull/654>`_: Add loop condition test in white list.
+
+
+Bug Fixes 
+~~~~~~~~~~~~
+
+- `#626 <https://github.com/beehive-lab/TornadoVM/pull/626>`_: Fix data accessors when using the ``UNDER_DEMAND`` transfer to host innovation from the task-graph. 
+- `#628 <https://github.com/beehive-lab/TornadoVM/pull/628>`_: Device filtering API fixed to use device type and device names. 
+- `#635 <https://github.com/beehive-lab/TornadoVM/pull/635>`_: Update nodes for local memory to be subtype of ``ValueNode`` instead of ``ConstantNode`` in the TornadoVM IR.
+- `#639 <https://github.com/beehive-lab/TornadoVM/pull/639>`_: Fix subgraph execution when combining with the ``GridScheduler``.
+- `#644 <https://github.com/beehive-lab/TornadoVM/pull/644>`_: Fix TornadoVM execution frame setter.
+- `#646 <https://github.com/beehive-lab/TornadoVM/pull/646>`_: Fix shared memory buffers across task-graphs when no new allocation is present as new parameters for the following task-graphs.
+- `#647 <https://github.com/beehive-lab/TornadoVM/pull/647>`_: Fix ``UNDER_DEMAND`` invocation for the batch processor mode and read-write arrays.
+- `#651 <https://github.com/beehive-lab/TornadoVM/pull/651>`_: Fix memory mapping regions for the PTX Backend.
+- `#653 <https://github.com/beehive-lab/TornadoVM/pull/653>`_: Object repetition with shared buffers on ``ON_DEVICE`` bytecodes.
+
+
 TornadoVM 1.0.10
 ---------------
 31/01/25

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,11 +3,11 @@
 # -- Project information
 
 project = "TornadoVM"
-copyright = "2013-2024, APT Group, Department of Computer Science"
+copyright = "2013-2025, APT Group, Department of Computer Science"
 author = "The University of Manchester"
 
-release = "v1.0.10"
-version = "v1.0.10"
+release = "v1.1.0"
+version = "v1.1.0"
 
 # -- General configuration
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -732,13 +732,13 @@ To use the TornadoVM API in your projects, you can checkout our maven repository
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>1.0.10</version>
+         <version>1.1.0</version>
       </dependency>
 
       <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>1.0.10</version>
+         <version>1.1.0</version>
       </dependency>
    </dependencies>
 
@@ -749,6 +749,7 @@ Notice that, for running with TornadoVM, you will need either the docker images 
 Versions available
 ==================
 
+* 1.1.0
 * 1.0.10
 * 1.0.9
 * 1.0.7

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>tornado</groupId>
     <artifactId>tornado</artifactId>
-    <version>1.1.0-dev</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
     <name>tornado</name>
     <url>https://github.com/beehive-lab/tornadovm</url>

--- a/tornado-annotation/pom.xml
+++ b/tornado-annotation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>tornado-annotation</artifactId>

--- a/tornado-api/pom.xml
+++ b/tornado-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>tornado</groupId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
 
     <groupId>tornado</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>1.1.0-dev</version>
+    <version>1.1.0</version>
 
     <name>tornado-api</name>
     <url>https://tornadovm.org</url>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-assembly</artifactId>
     <packaging>pom</packaging>

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -376,7 +376,7 @@ else:
 
 ENABLE_ASSERTIONS = "-ea "
 
-__VERSION__ = "1.1.0-dev"
+__VERSION__ = "1.1.0"
 
 try:
     javaHome = os.environ["JAVA_HOME"]

--- a/tornado-benchmarks/pom.xml
+++ b/tornado-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>tornado-benchmarks</artifactId>

--- a/tornado-drivers/drivers-common/pom.xml
+++ b/tornado-drivers/drivers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tornado-drivers/opencl-jni/pom.xml
+++ b/tornado-drivers/opencl-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-drivers-opencl-jni</artifactId>
     <name>tornado-drivers-opencl-jni</name>

--- a/tornado-drivers/opencl/pom.xml
+++ b/tornado-drivers/opencl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-drivers-opencl</artifactId>
     <name>tornado-drivers-opencl</name>

--- a/tornado-drivers/pom.xml
+++ b/tornado-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-drivers</artifactId>
     <name>tornado-drivers</name>

--- a/tornado-drivers/ptx-jni/pom.xml
+++ b/tornado-drivers/ptx-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-drivers-ptx-jni</artifactId>
     <name>tornado-drivers-ptx-jni</name>

--- a/tornado-drivers/ptx/pom.xml
+++ b/tornado-drivers/ptx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>tornado-drivers</artifactId>
         <groupId>tornado</groupId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-drivers-ptx</artifactId>
     <name>tornado-drivers-ptx</name>

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-drivers-spirv</artifactId>
     <name>tornado-drivers-spirv</name>

--- a/tornado-examples/pom.xml
+++ b/tornado-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-examples</artifactId>
     <name>tornado-examples</name>

--- a/tornado-matrices/pom.xml
+++ b/tornado-matrices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-matrices</artifactId>
     <name>tornado-matrices</name>

--- a/tornado-runtime/pom.xml
+++ b/tornado-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-runtime</artifactId>
     <name>tornado-runtime</name>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
-        <version>1.1.0-dev</version>
+        <version>1.1.0</version>
     </parent>
     <artifactId>tornado-unittests</artifactId>
     <name>tornado-unittests</name>


### PR DESCRIPTION
## Improvements

#620: Support of computation with mixed precision ``FP16`` to  ``FP32`` for matrix operations.
#622: New API to allow buffer mapping between two different buffers on the hardware accelerator.
#624: Enhanced TornadoVM profiler with correct information for the ``UNDER_DEMAND`` transfer to host data. 
#627: New feature to persist data on the hardware accelerator, and consume data already allocated on the hardware accelerator.
#630: Support for atomics using the kernel API for OpenCL and PTX backends. 
#636: TornadoVM bytecode logging improved. 
#642: Math functions extended: ``acosh`` and ``asinh`` supported for OpenCL and SPIR-V.
#645: Memory deallocations improved. Action by default when closing the ``TornadoExecutionPlan`` resource.


## Compatibility


#625: Documentation to build on RISC-V updated.
#632: Add maven build with Single thread.
#633: Add tests for running multiple task graphs with different grid schedulers. 
#638: Add tests to check force copy in buffers and persist buffers on the hardware accelerator.
#640: Rename XPUFuffer to FieldBuffer for all backends.
#649: Update the fast mode to live mode for testing.
#654: Add loop condition test in white list.


## Bug Fixes 

#626: Fix data accessors when using the ``UNDER_DEMAND`` transfer to host innovation from the task-graph. 
#628: Device filtering API fixed to use device type and device names. 
#635: Update nodes for local memory to be subtype of ``ValueNode`` instead of ``ConstantNode`` in the TornadoVM IR.
#639: Fix subgraph execution when combining with the ``GridScheduler``.
#644: Fix TornadoVM execution frame setter.
#646: Fix shared memory buffers across task-graphs when no new allocation is present as new parameters for the following task-graphs.
#647: Fix ``UNDER_DEMAND`` invocation for the batch processor mode and read-write arrays.
#651: Fix memory mapping regions for the PTX Backend.
#653: Object repetition with shared buffers on ``ON_DEVICE`` bytecodes.
