### PR TITLE
Support for updating object state from directly from the last executed task-graph 

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -223,20 +223,8 @@ public class ImmutableTaskGraph {
         taskGraph.mapOnDeviceMemoryRegion(destArray, srcArray, offset, taskGraphSrc.taskGraph.taskGraphImpl);
     }
 
-    void updatePersistedObjectState(ImmutableTaskGraph taskGraphSrc) {
-        taskGraph.updatePersistedObjectState(taskGraphSrc.taskGraph.taskGraphImpl);
-    }
-
     void setLastExecutedTaskGraph(ImmutableTaskGraph lastExecutedTaskGraph) {
         taskGraph.setLastExecutedTaskGraph(lastExecutedTaskGraph.taskGraph.taskGraphImpl);
-    }
-
-    String getLastExecutedTaskGraphName() {
-        if (taskGraph.getLastExecutedTask() != null) {
-            return taskGraph.getLastExecutedTask().getTaskGraphName();
-        } else {
-            return taskGraph.getTaskGraphName();
-        }
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -235,9 +235,8 @@ public class ImmutableTaskGraph {
         if (taskGraph.getLastExecutedTask() != null) {
             return taskGraph.getLastExecutedTask().getTaskGraphName();
         } else {
-            return "First executed task is this ";
+            return taskGraph.getTaskGraphName();
         }
-
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -24,6 +24,7 @@ import uk.ac.manchester.tornado.api.enums.ProfilerMode;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
 
+
 /**
  * A {@link TaskGraph} is encapsulated in this class and all actions over a task
  * graph are coded from this class. For instance, execution.
@@ -224,6 +225,19 @@ public class ImmutableTaskGraph {
 
     void updatePersistedObjectState(ImmutableTaskGraph taskGraphSrc) {
         taskGraph.updatePersistedObjectState(taskGraphSrc.taskGraph.taskGraphImpl);
+    }
+
+    void setLastExecutedTaskGraph(ImmutableTaskGraph lastExecutedTaskGraph) {
+        taskGraph.setLastExecutedTaskGraph(lastExecutedTaskGraph.taskGraph.taskGraphImpl);
+    }
+
+    String getLastExecutedTaskGraphName() {
+        if (taskGraph.getLastExecutedTask() != null) {
+            return taskGraph.getLastExecutedTask().getTaskGraphName();
+        } else {
+            return "First executed task is this ";
+        }
+
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -703,12 +703,11 @@ public class TaskGraph implements TaskGraphInterface {
         return this;
     }
 
-//    @Override
-//    public TaskGraph consumeFromDevice(Object... objects) {
-//        taskGraphImpl.consumeFromDevice(objects);
-//        return this;
-//    }
-
+    @Override
+    public TaskGraph consumeFromDevice(Object... objects) {
+        taskGraphImpl.consumeFromDevice(this.taskGraphName, objects);
+        return this;
+    }
 
     /**
      * Tag a set of objects (Java objects) to be transferred from the device to the

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -951,10 +951,6 @@ public class TaskGraph implements TaskGraphInterface {
         taskGraphImpl.mapOnDeviceMemoryRegion(destArray, srcArray, offset, taskGraphSrc);
     }
 
-    void updatePersistedObjectState(TornadoTaskGraphInterface taskGraphSrc) {
-        taskGraphImpl.updatePersistedObjectState(taskGraphSrc);
-    }
-
     void setLastExecutedTaskGraph(TornadoTaskGraphInterface lastExecutedTaskGraph) {
         taskGraphImpl.setLastExecutedTaskGraph(lastExecutedTaskGraph);
     }
@@ -966,9 +962,4 @@ public class TaskGraph implements TaskGraphInterface {
     TornadoTaskGraphInterface getTaskGraphImpl() {
         return taskGraphImpl;
     }
-
-    TornadoTaskGraphInterface getLastExecutedTask() {
-        return taskGraphImpl.getLastExecutedTaskGraph();
-    }
-
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -703,6 +703,13 @@ public class TaskGraph implements TaskGraphInterface {
         return this;
     }
 
+    @Override
+    public TaskGraph consumeFromDevice(Object... objects) {
+        taskGraphImpl.consumeFromDevice(objects);
+        return this;
+    }
+
+
     /**
      * Tag a set of objects (Java objects) to be transferred from the device to the
      * host after the execution completes. There are two modes:

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -956,12 +956,20 @@ public class TaskGraph implements TaskGraphInterface {
         taskGraphImpl.updatePersistedObjectState(taskGraphSrc);
     }
 
+    void setLastExecutedTaskGraph(TornadoTaskGraphInterface lastExecutedTaskGraph) {
+        taskGraphImpl.setLastExecutedTaskGraph(lastExecutedTaskGraph);
+    }
+
     public Collection<?> getOutputs() {
         return taskGraphImpl.getOutputs();
     }
 
     TornadoTaskGraphInterface getTaskGraphImpl() {
         return taskGraphImpl;
+    }
+
+    TornadoTaskGraphInterface getLastExecutedTask() {
+        return taskGraphImpl.getLastExecutedTaskGraph();
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -703,11 +703,11 @@ public class TaskGraph implements TaskGraphInterface {
         return this;
     }
 
-    @Override
-    public TaskGraph consumeFromDevice(Object... objects) {
-        taskGraphImpl.consumeFromDevice(objects);
-        return this;
-    }
+//    @Override
+//    public TaskGraph consumeFromDevice(Object... objects) {
+//        taskGraphImpl.consumeFromDevice(objects);
+//        return this;
+//    }
 
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
@@ -522,6 +522,8 @@ public interface TaskGraphInterface {
 
     TaskGraph consumeFromDevice(String uniqueTaskGraphName, Object... objects);
 
+    TaskGraph consumeFromDevice(Object... objects);
+
     /**
      * Tag a set of objects (Java objects) to be transferred from the device to the
      * host after the execution completes. There are two modes:

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
@@ -522,7 +522,7 @@ public interface TaskGraphInterface {
 
     TaskGraph consumeFromDevice(String uniqueTaskGraphName, Object... objects);
 
-//    TaskGraph consumeFromDevice(Object... objects);
+    TaskGraph consumeFromDevice(Object... objects);
 
     /**
      * Tag a set of objects (Java objects) to be transferred from the device to the

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
@@ -522,7 +522,7 @@ public interface TaskGraphInterface {
 
     TaskGraph consumeFromDevice(String uniqueTaskGraphName, Object... objects);
 
-    TaskGraph consumeFromDevice(Object... objects);
+//    TaskGraph consumeFromDevice(Object... objects);
 
     /**
      * Tag a set of objects (Java objects) to be transferred from the device to the

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -124,6 +124,7 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      *     The list of the immutable task-graphs in the {@code TornadoExecutionPlan}
      */
     private void updateAccess(ImmutableTaskGraph... immutableTaskGraphs) {
+        System.out.println("CCC UPDATE ACCESS!!");
         if (immutableTaskGraphs.length > 1) {
             for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphs) {
                 TaskGraph taskGraph = immutableTaskGraph.getTaskGraph();

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -124,7 +124,6 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      *     The list of the immutable task-graphs in the {@code TornadoExecutionPlan}
      */
     private void updateAccess(ImmutableTaskGraph... immutableTaskGraphs) {
-        System.out.println("CCC UPDATE ACCESS!!");
         if (immutableTaskGraphs.length > 1) {
             for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphs) {
                 TaskGraph taskGraph = immutableTaskGraph.getTaskGraph();
@@ -182,6 +181,7 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
         TornadoProfilerResult profilerResult = new TornadoProfilerResult(tornadoExecutor, this.getTraceExecutionPlan());
         TornadoExecutionResult executionResult = new TornadoExecutionResult(profilerResult);
         planResults.add(executionResult);
+        tornadoExecutor.updateLastExecutedTaskGraph();
         return executionResult;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -229,11 +229,24 @@ class TornadoExecutor {
             subgraphList = new ArrayList<>();
             immutableTaskGraphList.forEach(g -> Collections.addAll(subgraphList, g));
         }
+        // Validate that the graphIndex is within bounds of subgraphList
+        System.out.println("S-pre " + subgraphList.get(graphIndex).getLastExecutedTaskGraphName());
+        setLastExecutedGraph(subgraphList.get(graphIndex));
+
         processPersistentStates(graphIndex);
         immutableTaskGraphList.clear();
         Collections.addAll(immutableTaskGraphList, subgraphList.get(graphIndex));
+
+        System.out.println("S-after " + subgraphList.get(graphIndex).getLastExecutedTaskGraphName());
     }
 
+    private void setLastExecutedGraph(ImmutableTaskGraph  lastExecutedGraph) {
+        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.setLastExecutedTaskGraph(lastExecutedGraph));
+
+    }
+//    private void setLastExecutedGraph(int graphIndex) {
+//        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.setLastExecutedTaskGraph(getGraph(graphIndex)));
+//    }
     /**
      * Processes the persistent states of a specified subgraph.
      *

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -230,14 +230,14 @@ class TornadoExecutor {
             immutableTaskGraphList.forEach(g -> Collections.addAll(subgraphList, g));
         }
         // Validate that the graphIndex is within bounds of subgraphList
-        System.out.println("S-pre " + subgraphList.get(graphIndex).getLastExecutedTaskGraphName());
+        System.out.println("S-pre " + subgraphList.get(graphIndex).getLastExecutedTaskGraphName() + " soize " + subgraphList.size());
         setLastExecutedGraph(subgraphList.get(graphIndex));
 
         processPersistentStates(graphIndex);
         immutableTaskGraphList.clear();
         Collections.addAll(immutableTaskGraphList, subgraphList.get(graphIndex));
 
-        System.out.println("S-after " + subgraphList.get(graphIndex).getLastExecutedTaskGraphName());
+        System.out.println("S-after " + subgraphList.get(graphIndex).getLastExecutedTaskGraphName()+ " soize " + subgraphList.size());
     }
 
     private void setLastExecutedGraph(ImmutableTaskGraph  lastExecutedGraph) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -262,24 +262,6 @@ class TornadoExecutor {
         }
     }
 
-    private ImmutableTaskGraph getGraphByName(String uniqueName) {
-        // First try to find in subgraphList if it exists
-        if (subgraphList != null) {
-            for (ImmutableTaskGraph immutableTaskGraph : subgraphList) {
-                if (immutableTaskGraph.getTaskGraph().getTaskGraphName().equals(uniqueName)) {
-                    return immutableTaskGraph;
-                }
-            }
-        }
-        // Fallback to immutableTaskGraphList
-        for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {
-            if (immutableTaskGraph.getTaskGraph().getTaskGraphName().equals(uniqueName)) {
-                return immutableTaskGraph;
-            }
-        }
-        throw new TornadoRuntimeException("TaskGraph with name " + uniqueName + " does not exist in current executor");
-    }
-
     void selectAll() {
         if (subgraphList == null) {
             return;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -40,6 +40,8 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void setDevice(TornadoDevice device);
 
+    void updatePersistedObjectState();
+
     void setDevice(String taskName, TornadoDevice device);
 
     TornadoDevice getDeviceForTask(String id);
@@ -136,12 +138,8 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void mapOnDeviceMemoryRegion(Object destArray, Object srcArray, long offset, TornadoTaskGraphInterface taskGraphSrc);
 
-    void updatePersistedObjectState(TornadoTaskGraphInterface taskGraphSrc);
-
     void updateObjectAccess();
 
     void setLastExecutedTaskGraph(TornadoTaskGraphInterface lastExecutedTaskGraph);
-
-    TornadoTaskGraphInterface getLastExecutedTaskGraph();
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -76,6 +76,8 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void consumeFromDevice(String uniqueTaskGraphName, Object... objects);
 
+    void consumeFromDevice(Object... objects);
+
     void dump();
 
     void warmup(ExecutorFrame executionPackage);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -140,4 +140,8 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void updateObjectAccess();
 
+    void setLastExecutedTaskGraph(TornadoTaskGraphInterface lastExecutedTaskGraph);
+
+    TornadoTaskGraphInterface getLastExecutedTaskGraph();
+
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -76,7 +76,7 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void consumeFromDevice(String uniqueTaskGraphName, Object... objects);
 
-//    void consumeFromDevice(Object... objects);
+    void consumeFromDevice(Object... objects);
 
     void dump();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -76,7 +76,7 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void consumeFromDevice(String uniqueTaskGraphName, Object... objects);
 
-    void consumeFromDevice(Object... objects);
+//    void consumeFromDevice(Object... objects);
 
     void dump();
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -61,7 +61,6 @@ import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.Policy;
 import uk.ac.manchester.tornado.api.TaskGraph;
-import uk.ac.manchester.tornado.api.TaskGraphInterface;
 import uk.ac.manchester.tornado.api.TornadoBackend;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoRuntime;
@@ -585,11 +584,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
-    public TornadoTaskGraphInterface getLastExecutedTaskGraph() {
-        return lastExecutedTaskGraph;
-    }
-
-    @Override
     public long getTotalBytesTransferred() {
         return getProfilerValue(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES) + getProfilerValue(TOTAL_COPY_OUT_SIZE_BYTES);
     }
@@ -666,20 +660,17 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
 
     @Override
-    public void updatePersistedObjectState(TornadoTaskGraphInterface taskGraphSrc) {
-        if (taskGraphSrc == null) {
+    public void updatePersistedObjectState() {
+        if (this.lastExecutedTaskGraph == null) {
+            //this indicates that this is the first task-graph executed
             return;
         }
-
+        
         TornadoTaskGraph graphSrc = (TornadoTaskGraph) this.lastExecutedTaskGraph;
         List<Object> objectsToSync = executionContext.getPersistedTaskToObjectsMap().get(graphSrc.taskGraphName);
 
         if (objectsToSync == null) {
             objectsToSync = executionContext.getPersistedObjects();
-//            for (Object object : objectsToSync) {
-//                System.out.println("Obj to sync " + object.toString());
-////                executionContext.addPersistedObject(this.taskGraphName, object);
-//            }
             executionContext.addPersistedObject(this.taskGraphName, objectsToSync);
         }
 
@@ -1667,7 +1658,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         // and other resources (e.g., Level Zero Command Lists).
         executionContext.setExecutionPlanId(executionPlanId);
 
-        updatePersistedObjectState(this.getLastExecutedTaskGraph());
+        updatePersistedObjectState();
 
         TornadoTaskGraphInterface reduceTaskGraph = null;
         if (TornadoOptions.EXPERIMENTAL_REDUCE && !(getId().startsWith(TASK_GRAPH_PREFIX))) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -658,14 +658,13 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         }
     }
 
-
     @Override
     public void updatePersistedObjectState() {
         if (this.lastExecutedTaskGraph == null) {
             //this indicates that this is the first task-graph executed
             return;
         }
-        
+
         TornadoTaskGraph graphSrc = (TornadoTaskGraph) this.lastExecutedTaskGraph;
         List<Object> objectsToSync = executionContext.getPersistedTaskToObjectsMap().get(graphSrc.taskGraphName);
 
@@ -1163,11 +1162,6 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             argumentsLookUp.add(parameter);
         }
     }
-
-    //    @Override
-//    public void consumeFromDevice(Object... objects) {
-//
-//    }
 
     private boolean isANumber(Object parameter) {
         return parameter instanceof Number;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -1135,10 +1135,10 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         }
     }
 
-    @Override
-    public void consumeFromDevice(Object... objects) {
-
-    }
+//    @Override
+//    public void consumeFromDevice(Object... objects) {
+//
+//    }
 
     private boolean isANumber(Object parameter) {
         return parameter instanceof Number;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -2002,7 +2002,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             }
         }
 
-        if ((policy == Policy.PERFORMANCE || policy == Policy.END_2_END) && (masterThreadID == java.lang.Thread.currentThread().getId())) {
+        if ((policy == Policy.PERFORMANCE || policy == Policy.END_2_END) && (masterThreadID == Thread.currentThread().getId())) {
             int deviceWinnerIndex = synchronizeWithPolicy(policy, totalTimers);
             policyTimeTable.put(policy, deviceWinnerIndex);
             if (DEBUG) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -61,6 +61,7 @@ import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.Policy;
 import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraphInterface;
 import uk.ac.manchester.tornado.api.TornadoBackend;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoRuntime;
@@ -175,9 +176,9 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     private List<TaskPackage> taskPackages;
     private List<Object> streamOutObjects;
     private List<Object> streamInObjects;
-    private List<Object> persistentObjects;
 
     private Map<TornadoTaskGraph, List<Object>> taskToPersistentObjectMap;
+    private TornadoTaskGraphInterface lastExecutedTaskGraph;
 
     private Set<Object> argumentsLookUp;
 
@@ -230,6 +231,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         inputModesObjects = new ArrayList<>();
         outputModeObjects = new ArrayList<>();
         taskToPersistentObjectMap = new HashMap<>();
+        lastExecutedTaskGraph = null;
     }
 
     static void performStreamInObject(TaskGraph task, Object inputObject, final int dataTransferMode) {
@@ -412,6 +414,8 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         newTaskGraph.outputModeObjects = Collections.unmodifiableList(this.outputModeObjects);
         newTaskGraph.taskToPersistentObjectMap = Collections.unmodifiableMap(this.taskToPersistentObjectMap);
 
+        newTaskGraph.lastExecutedTaskGraph = this.lastExecutedTaskGraph;
+
         newTaskGraph.streamOutObjects = Collections.unmodifiableList(this.streamOutObjects);
         newTaskGraph.hlBuffer = this.hlBuffer;
 
@@ -573,6 +577,16 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 }
             }
         }
+    }
+
+    @Override
+    public void setLastExecutedTaskGraph(TornadoTaskGraphInterface lastExecutedTaskGraph) {
+        this.lastExecutedTaskGraph = lastExecutedTaskGraph;
+    }
+
+    @Override
+    public TornadoTaskGraphInterface getLastExecutedTaskGraph() {
+        return lastExecutedTaskGraph;
     }
 
     @Override
@@ -1119,6 +1133,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
             argumentsLookUp.add(parameter);
         }
+    }
+
+    @Override
+    public void consumeFromDevice(Object... objects) {
+
     }
 
     private boolean isANumber(Object parameter) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
@@ -280,6 +280,48 @@ public class TestSharedBuffers extends TornadoTestBase {
     }
 
     @Test
+    public void testMultipleSharedObjectsEmptyConsume() throws TornadoExecutionPlanException {
+        IntArray a = new IntArray(numElements);
+        IntArray b = new IntArray(numElements);
+        IntArray c = new IntArray(numElements);
+        IntArray d = new IntArray(numElements);
+
+        a.init(10);
+        b.init(20);
+
+        // Create first task graph named "s0"
+        TaskGraph tg1 = new TaskGraph("s0") //
+                // Transfer arrays 'a' and 'b' to the device only on first execution
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                // Execute the add method (a + b = c)
+                .task("t0", TestHello::add, a, b, c) //
+                // Keep arrays 'a' and 'b' on the device memory for later use
+                .persistOnDevice(a, b);
+
+        // Create second task graph named "s1"
+        TaskGraph tg2 = new TaskGraph("s1") //
+                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
+                .consumeFromDevice(a, b) //
+                // Execute the add method (a + b = d), creating separate output in 'd'
+                .task("t1", TestHello::add, a, b, d) //
+                // Transfer results back to host memory after execution
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, d);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot())) {
+            // Execute the first graph (a + b = c)
+            executionPlan.withGraph(0).execute();
+
+            // Execute the second graph (a + b = d)
+            executionPlan.withGraph(1).execute();
+
+            // Verify results: for each element, check if value is 30
+            for (int i = 0; i < a.getSize(); i++) {
+                assertEquals(30, d.get(i)); // Expected: 10 + 20 = 30
+            }
+        }
+    }
+
+    @Test
     public void testThreeTaskGraphsWithSharedBuffers() throws TornadoExecutionPlanException {
         IntArray a = new IntArray(numElements);
         IntArray b = new IntArray(numElements);
@@ -315,6 +357,62 @@ public class TestSharedBuffers extends TornadoTestBase {
         TaskGraph tg3 = new TaskGraph("s2") //
                 // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
                 .consumeFromDevice("s1", r) //
+                // Execute the add method (a + b = d), creating separate output in 'd'
+                .task("t1", TestHello::add, r, r, r) //
+                // Transfer results back to host memory after execution
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, r);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot(), tg3.snapshot())) {
+            // Execute the first graph (a + b = c)
+            executionPlan.withGraph(0).execute();
+            // Execute the second graph (a + b = d)
+            executionPlan.withGraph(1).execute();
+            // Execute the second graph (a + b = d)
+            executionPlan.withGraph(2).execute();
+
+            // Verify results: for each element, check if value is 30
+            for (int i = 0; i < a.getSize(); i++) {
+                assertEquals(70, r.get(i)); // Expected: 35 + 35 = 70
+            }
+        }
+    }
+
+    @Test
+    public void testThreeTaskGraphsWithSharedBuffersEmptyConsume() throws TornadoExecutionPlanException {
+        IntArray a = new IntArray(numElements);
+        IntArray b = new IntArray(numElements);
+        IntArray c = new IntArray(numElements);
+        IntArray d = new IntArray(numElements);
+        IntArray r = new IntArray(numElements);
+
+        a.init(10);
+        b.init(20);
+        d.init(5);
+
+        // Create first task graph named "s0"
+        TaskGraph tg1 = new TaskGraph("s0") //
+                // Transfer arrays 'a' and 'b' to the device only on first execution
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                // Execute the add method (a + b = c)
+                .task("t0", TestHello::add, a, b, c) //
+                // Keep arrays 'a' and 'b' on the device memory for later use
+                .persistOnDevice(c);
+
+        // Create second task graph named "s1"
+        TaskGraph tg2 = new TaskGraph("s1") //
+                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
+                .consumeFromDevice(c) //
+                //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, d) //
+                // Execute the add method (a + b = d), creating separate output in 'd'
+                .task("t1", TestHello::add, c, d, r) //
+                // Transfer results back to host memory after execution
+                .persistOnDevice(r);
+
+        // Create third task graph named "s2"
+        TaskGraph tg3 = new TaskGraph("s2") //
+                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
+                .consumeFromDevice(r) //
                 // Execute the add method (a + b = d), creating separate output in 'd'
                 .task("t1", TestHello::add, r, r, r) //
                 // Transfer results back to host memory after execution
@@ -507,14 +605,17 @@ public class TestSharedBuffers extends TornadoTestBase {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c, sharedContext);
 
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot(), tg3.snapshot())) {
-            // Execute the first graph
-            executionPlan.withGraph(0).execute();
 
-            // Execute the second graph
-            executionPlan.withGraph(1).execute();
+            for (int i = 0; i < 20000; i++) {
+                executionPlan.withGraph(0).execute();
 
-            // Execute the third graph
-            executionPlan.withGraph(2).execute();
+                // Execute the second graph
+                executionPlan.withGraph(1).execute();
+
+                // Execute the third graph
+                executionPlan.withGraph(2).execute();
+
+            } // Execute the first graph
 
             // Add assertions based on expected values
             boolean hasNonZeroOutput = false;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
@@ -424,8 +425,9 @@ public class TestSharedBuffers extends TornadoTestBase {
             // Execute the second graph (a + b = d)
             executionPlan.withGraph(1).execute();
             // Execute the second graph (a + b = d)
-            executionPlan.withGraph(2).execute();
+            TornadoExecutionResult executionResult = executionPlan.withGraph(2).execute();
 
+            System.out.println(executionResult.isReady());
             // Verify results: for each element, check if value is 30
             for (int i = 0; i < a.getSize(); i++) {
                 assertEquals(70, r.get(i)); // Expected: 35 + 35 = 70
@@ -530,38 +532,6 @@ public class TestSharedBuffers extends TornadoTestBase {
         }
     }
 
-    /**
-     * Tests sharing a context buffer across multiple task graphs while processing data.
-     *
-     * <p>This test demonstrates how to maintain shared context state across three task graphs
-     * while performing data transformations. Key aspects demonstrated include:</p>
-     *
-     * <ul>
-     * <li>Initializing and passing a shared context buffer across multiple graphs</li>
-     * <li>Updating context state in each processing stage</li>
-     * <li>Using context values to influence data processing</li>
-     * <li>Proper persistence and consumption of both result and context buffers</li>
-     * </ul>
-     *
-     * <p><strong>Key Pattern:</strong> This test shows how to use a distinct buffer
-     * specifically for maintaining state/context across task graph executions, separate
-     * from the data being processed.</p>
-     *
-     * <p><strong>Implementation Notes:</strong></p>
-     * <ul>
-     * <li>The first graph only persists the result buffer but not the context</li>
-     * <li>The second graph must explicitly consume the result from the first graph</li>
-     * <li>The context is updated in each graph before being used in processing</li>
-     * <li>Both result and context are finally transferred back to host for verification</li>
-     * </ul>
-     *
-     * <p><strong>Common Pitfall:</strong> Forgetting to list a buffer in either
-     * {@code persistOnDevice()} or {@code consumeFromDevice()} will result in buffer
-     * unavailability or undefined behavior.</p>
-     *
-     * @throws TornadoExecutionPlanException
-     *     If execution of any task graph fails
-     */
     @Test
     public void testThreeTaskGraphsWithSharedContextBuffer() throws TornadoExecutionPlanException {
         IntArray a = new IntArray(numElements);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
@@ -280,47 +280,47 @@ public class TestSharedBuffers extends TornadoTestBase {
         }
     }
 
-//    @Test
-//    public void testMultipleSharedObjectsEmptyConsume() throws TornadoExecutionPlanException {
-//        IntArray a = new IntArray(numElements);
-//        IntArray b = new IntArray(numElements);
-//        IntArray c = new IntArray(numElements);
-//        IntArray d = new IntArray(numElements);
-//
-//        a.init(10);
-//        b.init(20);
-//
-//        // Create first task graph named "s0"
-//        TaskGraph tg1 = new TaskGraph("s0") //
-//                // Transfer arrays 'a' and 'b' to the device only on first execution
-//                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
-//                // Execute the add method (a + b = c)
-//                .task("t0", TestHello::add, a, b, c) //
-//                // Keep arrays 'a' and 'b' on the device memory for later use
-//                .persistOnDevice(a, b);
-//
-//        // Create second task graph named "s1"
-//        TaskGraph tg2 = new TaskGraph("s1") //
-//                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
-//                .consumeFromDevice(a, b) //
-//                // Execute the add method (a + b = d), creating separate output in 'd'
-//                .task("t1", TestHello::add, a, b, d) //
-//                // Transfer results back to host memory after execution
-//                .transferToHost(DataTransferMode.EVERY_EXECUTION, d);
-//
-//        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot())) {
-//            // Execute the first graph (a + b = c)
-//            executionPlan.withGraph(0).execute();
-//
-//            // Execute the second graph (a + b = d)
-//            executionPlan.withGraph(1).execute();
-//
-//            // Verify results: for each element, check if value is 30
-//            for (int i = 0; i < a.getSize(); i++) {
-//                assertEquals(30, d.get(i)); // Expected: 10 + 20 = 30
-//            }
-//        }
-//    }
+    //    @Test
+    //    public void testMultipleSharedObjectsEmptyConsume() throws TornadoExecutionPlanException {
+    //        IntArray a = new IntArray(numElements);
+    //        IntArray b = new IntArray(numElements);
+    //        IntArray c = new IntArray(numElements);
+    //        IntArray d = new IntArray(numElements);
+    //
+    //        a.init(10);
+    //        b.init(20);
+    //
+    //        // Create first task graph named "s0"
+    //        TaskGraph tg1 = new TaskGraph("s0") //
+    //                // Transfer arrays 'a' and 'b' to the device only on first execution
+    //                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+    //                // Execute the add method (a + b = c)
+    //                .task("t0", TestHello::add, a, b, c) //
+    //                // Keep arrays 'a' and 'b' on the device memory for later use
+    //                .persistOnDevice(a, b);
+    //
+    //        // Create second task graph named "s1"
+    //        TaskGraph tg2 = new TaskGraph("s1") //
+    //                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
+    //                .consumeFromDevice(a, b) //
+    //                // Execute the add method (a + b = d), creating separate output in 'd'
+    //                .task("t1", TestHello::add, a, b, d) //
+    //                // Transfer results back to host memory after execution
+    //                .transferToHost(DataTransferMode.EVERY_EXECUTION, d);
+    //
+    //        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot())) {
+    //            // Execute the first graph (a + b = c)
+    //            executionPlan.withGraph(0).execute();
+    //
+    //            // Execute the second graph (a + b = d)
+    //            executionPlan.withGraph(1).execute();
+    //
+    //            // Verify results: for each element, check if value is 30
+    //            for (int i = 0; i < a.getSize(); i++) {
+    //                assertEquals(30, d.get(i)); // Expected: 10 + 20 = 30
+    //            }
+    //        }
+    //    }
 
     @Test
     public void testThreeTaskGraphsWithSharedBuffers() throws TornadoExecutionPlanException {
@@ -378,95 +378,62 @@ public class TestSharedBuffers extends TornadoTestBase {
         }
     }
 
-//    @Test
-//    public void testThreeTaskGraphsWithSharedBuffersEmptyConsume() throws TornadoExecutionPlanException {
-//        IntArray a = new IntArray(numElements);
-//        IntArray b = new IntArray(numElements);
-//        IntArray c = new IntArray(numElements);
-//        IntArray d = new IntArray(numElements);
-//        IntArray r = new IntArray(numElements);
-//
-//        a.init(10);
-//        b.init(20);
-//        d.init(5);
-//
-//        // Create first task graph named "s0"
-//        TaskGraph tg1 = new TaskGraph("s0") //
-//                // Transfer arrays 'a' and 'b' to the device only on first execution
-//                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
-//                // Execute the add method (a + b = c)
-//                .task("t0", TestHello::add, a, b, c) //
-//                // Keep arrays 'a' and 'b' on the device memory for later use
-//                .persistOnDevice(c);
-//
-//        // Create second task graph named "s1"
-//        TaskGraph tg2 = new TaskGraph("s1") //
-//                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
-//                .consumeFromDevice(c) //
-//                //
-//                .transferToDevice(DataTransferMode.FIRST_EXECUTION, d) //
-//                // Execute the add method (a + b = d), creating separate output in 'd'
-//                .task("t1", TestHello::add, c, d, r) //
-//                // Transfer results back to host memory after execution
-//                .persistOnDevice(r);
-//
-//        // Create third task graph named "s2"
-//        TaskGraph tg3 = new TaskGraph("s2") //
-//                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
-//                .consumeFromDevice(r) //
-//                // Execute the add method (a + b = d), creating separate output in 'd'
-//                .task("t1", TestHello::add, r, r, r) //
-//                // Transfer results back to host memory after execution
-//                .transferToHost(DataTransferMode.EVERY_EXECUTION, r);
-//
-//        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot(), tg3.snapshot())) {
-//            // Execute the first graph (a + b = c)
-//            executionPlan.withGraph(0).execute();
-//            // Execute the second graph (a + b = d)
-//            executionPlan.withGraph(1).execute();
-//            // Execute the second graph (a + b = d)
-//            TornadoExecutionResult executionResult = executionPlan.withGraph(2).execute();
-//
-//            System.out.println(executionResult.isReady());
-//            // Verify results: for each element, check if value is 30
-//            for (int i = 0; i < a.getSize(); i++) {
-//                assertEquals(70, r.get(i)); // Expected: 35 + 35 = 70
-//            }
-//        }
-//    }
+    @Test
+    public void testThreeTaskGraphsWithSharedBuffersEmptyConsume() throws TornadoExecutionPlanException {
+        IntArray a = new IntArray(numElements);
+        IntArray b = new IntArray(numElements);
+        IntArray c = new IntArray(numElements);
+        IntArray d = new IntArray(numElements);
+        IntArray r = new IntArray(numElements);
 
-    /**
-     * Tests the persistence of buffers across multiple sequential task graphs with context state management.
-     *
-     * <p>This test demonstrates a four-stage processing pipeline where both intermediate result data and
-     * context state are maintained across task graph executions. It showcases:</p>
-     *
-     * <ul>
-     * <li>Data flow between consecutive task graphs using persistent buffers</li>
-     * <li>Context initialization, updating, and finalization across multiple graphs</li>
-     * <li>Proper pipeline execution with sequential dependencies</li>
-     * <li>The required "touch" operation before transferring results back to host</li>
-     * </ul>
-     *
-     * <p><strong>API Requirements:</strong></p>
-     * <ul>
-     * <li>Buffers must be explicitly marked with {@code persistOnDevice()} to remain accessible</li>
-     * <li>Consuming graphs must use {@code consumeFromDevice()} with the source graph's name</li>
-     * <li>All buffers being consumed must be listed explicitly in the consume call</li>
-     * <li>Graphs must be executed in dependency order</li>
-     * <li>A "touch" operation is required on output buffers before transfer to ensure proper copy-back</li>
-     * </ul>
-     *
-     * <p><strong>Limitations:</strong></p>
-     * <ul>
-     * <li>No automatic scheduling - execution order must match data dependencies</li>
-     * <li>No implicit persistence - all buffers to persist must be explicitly listed</li>
-     * <li>Graph names must be consistent between producer and consumer</li>
-     * </ul>
-     *
-     * @throws TornadoExecutionPlanException
-     *     If execution of any task graph fails
-     */
+        a.init(10);
+        b.init(20);
+        d.init(5);
+
+        // Create first task graph named "s0"
+        TaskGraph tg1 = new TaskGraph("s0") //
+                // Transfer arrays 'a' and 'b' to the device only on first execution
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                // Execute the add method (a + b = c)
+                .task("t0", TestHello::add, a, b, c) //
+                // Keep arrays 'a' and 'b' on the device memory for later use
+                .persistOnDevice(c);
+
+        // Create second task graph named "s1"
+        TaskGraph tg2 = new TaskGraph("s1") //
+                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
+                .consumeFromDevice(c) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, d) //
+                // Execute the add method (a + b = d), creating separate output in 'd'
+                .task("t1", TestHello::add, c, d, r) //
+                // Transfer results back to host memory after execution
+                .persistOnDevice(r);
+
+        // Create third task graph named "s2"
+        TaskGraph tg3 = new TaskGraph("s2") //
+                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
+                .consumeFromDevice(r) //
+                // Execute the add method (a + b = d), creating separate output in 'd'
+                .task("t1", TestHello::add, r, r, r) //
+                // Transfer results back to host memory after execution
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, r);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot(), tg3.snapshot())) {
+            // Execute the first graph (a + b = c)
+            executionPlan.withGraph(0).execute();
+            // Execute the second graph (a + b = d)
+            executionPlan.withGraph(1).execute();
+            // Execute the second graph (a + b = d)
+            TornadoExecutionResult executionResult = executionPlan.withGraph(2).execute();
+
+            System.out.println(executionResult.isReady());
+            // Verify results: for each element, check if value is 30
+            for (int i = 0; i < a.getSize(); i++) {
+                assertEquals(70, r.get(i)); // Expected: 35 + 35 = 70
+            }
+        }
+    }
+
     @Test
     public void testFourTaskGraphsWithPersistentBuffers() throws TornadoExecutionPlanException {
         // Smaller buffer size to make the example more focused

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
@@ -280,47 +280,47 @@ public class TestSharedBuffers extends TornadoTestBase {
         }
     }
 
-    @Test
-    public void testMultipleSharedObjectsEmptyConsume() throws TornadoExecutionPlanException {
-        IntArray a = new IntArray(numElements);
-        IntArray b = new IntArray(numElements);
-        IntArray c = new IntArray(numElements);
-        IntArray d = new IntArray(numElements);
-
-        a.init(10);
-        b.init(20);
-
-        // Create first task graph named "s0"
-        TaskGraph tg1 = new TaskGraph("s0") //
-                // Transfer arrays 'a' and 'b' to the device only on first execution
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
-                // Execute the add method (a + b = c)
-                .task("t0", TestHello::add, a, b, c) //
-                // Keep arrays 'a' and 'b' on the device memory for later use
-                .persistOnDevice(a, b);
-
-        // Create second task graph named "s1"
-        TaskGraph tg2 = new TaskGraph("s1") //
-                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
-                .consumeFromDevice(a, b) //
-                // Execute the add method (a + b = d), creating separate output in 'd'
-                .task("t1", TestHello::add, a, b, d) //
-                // Transfer results back to host memory after execution
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, d);
-
-        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot())) {
-            // Execute the first graph (a + b = c)
-            executionPlan.withGraph(0).execute();
-
-            // Execute the second graph (a + b = d)
-            executionPlan.withGraph(1).execute();
-
-            // Verify results: for each element, check if value is 30
-            for (int i = 0; i < a.getSize(); i++) {
-                assertEquals(30, d.get(i)); // Expected: 10 + 20 = 30
-            }
-        }
-    }
+//    @Test
+//    public void testMultipleSharedObjectsEmptyConsume() throws TornadoExecutionPlanException {
+//        IntArray a = new IntArray(numElements);
+//        IntArray b = new IntArray(numElements);
+//        IntArray c = new IntArray(numElements);
+//        IntArray d = new IntArray(numElements);
+//
+//        a.init(10);
+//        b.init(20);
+//
+//        // Create first task graph named "s0"
+//        TaskGraph tg1 = new TaskGraph("s0") //
+//                // Transfer arrays 'a' and 'b' to the device only on first execution
+//                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+//                // Execute the add method (a + b = c)
+//                .task("t0", TestHello::add, a, b, c) //
+//                // Keep arrays 'a' and 'b' on the device memory for later use
+//                .persistOnDevice(a, b);
+//
+//        // Create second task graph named "s1"
+//        TaskGraph tg2 = new TaskGraph("s1") //
+//                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
+//                .consumeFromDevice(a, b) //
+//                // Execute the add method (a + b = d), creating separate output in 'd'
+//                .task("t1", TestHello::add, a, b, d) //
+//                // Transfer results back to host memory after execution
+//                .transferToHost(DataTransferMode.EVERY_EXECUTION, d);
+//
+//        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot())) {
+//            // Execute the first graph (a + b = c)
+//            executionPlan.withGraph(0).execute();
+//
+//            // Execute the second graph (a + b = d)
+//            executionPlan.withGraph(1).execute();
+//
+//            // Verify results: for each element, check if value is 30
+//            for (int i = 0; i < a.getSize(); i++) {
+//                assertEquals(30, d.get(i)); // Expected: 10 + 20 = 30
+//            }
+//        }
+//    }
 
     @Test
     public void testThreeTaskGraphsWithSharedBuffers() throws TornadoExecutionPlanException {
@@ -378,62 +378,62 @@ public class TestSharedBuffers extends TornadoTestBase {
         }
     }
 
-    @Test
-    public void testThreeTaskGraphsWithSharedBuffersEmptyConsume() throws TornadoExecutionPlanException {
-        IntArray a = new IntArray(numElements);
-        IntArray b = new IntArray(numElements);
-        IntArray c = new IntArray(numElements);
-        IntArray d = new IntArray(numElements);
-        IntArray r = new IntArray(numElements);
-
-        a.init(10);
-        b.init(20);
-        d.init(5);
-
-        // Create first task graph named "s0"
-        TaskGraph tg1 = new TaskGraph("s0") //
-                // Transfer arrays 'a' and 'b' to the device only on first execution
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
-                // Execute the add method (a + b = c)
-                .task("t0", TestHello::add, a, b, c) //
-                // Keep arrays 'a' and 'b' on the device memory for later use
-                .persistOnDevice(c);
-
-        // Create second task graph named "s1"
-        TaskGraph tg2 = new TaskGraph("s1") //
-                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
-                .consumeFromDevice(c) //
-                //
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION, d) //
-                // Execute the add method (a + b = d), creating separate output in 'd'
-                .task("t1", TestHello::add, c, d, r) //
-                // Transfer results back to host memory after execution
-                .persistOnDevice(r);
-
-        // Create third task graph named "s2"
-        TaskGraph tg3 = new TaskGraph("s2") //
-                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
-                .consumeFromDevice(r) //
-                // Execute the add method (a + b = d), creating separate output in 'd'
-                .task("t1", TestHello::add, r, r, r) //
-                // Transfer results back to host memory after execution
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, r);
-
-        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot(), tg3.snapshot())) {
-            // Execute the first graph (a + b = c)
-            executionPlan.withGraph(0).execute();
-            // Execute the second graph (a + b = d)
-            executionPlan.withGraph(1).execute();
-            // Execute the second graph (a + b = d)
-            TornadoExecutionResult executionResult = executionPlan.withGraph(2).execute();
-
-            System.out.println(executionResult.isReady());
-            // Verify results: for each element, check if value is 30
-            for (int i = 0; i < a.getSize(); i++) {
-                assertEquals(70, r.get(i)); // Expected: 35 + 35 = 70
-            }
-        }
-    }
+//    @Test
+//    public void testThreeTaskGraphsWithSharedBuffersEmptyConsume() throws TornadoExecutionPlanException {
+//        IntArray a = new IntArray(numElements);
+//        IntArray b = new IntArray(numElements);
+//        IntArray c = new IntArray(numElements);
+//        IntArray d = new IntArray(numElements);
+//        IntArray r = new IntArray(numElements);
+//
+//        a.init(10);
+//        b.init(20);
+//        d.init(5);
+//
+//        // Create first task graph named "s0"
+//        TaskGraph tg1 = new TaskGraph("s0") //
+//                // Transfer arrays 'a' and 'b' to the device only on first execution
+//                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+//                // Execute the add method (a + b = c)
+//                .task("t0", TestHello::add, a, b, c) //
+//                // Keep arrays 'a' and 'b' on the device memory for later use
+//                .persistOnDevice(c);
+//
+//        // Create second task graph named "s1"
+//        TaskGraph tg2 = new TaskGraph("s1") //
+//                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
+//                .consumeFromDevice(c) //
+//                //
+//                .transferToDevice(DataTransferMode.FIRST_EXECUTION, d) //
+//                // Execute the add method (a + b = d), creating separate output in 'd'
+//                .task("t1", TestHello::add, c, d, r) //
+//                // Transfer results back to host memory after execution
+//                .persistOnDevice(r);
+//
+//        // Create third task graph named "s2"
+//        TaskGraph tg3 = new TaskGraph("s2") //
+//                // Get arrays 'a' and 'b' from the first task graph (no new transfer needed)
+//                .consumeFromDevice(r) //
+//                // Execute the add method (a + b = d), creating separate output in 'd'
+//                .task("t1", TestHello::add, r, r, r) //
+//                // Transfer results back to host memory after execution
+//                .transferToHost(DataTransferMode.EVERY_EXECUTION, r);
+//
+//        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot(), tg3.snapshot())) {
+//            // Execute the first graph (a + b = c)
+//            executionPlan.withGraph(0).execute();
+//            // Execute the second graph (a + b = d)
+//            executionPlan.withGraph(1).execute();
+//            // Execute the second graph (a + b = d)
+//            TornadoExecutionResult executionResult = executionPlan.withGraph(2).execute();
+//
+//            System.out.println(executionResult.isReady());
+//            // Verify results: for each element, check if value is 30
+//            for (int i = 0; i < a.getSize(); i++) {
+//                assertEquals(70, r.get(i)); // Expected: 35 + 35 = 70
+//            }
+//        }
+//    }
 
     /**
      * Tests the persistence of buffers across multiple sequential task graphs with context state management.
@@ -483,7 +483,7 @@ public class TestSharedBuffers extends TornadoTestBase {
         inputBuffer.init(10);
         contextBuffer.init(2);
 
-        // @formatter:off 
+        // @formatter:off
         // First Task Graph: Initial Processing
         TaskGraph firstGraph = new TaskGraph("firstProcessing")
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, inputBuffer, contextBuffer)
@@ -576,7 +576,7 @@ public class TestSharedBuffers extends TornadoTestBase {
 
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg1.snapshot(), tg2.snapshot(), tg3.snapshot())) {
 
-            for (int i = 0; i < 20000; i++) {
+            for (int i = 0; i < 5; i++) {
                 executionPlan.withGraph(0).execute();
 
                 // Execute the second graph
@@ -584,8 +584,9 @@ public class TestSharedBuffers extends TornadoTestBase {
 
                 // Execute the third graph
                 executionPlan.withGraph(2).execute();
-
             } // Execute the first graph
+
+            executionPlan.getTraceExecutionPlan();
 
             // Add assertions based on expected values
             boolean hasNonZeroOutput = false;


### PR DESCRIPTION
#### Description

Currently, with ```consumeFromDevice(taskgraphName, objects...)```, users must explicitly specify the source task graph from which objects will be consumed. This creates a rigid dependency structure where objects can only be consumed from a single, named task graph. This limits complex pipeline designs where objects might be updated by different task graphs in varying execution patterns.

This PR introduces the following enhancements:

* Automatic Task Graph Tracking: Added support for tracking the last executed task graph in the execution plan, eliminating the need to explicitly name source task graphs.
* Simplified API: Introduced a new consumeFromDevice(objects...) method that automatically uses the last executed task graph as the source, making the API more intuitive and reducing boilerplate.
* Improved State Management: Moved state update functionality closer to execution to ensure consistent buffer states across multiple task graphs.
* Enhanced Execution Context: The execution plan now properly updates all task graphs about the last execution, enabling more flexible pipeline designs.

Implementation Details

* Added lastExecutedTaskGraph tracking in TornadoTaskGraph
* Modified TornadoExecutor to properly update all task graphs with execution information
* Implemented new overload of consumeFromDevice that doesn't require task graph name
* Enhanced persistence mechanism to track objects across task graph boundaries
* Added comprehensive tests demonstrating the new capabilities

#### Problem description

If the patch provides a fix for a bug, please describe what was the issue and how to reproduce the issue.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash 
tornado-test -pbc -V uk.ac.manchester.tornado.unittests.api.TestSharedBuffers#testThreeTaskGraphsWithSharedBuffersEmptyConsume
```

Expected output:

```bash
Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@7ac0e420 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@6fb365ed on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@a22cb6a on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x7ac0e420] uk.ac.manchester.tornado.api.types.arrays.IntArray@7ac0e420 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0, offset=0 [event list=-1]
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x6fb365ed] uk.ac.manchester.tornado.api.types.arrays.IntArray@6fb365ed on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0, offset=0 [event list=-1]
bc:  LAUNCH  task s0.t0 - add on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  DEALLOC [0x7ac0e420] uk.ac.manchester.tornado.api.types.arrays.IntArray@7ac0e420 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x6fb365ed] uk.ac.manchester.tornado.api.types.arrays.IntArray@6fb365ed [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  BARRIER  event-list 4
bc:  END
 

Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@324a0017 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ON_DEVICE_BUFFER [0xa22cb6a] uk.ac.manchester.tornado.api.types.arrays.IntArray@a22cb6a on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x59b38691] uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0, offset=0 [event list=-1]
bc:  LAUNCH  task s1.t1 - add on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  DEALLOC [0x59b38691] uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  BARRIER  event-list 3
bc:  END
 

Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ON_DEVICE_BUFFER [0x324a0017] uk.ac.manchester.tornado.api.types.arrays.IntArray@324a0017 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  LAUNCH  task s2.t1 - add on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x324a0017] uk.ac.manchester.tornado.api.types.arrays.IntArray@324a0017 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, sizeBatch=0, offset=0 [event list=1]
bc:  END
 
```
----------------------------------------------------------------------------
