### PR TITLE
[fix] Added guard conditions for UPS metrics when profiling across all backends

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLKernelScheduler.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/scheduler/OCLKernelScheduler.java
@@ -69,12 +69,14 @@ public abstract class OCLKernelScheduler {
         if (TornadoOptions.isProfilerEnabled()) {
             // Metrics captured before blocking
             meta.getProfiler().setTaskPowerUsage(ProfilerType.POWER_USAGE_mW, meta.getId(), deviceContext.getPowerUsage());
-            meta.getProfiler().setSystemPowerConsumption(ProfilerType.SYSTEM_POWER_CONSUMPTION_W, meta.getId(), (UpsMeterReader.getOutputPowerMetric() != null)
-                    ? Long.parseLong(UpsMeterReader.getOutputPowerMetric())
-                    : -1);
-            meta.getProfiler().setSystemVoltage(ProfilerType.SYSTEM_VOLTAGE_V, meta.getId(), (UpsMeterReader.getOutputVoltageMetric() != null)
-                    ? Long.parseLong(UpsMeterReader.getOutputVoltageMetric())
-                    : -1);
+            if (TornadoOptions.isUpsReaderEnabled()) {
+                meta.getProfiler().setSystemPowerConsumption(ProfilerType.SYSTEM_POWER_CONSUMPTION_W, meta.getId(), (UpsMeterReader.getOutputPowerMetric() != null)
+                        ? Long.parseLong(UpsMeterReader.getOutputPowerMetric())
+                        : -1);
+                meta.getProfiler().setSystemVoltage(ProfilerType.SYSTEM_VOLTAGE_V, meta.getId(), (UpsMeterReader.getOutputVoltageMetric() != null)
+                        ? Long.parseLong(UpsMeterReader.getOutputVoltageMetric())
+                        : -1);
+            }
 
             Event tornadoKernelEvent = deviceContext.resolveEvent(executionPlanId, taskEvent);
             tornadoKernelEvent.waitForEvents(executionPlanId);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXDeviceContext.java
@@ -353,12 +353,14 @@ public class PTXDeviceContext implements TornadoDeviceContext {
         if (TornadoOptions.isProfilerEnabled()) {
             // Metrics captured before blocking
             meta.getProfiler().setTaskPowerUsage(ProfilerType.POWER_USAGE_mW, meta.getId(), getPowerUsage());
-            meta.getProfiler().setSystemPowerConsumption(ProfilerType.SYSTEM_POWER_CONSUMPTION_W, meta.getId(), (UpsMeterReader.getOutputPowerMetric() != null)
-                    ? Long.parseLong(UpsMeterReader.getOutputPowerMetric())
-                    : -1);
-            meta.getProfiler().setSystemVoltage(ProfilerType.SYSTEM_VOLTAGE_V, meta.getId(), (UpsMeterReader.getOutputVoltageMetric() != null)
-                    ? Long.parseLong(UpsMeterReader.getOutputVoltageMetric())
-                    : -1);
+            if (TornadoOptions.isUpsReaderEnabled()) {
+                meta.getProfiler().setSystemPowerConsumption(ProfilerType.SYSTEM_POWER_CONSUMPTION_W, meta.getId(), (UpsMeterReader.getOutputPowerMetric() != null)
+                        ? Long.parseLong(UpsMeterReader.getOutputPowerMetric())
+                        : -1);
+                meta.getProfiler().setSystemVoltage(ProfilerType.SYSTEM_VOLTAGE_V, meta.getId(), (UpsMeterReader.getOutputVoltageMetric() != null)
+                        ? Long.parseLong(UpsMeterReader.getOutputVoltageMetric())
+                        : -1);
+            }
 
             Event tornadoKernelEvent = resolveEvent(executionPlanId, taskEvent);
             tornadoKernelEvent.waitForEvents(executionPlanId);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVLevelZeroInstalledCode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVLevelZeroInstalledCode.java
@@ -252,12 +252,14 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
         launchKernelWithLevelZero(executionPlanId, kernel, deviceThreadScheduling, threadBlockDispatcher);
 
         if (TornadoOptions.isProfilerEnabled()) {
-            meta.getProfiler().setSystemPowerConsumption(ProfilerType.SYSTEM_POWER_CONSUMPTION_W, meta.getId(), (UpsMeterReader.getOutputPowerMetric() != null)
-                    ? Long.parseLong(UpsMeterReader.getOutputPowerMetric())
-                    : -1);
-            meta.getProfiler().setSystemVoltage(ProfilerType.SYSTEM_VOLTAGE_V, meta.getId(), (UpsMeterReader.getOutputVoltageMetric() != null)
-                    ? Long.parseLong(UpsMeterReader.getOutputVoltageMetric())
-                    : -1);
+            if (TornadoOptions.isUpsReaderEnabled()) {
+                meta.getProfiler().setSystemPowerConsumption(ProfilerType.SYSTEM_POWER_CONSUMPTION_W, meta.getId(), (UpsMeterReader.getOutputPowerMetric() != null)
+                        ? Long.parseLong(UpsMeterReader.getOutputPowerMetric())
+                        : -1);
+                meta.getProfiler().setSystemVoltage(ProfilerType.SYSTEM_VOLTAGE_V, meta.getId(), (UpsMeterReader.getOutputVoltageMetric() != null)
+                        ? Long.parseLong(UpsMeterReader.getOutputVoltageMetric())
+                        : -1);
+            }
             kernelTimeStamp.solveEvent(executionPlanId, meta);
             ((SPIRVLevelZeroPowerMetricHandler) deviceContext.getPowerMetric()).readFinalCounters();
             meta.getProfiler().setTaskPowerUsage(ProfilerType.POWER_USAGE_mW, meta.getId(), deviceContext.getPowerUsage());

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVOCLInstalledCode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVOCLInstalledCode.java
@@ -167,12 +167,14 @@ public class SPIRVOCLInstalledCode extends SPIRVInstalledCode {
         if (TornadoOptions.isProfilerEnabled()) {
             // Metrics captured before blocking
             meta.getProfiler().setTaskPowerUsage(ProfilerType.POWER_USAGE_mW, meta.getId(), deviceContext.getPowerUsage());
-            meta.getProfiler().setSystemPowerConsumption(ProfilerType.SYSTEM_POWER_CONSUMPTION_W, meta.getId(), (UpsMeterReader.getOutputPowerMetric() != null)
-                    ? Long.parseLong(UpsMeterReader.getOutputPowerMetric())
-                    : -1);
-            meta.getProfiler().setSystemVoltage(ProfilerType.SYSTEM_VOLTAGE_V, meta.getId(), (UpsMeterReader.getOutputVoltageMetric() != null)
-                    ? Long.parseLong(UpsMeterReader.getOutputVoltageMetric())
-                    : -1);
+            if (TornadoOptions.isUpsReaderEnabled()) {
+                meta.getProfiler().setSystemPowerConsumption(ProfilerType.SYSTEM_POWER_CONSUMPTION_W, meta.getId(), (UpsMeterReader.getOutputPowerMetric() != null)
+                        ? Long.parseLong(UpsMeterReader.getOutputPowerMetric())
+                        : -1);
+                meta.getProfiler().setSystemVoltage(ProfilerType.SYSTEM_VOLTAGE_V, meta.getId(), (UpsMeterReader.getOutputVoltageMetric() != null)
+                        ? Long.parseLong(UpsMeterReader.getOutputVoltageMetric())
+                        : -1);
+            }
 
             Event tornadoKernelEvent = deviceContext.resolveEvent(executionPlanId, taskEvent);
             tornadoKernelEvent.waitForEvents(executionPlanId);


### PR DESCRIPTION
#### Description

This PR provides a fix for a bug that was spotted on `macOS` systems. When profiling with the TornadoVM profiler was enabled, the system was trying to read metrics from the UPS system. However, this should not be enabled if the flag for UPS reading is not enabled (i.e., if the `-Dtornado.ups.ip` is empty).

This PR adds relevant conditions to perform this check.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Provide instructions about how to test the new patch. 

```bash
make BACKEND=opencl && make fast-tests
make BACKEND=ptx && make fast-tests
make BACKEND=spirv && make fast-tests
```

----------------------------------------------------------------------------
