### PR TITLE
[nit] Avoid bytecode logging for header bytecode  during VM warm-up.

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -275,7 +275,7 @@ public class TornadoVMInterpreter {
         initWaitEventList();
 
         StringBuilder logBuilder = null;
-        if (TornadoOptions.LOG_BYTECODES()) {
+        if (TornadoOptions.LOG_BYTECODES() && !isWarmup) {
             logBuilder = new StringBuilder();
             logBuilder.append(InterpreterUtilities.debugHighLightHelper("Interpreter instance running bytecodes for: ")).append(interpreterDevice).append(InterpreterUtilities.debugHighLightHelper(
                     " Running in thread: ")).append(Thread.currentThread().getName()).append("\n");


### PR DESCRIPTION
#### Description

During interpreter warm-up, bytecode execution should not be logged. However, a check was missing for the bytecode header, causing only the header to be logged while the rest of the bytecodes were properly suppressed. This resulted in misleading and incomplete output logs.


**Before this fix:**
The logs would show duplicate headers without the corresponding bytecodes:

```bash
Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main <--- This header shouldn't appear during warm-up!


Interpreter instance running bytecodes for:   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 Running in thread:  main
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@6ebd78d1 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
bc:  ALLOC uk.ac.manchester.tornado.api.types.arrays.IntArray@436390f4 on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 3070 , size=88, batchSize=0
# ... rest of bytecode log ...
```



#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No




----------------------------------------------------------------------------
