### PR TITLE
[feature] Add functionality to dump TornadoVM internal bytecodes to a log file

### DIFF
--- a/tornado-assembly/src/bin/tornado
+++ b/tornado-assembly/src/bin/tornado
@@ -41,6 +41,7 @@ __TORNADOVM_DUMP_PROFILER__ = " -Dtornado.profiler=True -Dtornado.log.profiler=T
 __TORNADOVM_ENABLE_PROFILER_SILENT__ = " -Dtornado.profiler=True -Dtornado.log.profiler=True "
 __TORNADOVM_ENABLE_PROFILER_CONSOLE__ = " -Dtornado.profiler=True "
 __TORNADOVM_ENABLE_CONCURRENT__DEVICES__ = " -Dtornado.concurrent.devices=True "
+__TORNADOVM_DUMP_BYTECODES_DIR__ = " -Dtornado.dump.bytecodes.dir="
 
 # ########################################################
 # LIST OF TORNADOVM PROVIDERS: Set of Java Classes that
@@ -214,6 +215,9 @@ class TornadoVMRunnerTool():
 
         if (args.printBytecodes):
             tornadoFlags = tornadoFlags + __TORNADOVM_PRINT_BC__
+
+        if (args.dump_bytecodes_dir != None):
+            tornadoFlags = tornadoFlags + __TORNADOVM_DUMP_BYTECODES_DIR__ + args.dump_bytecodes_dir + " "
 
         if (args.enableConcurrentDevices):
             tornadoFlags = tornadoFlags + __TORNADOVM_ENABLE_CONCURRENT__DEVICES__
@@ -473,6 +477,7 @@ def parseArguments():
     parser.add_argument("--truffle", action="store", dest="truffle_language", default=None,
                         help="Enable Truffle languages through TornadoVM. Example: --truffle python|r|js")
     parser.add_argument("--intellijinit", action="store_true", dest="intellijinit", default=False, help="Generate internal xml files for IntelliJ IDE")
+    parser.add_argument('--dumpBC', action="store", dest="dump_bytecodes_dir", default=None, help="Dump the TornadoVM bytecodes to a directory")
     parser.add_argument("param1", nargs="?")
     parser.add_argument("param2", nargs="?")
     parser.add_argument("param3", nargs="?")

--- a/tornado-assembly/src/bin/tornado
+++ b/tornado-assembly/src/bin/tornado
@@ -41,7 +41,7 @@ __TORNADOVM_DUMP_PROFILER__ = " -Dtornado.profiler=True -Dtornado.log.profiler=T
 __TORNADOVM_ENABLE_PROFILER_SILENT__ = " -Dtornado.profiler=True -Dtornado.log.profiler=True "
 __TORNADOVM_ENABLE_PROFILER_CONSOLE__ = " -Dtornado.profiler=True "
 __TORNADOVM_ENABLE_CONCURRENT__DEVICES__ = " -Dtornado.concurrent.devices=True "
-__TORNADOVM_DUMP_BYTECODES_DIR__ = " -Dtornado.dump.bytecodes.dir="
+__TORNADOVM_DUMP_BYTECODES_DIR__ = " -Dtornado.print.bytecodes=True -Dtornado.dump.bytecodes.dir="
 
 # ########################################################
 # LIST OF TORNADOVM PROVIDERS: Set of Java Classes that

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
@@ -64,6 +64,7 @@ public final class RuntimeUtilities {
 
     public static final String FPGA_OUTPUT_FILENAME = "outputFPGA.log";
     public static final String FPGA_ERROR_FILENAME = "errorFPGA.log";
+    public static final String BYTECODES_FILENAME = "tornadovm_bytecodes.log";
 
     private RuntimeUtilities() {
     }
@@ -495,5 +496,37 @@ public final class RuntimeUtilities {
         } catch (IOException e) {
             throw new TornadoRuntimeException("JSon profiler file cannot be append");
         }
+    }
+
+    public static void writeBytecodeToFile(StringBuilder logBuilder) {
+        if (TornadoOptions.PRINT_BYTECODES) {
+            String filePath = getFilePath();
+
+            // Use existing method to write to file, with append set to true
+            try (FileWriter fw = new FileWriter(filePath, true)) {
+                BufferedWriter bw = new BufferedWriter(fw);
+                bw.write(logBuilder.toString());
+                bw.flush();
+            } catch (IOException e) {
+                new TornadoLogger().error("unable to dump bytecodes: ", e.getMessage());
+                throw new RuntimeException("unable to dump bytecodes: " + e.getMessage());
+            }
+        }
+    }
+
+    private static String getFilePath() {
+        String filePath;
+
+        if (TornadoOptions.DUMP_BYTECODES != null && !TornadoOptions.DUMP_BYTECODES.isEmpty()) {
+            // Create directory if it doesn't exist
+            File directory = new File(TornadoOptions.DUMP_BYTECODES);
+            if (!directory.exists()) {
+                directory.mkdirs();
+            }
+            filePath = TornadoOptions.DUMP_BYTECODES + File.separator + BYTECODES_FILENAME;
+        } else {
+            filePath = BYTECODES_FILENAME;
+        }
+        return filePath;
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -113,6 +113,11 @@ public class TornadoOptions {
     public static final boolean PRINT_BYTECODES = getBooleanValue("tornado.print.bytecodes", FALSE);
 
     /**
+     * Option to dump TornadoVM Internal Bytecodes into a file.
+     */
+    public static final String DUMP_BYTECODES = getProperty("tornado.dump.bytecodes.dir", "");
+
+    /**
      * Option to enable experimental and new option for performing automatic full
      * reductions.
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -54,6 +54,7 @@ import uk.ac.manchester.tornado.api.profiler.TornadoProfiler;
 import uk.ac.manchester.tornado.api.runtime.TaskContextInterface;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
+import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
@@ -395,6 +396,10 @@ public class TornadoVMInterpreter {
 
         if (TornadoOptions.PRINT_BYTECODES) {
             System.out.println(logBuilder);
+        }
+
+        if (!TornadoOptions.DUMP_BYTECODES.isBlank()) {
+            RuntimeUtilities.writeBytecodeToFile(logBuilder);
         }
 
         return barrier;


### PR DESCRIPTION
#### Description

This PR adds functionality to dump the TornaoVM bytecodes into a log file for debugging purposes or to visualize them directly with [TornadoVM Bytecode Analyzer](https://github.com/mikepapadim/tornadovm-bytecode-analyzer).

Also, extend the tornado running script with support for:
```bash
--dumpBC PATH/FILENAME 
```
#### Problem description

If the patch provides a fix for a bug, please describe what was the issue and how to reproduce the issue.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
tornado-test --jvm="-Dtornado.dump.bytecodes.dir=$(pwd)" -pbc -V uk.ac.manchester.tornado.unittests.api.TestSharedBuffers#testMultipleSharedObjects

 tornado --dumpBC PATH/FILENAME   -m tornado.examples/uk.ac.manchester.tornado.examples.vectors.VectorAddTest plain

```

the above test will store the log file as `tornadovm_bytecodes.log` in your current path that you are running tornado. One can modify the path to any existing dir or new one want to create and store the bytecodes. 
----------------------------------------------------------------------------
