### PR TITLE
[feature] Extend TornadoVM bytecodes with `PERSIST_BUFFER` bc to improve tracking of an object lifecycle

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoGraphBuilder.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoGraphBuilder.java
@@ -84,15 +84,6 @@ public class TornadoGraphBuilder {
         persistNode.addValue((ObjectNode) arg);
     }
 
-    private static void createPersistOnDeviceNode(ContextNode context, TornadoGraph graph, AbstractNode arg, AbstractNode[] args, int argIndex, AllocateMultipleBuffersNode persistNode) {
-        final OnDeviceObjectNode onDeviceObjectNode = new OnDeviceObjectNode(context);
-        onDeviceObjectNode.setValue((ObjectNode) arg);
-        graph.add(onDeviceObjectNode);
-        context.addUse(onDeviceObjectNode);
-        args[argIndex] = onDeviceObjectNode;
-        persistNode.addValue((ObjectNode) arg);
-    }
-
     private static void createCopyInNode(ContextNode context, TornadoGraph graph, AbstractNode arg, AbstractNode[] args, int argIndex, AllocateMultipleBuffersNode persistNode) {
         final CopyInNode copyInNode = new CopyInNode(context);
         copyInNode.setValue((ObjectNode) arg);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
@@ -90,7 +90,7 @@ public class TornadoVMBytecodeBuilder {
         if (node instanceof AllocateMultipleBuffersNode allocateMultipleBuffersNode) {
             bitcodeASM.allocate(allocateMultipleBuffersNode.getValues(), batchSize);
         } else if (node instanceof OnDeviceObjectNode onDeviceObjectNode) {
-            bitcodeASM.onDevice(onDeviceObjectNode.getValue().getIndex(), dependencyBC, offset, batchSize);
+            bitcodeASM.onDevice(onDeviceObjectNode.getValue().getIndex(), dependencyBC);
         } else if (node instanceof CopyInNode copyInNode) {
             bitcodeASM.transferToDeviceOnce(copyInNode.getValue().getIndex(), dependencyBC, offset, batchSize);
         } else if (node instanceof AllocateNode allocateNode) {
@@ -103,7 +103,7 @@ public class TornadoVMBytecodeBuilder {
         } else if (node instanceof DeallocateNode deallocateNode) {
             bitcodeASM.deallocate((deallocateNode.getValue().getIndex()));
         } else if (node instanceof PersistedObjectNode persistedObjectNode) {
-            bitcodeASM.persist(persistedObjectNode.getValue().getIndex(), dependencyBC, offset, batchSize);
+            bitcodeASM.persist(persistedObjectNode.getValue().getIndex(), dependencyBC);
         } else if (node instanceof TaskNode taskNodee) {
             final TaskNode taskNode = taskNodee;
             bitcodeASM.launch(taskNode.getContext().getDeviceIndex(), taskNode.getTaskIndex(), taskNode.getNumArgs(), dependencyBC, offset, nThreads);
@@ -206,20 +206,16 @@ public class TornadoVMBytecodeBuilder {
             }
         }
 
-        public void onDevice(int object, int dep, long offset, long size) {
+        public void onDevice(int object, int dep) {
             buffer.put(TornadoVMBytecodes.ON_DEVICE.value);
             buffer.putInt(object);
             buffer.putInt(dep);
-            buffer.putLong(offset);
-            buffer.putLong(size);
         }
 
-        public void persist(int object, int dep, long offset, long size) {
+        public void persist(int object, int dep) {
             buffer.put(TornadoVMBytecodes.PERSIST.value);
             buffer.putInt(object);
             buffer.putInt(dep);
-            buffer.putLong(offset);
-            buffer.putLong(size);
         }
 
         public void deallocate(int object) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
@@ -41,6 +41,7 @@ import uk.ac.manchester.tornado.runtime.graph.nodes.DeallocateNode;
 import uk.ac.manchester.tornado.runtime.graph.nodes.DependentReadNode;
 import uk.ac.manchester.tornado.runtime.graph.nodes.ObjectNode;
 import uk.ac.manchester.tornado.runtime.graph.nodes.OnDeviceObjectNode;
+import uk.ac.manchester.tornado.runtime.graph.nodes.PersistedObjectNode;
 import uk.ac.manchester.tornado.runtime.graph.nodes.StreamInNode;
 import uk.ac.manchester.tornado.runtime.graph.nodes.TaskNode;
 
@@ -101,6 +102,8 @@ public class TornadoVMBytecodeBuilder {
             bitcodeASM.transferToDeviceAlways(streamInNode.getValue().getIndex(), dependencyBC, offset, batchSize);
         } else if (node instanceof DeallocateNode deallocateNode) {
             bitcodeASM.deallocate((deallocateNode.getValue().getIndex()));
+        } else if (node instanceof PersistedObjectNode persistedObjectNode) {
+            bitcodeASM.persist(persistedObjectNode.getValue().getIndex(), dependencyBC, offset, batchSize);
         } else if (node instanceof TaskNode taskNodee) {
             final TaskNode taskNode = taskNodee;
             bitcodeASM.launch(taskNode.getContext().getDeviceIndex(), taskNode.getTaskIndex(), taskNode.getNumArgs(), dependencyBC, offset, nThreads);
@@ -205,6 +208,14 @@ public class TornadoVMBytecodeBuilder {
 
         public void onDevice(int object, int dep, long offset, long size) {
             buffer.put(TornadoVMBytecodes.ON_DEVICE.value);
+            buffer.putInt(object);
+            buffer.putInt(dep);
+            buffer.putLong(offset);
+            buffer.putLong(size);
+        }
+
+        public void persist(int object, int dep, long offset, long size) {
+            buffer.put(TornadoVMBytecodes.PERSIST.value);
             buffer.putInt(object);
             buffer.putInt(dep);
             buffer.putLong(offset);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodes.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodes.java
@@ -203,8 +203,19 @@ public enum TornadoVMBytecodes {
      * ON_DEVICE(obj,dest)
      * </code>
      */
-    ON_DEVICE((byte) 25);
+    ON_DEVICE((byte) 25),
 
+
+    /**
+     * Persist a buffer on a device.
+     * <p>
+     * Format:
+     *
+     * <code>
+     * PERSIST(obj,dest)
+     * </code>
+     */
+    PERSIST((byte) 26);
 
     final byte value;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/nodes/PersistedObjectNode.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/nodes/PersistedObjectNode.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.runtime.graph.nodes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PersistedObjectNode extends ContextOpNode{
+    private ObjectNode value;
+
+    public PersistedObjectNode(ContextNode context) {
+        super(context);
+    }
+
+    public ObjectNode getValue() {
+        return value;
+    }
+
+    public void setValue(ObjectNode object) {
+        value = object;
+    }
+
+    @Override
+    public String toString() {
+        if (value == null) {
+            return String.format("[%d]: persist on-device object (value not set)", id);
+        } else {
+            return String.format("[%d]: persist object %d on-device", id, value.getIndex());
+        }
+    }
+
+    @Override
+    public boolean hasInputs() {
+        return value != null;
+    }
+
+    @Override
+    public List<AbstractNode> getInputs() {
+        if (!hasInputs()) {
+            return Collections.emptyList();
+        }
+
+        final List<AbstractNode> result = new ArrayList<AbstractNode>();
+        result.add(value);
+        return result;
+    }
+}

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
@@ -63,6 +63,15 @@ class DebugInterpreter {
         appendLogBuilder(verbose, logBuilder);
     }
 
+    static void logPersistedObject(Object object, TornadoXPUDevice interpreterDevice, StringBuilder logBuilder) {
+        String verbose = String.format("bc: %s[0x%x] %s on %s", //
+                InterpreterUtilities.debugHighLightBC("PERSIST_BUFFER"), //
+                object.hashCode(), //
+                object, //
+                InterpreterUtilities.debugDeviceBC(interpreterDevice));
+        appendLogBuilder(verbose, logBuilder);
+    }
+
     static void logTransferToDeviceOnce(List<Integer> allEvents, Object object, TornadoXPUDevice deviceForInterpreter, //
             long sizeObject, long sizeBatch, long offset, final int eventList, StringBuilder logBuilder) {
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
@@ -56,7 +56,7 @@ class DebugInterpreter {
 
     static void logOnDeviceObject(Object object, TornadoXPUDevice interpreterDevice, StringBuilder logBuilder) {
         String verbose = String.format("bc: %s[0x%x] %s on %s", //
-                InterpreterUtilities.debugHighLightBC("ON_DEVICE_BUFFER"), //
+                InterpreterUtilities.debugHighLightBC("ON_DEVICE"), //
                 object.hashCode(), //
                 object, //
                 InterpreterUtilities.debugDeviceBC(interpreterDevice));
@@ -65,7 +65,7 @@ class DebugInterpreter {
 
     static void logPersistedObject(Object object, TornadoXPUDevice interpreterDevice, StringBuilder logBuilder) {
         String verbose = String.format("bc: %s[0x%x] %s on %s", //
-                InterpreterUtilities.debugHighLightBC("PERSIST_BUFFER"), //
+                InterpreterUtilities.debugHighLightBC("PERSIST"), //
                 object.hashCode(), //
                 object, //
                 InterpreterUtilities.debugDeviceBC(interpreterDevice));

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -344,9 +344,6 @@ public class TornadoVMInterpreter {
             } else if (op == TornadoVMBytecodes.ON_DEVICE.value()) {
                 final int objectIndex = bytecodeResult.getInt();
                 final int eventId = bytecodeResult.getInt();
-                final long offset = bytecodeResult.getLong();
-                final long sizeBatch = bytecodeResult.getLong();
-                final int[] waitList = (useDependencies && eventId != -1) ? events[eventId] : null;
                 if (isWarmup) {
                     continue;
                 }
@@ -354,13 +351,10 @@ public class TornadoVMInterpreter {
             } else if (op == TornadoVMBytecodes.PERSIST.value()) {
                 final int objectIndex = bytecodeResult.getInt();
                 final int eventId = bytecodeResult.getInt();
-                final long offset = bytecodeResult.getLong();
-                final long sizeBatch = bytecodeResult.getLong();
-                final int[] waitList = (useDependencies && eventId != -1) ? events[eventId] : null;
                 if (isWarmup) {
                     continue;
                 }
-                lastEvent = persist(logBuilder, objectIndex, eventId);
+                lastEvent = executePersist(logBuilder, objectIndex, eventId);
             } else if (op == TornadoVMBytecodes.BARRIER.value()) {
                 final int eventId = bytecodeResult.getInt();
                 final int[] waitList = (useDependencies && eventId != -1) ? events[eventId] : null;
@@ -528,7 +522,7 @@ public class TornadoVMInterpreter {
         return -1;
     }
 
-    private int persist(StringBuilder logBuilder, final int objectIndex, final int eventId) {
+    private int executePersist(StringBuilder logBuilder, final int objectIndex, final int eventId) {
         Object object = objects.get(objectIndex);
         if (TornadoOptions.PRINT_BYTECODES) {
             DebugInterpreter.logPersistedObject(object, interpreterDevice, logBuilder);


### PR DESCRIPTION
#### Description

This PR addresses an issue with object persistence in TornadoVM's bytecode generation. Objects marked for persistence in the task graph were not properly captured by the existing bytecodes, leading to potential memory management issues in subsequent task graph executions.

The fix extends the bytecode generation to explicitly capture the state of persisted objects using a new `PERSIST_BUFFER` bytecode operation, ensuring that objects intended for reuse across multiple task graph executions are properly tracked and maintained.

Before the fix:
```bash
Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@6aa3a905 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x3a0baae5] uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0, offset=0 [event list=-1]
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x4f25b795] uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0, offset=0 [event list=-1]
bc:  LAUNCH  task s0.t0 - add on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  DEALLOC [0x6aa3a905] uk.ac.manchester.tornado.api.types.arrays.IntArray@6aa3a905 [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  BARRIER  event-list 3
bc:  END


Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ON_DEVICE_BUFFER [0x3a0baae5] uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  ON_DEVICE_BUFFER [0x4f25b795] uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  LAUNCH  task s1.t1 - add on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x59b38691] uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, sizeBatch=0, offset=0 [event list=1]
bc:  DEALLOC [0x3a0baae5] uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  DEALLOC [0x4f25b795] uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  DEALLOC [0x59b38691] uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  END

```

After the fix:
```bash
Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@6aa3a905 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x3a0baae5] uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0, offset=0 [event list=-1]
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x4f25b795] uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0, offset=0 [event list=-1]
bc:  LAUNCH  task s0.t0 - add on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  PERSIST_BUFFER [0x3a0baae5] uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  PERSIST_BUFFER [0x4f25b795] uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  DEALLOC [0x6aa3a905] uk.ac.manchester.tornado.api.types.arrays.IntArray@6aa3a905 [Status:  Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  BARRIER  event-list 3
bc:  END


Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ON_DEVICE_BUFFER [0x3a0baae5] uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  ON_DEVICE_BUFFER [0x4f25b795] uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  LAUNCH  task s1.t1 - add on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x59b38691] uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, sizeBatch=0, offset=0 [event list=1]
bc:  DEALLOC [0x3a0baae5] uk.ac.manchester.tornado.api.types.arrays.IntArray@3a0baae5 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  DEALLOC [0x4f25b795] uk.ac.manchester.tornado.api.types.arrays.IntArray@4f25b795 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  DEALLOC [0x59b38691] uk.ac.manchester.tornado.api.types.arrays.IntArray@59b38691 [Status:  Freed ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070
bc:  END
```

#### Problem description

If the patch provides a fix for a bug, please describe what was the issue and how to reproduce the issue.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
tornado-test -pbc -V uk.ac.manchester.tornado.unittests.api.TestSharedBuffers#testMultipleSharedObjects
```
----------------------------------------------------------------------------
