### PR TITLE
Fix closing bracket for flash attention

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
@@ -301,6 +301,18 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
                  */
                 closeBlock(block);
                 incrementClosedLoops(loopBeginBlock);
+            } else {
+                // This case is encountered in the uk.ac.manchester.tornado.unittests.codegen.CodeGenTest#testFlashAttention unittest
+                LoopBeginNode loopBeginNode = (LoopBeginNode) loopBeginBlock.getBeginNode();
+                if (loopBeginNode.loopExits().count() == 1) {
+                    // if there is only one exit for the loop
+                    LoopExitNode loopExitNode = loopBeginNode.loopExits().first();
+                    // if the exit is followed by and IfNode the loop will not close, so close it here
+                    if (loopExitNode.next() instanceof IfNode) {
+                        closeBlock(block);
+                        incrementClosedLoops(loopBeginBlock);
+                    }
+                }
             }
         } else {
             closeBlock(block);


### PR DESCRIPTION
#### Description

This PR addressed the code generation error reported in the issue #680.  In case there is a merge block two blocks above the `LoopEnd` block which is being examined by the `closeScope`, the rest of the loop exit points are checked. If there is only one loop exit point, the code in the PR checks if the only `LoopExit` node is followed by and `IfNode`, indicating nesting.  Since, in case of nesting, the `LoopExit` node is not expected to close the loop associated with it, the only other point which can close the loop is the `LoopEnd` block examined by the `closeScope`. Therefore, if this is the case, we proceed by closing the loop. 

Kfusion, TornadoVM-Raytracer and the unittests have all been checked and are not breaking with this fix. 

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Run `tornado-test -V uk.ac.manchester.tornado.unittests.codegen.CodeGenTest#testFlashAttention`
