### PR TITLE
Improve output on `TRANSER_TO_DEVICE_ONCE` bc with marking non-executed actions

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
@@ -45,7 +45,7 @@ class DebugInterpreter {
     }
 
     static void logDeallocObject(Object object, TornadoXPUDevice interpreterDevice, StringBuilder logBuilder, boolean materializeDealloc) {
-        String verbose = String.format("bc: %s[0x%x] %s [Status: %s] on %s", //
+        String verbose = String.format("bc: %s[0x%x] %s [Status:%s] on %s", //
                 materializeDealloc ? InterpreterUtilities.debugHighLightBC("DEALLOC") : InterpreterUtilities.debugHighLightNonExecBC("DEALLOC"), //
                 object.hashCode(), //
                 object, //
@@ -66,11 +66,15 @@ class DebugInterpreter {
     static void logTransferToDeviceOnce(List<Integer> allEvents, Object object, TornadoXPUDevice deviceForInterpreter, //
             long sizeObject, long sizeBatch, long offset, final int eventList, StringBuilder logBuilder) {
 
-        String coloredText = allEvents != null //
+        boolean executed = allEvents != null;
+
+        String transferStatus = executed ? "Transferred" : "Present";
+
+        String coloredText = executed //
                 ? InterpreterUtilities.debugHighLightBC("TRANSFER_HOST_TO_DEVICE_ONCE") //
                 : InterpreterUtilities.debugHighLightNonExecBC("TRANSFER_HOST_TO_DEVICE_ONCE"); //
 
-        String verbose = String.format("bc: %s [Object Hash Code=0x%x] %s on %s, size=%d, batchSize=%d, offset=%d [event list=%d]", //
+        String verbose = String.format("bc: %s [Object Hash Code=0x%x] %s on %s, size=%d, batchSize=%d, offset=%d [event list=%d], [Status:%s] ", //
                 coloredText, //
                 object.hashCode(), //
                 object, //
@@ -78,7 +82,8 @@ class DebugInterpreter {
                 sizeObject, // 
                 sizeBatch, //
                 offset, //
-                eventList);
+                eventList, //
+                InterpreterUtilities.debugHighLightNonExecBC(transferStatus));
 
         appendLogBuilder(verbose, logBuilder);
     }


### PR DESCRIPTION
#### Description

Previsouly, `TRANSFER_HOST_TO_DEVICE_ONCE` when executed multiple times didn't capture an empty action when data is already on-device from previous execution. This PR adds an extract field to mark the status for this bytecode as `Transferred` or `Present`.

Before:
```bash
Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x4748a0f9] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1], 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x3a12c404] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1], 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x2df6226d] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1],
bc:  LAUNCH  task s0.t0 - addVectorInt2 on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x2df6226d] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, sizeBatch=0, offset=0 [event list=1]
bc:  DEALLOC [0x4748a0f9] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x3a12c404] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x2df6226d] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  END
 

Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x4748a0f9] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1],
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x3a12c404] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1], 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x2df6226d] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1], 
bc:  LAUNCH  task s0.t0 - addVectorInt2 on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x2df6226d] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, sizeBatch=0, offset=0 [event list=1]
bc:  DEALLOC [0x4748a0f9] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x3a12c404] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x2df6226d] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  END
```

After:

```bash
Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x4748a0f9] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1], [Status: Transferred ] 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x3a12c404] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1], [Status: Transferred ] 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x2df6226d] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1], [Status: Transferred ] 
bc:  LAUNCH  task s0.t0 - addVectorInt2 on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x2df6226d] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, sizeBatch=0, offset=0 [event list=1]
bc:  DEALLOC [0x4748a0f9] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x3a12c404] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x2df6226d] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  END
 

Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  ALLOC VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x4748a0f9] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1], [Status: Present ] 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x3a12c404] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1], [Status: Present ] 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x2df6226d] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, batchSize=0, offset=0 [event list=-1], [Status: Present ] 
bc:  LAUNCH  task s0.t0 - addVectorInt2 on  [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070, numThreadBatch=0, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x2df6226d] VectorInt2 <16> on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=184, sizeBatch=0, offset=0 [event list=1]
bc:  DEALLOC [0x4748a0f9] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x3a12c404] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  DEALLOC [0x2df6226d] VectorInt2 <16> [Status: Persisted ] on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 
bc:  END
```


#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No


----------------------------------------------------------------------------
