### PR TITLE
Apply rescheduling of true branches only for conditions

### DIFF
--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompilationResultBuilder.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/PTXCompilationResultBuilder.java
@@ -49,6 +49,7 @@ import org.graalvm.compiler.nodes.ControlSplitNode;
 import org.graalvm.compiler.nodes.EndNode;
 import org.graalvm.compiler.nodes.FixedNode;
 import org.graalvm.compiler.nodes.IfNode;
+import org.graalvm.compiler.nodes.LoopBeginNode;
 import org.graalvm.compiler.nodes.LoopEndNode;
 import org.graalvm.compiler.nodes.LoopExitNode;
 import org.graalvm.compiler.nodes.MergeNode;
@@ -306,19 +307,34 @@ public class PTXCompilationResultBuilder extends CompilationResultBuilder {
         if (!basicBlock.isLoopHeader() && basicBlock.getDominator() != null && basicBlock.getDominator().getEndNode() instanceof IfNode) {
             IfNode ifNode = (IfNode) basicBlock.getDominator().getEndNode();
             HIRBlock blockTrueBranch = getBlockTrueBranch(basicBlock);
-            if (isFalseSuccessorWithLoopEnd(ifNode, basicBlock) //
-                    || (isCurrentBlockAFalseBranch(ifNode, basicBlock) //
-                            && isTrueBranchALoopExitNode(ifNode) //
-                            && isTrueBranchWithEndNodeOrNotControlSplit(blockTrueBranch))) {
-                for (int i = 0; i < basicBlock.getDominator().getSuccessorCount(); i++) {
-                    HIRBlock successor = basicBlock.getDominator().getSuccessorAt(i);
-                    if (successor.getBeginNode() == ifNode.trueSuccessor() && !visited.contains(successor)) {
-                        pending.put(basicBlock, successor);
-                        rescheduleBasicBlock(basicBlock, visitor, visited, pending);
+            // implement rescheduling for condition if nodes
+            if (isNotLoopBeginIf(ifNode)) {
+                boolean shouldReschedule = isFalseSuccessorWithLoopEnd(ifNode, basicBlock) //
+                        || (isCurrentBlockAFalseBranch(ifNode, basicBlock) //
+                        && isTrueBranchALoopExitNode(ifNode) //
+                        && isTrueBranchWithEndNodeOrNotControlSplit(blockTrueBranch));
+
+                if (shouldReschedule) {
+                    for (int i = 0; i < basicBlock.getDominator().getSuccessorCount(); i++) {
+                        HIRBlock successor = basicBlock.getDominator().getSuccessorAt(i);
+                        if (successor.getBeginNode() == ifNode.trueSuccessor() && !visited.contains(successor)) {
+                            pending.put(basicBlock, successor);
+                            rescheduleBasicBlock(basicBlock, visitor, visited, pending);
+                        }
                     }
                 }
             }
         }
+    }
+
+    /**
+     * This function examines if a given {@code IfNode} is generated for a condition or if it is part of the loop logic (LoopBegin -> If).
+     *
+     * @param ifNode The {@code IfNode} to be examined.
+     * @return true if the {@code IfNode} is not associated with the loop iteration, false otherwise.
+     */
+    private boolean isNotLoopBeginIf(IfNode ifNode) {
+        return !(ifNode.predecessor() instanceof LoopBeginNode);
     }
 
     private void traverseControlFlowGraph(HIRBlock basicBlock, PTXBlockVisitor visitor, HashSet<HIRBlock> visited, HashMap<HIRBlock, HIRBlock> pending) {


### PR DESCRIPTION
#### Description
This PR fixes an issue with the scheduling of true branches. The logic to prioritise true branches was applied for all `IfNode` nodes, however, the rescheduling is only necessary if the `IfNode` is associated with a condition (for instance if there is a `break` or a `return` in the code). In this PR, a check is performed to ensure that the `IfNode` is not associated with a `LoopBegin` node (to evaluate the loop bounds) and rather it is generated due to a condition in the code, and only then it applies the logic to reschedule the necessary branches. 

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Run 
`tornado-test -V uk.ac.manchester.tornado.unittests.compute.ComputeTests#testGroupedQueryAttention `
and 
`make tests`
