### PR TITLE
Refactoring of the Matrix4x4Float type

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix4x4Float.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/matrix/Matrix4x4Float.java
@@ -58,11 +58,11 @@ public final class Matrix4x4Float implements TornadoMatrixInterface<FloatBuffer>
         return j + (i * COLUMNS);
     }
 
-    private float get(int index) {
+    public float get(int index) {
         return storage.get(index);
     }
 
-    private void set(int index, float value) {
+    public void set(int index, float value) {
         storage.set(index, value);
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/GraphicsKernels.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/GraphicsKernels.java
@@ -17,12 +17,12 @@
  */
 package uk.ac.manchester.tornado.benchmarks;
 
-import static uk.ac.manchester.tornado.api.math.TornadoMath.rotate;
 import static uk.ac.manchester.tornado.api.types.vectors.Float4.add;
 
 import java.util.stream.IntStream;
 
 import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.collections.VectorFloat3;
 import uk.ac.manchester.tornado.api.types.images.ImageFloat;
@@ -45,7 +45,7 @@ public final class GraphicsKernels {
     public static void rotateVector(VectorFloat3 output, Matrix4x4Float m, VectorFloat3 input) {
         for (@Parallel int i = 0; i < output.getLength(); i++) {
             final Float3 x = input.get(i);
-            final Float3 y = rotate(m, x);
+            final Float3 y = TornadoMath.rotate(m, x);
             output.set(i, y);
         }
     }
@@ -62,7 +62,7 @@ public final class GraphicsKernels {
         for (@Parallel int i = 0; i < output.Y(); i++) {
             for (@Parallel int j = 0; j < output.X(); j++) {
                 final Float3 x = input.get(j, i);
-                final Float3 y = rotate(m, x);
+                final Float3 y = TornadoMath.rotate(m, x);
                 output.set(j, i, y);
             }
         }
@@ -73,7 +73,7 @@ public final class GraphicsKernels {
             final int j = index % output.X();
             final int i = index / output.X();
             final Float3 x = input.get(j, i);
-            final Float3 y = rotate(m, x);
+            final Float3 y = TornadoMath.rotate(m, x);
             output.set(j, i, y);
         });
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/slam/GraphicsTests.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/slam/GraphicsTests.java
@@ -78,9 +78,6 @@ import uk.ac.manchester.tornado.unittests.slam.utils.Renderer;
  */
 public class GraphicsTests extends TornadoTestBase {
     // CHECKSTYLE:OFF
-
-    private static final float INVALID = -2;
-
     private static void testPhiNode(ImageFloat3 vertices, ImageFloat depths, Matrix4x4Float invK) {
         final float depth = depths.get(0, 0);
         final Float3 pix = new Float3(0, 0, 1f);
@@ -207,10 +204,10 @@ public class GraphicsTests extends TornadoTestBase {
                     if (length(surfNorm) != 0) {
                         normal = normalise(surfNorm);
                     } else {
-                        normal = new Float3(INVALID, 0f, 0f);
+                        normal = new Float3(Constants.INVALID, 0f, 0f);
                     }
                 } else {
-                    normal = new Float3(INVALID, 0f, 0f);
+                    normal = new Float3(Constants.INVALID, 0f, 0f);
                     position = new Float3();
                 }
 


### PR DESCRIPTION
#### Description

This PR includes the following:
- Refactoring of the access modifiers for the `set` and `get` methods of the `Matrix4x4Float` type. Those methods are regularly public in order to be accessed by programmers.
- Refactoring of the `GraphicsKernel` class, in order to import the `TornadoMath` class instead of the inner method name. This change makes those TornadoVM tasks compatible with the implementation in [TornadoInsight](https://github.com/beehive-lab/tornado-insight) (the IntelliJ plugin). 
- Refactoring of test to use constant defined in the inner class.

#### Problem description

The main problem was the incompatibility with TornadoInsight, which revealed that the `Matrix4x4Float` type could not be properly set/get by programmers.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
make 
tornado-test -V uk.ac.manchester.tornado.unittests.slam.GraphicsTests#testRotate
tornado-test -V uk.ac.manchester.tornado.unittests.slam.GraphicsTests#testTrackPose
tornado-test -V uk.ac.manchester.tornado.unittests.slam.GraphicsTests#raycastTest
```

----------------------------------------------------------------------------
