### PR TITLE
[fix] kernel name for the PTX with sanitizer check

### DIFF
--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -25,7 +25,6 @@ package uk.ac.manchester.tornado.drivers.ptx;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
 import static uk.ac.manchester.tornado.api.utils.TornadoAPIUtils.isBoxedPrimitive;
-import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernelName;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -47,6 +46,7 @@ import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.drivers.common.TornadoBufferProvider;
 import uk.ac.manchester.tornado.drivers.common.power.PowerMetric;
+import uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil;
 import uk.ac.manchester.tornado.drivers.ptx.graal.compiler.PTXCompilationResult;
 import uk.ac.manchester.tornado.drivers.ptx.mm.PTXKernelStackFrame;
 import uk.ac.manchester.tornado.drivers.ptx.mm.PTXMemoryManager;
@@ -377,7 +377,7 @@ public class PTXDeviceContext implements TornadoDeviceContext {
     @Override
     public boolean isCached(long executionPlanId, String methodName, SchedulableTask task) {
         PTXCodeCache ptxCodeCache = getPTXCodeCache(executionPlanId);
-        return ptxCodeCache.isCached(buildKernelName(methodName, task));
+        return ptxCodeCache.isCached(PTXCodeUtil.buildKernelName(methodName, task));
     }
 
     public void destroyStream(long executionPlanId) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -23,8 +23,6 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.runtime;
 
-import static uk.ac.manchester.tornado.drivers.ptx.graal.PTXCodeUtil.buildKernelName;
-
 import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.nio.file.Files;
@@ -185,7 +183,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
                 profiler.stop(ProfilerType.TASK_COMPILE_GRAAL_TIME, taskMeta.getId());
                 profiler.sum(ProfilerType.TOTAL_GRAAL_COMPILE_TIME, profiler.getTaskTimer(ProfilerType.TASK_COMPILE_GRAAL_TIME, taskMeta.getId()));
             } else {
-                result = new PTXCompilationResult(buildKernelName(resolvedMethod.getName(), executable), taskMeta);
+                result = new PTXCompilationResult(PTXCodeUtil.buildKernelName(resolvedMethod.getName(), executable), taskMeta);
             }
 
             profiler.start(ProfilerType.TASK_COMPILE_DRIVER_TIME, taskMeta.getId());
@@ -206,7 +204,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
     private TornadoInstalledCode compilePreBuiltTask(long executionPlanId, SchedulableTask task) {
         final PTXDeviceContext deviceContext = getDeviceContext();
         final PrebuiltTask executable = (PrebuiltTask) task;
-        String functionName = buildKernelName(executable.getEntryPoint(), executable);
+        String functionName = PTXCodeUtil.buildKernelName(executable.getEntryPoint(), executable);
         if (deviceContext.isCached(executionPlanId, executable.getEntryPoint(), executable)) {
             return deviceContext.getInstalledCode(executionPlanId, functionName);
         }
@@ -239,7 +237,7 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
             ResolvedJavaMethod resolvedMethod = TornadoCoreRuntime.getTornadoRuntime().resolveMethod(compilableTask.getMethod());
             methodName = resolvedMethod.getName();
         }
-        String functionName = buildKernelName(methodName, task);
+        String functionName = PTXCodeUtil.buildKernelName(methodName, task);
         return getDeviceContext().getInstalledCode(executionPlanId, functionName);
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestIntegers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/TestIntegers.java
@@ -45,7 +45,9 @@ public class TestIntegers extends TornadoTestBase {
         IntArray a = new IntArray(numElements);
 
         TaskGraph taskGraph = new TaskGraph("s0") //
-                .task("t0", TestKernels::copyTestZero, a) //
+                // use an odd task-id to check that the task is compiled correctly.
+                // task-name only affects the generated kernel name in the PTX backend.
+                .task("t,@", TestKernels::copyTestZero, a) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, a);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();


### PR DESCRIPTION
#### Description

Fix issue #663. The problem is that, for the generated PTX kernel, the task-id is used. If the task-id contains illegal C characters for a function name, then it does not compile the PTX kernel.

This patch adds a sanitizer to check for non-legal characters and replace them with another character.

Thank you for contributing to TornadoVM. This template provides checkpoints before opening PR, and a template to be filled when submitting a PR on GitHub.

Related issue: #663 

#### Problem description

As describe above.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [X] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make BACKEND=ptx
tornado-test --printKernel -V uk.ac.manchester.tornado.unittests.foundation.TestIntegers#test01
```
