### PR TITLE
Refactoring the Configuration of Logging the TornadoVM Bytecodes 

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/RuntimeUtilities.java
@@ -499,19 +499,30 @@ public final class RuntimeUtilities {
     }
 
     public static void writeBytecodeToFile(StringBuilder logBuilder) {
-        if (TornadoOptions.PRINT_BYTECODES) {
-            String filePath = getFilePath();
-
-            // Use existing method to write to file, with append set to true
-            try (FileWriter fw = new FileWriter(filePath, true)) {
-                BufferedWriter bw = new BufferedWriter(fw);
-                bw.write(logBuilder.toString());
-                bw.flush();
-            } catch (IOException e) {
-                new TornadoLogger().error("unable to dump bytecodes: ", e.getMessage());
-                throw new RuntimeException("unable to dump bytecodes: " + e.getMessage());
-            }
+        String filePath = getFilePath();
+        try (FileWriter fw = new FileWriter(filePath, true)) {
+            BufferedWriter bw = new BufferedWriter(fw);
+            // Clean ANSI escape sequences before writing
+            String cleanedString = removeAnsiEscapeCodes(logBuilder.toString());
+            bw.write(cleanedString);
+            bw.flush();
+        } catch (IOException e) {
+            new TornadoLogger().error("unable to dump bytecodes: ", e.getMessage());
+            throw new RuntimeException("unable to dump bytecodes: " + e.getMessage());
         }
+    }
+
+    /**
+     * Removes ANSI escape sequences from the input string.
+     *
+     * @param input
+     *     String potentially containing ANSI escape codes
+     * @return String with all ANSI escape sequences removed
+     */
+    private static String removeAnsiEscapeCodes(String input) {
+        // Pattern to match ANSI escape sequences
+        // This matches the most common escape codes, beginning with ESC [ and ending with m
+        return input.replaceAll("\u001B\\[[;\\d]*m", "");
     }
 
     private static String getFilePath() {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -350,6 +350,13 @@ public class TornadoOptions {
     }
 
     /**
+     * Option for logging the TornadoVM Bytecodes when printing in console is enabled or dumping them into a file.
+     */
+    public static boolean LOG_BYTECODES() {
+        return TornadoOptions.PRINT_BYTECODES || !TornadoOptions.DUMP_BYTECODES.isBlank();
+    }
+
+    /**
      * Option to reuse device buffers every time a task-graph is executed. True by
      * default.
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -275,7 +275,7 @@ public class TornadoVMInterpreter {
         initWaitEventList();
 
         StringBuilder logBuilder = null;
-        if (TornadoOptions.PRINT_BYTECODES) {
+        if (TornadoOptions.LOG_BYTECODES()) {
             logBuilder = new StringBuilder();
             logBuilder.append(InterpreterUtilities.debugHighLightHelper("Interpreter instance running bytecodes for: ")).append(interpreterDevice).append(InterpreterUtilities.debugHighLightHelper(
                     " Running in thread: ")).append(Thread.currentThread().getName()).append("\n");
@@ -377,7 +377,7 @@ public class TornadoVMInterpreter {
                 }
                 lastEvent = executeBarrier(logBuilder, eventId, waitList);
             } else if (op == TornadoVMBytecodes.END.value()) {
-                if (!isWarmup && TornadoOptions.PRINT_BYTECODES) {
+                if (!isWarmup && TornadoOptions.LOG_BYTECODES()) {
                     logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC("END\n")).append("\n");
                 }
                 break;
@@ -499,7 +499,7 @@ public class TornadoVMInterpreter {
         // Dump printing after object allocation, so the XPU-Buffer is created,
         // and we can query the size without having to use Java type analysis
         // to obtain the size at this point. 
-        if (TornadoOptions.PRINT_BYTECODES) {
+        if (TornadoOptions.LOG_BYTECODES()) {
             int objIndex = 0;
             for (XPUDeviceBufferState state : objectStates) {
                 long size = state.getXPUBuffer().size();
@@ -545,7 +545,7 @@ public class TornadoVMInterpreter {
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
         long spaceDeallocated = interpreterDevice.deallocate(objectState);
         // Update current device area use
-        if (TornadoOptions.PRINT_BYTECODES && isNotObjectAtomic(object)) {
+        if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
             boolean materializeDealloc = spaceDeallocated != 0;
             DebugInterpreter.logDeallocObject(object, interpreterDevice, tornadoVMBytecodeList, materializeDealloc);
         }
@@ -555,7 +555,7 @@ public class TornadoVMInterpreter {
 
     private int executeOnDevice(StringBuilder logBuilder, final int objectIndex, final int eventId) {
         Object object = objects.get(objectIndex);
-        if (TornadoOptions.PRINT_BYTECODES) {
+        if (TornadoOptions.LOG_BYTECODES()) {
             DebugInterpreter.logOnDeviceObject(object, interpreterDevice, logBuilder);
         }
         resetEventIndexes(eventId);
@@ -580,7 +580,7 @@ public class TornadoVMInterpreter {
         }
         resetEventIndexes(eventId);
 
-        if (TornadoOptions.PRINT_BYTECODES && isNotObjectAtomic(object)) {
+        if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
             long sizeObject = objectState.getXPUBuffer().size();
             DebugInterpreter.logTransferToDeviceOnce(allEvents, object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
@@ -612,7 +612,7 @@ public class TornadoVMInterpreter {
 
         resetEventIndexes(eventId);
 
-        if (TornadoOptions.PRINT_BYTECODES && isNotObjectAtomic(object)) {
+        if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
             long sizeObject = objectState.getXPUBuffer().size();
             DebugInterpreter.logTransferToDeviceAlways(object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
@@ -642,7 +642,7 @@ public class TornadoVMInterpreter {
         }
 
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
-        if (TornadoOptions.PRINT_BYTECODES) {
+        if (TornadoOptions.LOG_BYTECODES()) {
             long sizeObject = objectState.getXPUBuffer().size();
             DebugInterpreter.logTransferToHostAlways(object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
@@ -676,7 +676,7 @@ public class TornadoVMInterpreter {
         }
 
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
-        if (TornadoOptions.PRINT_BYTECODES) {
+        if (TornadoOptions.LOG_BYTECODES()) {
             long sizeOfObject = objectState.getXPUBuffer().size();
             DebugInterpreter.logTransferToHostAlwaysBlocking(object, interpreterDevice, logBuilder, sizeOfObject, sizeBatch, offset, eventId);
         }
@@ -885,13 +885,13 @@ public class TornadoVMInterpreter {
                     timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, value);
                 }
             }
-            if (TornadoOptions.PRINT_BYTECODES) {
+            if (TornadoOptions.LOG_BYTECODES()) {
                 DebugInterpreter.logStreamInAtomic(bufferAtomics, interpreterDevice, eventId, logBuilder);
 
             }
         }
 
-        if (TornadoOptions.PRINT_BYTECODES) {
+        if (TornadoOptions.LOG_BYTECODES()) {
             DebugInterpreter.logLaunchTask(task, interpreterDevice, batchThreads, offset, eventId, logBuilder);
         }
 
@@ -922,7 +922,7 @@ public class TornadoVMInterpreter {
 
     private void executeDependency(StringBuilder logBuilder, int lastEvent, int eventId) {
         if (useDependencies && lastEvent != -1) {
-            if (TornadoOptions.PRINT_BYTECODES) {
+            if (TornadoOptions.LOG_BYTECODES()) {
                 DebugInterpreter.logAddDependency(lastEvent, eventId, logBuilder);
             }
             TornadoInternalError.guarantee(eventsIndexes[eventId] < events[eventId].length, "event list is too small");
@@ -932,7 +932,7 @@ public class TornadoVMInterpreter {
     }
 
     private int executeBarrier(StringBuilder logBuilder, int eventId, int[] waitList) {
-        if (TornadoOptions.PRINT_BYTECODES) {
+        if (TornadoOptions.LOG_BYTECODES()) {
             DebugInterpreter.logBarrier(eventId, logBuilder);
         }
 
@@ -1024,8 +1024,10 @@ public class TornadoVMInterpreter {
      * Used to track the number of persistent objects and the number of objects
      * that need to be allocated.
      *
-     * @param persistentObjectCount Number of persistent objects that don't need allocation
-     * @param objectsToAlloc Number of objects that need to be allocated
+     * @param persistentObjectCount
+     *     Number of persistent objects that don't need allocation
+     * @param objectsToAlloc
+     *     Number of objects that need to be allocated
      */
     public record ObjectAllocationInfo(int persistentObjectCount, int objectsToAlloc) {
     }


### PR DESCRIPTION
#### Description

This PR provides a small refactoring to fix the issue of printing the bytecodes in the console when the programmer wants to only store them in a file. Additionally, it fixes an issue with the ANSI espace characters during the logging of bytecodes.

To simplify this procedure, I added a method `TornadoOptions.LOG_BYTECODES()` which is now used in the TornadoInterpreter class to log the bytecodes. This method is true when the programmer has used:
- the option to print the bytecodes in console, via`-Dtornado.print.bytecodes=True`.
- or the option to save the bytecodes in a file, via `-Dtornado.dump.bytecodes.dir=<path-to-file>`.

Regarding the issue with the escape characters this affects the bytecode analyzer. 
A snapshot of the issue when bytecodes are saved in file:
```bash
[34mInterpreter instance running bytecodes for:  [0m [Apple] -- Apple M4 Pro[34m Running in thread:  [0mmain
bc: [31m ALLOC [0muk.ac.manchester.tornado.api.types.arrays.FloatArray@c46bcd4 on [36m  [Apple] -- Apple M4 Pro [0m, size=2072, batchSize=0
bc: [31m ALLOC [0muk.ac.manchester.tornado.api.types.arrays.FloatArray@8e50104 on [36m  [Apple] -- Apple M4 Pro [0m, size=2072, batchSize=0
bc: [31m ALLOC [0muk.ac.manchester.tornado.api.types.arrays.FloatArray@1583741e on [36m  [Apple] -- Apple M4 Pro [0m, size=2072, batchSize=0
bc: [31m ALLOC [0muk.ac.manchester.tornado.api.types.arrays.FloatArray@5b367418 on [36m  [Apple] -- Apple M4 Pro [0m, size=2072, batchSize=0
bc: [31m ALLOC [0muk.ac.manchester.tornado.api.types.arrays.IntArray@36060e on [36m  [Apple] -- Apple M4 Pro [0m, size=28, batchSize=0
bc: [31m TRANSFER_HOST_TO_DEVICE_ONCE [0m [Object Hash Code=0xc46bcd4] uk.ac.manchester.tornado.api.types.arrays.FloatArray@c46bcd4 on [36m  [Apple] -- Apple M4 Pro [0m, size=2072, batchSize=0, offset=0 [event list=-1], [Status:[33m Transferred [0m] 
bc: [31m TRANSFER_HOST_TO_DEVICE_ONCE [0m [Object Hash Code=0x8e50104] uk.ac.manchester.tornado.api.types.arrays.FloatArray@8e50104 on [36m  [Apple] -- Apple M4 Pro [0m, size=2072, batchSize=0, offset=0 [event list=-1], [Status:[33m Transferred [0m] 
bc: [31m TRANSFER_HOST_TO_DEVICE_ONCE [0m [Object Hash Code=0x1583741e] uk.ac.manchester.tornado.api.types.arrays.FloatArray@1583741e on [36m  [Apple] -- Apple M4 Pro [0m, size=2072, batchSize=0, offset=0 [event list=-1], [Status:[33m Transferred [0m] 
bc: [31m TRANSFER_HOST_TO_DEVICE_ONCE [0m [Object Hash Code=0x5b367418] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5b367418 on [36m  [Apple] -- Apple M4 Pro [0m, size=2072, batchSize=0, offset=0 [event list=-1], [Status:[33m Transferred [0m] 
bc: [31m TRANSFER_HOST_TO_DEVICE_ONCE [0m [Object Hash Code=0x36060e] uk.ac.manchester.tornado.api.types.arrays.IntArray@36060e on [36m  [Apple] -- Apple M4 Pro [0m, size=28, batchSize=0, offset=0 [event list=-1], [Status:[33m Transferred [0m] 
bc: [31m LAUNCH [0m task s0.t0 - computeDFT on  [Apple] -- Apple M4 Pro, numThreadBatch=0, offset=0 [event list=0]
bc: [31m TRANSFER_DEVICE_TO_HOST_ALWAYS [0m[0x1583741e] uk.ac.manchester.tornado.api.types.arrays.FloatArray@1583741e on [36m  [Apple] -- Apple M4 Pro [0m, size=2072, batchSize=0, offset=0 [event list=1]
bc: [31m TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING [0m [0x5b367418] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5b367418 on [36m  [Apple] -- Apple M4 Pro [0m, size=2072, sizeBatch=0, offset=0 [event list=2]
bc: [33m DEALLOC [0m[0xc46bcd4] uk.ac.manchester.tornado.api.types.arrays.FloatArray@c46bcd4 [Status:[33m Persisted [0m] on [36m  [Apple] -- Apple M4 Pro [0m
bc: [33m DEALLOC [0m[0x8e50104] uk.ac.manchester.tornado.api.types.arrays.FloatArray@8e50104 [Status:[33m Persisted [0m] on [36m  [Apple] -- Apple M4 Pro [0m
bc: [33m DEALLOC [0m[0x1583741e] uk.ac.manchester.tornado.api.types.arrays.FloatArray@1583741e [Status:[33m Persisted [0m] on [36m  [Apple] -- Apple M4 Pro [0m
bc: [33m DEALLOC [0m[0x5b367418] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5b367418 [Status:[33m Persisted [0m] on [36m  [Apple] -- Apple M4 Pro [0m
bc: [31m DEALLOC [0m[0x36060e] uk.ac.manchester.tornado.api.types.arrays.IntArray@36060e [Status:[33m Freed [0m] on [36m  [Apple] -- Apple M4 Pro [0m
bc: [31m END
 [0m
```

Current log:
```bash
Interpreter instance running bytecodes for:   [Apple] -- Apple M4 Pro Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@c46bcd4 on   [Apple] -- Apple M4 Pro , size=2072, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@8e50104 on   [Apple] -- Apple M4 Pro , size=2072, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@1583741e on   [Apple] -- Apple M4 Pro , size=2072, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.FloatArray@5b367418 on   [Apple] -- Apple M4 Pro , size=2072, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@36060e on   [Apple] -- Apple M4 Pro , size=28, batchSize=0
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0xc46bcd4] uk.ac.manchester.tornado.api.types.arrays.FloatArray@c46bcd4 on   [Apple] -- Apple M4 Pro , size=2072, batchSize=0, offset=0 [event list=-1], [Status: Transferred ] 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x8e50104] uk.ac.manchester.tornado.api.types.arrays.FloatArray@8e50104 on   [Apple] -- Apple M4 Pro , size=2072, batchSize=0, offset=0 [event list=-1], [Status: Transferred ] 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x1583741e] uk.ac.manchester.tornado.api.types.arrays.FloatArray@1583741e on   [Apple] -- Apple M4 Pro , size=2072, batchSize=0, offset=0 [event list=-1], [Status: Transferred ] 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x5b367418] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5b367418 on   [Apple] -- Apple M4 Pro , size=2072, batchSize=0, offset=0 [event list=-1], [Status: Transferred ] 
bc:  TRANSFER_HOST_TO_DEVICE_ONCE  [Object Hash Code=0x36060e] uk.ac.manchester.tornado.api.types.arrays.IntArray@36060e on   [Apple] -- Apple M4 Pro , size=28, batchSize=0, offset=0 [event list=-1], [Status: Transferred ] 
bc:  LAUNCH  task s0.t0 - computeDFT on  [Apple] -- Apple M4 Pro, numThreadBatch=0, offset=0 [event list=0]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS [0x1583741e] uk.ac.manchester.tornado.api.types.arrays.FloatArray@1583741e on   [Apple] -- Apple M4 Pro , size=2072, batchSize=0, offset=0 [event list=1]
bc:  TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING  [0x5b367418] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5b367418 on   [Apple] -- Apple M4 Pro , size=2072, sizeBatch=0, offset=0 [event list=2]
bc:  DEALLOC [0xc46bcd4] uk.ac.manchester.tornado.api.types.arrays.FloatArray@c46bcd4 [Status: Persisted ] on   [Apple] -- Apple M4 Pro 
bc:  DEALLOC [0x8e50104] uk.ac.manchester.tornado.api.types.arrays.FloatArray@8e50104 [Status: Persisted ] on   [Apple] -- Apple M4 Pro 
bc:  DEALLOC [0x1583741e] uk.ac.manchester.tornado.api.types.arrays.FloatArray@1583741e [Status: Persisted ] on   [Apple] -- Apple M4 Pro 
bc:  DEALLOC [0x5b367418] uk.ac.manchester.tornado.api.types.arrays.FloatArray@5b367418 [Status: Persisted ] on   [Apple] -- Apple M4 Pro 
bc:  DEALLOC [0x36060e] uk.ac.manchester.tornado.api.types.arrays.IntArray@36060e [Status: Freed ] on   [Apple] -- Apple M4 Pro 
bc:  END
```

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
make
tornado --jvm="-Dtornado.print.bytecodes=True" -m tornado.examples/uk.ac.manchester.tornado.examples.dynamic.DFTMT 512 tornado 1
tornado --jvm="-Dtornado.dump.bytecodes.dir=<path-to-file>" -m tornado.examples/uk.ac.manchester.tornado.examples.dynamic.DFTMT 512 tornado 1
```
----------------------------------------------------------------------------
