### PR TITLE
[compiler] Fix 1.0/sqrt(x) replacement with native rsqrt(x) function

### DIFF
--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/InverseSquareRootPhase.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/InverseSquareRootPhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * Copyright (c) 2021, 2025 APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/InverseSquareRootPhase.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/InverseSquareRootPhase.java
@@ -10,7 +10,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -31,9 +31,13 @@ import org.graalvm.compiler.nodes.calc.FloatDivNode;
 import org.graalvm.compiler.nodes.calc.SqrtNode;
 import org.graalvm.compiler.phases.Phase;
 
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.RSqrtNode;
 
 public class InverseSquareRootPhase extends Phase {
+    private static final String ONE = "1.0";
+    private static final String SQRT = "SQRT";
+
     @Override
     public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
         return ALWAYS_APPLICABLE;
@@ -44,19 +48,31 @@ public class InverseSquareRootPhase extends Phase {
         graph.getNodes().filter(FloatDivNode.class).forEach(floatDivisionNode -> {
 
             // The combination is 1/sqrt(x)
-            if (floatDivisionNode.getX() instanceof ConstantNode) {
-                ConstantNode constant = (ConstantNode) floatDivisionNode.getX();
-                if ((constant.getValue().toValueString().equals("1.0")) && (floatDivisionNode.getY() instanceof SqrtNode)) {
-                    SqrtNode intrinsicNode = (SqrtNode) floatDivisionNode.getY();
-                    ValueNode n = intrinsicNode.getValue();
-                    RSqrtNode rsqrtNode = new RSqrtNode(n);
-                    graph.addOrUnique(rsqrtNode);
-                    intrinsicNode.removeUsage(floatDivisionNode);
-                    if (intrinsicNode.hasNoUsages()) {
-                        intrinsicNode.safeDelete();
+            if (floatDivisionNode.getX() instanceof ConstantNode constant) {
+                if ((constant.getValue().toValueString().equals(ONE))) {
+                    if ((floatDivisionNode.getY() instanceof SqrtNode intrinsicNode)) {
+                        ValueNode n = intrinsicNode.getValue();
+                        RSqrtNode rsqrtNode = new RSqrtNode(n);
+                        graph.addOrUnique(rsqrtNode);
+                        intrinsicNode.removeUsage(floatDivisionNode);
+                        if (intrinsicNode.hasNoUsages()) {
+                            intrinsicNode.safeDelete();
+                        }
+                        floatDivisionNode.replaceAtUsages(rsqrtNode);
+                        floatDivisionNode.safeDelete();
+                    } else if ((floatDivisionNode.getY() instanceof PTXFPUnaryIntrinsicNode OCLFPUnaryIntrinsicNode)) {
+                        if (OCLFPUnaryIntrinsicNode.getOperation().equals(SQRT)) {
+                            ValueNode n = OCLFPUnaryIntrinsicNode.getValue();
+                            RSqrtNode rsqrtNode = new RSqrtNode(n);
+                            graph.addOrUnique(rsqrtNode);
+                            OCLFPUnaryIntrinsicNode.removeUsage(floatDivisionNode);
+                            if (OCLFPUnaryIntrinsicNode.hasNoUsages()) {
+                                OCLFPUnaryIntrinsicNode.safeDelete();
+                            }
+                            floatDivisionNode.replaceAtUsages(rsqrtNode);
+                            floatDivisionNode.safeDelete();
+                        }
                     }
-                    floatDivisionNode.replaceAtUsages(rsqrtNode);
-                    floatDivisionNode.safeDelete();
                 }
             }
         });

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/InverseSquareRootPhase.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/InverseSquareRootPhase.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2021, APT Group, Department of Computer Science,
+ * Copyright (c) 2021, 2025 APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2009-2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -13,7 +13,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -31,12 +31,16 @@ import org.graalvm.compiler.nodes.GraphState;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.FloatDivNode;
+import org.graalvm.compiler.nodes.calc.SqrtNode;
 import org.graalvm.compiler.phases.Phase;
 
-import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.RSqrtNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.RSqrtNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SPIRVFPUnaryIntrinsicNode;
 
 public class InverseSquareRootPhase extends Phase {
+    private static final String ONE = "1.0";
+    private static final String SQRT = "SQRT";
+
     public Optional<NotApplicable> notApplicableTo(GraphState graphState) {
         return ALWAYS_APPLICABLE;
     }
@@ -47,11 +51,9 @@ public class InverseSquareRootPhase extends Phase {
         graph.getNodes().filter(FloatDivNode.class).forEach(floatDivisionNode -> {
 
             // The combination is 1/sqrt(x)
-            if (floatDivisionNode.getX() instanceof ConstantNode) {
-                ConstantNode constant = (ConstantNode) floatDivisionNode.getX();
-                if ((constant.getValue().toValueString().equals("1.0")) && (floatDivisionNode.getY() instanceof SPIRVFPUnaryIntrinsicNode)) {
-                    SPIRVFPUnaryIntrinsicNode intrinsicNode = (SPIRVFPUnaryIntrinsicNode) floatDivisionNode.getY();
-                    if (intrinsicNode.getIntrinsicOperation() == SPIRVFPUnaryIntrinsicNode.SPIRVUnaryOperation.SQRT) {
+            if (floatDivisionNode.getX() instanceof ConstantNode constant) {
+                if ((constant.getValue().toValueString().equals(ONE))) {
+                    if ((floatDivisionNode.getY() instanceof SqrtNode intrinsicNode)) {
                         ValueNode n = intrinsicNode.getValue();
                         RSqrtNode rsqrtNode = new RSqrtNode(n);
                         graph.addOrUnique(rsqrtNode);
@@ -61,6 +63,18 @@ public class InverseSquareRootPhase extends Phase {
                         }
                         floatDivisionNode.replaceAtUsages(rsqrtNode);
                         floatDivisionNode.safeDelete();
+                    } else if ((floatDivisionNode.getY() instanceof SPIRVFPUnaryIntrinsicNode spirvfpUnaryIntrinsicNode)) {
+                        if (spirvfpUnaryIntrinsicNode.getOperation().equals(SQRT)) {
+                            ValueNode n = spirvfpUnaryIntrinsicNode.getValue();
+                            RSqrtNode rsqrtNode = new RSqrtNode(n);
+                            graph.addOrUnique(rsqrtNode);
+                            spirvfpUnaryIntrinsicNode.removeUsage(floatDivisionNode);
+                            if (spirvfpUnaryIntrinsicNode.hasNoUsages()) {
+                                spirvfpUnaryIntrinsicNode.safeDelete();
+                            }
+                            floatDivisionNode.replaceAtUsages(rsqrtNode);
+                            floatDivisionNode.safeDelete();
+                        }
                     }
                 }
             }

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/InverseSquareRootPhase.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/InverseSquareRootPhase.java
@@ -34,7 +34,7 @@ import org.graalvm.compiler.nodes.calc.FloatDivNode;
 import org.graalvm.compiler.nodes.calc.SqrtNode;
 import org.graalvm.compiler.phases.Phase;
 
-import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.RSqrtNode;
+import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.RSqrtNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SPIRVFPUnaryIntrinsicNode;
 
 public class InverseSquareRootPhase extends Phase {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestMath.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestMath.java
@@ -198,6 +198,51 @@ public class TestMath extends TornadoTestBase {
         }
     }
 
+    /**
+     * Test that verifies the InverseSquareRootPhase optimization replaces 1.0/sqrt(x) with rsqrt(x).
+     */
+    public static void testInverseSquareRoot(DoubleArray a) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            // This pattern (1.0 / Math.sqrt(x)) should be recognized and optimized to rsqrt(x)
+            a.set(i, 1.0 / Math.sqrt(a.get(i)));
+        }
+    }
+
+    @Test
+    public void testOptimizedInverseSquareRoot() throws TornadoExecutionPlanException {
+        final int size = 128;
+        DoubleArray data = new DoubleArray(size);
+        DoubleArray seq = new DoubleArray(size);
+
+        // Initialize with positive random values to avoid sqrt of negative numbers
+        IntStream.range(0, size).parallel().forEach(i -> {
+            double value = Math.random() + 0.1; // Ensure positive values
+            data.set(i, value);
+            seq.set(i, value);
+        });
+
+        // Create and execute the task graph that should trigger the optimization
+        TaskGraph taskGraph = new TaskGraph("s0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, data)
+                .task("t0", TestMath::testInverseSquareRoot, data)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            // Execute the optimized version
+            executionPlan.execute();
+        }
+
+        // Execute the sequential version for comparison
+        testInverseSquareRoot(seq);
+
+        // Compare results
+        for (int i = 0; i < size; i++) {
+            assertEquals(data.get(i), seq.get(i), 0.01);
+        }
+    }
+
+
     @Test
     public void testMathCos() throws TornadoExecutionPlanException {
         final int size = 128;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestMath.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/math/TestMath.java
@@ -201,12 +201,20 @@ public class TestMath extends TornadoTestBase {
     /**
      * Test that verifies the InverseSquareRootPhase optimization replaces 1.0/sqrt(x) with rsqrt(x).
      */
-    public static void testInverseSquareRoot(DoubleArray a) {
+    public static void testInverseSquareRootJavaMath(DoubleArray a) {
         for (@Parallel int i = 0; i < a.getSize(); i++) {
             // This pattern (1.0 / Math.sqrt(x)) should be recognized and optimized to rsqrt(x)
             a.set(i, 1.0 / Math.sqrt(a.get(i)));
         }
     }
+
+    public static void testInverseSquareRootTornadoMath(DoubleArray a) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            // This pattern (1.0 / Math.sqrt(x)) should be recognized and optimized to rsqrt(x)
+            a.set(i, 1.0 / TornadoMath.sqrt(a.get(i)));
+        }
+    }
+
 
     @Test
     public void testOptimizedInverseSquareRoot() throws TornadoExecutionPlanException {
@@ -224,7 +232,7 @@ public class TestMath extends TornadoTestBase {
         // Create and execute the task graph that should trigger the optimization
         TaskGraph taskGraph = new TaskGraph("s0")
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, data)
-                .task("t0", TestMath::testInverseSquareRoot, data)
+                .task("t0", TestMath::testInverseSquareRootTornadoMath, data)
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
@@ -234,7 +242,41 @@ public class TestMath extends TornadoTestBase {
         }
 
         // Execute the sequential version for comparison
-        testInverseSquareRoot(seq);
+        testInverseSquareRootTornadoMath(seq);
+
+        // Compare results
+        for (int i = 0; i < size; i++) {
+            assertEquals(data.get(i), seq.get(i), 0.01);
+        }
+    }
+
+    @Test
+    public void testOptimizedInverseSquareRootJavaMath() throws TornadoExecutionPlanException {
+        final int size = 128;
+        DoubleArray data = new DoubleArray(size);
+        DoubleArray seq = new DoubleArray(size);
+
+        // Initialize with positive random values to avoid sqrt of negative numbers
+        IntStream.range(0, size).parallel().forEach(i -> {
+            double value = Math.random() + 0.1; // Ensure positive values
+            data.set(i, value);
+            seq.set(i, value);
+        });
+
+        // Create and execute the task graph that should trigger the optimization
+        TaskGraph taskGraph = new TaskGraph("s0")
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, data)
+                .task("t0", TestMath::testInverseSquareRootJavaMath, data)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            // Execute the optimized version
+            executionPlan.execute();
+        }
+
+        // Execute the sequential version for comparison
+        testInverseSquareRootJavaMath(seq);
 
         // Compare results
         for (int i = 0; i < size; i++) {


### PR DESCRIPTION
#### Description

It seems that at some point something changed in the IR level and the ``InverseSquareRootPhase`` does not capture all patterns in the IR level, so it doesn't not properly apply the optimization to replace ``1/sqrt(x)`` with a native function for ``rsqrt(x)``.

Input code:
```java
public static void testInverseSquareRoot(DoubleArray a) {
    for (@Parallel int i = 0; i < a.getSize(); i++) {
        // This pattern (1.0 / Math.sqrt(x)) should be recognized and optimized to rsqrt(x)
        a.set(i, 1.0 / TornadoMath.sqrt(a.get(i)));
    }
}
```

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [x] Yes
- [ ] No

#### How to test the new patch?

```bash
tornado-test --printKernel -V uk.ac.manchester.tornado.unittests.math.TestMath#testOptimizedInverseSquareRoot
```



Before the fix:
```c++
#pragma OPENCL EXTENSION cl_khr_fp64 : enable  
#pragma OPENCL EXTENSION cl_khr_fp16 : enable  
#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable  
__kernel void testInverseSquareRoot(__global long *_kernel_context, __constant uchar *_constant_region, __local uchar *_local_region, __global int *_atomics, __global uchar *a)
{
  int i_1, i_2, i_3, i_4, i_11; 
  double d_8, d_10, d_9; 
  ulong ul_0, ul_7; 
  long l_5, l_6; 

  // BLOCK 0
  ul_0  =  (ulong) a;
  i_1  =  get_global_size(0);
  i_2  =  get_global_id(0);
  // BLOCK 1 MERGES [0 2 ]
  i_3  =  i_2;
  for(;i_3 < 128;)
  {
    // BLOCK 2
    i_4  =  i_3 + 3;
    l_5  =  (long) i_4;
    l_6  =  l_5 << 3;
    ul_7  =  ul_0 + l_6;
    d_8  =  *((__global double *) ul_7);
    d_9  =  native_sqrt(d_8);
    d_10  =  1.0 / d_9;
    *((__global double *) ul_7)  =  d_10;
    i_11  =  i_1 + i_3;
    i_3  =  i_11;
  }  // B2
  // BLOCK 3
  return;
}  //  kernel

```

After the fix:
```c++
__kernel void testInverseSquareRoot(__global long *_kernel_context, __constant uchar *_constant_region, __local uchar *_local_region, __global int *_atomics, __global uchar *a)
{
  ulong ul_7, ul_0; 
  long l_6, l_5; 
  int i_1, i_3, i_2, i_10, i_4; 
  double d_9, d_8; 

  // BLOCK 0
  ul_0  =  (ulong) a;
  i_1  =  get_global_size(0);
  i_2  =  get_global_id(0);
  // BLOCK 1 MERGES [0 2 ]
  i_3  =  i_2;
  for(;i_3 < 128;)
  {
    // BLOCK 2
    i_4  =  i_3 + 3;
    l_5  =  (long) i_4;
    l_6  =  l_5 << 3;
    ul_7  =  ul_0 + l_6;
    d_8  =  *((__global double *) ul_7);
    d_9  =  rsqrt(d_8);
    *((__global double *) ul_7)  =  d_9;
    i_10  =  i_1 + i_3;
    i_3  =  i_10;
  }  // B2
  // BLOCK 3
  return;
}  //  kernel

```
----------------------------------------------------------------------------
