### PR TITLE
[hotfix] Fix reverse condition that causes revert bytecode logging

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -502,7 +502,7 @@ public class TornadoVMInterpreter {
         long spaceDeallocated = interpreterDevice.deallocate(objectState);
         // Update current device area use
         if (TornadoOptions.PRINT_BYTECODES && isNotObjectAtomic(object)) {
-            boolean materializeDealloc = spaceDeallocated == 0;
+            boolean materializeDealloc = spaceDeallocated != 0;
             DebugInterpreter.logDeallocObject(object, interpreterDevice, tornadoVMBytecodeList, materializeDealloc);
         }
         graphExecutionContext.setCurrentDeviceMemoryUsage(graphExecutionContext.getCurrentDeviceMemoryUsage() - spaceDeallocated);


### PR DESCRIPTION
The condition that checks if a deallocation is perfomed was the reversed, so it was causing printing freed buffers as persisted and persited as freed.