### PR TITLE
Optimize number of batch allocations

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/DeviceBufferState.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/DeviceBufferState.java
@@ -39,4 +39,8 @@ public interface DeviceBufferState {
 
     long getPartialCopySize();
 
+    boolean isBufferReused();
+
+    void markBufferAsReused();
+
 }

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/TornadoBufferProvider.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/TornadoBufferProvider.java
@@ -22,6 +22,7 @@
  */
 package uk.ac.manchester.tornado.drivers.common;
 
+import static uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray.ARRAY_HEADER;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.DEVICE_AVAILABLE_MEMORY;
 
 import java.util.ArrayList;
@@ -71,6 +72,18 @@ public abstract class TornadoBufferProvider {
         return bufferAccesses;
     }
 
+    /**
+     * This function is invoked before the allocation with batch processing takes place.
+     * It iterates over the list of used buffers, and if a buffer with the same
+     * access type and size has already been allocated, it returns true to signify that
+     * this buffer can be reused for this batch. Otherwise, it returns false.
+     *
+     * @param batchSize The size of the current batch
+     * @param access The access type of the object (READ-ONLY, WRITE-ONLY, READ-WRITE)
+     * @param numberOfBuffersForAccessType The number of buffers that are required to be allocated for this access type
+     *
+     * @return True if a buffer to reuse is available, or false otherwise.
+     */
     public boolean reuseBufferForBatchProcessing(long batchSize, Access access, int numberOfBuffersForAccessType) {
         boolean matchFound = false;
         if (!usedBuffers.get(access).isEmpty()) {
@@ -79,7 +92,7 @@ public abstract class TornadoBufferProvider {
                     return false;
                 }
                 long size = bufferContainer.size;
-                matchFound = (size == batchSize + 24);
+                matchFound = (size == batchSize + ARRAY_HEADER);
                 if (matchFound) {
                     logger.debug("Reuse buffer %s from the used-list for batch processing. Batch Size = %s, Access = %s %n", bufferContainer, batchSize, access);
                 }

--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/TornadoBufferProvider.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/TornadoBufferProvider.java
@@ -71,6 +71,23 @@ public abstract class TornadoBufferProvider {
         return bufferAccesses;
     }
 
+    public boolean reuseBufferForBatchProcessing(long batchSize, Access access, int numberOfBuffersForAccessType) {
+        boolean matchFound = false;
+        if (!usedBuffers.get(access).isEmpty()) {
+            for (BufferContainer bufferContainer : usedBuffers.get(access)) {
+                if (usedBuffers.get(access).size() < numberOfBuffersForAccessType) {
+                    return false;
+                }
+                long size = bufferContainer.size;
+                matchFound = (size == batchSize + 24);
+                if (matchFound) {
+                    logger.debug("Reuse buffer %s from the used-list for batch processing. Batch Size = %s, Access = %s %n", bufferContainer, batchSize, access);
+                }
+            }
+        }
+        return matchFound;
+    }
+
     protected abstract long allocateBuffer(long size, Access access);
 
     protected abstract void releaseBuffer(long buffer);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -587,8 +587,17 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         }
         long allocatedSpace = 0L;
         for (int i = 0; i < objects.length; i++) {
-            logger.debug("Allocate object %s with access: %s", objects[i], accesses[i]);
-            allocatedSpace += allocate(objects[i], batchSize, states[i], accesses[i]);
+            if (batchSize != 0 ) {
+                int numberOfBuffersForAccessType = distinctAccesses.get(accesses[i]);
+                // if there are no buffers available in the used-list to reuse, allocate new ones
+                if (!bufferProvider.reuseBufferForBatchProcessing(batchSize, accesses[i], numberOfBuffersForAccessType)) {
+                    logger.debug("Allocate object %s with access: %s", objects[i], accesses[i]);
+                    allocatedSpace += allocate(objects[i], batchSize, states[i], accesses[i]);
+                }
+            } else {
+                logger.debug("Allocate object %s with access: %s", objects[i], accesses[i]);
+                allocatedSpace += allocate(objects[i], batchSize, states[i], accesses[i]);
+            }
         }
         return allocatedSpace;
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -585,21 +585,28 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
                 bufferProvider.resetBuffers(access);
             }
         }
+
         long allocatedSpace = 0L;
         for (int i = 0; i < objects.length; i++) {
-            if (batchSize != 0 ) {
-                int numberOfBuffersForAccessType = distinctAccesses.get(accesses[i]);
-                // if there are no buffers available in the used-list to reuse, allocate new ones
-                if (!bufferProvider.reuseBufferForBatchProcessing(batchSize, accesses[i], numberOfBuffersForAccessType)) {
-                    logger.debug("Allocate object %s with access: %s", objects[i], accesses[i]);
-                    allocatedSpace += allocate(objects[i], batchSize, states[i], accesses[i]);
-                }
-            } else {
+            if (!reuseBatchBuffer(batchSize, accesses[i], bufferProvider, distinctAccesses, states[i])) {
                 logger.debug("Allocate object %s with access: %s", objects[i], accesses[i]);
                 allocatedSpace += allocate(objects[i], batchSize, states[i], accesses[i]);
             }
+
         }
         return allocatedSpace;
+    }
+
+    private boolean reuseBatchBuffer(long batchSize, Access access, TornadoBufferProvider bufferProvider, HashMap<Access, Integer> distinctAccesses, DeviceBufferState state) {
+        if (batchSize != 0) {
+            int numberOfBuffersForAccessType = distinctAccesses.get(access);
+            // if there is a buffer available in the used-list with the same access type, reuse it
+            if (bufferProvider.reuseBufferForBatchProcessing(batchSize, access, numberOfBuffersForAccessType)) {
+                state.markBufferAsReused();
+                return true;
+            }
+        }
+        return false;
     }
 
     private XPUBuffer newDeviceBufferAllocation(Object object, long batchSize, DeviceBufferState deviceObjectState, Access access) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -30,6 +30,7 @@ import java.lang.foreign.MemorySegment;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -287,9 +288,24 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
         return result;
     }
 
+    private HashMap<Access, Integer> getNumOfDistinctAccess(Access[] accesses) {
+        HashMap<Access, Integer> distinctAccesses = new HashMap<>();
+        for (Access access : accesses) {
+            if (distinctAccesses.containsKey(access)) {
+                int numOfAccesses = distinctAccesses.get(access);
+                distinctAccesses.replace(access, numOfAccesses, numOfAccesses + 1);
+            } else {
+                distinctAccesses.put(access, 1);
+            }
+        }
+        return distinctAccesses;
+    }
+
     @Override
     public synchronized long allocateObjects(Object[] objects, long batchSize, DeviceBufferState[] states, Access[] accesses) {
         TornadoBufferProvider bufferProvider = getDeviceContext().getBufferProvider();
+        HashMap<Access, Integer> distinctAccesses = getNumOfDistinctAccess(accesses);
+
         for (Access access : accesses) {
             if (!bufferProvider.isNumFreeBuffersAvailable(objects.length, access)) {
                 bufferProvider.resetBuffers(access);
@@ -297,8 +313,17 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
         }
         long allocatedSpace = 0;
         for (int i = 0; i < objects.length; i++) {
-            logger.debug("Allocate object %s with access: %s", objects[i], accesses[i]);
-            allocatedSpace += allocate(objects[i], batchSize, states[i], accesses[i]);
+            if (batchSize != 0 ) {
+                int numberOfBuffersForAccessType = distinctAccesses.get(accesses[i]);
+                // if there are no buffers available in the used-list to reuse, allocate new ones
+                if (!bufferProvider.reuseBufferForBatchProcessing(batchSize, accesses[i], numberOfBuffersForAccessType)) {
+                    logger.debug("Allocate object %s with access: %s", objects[i], accesses[i]);
+                    allocatedSpace += allocate(objects[i], batchSize, states[i], accesses[i]);
+                }
+            } else {
+                logger.debug("Allocate object %s with access: %s", objects[i], accesses[i]);
+                allocatedSpace += allocate(objects[i], batchSize, states[i], accesses[i]);
+            }
         }
         return allocatedSpace;
     }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/runtime/SPIRVTornadoDevice.java
@@ -335,19 +335,24 @@ public class SPIRVTornadoDevice implements TornadoXPUDevice {
         }
         long allocatedSpace = 0;
         for (int i = 0; i < objects.length; i++) {
-            if (batchSize != 0 ) {
-                int numberOfBuffersForAccessType = distinctAccesses.get(accesses[i]);
-                // if there are no buffers available in the used-list to reuse, allocate new ones
-                if (!bufferProvider.reuseBufferForBatchProcessing(batchSize, accesses[i], numberOfBuffersForAccessType)) {
-                    logger.debug("Allocate object %s with access: %s", objects[i], accesses[i]);
-                    allocatedSpace += allocate(objects[i], batchSize, states[i], accesses[i]);
-                }
-            } else {
+            if (!reuseBatchBuffer(batchSize, accesses[i], bufferProvider, distinctAccesses)) {
                 logger.debug("Allocate object %s with access: %s", objects[i], accesses[i]);
                 allocatedSpace += allocate(objects[i], batchSize, states[i], accesses[i]);
             }
+
         }
         return allocatedSpace;
+    }
+
+    private boolean reuseBatchBuffer(long batchSize, Access access, TornadoBufferProvider bufferProvider, HashMap<Access, Integer> distinctAccesses) {
+        if (batchSize != 0) {
+            int numberOfBuffersForAccessType = distinctAccesses.get(access);
+            // if there is a buffer available in the used-list with the same access type, reuse it
+            if (bufferProvider.reuseBufferForBatchProcessing(batchSize, access, numberOfBuffersForAccessType)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private XPUBuffer createNewBufferAllocation(Object object, long batchSize, DeviceBufferState state, Access access) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/XPUDeviceBufferState.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/XPUDeviceBufferState.java
@@ -36,6 +36,7 @@ public class XPUDeviceBufferState implements DeviceBufferState {
     private boolean bufferHasContent;
     private boolean lockBuffer;
     private long partialSize;
+    private boolean reuseBuffer = false;
 
     @Override
     public void setXPUBuffer(XPUBuffer value) {
@@ -106,6 +107,16 @@ public class XPUDeviceBufferState implements DeviceBufferState {
     @Override
     public long getPartialCopySize() {
         return this.partialSize;
+    }
+
+    @Override
+    public boolean isBufferReused() {
+        return reuseBuffer;
+    }
+
+    @Override
+    public void markBufferAsReused() {
+        reuseBuffer = true;
     }
 
     public XPUDeviceBufferState createSnapshot() {


### PR DESCRIPTION
#### Description

Currently,  TornadoVM performs an allocation and deallocation for every batch of the input data. This PR proposes reusing the buffers that are allocated after the first allocation for all the batches of the same size that will follow and deallocating when the final batch of said size concludes. If the batches are not even, there is a final allocation-deallocation sequence for the remaining batch, as in develop. Below is an example of the bytecodes generated for the unittest `uk.ac.manchester.tornado.unittests.batches.TestBatches#test300MB` in develop and in the current PR. 

== develop
```
Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=0 [event list=-1]
bc:  LAUNCH  task s0.t0 - compute on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU, numThreadBatch=75000000, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=0 [event list=1]
bc:  DEALLOC [0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  DEALLOC [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=300000000 [event list=-1]
bc:  LAUNCH  task s0.t0 - compute on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU, numThreadBatch=75000000, offset=300000000 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=300000000 [event list=1]
bc:  DEALLOC [0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  DEALLOC [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=600000000 [event list=-1]
bc:  LAUNCH  task s0.t0 - compute on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU, numThreadBatch=75000000, offset=600000000 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=600000000 [event list=1]
bc:  DEALLOC [0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  DEALLOC [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=100000000, batchSize=100000000
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=100000000, batchSize=100000000
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=100000000, batchSize=100000000, offset=900000000 [event list=-1]
bc:  LAUNCH  task s0.t0 - compute on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU, numThreadBatch=25000000, offset=900000000 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=100000000, sizeBatch=100000000, offset=900000000 [event list=1]
bc:  DEALLOC [0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  DEALLOC [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  END
```

== this PR 
```
Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=0 [event list=-1]
bc:  LAUNCH  task s0.t0 - compute on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU, numThreadBatch=75000000, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=0 [event list=1]
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=300000000 [event list=-1]
bc:  LAUNCH  task s0.t0 - compute on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU, numThreadBatch=75000000, offset=300000000 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=300000000 [event list=1]
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=600000000 [event list=-1]
bc:  LAUNCH  task s0.t0 - compute on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU, numThreadBatch=75000000, offset=600000000 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=300000000, batchSize=300000000, offset=600000000 [event list=1]
bc:  DEALLOC [0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  DEALLOC [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=100000000, batchSize=100000000
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=100000000, batchSize=100000000
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=100000000, batchSize=100000000, offset=900000000 [event list=-1]
bc:  LAUNCH  task s0.t0 - compute on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU, numThreadBatch=25000000, offset=900000000 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU , size=100000000, sizeBatch=100000000, offset=900000000 [event list=1]
bc:  DEALLOC [0x5adb0db3] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5adb0db3 [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  DEALLOC [0x4879dfad] uk.ac.manchester.tornado.api.types.arrays.FloatArray@4879dfad [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4070 Laptop GPU 
bc:  END
```

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Run `tornado-test -V -pbc uk.ac.manchester.tornado.unittests.batches.TestBatches#test300MB`
