### PR TITLE
[riscv] Build patches for RISC-V fixed for v1.1.0

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -631,7 +631,7 @@ Then, download the script to apply the patch for the OpenCL backend:
 
 .. code:: bash
 
-   wget https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/748f71a1871f3bf839c8889a31c09c55f6969186/apply-riscv-patch.sh
+   wget https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/f91c67f43e4da14eb80b79e88441604d9c6ba829/apply-riscv-patch.sh
    bash apply-riscv-patch.sh 
 
 
@@ -642,7 +642,7 @@ If you want to enable both OpenCL and SPIR-V backends, use the following patch:
 
 .. code:: bash
 
-   wget https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/748f71a1871f3bf839c8889a31c09c55f6969186/apply-riscv-spirv-patch.sh
+   wget https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/f91c67f43e4da14eb80b79e88441604d9c6ba829/apply-riscv-spirv-patch.sh
    bash apply-riscv-spirv-patch.sh
 
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -642,7 +642,7 @@ If you want to enable both OpenCL and SPIR-V backends, use the following patch:
 
 .. code:: bash
 
-   wget https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/f91c67f43e4da14eb80b79e88441604d9c6ba829/apply-riscv-spirv-patch.sh
+   https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/8b96300b487d7aa510038022b9e9fa174d51b6b1/apply-riscv-spirv-patch.sh
    bash apply-riscv-spirv-patch.sh
 
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -631,7 +631,7 @@ Then, download the script to apply the patch for the OpenCL backend:
 
 .. code:: bash
 
-   wget https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/f91c67f43e4da14eb80b79e88441604d9c6ba829/apply-riscv-patch.sh
+   wget https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/ec4065b7e352ac4f5aeb990c7e44494a98af8daa/apply-riscv-patch.sh
    bash apply-riscv-patch.sh 
 
 
@@ -642,7 +642,7 @@ If you want to enable both OpenCL and SPIR-V backends, use the following patch:
 
 .. code:: bash
 
-   https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/8b96300b487d7aa510038022b9e9fa174d51b6b1/apply-riscv-spirv-patch.sh
+   https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/ec4065b7e352ac4f5aeb990c7e44494a98af8daa/apply-riscv-spirv-patch.sh
    bash apply-riscv-spirv-patch.sh
 
 


### PR DESCRIPTION
#### Description

With every new version of TornadoVM we need to update the links for the RISC-V patch installer. This PR provides the updated links. 

#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
$ wget https://gist.githubusercontent.com/jjfumero/c191f7e69a653c4f59f238d5856201aa/raw/f91c67f43e4da14eb80b79e88441604d9c6ba829/apply-riscv-patch.sh

$ bash apply-riscv-patch.sh
```
