### PR TITLE
[Fix] Grid Scheduler Name checker for execution plans with multiple task-graphs

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -226,4 +226,7 @@ public class ImmutableTaskGraph {
         taskGraph.updatePersistedObjectState(taskGraphSrc.taskGraph.taskGraphImpl);
     }
 
+    boolean isGridRegistered() {
+        return taskGraph.isGridRegistered();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -957,4 +957,7 @@ public class TaskGraph implements TaskGraphInterface {
         return taskGraphImpl;
     }
 
+    public boolean isGridRegistered() {
+        return taskGraphImpl.isGridRegistered();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -346,7 +346,14 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      * @return {@link TornadoExecutionPlan}
      */
     public TornadoExecutionPlan withGridScheduler(GridScheduler gridScheduler) {
-        tornadoExecutor.withGridScheduler(gridScheduler);
+        boolean isGridRegistered = tornadoExecutor.withGridScheduler(gridScheduler);
+        if (!isGridRegistered) {
+            // check for the whole set of task-graphs
+            isGridRegistered = tornadoExecutor.checkAllTaskGraphsForGridScheduler();
+            if (!isGridRegistered) {
+                throw new TornadoRuntimeException("[ERROR] GridScheduler Name not registered in any task-graph");
+            }
+        }
         executionFrame.setGridScheduler(gridScheduler);
         return new WithGridScheduler(this, gridScheduler);
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -47,8 +47,13 @@ class TornadoExecutor {
         immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.execute(executionPackage));
     }
 
-    void withGridScheduler(GridScheduler gridScheduler) {
-        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.withGridScheduler(gridScheduler));
+    boolean withGridScheduler(GridScheduler gridScheduler) {
+        boolean checkGridRegistered = false;
+        for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {
+            immutableTaskGraph.withGridScheduler(gridScheduler);
+            checkGridRegistered |= immutableTaskGraph.isGridRegistered();
+        }
+        return checkGridRegistered;
     }
 
     void warmup(ExecutorFrame executorFrame) {
@@ -303,4 +308,15 @@ class TornadoExecutor {
         taskGraphDest.mapOnDeviceMemoryRegion(destArray, srcArray, offset, taskGraphSrc);
     }
 
+    boolean checkAllTaskGraphsForGridScheduler() {
+        if (subgraphList == null) {
+            return false;
+        }
+        for (ImmutableTaskGraph immutableTaskGraph : subgraphList) {
+            if (immutableTaskGraph.isGridRegistered()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -138,4 +138,5 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void updateObjectAccess();
 
+    boolean isGridRegistered();
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -576,6 +576,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
+    public boolean isGridRegistered() {
+        return checkGridSchedulerNames();
+    }
+
+    @Override
     public long getTotalBytesTransferred() {
         return getProfilerValue(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES) + getProfilerValue(TOTAL_COPY_OUT_SIZE_BYTES);
     }
@@ -1672,12 +1677,9 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         return false;
     }
 
-    private void checkGridSchedulerNames() {
+    private boolean checkGridSchedulerNames() {
         Set<String> gridTaskNames = gridScheduler.keySet();
-        boolean found = gridTaskNames.stream().anyMatch(this::isTaskNamePresent);
-        if (!found) {
-            throw new TornadoRuntimeException("[ERROR] Grid scheduler names: " + gridTaskNames + " -> not found in the Task-Graph");
-        }
+        return gridTaskNames.stream().anyMatch(this::isTaskNamePresent);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
#### Description

This PR fixes the checker for the task-graph names needed for the `GridScheduler.` There was a bug when we have multiple task-graphs in a single execution plan. With this PR, the global check/control  is done at the execution plan level , rather the task-graph. 

#### Problem description

See below

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-test -V -pk --threadInfo uk.ac.manchester.tornado.unittests.grid.TestGridScheduler#testMultiTaskGraphs
```

