### PR TITLE
[proposal] New API Functions for WarmUp

### DIFF
--- a/tornado-api/src/main/java/module-info.java
+++ b/tornado-api/src/main/java/module-info.java
@@ -16,7 +16,6 @@
  *
  */
 module tornado.api {
-    requires jmh.core;
     exports uk.ac.manchester.tornado.api;
     exports uk.ac.manchester.tornado.api.annotations;
     exports uk.ac.manchester.tornado.api.common;

--- a/tornado-api/src/main/java/module-info.java
+++ b/tornado-api/src/main/java/module-info.java
@@ -16,6 +16,7 @@
  *
  */
 module tornado.api {
+    requires jmh.core;
     exports uk.ac.manchester.tornado.api;
     exports uk.ac.manchester.tornado.api.annotations;
     exports uk.ac.manchester.tornado.api.common;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionPlanType.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionPlanType.java
@@ -23,7 +23,6 @@ import uk.ac.manchester.tornado.api.plan.types.OffPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.OffProfiler;
 import uk.ac.manchester.tornado.api.plan.types.OffThreadInfo;
 import uk.ac.manchester.tornado.api.plan.types.WithAllGraphs;
-import uk.ac.manchester.tornado.api.plan.types.WithAoTCompilation;
 import uk.ac.manchester.tornado.api.plan.types.WithBatch;
 import uk.ac.manchester.tornado.api.plan.types.WithClearProfiles;
 import uk.ac.manchester.tornado.api.plan.types.WithCompilerFlags;
@@ -35,17 +34,20 @@ import uk.ac.manchester.tornado.api.plan.types.WithFreeDeviceMemory;
 import uk.ac.manchester.tornado.api.plan.types.WithGraph;
 import uk.ac.manchester.tornado.api.plan.types.WithGridScheduler;
 import uk.ac.manchester.tornado.api.plan.types.WithMemoryLimit;
+import uk.ac.manchester.tornado.api.plan.types.WithPreCompilation;
 import uk.ac.manchester.tornado.api.plan.types.WithPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.WithProfiler;
 import uk.ac.manchester.tornado.api.plan.types.WithResetDevice;
 import uk.ac.manchester.tornado.api.plan.types.WithThreadInfo;
+import uk.ac.manchester.tornado.api.plan.types.WithWarmUpIterations;
+import uk.ac.manchester.tornado.api.plan.types.WithWarmUpTime;
 
 public abstract sealed class ExecutionPlanType extends TornadoExecutionPlan //
         permits OffConcurrentDevices, OffMemoryLimit, OffPrintKernel, OffProfiler, //
-        OffThreadInfo, WithAllGraphs, WithBatch, WithClearProfiles, WithCompilerFlags,  //
+        OffThreadInfo, WithAllGraphs, WithPreCompilation, WithBatch, WithClearProfiles, WithCompilerFlags, //
         WithConcurrentDevices, WithDefaultScheduler, WithDevice, WithDynamicReconfiguration, //
-        WithFreeDeviceMemory, WithGraph, WithGridScheduler, WithMemoryLimit, WithPrintKernel, //
-        WithProfiler, WithResetDevice, WithThreadInfo, WithAoTCompilation { //
+        WithFreeDeviceMemory, WithGraph, WithGridScheduler, WithMemoryLimit, WithPrintKernel, WithProfiler, //
+        WithResetDevice, WithThreadInfo, WithWarmUpIterations, WithWarmUpTime { //
 
     public ExecutionPlanType(TornadoExecutionPlan parentNode) {
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionPlanType.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionPlanType.java
@@ -23,6 +23,7 @@ import uk.ac.manchester.tornado.api.plan.types.OffPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.OffProfiler;
 import uk.ac.manchester.tornado.api.plan.types.OffThreadInfo;
 import uk.ac.manchester.tornado.api.plan.types.WithAllGraphs;
+import uk.ac.manchester.tornado.api.plan.types.WithAoTCompilation;
 import uk.ac.manchester.tornado.api.plan.types.WithBatch;
 import uk.ac.manchester.tornado.api.plan.types.WithClearProfiles;
 import uk.ac.manchester.tornado.api.plan.types.WithCompilerFlags;
@@ -38,14 +39,13 @@ import uk.ac.manchester.tornado.api.plan.types.WithPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.WithProfiler;
 import uk.ac.manchester.tornado.api.plan.types.WithResetDevice;
 import uk.ac.manchester.tornado.api.plan.types.WithThreadInfo;
-import uk.ac.manchester.tornado.api.plan.types.WithWarmUp;
 
 public abstract sealed class ExecutionPlanType extends TornadoExecutionPlan //
         permits OffConcurrentDevices, OffMemoryLimit, OffPrintKernel, OffProfiler, //
         OffThreadInfo, WithAllGraphs, WithBatch, WithClearProfiles, WithCompilerFlags,  //
         WithConcurrentDevices, WithDefaultScheduler, WithDevice, WithDynamicReconfiguration, //
         WithFreeDeviceMemory, WithGraph, WithGridScheduler, WithMemoryLimit, WithPrintKernel, //
-        WithProfiler, WithResetDevice, WithThreadInfo, WithWarmUp { //
+        WithProfiler, WithResetDevice, WithThreadInfo, WithAoTCompilation { //
 
     public ExecutionPlanType(TornadoExecutionPlan parentNode) {
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -50,8 +50,8 @@ public class ImmutableTaskGraph {
         this.taskGraph.execute(executionPackage);
     }
 
-    void warmup(ExecutorFrame executionPackage) {
-        taskGraph.warmup(executionPackage);
+    void withAoTCompilation(ExecutorFrame executionPackage) {
+        taskGraph.withAoTCompilation(executionPackage);
     }
 
     void withDevice(TornadoDevice device) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -50,8 +50,8 @@ public class ImmutableTaskGraph {
         this.taskGraph.execute(executionPackage);
     }
 
-    void withAoTCompilation(ExecutorFrame executionPackage) {
-        taskGraph.withAoTCompilation(executionPackage);
+    void withPreCompilation(ExecutorFrame executionPackage) {
+        taskGraph.withPreCompilation(executionPackage);
     }
 
     void withDevice(TornadoDevice device) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -804,8 +804,8 @@ public class TaskGraph implements TaskGraphInterface {
         taskGraphImpl.execute(executionPackage).waitOn();
     }
 
-    void warmup(ExecutorFrame executionPackage) {
-        taskGraphImpl.warmup(executionPackage);
+    void withAoTCompilation(ExecutorFrame executionPackage) {
+        taskGraphImpl.withAoTCompilation(executionPackage);
     }
 
     void dumpProfiles() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -804,8 +804,8 @@ public class TaskGraph implements TaskGraphInterface {
         taskGraphImpl.execute(executionPackage).waitOn();
     }
 
-    void withAoTCompilation(ExecutorFrame executionPackage) {
-        taskGraphImpl.withAoTCompilation(executionPackage);
+    void withPreCompilation(ExecutorFrame executionPackage) {
+        taskGraphImpl.withPreCompilation(executionPackage);
     }
 
     void dumpProfiles() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -33,7 +33,6 @@ import uk.ac.manchester.tornado.api.plan.types.OffPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.OffProfiler;
 import uk.ac.manchester.tornado.api.plan.types.OffThreadInfo;
 import uk.ac.manchester.tornado.api.plan.types.WithAllGraphs;
-import uk.ac.manchester.tornado.api.plan.types.WithAoTCompilation;
 import uk.ac.manchester.tornado.api.plan.types.WithBatch;
 import uk.ac.manchester.tornado.api.plan.types.WithClearProfiles;
 import uk.ac.manchester.tornado.api.plan.types.WithCompilerFlags;
@@ -45,10 +44,13 @@ import uk.ac.manchester.tornado.api.plan.types.WithFreeDeviceMemory;
 import uk.ac.manchester.tornado.api.plan.types.WithGraph;
 import uk.ac.manchester.tornado.api.plan.types.WithGridScheduler;
 import uk.ac.manchester.tornado.api.plan.types.WithMemoryLimit;
+import uk.ac.manchester.tornado.api.plan.types.WithPreCompilation;
 import uk.ac.manchester.tornado.api.plan.types.WithPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.WithProfiler;
 import uk.ac.manchester.tornado.api.plan.types.WithResetDevice;
 import uk.ac.manchester.tornado.api.plan.types.WithThreadInfo;
+import uk.ac.manchester.tornado.api.plan.types.WithWarmUpIterations;
+import uk.ac.manchester.tornado.api.plan.types.WithWarmUpTime;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 
@@ -222,9 +224,9 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      *
      * @return {@link TornadoExecutionPlan}
      */
-    public TornadoExecutionPlan withAoTCompilation() {
-        tornadoExecutor.withAoTCompilation(executionFrame);
-        return new WithAoTCompilation(this);
+    public TornadoExecutionPlan withPreCompilation() {
+        tornadoExecutor.withPreCompilation(executionFrame);
+        return new WithPreCompilation(this);
     }
 
     /**
@@ -612,19 +614,37 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      * of time.
      * 
      * @param milliseconds
-     *     Amount of time in milliseconds to warm up the execution plan. This amount means that the
-     *     execution plan will run, at least for the specified amount of time. if the tasks within the task-graphs
+     *     Amount of time to warm up the execution plan. This amount means that the execution plan will run,
+     *     at least for the specified amount of time. if the tasks within the task-graphs
      *     takes longer to execute, in a second run, the code will not be dispatched.
      * @return {@link TornadoExecutionPlan}
      * 
      * @throws {@link
      *     InterruptedException}
      */
-    public TornadoExecutionPlan withWarmUp(long milliseconds) throws InterruptedException {
+    public TornadoExecutionPlan withWarmUpTime(long milliseconds) throws InterruptedException {
         if (milliseconds < 0) {
             throw new TornadoRuntimeException("[ERROR] Warm-up time cannot be negative");
         }
-        tornadoExecutor.withWarmUp(milliseconds, executionFrame);
-        return this;
+        tornadoExecutor.withWarmUpTime(milliseconds, executionFrame);
+        return new WithWarmUpTime(this, milliseconds);
+    }
+
+    /**
+     * This function allows developers to warm up the whole execution plan before running it. This covers
+     * copy in and out data, compiling all tasks and executing all tasks once for the specified amount
+     * of time.
+     *
+     * @param iterations
+     *     Number of iterations to run the whole execution plan as warm-up.
+     * @return {@link TornadoExecutionPlan}
+     *
+     */
+    public TornadoExecutionPlan withWarmUpIterations(int iterations) {
+        if (iterations < 0) {
+            throw new TornadoRuntimeException("[ERROR] Warm-up time cannot be negative");
+        }
+        tornadoExecutor.withWarmUpIterations(iterations, executionFrame);
+        return new WithWarmUpIterations(this, iterations);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -605,4 +605,26 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
     public void mapOnDeviceMemoryRegion(Object destTornadoArray, Object srcTornadoArray, long offset, int fromGraphIndex, int toGraphIndex) {
         tornadoExecutor.mapOnDeviceMemoryRegion(destTornadoArray, srcTornadoArray, offset, fromGraphIndex, toGraphIndex);
     }
+
+    /**
+     * This function allows developers to warm up the whole execution plan before running it. This covers
+     * copy in and out data, compiling all tasks and executing all tasks once for the specified amount
+     * of time.
+     * 
+     * @param milliseconds
+     *     Amount of time in milliseconds to warm up the execution plan. This amount means that the
+     *     execution plan will run, at least for the specified amount of time. if the tasks within the task-graphs
+     *     takes longer to execute, in a second run, the code will not be dispatched.
+     * @return {@link TornadoExecutionPlan}
+     * 
+     * @throws {@link
+     *     InterruptedException}
+     */
+    public TornadoExecutionPlan withWarmUp(long milliseconds) throws InterruptedException {
+        if (milliseconds < 0) {
+            throw new TornadoRuntimeException("[ERROR] Warm-up time cannot be negative");
+        }
+        tornadoExecutor.withWarmUp(milliseconds, executionFrame);
+        return this;
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -33,6 +33,7 @@ import uk.ac.manchester.tornado.api.plan.types.OffPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.OffProfiler;
 import uk.ac.manchester.tornado.api.plan.types.OffThreadInfo;
 import uk.ac.manchester.tornado.api.plan.types.WithAllGraphs;
+import uk.ac.manchester.tornado.api.plan.types.WithAoTCompilation;
 import uk.ac.manchester.tornado.api.plan.types.WithBatch;
 import uk.ac.manchester.tornado.api.plan.types.WithClearProfiles;
 import uk.ac.manchester.tornado.api.plan.types.WithCompilerFlags;
@@ -48,7 +49,6 @@ import uk.ac.manchester.tornado.api.plan.types.WithPrintKernel;
 import uk.ac.manchester.tornado.api.plan.types.WithProfiler;
 import uk.ac.manchester.tornado.api.plan.types.WithResetDevice;
 import uk.ac.manchester.tornado.api.plan.types.WithThreadInfo;
-import uk.ac.manchester.tornado.api.plan.types.WithWarmUp;
 import uk.ac.manchester.tornado.api.runtime.ExecutorFrame;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 
@@ -222,9 +222,9 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      *
      * @return {@link TornadoExecutionPlan}
      */
-    public TornadoExecutionPlan withWarmUp() {
-        tornadoExecutor.warmup(executionFrame);
-        return new WithWarmUp(this);
+    public TornadoExecutionPlan withAoTCompilation() {
+        tornadoExecutor.withAoTCompilation(executionFrame);
+        return new WithAoTCompilation(this);
     }
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
@@ -68,8 +69,8 @@ class TornadoExecutor {
         }
     }
 
-    void withAoTCompilation(ExecutorFrame executorFrame) {
-        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.withAoTCompilation(executorFrame));
+    void withPreCompilation(ExecutorFrame executorFrame) {
+        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.withPreCompilation(executorFrame));
     }
 
     void withBatch(String batchSize) {
@@ -328,7 +329,7 @@ class TornadoExecutor {
         return false;
     }
 
-    public void withWarmUp(long milliseconds, ExecutorFrame executorFrame) throws InterruptedException {
+    public void withWarmUpTime(long milliseconds, ExecutorFrame executorFrame) throws InterruptedException {
         AtomicBoolean run = new AtomicBoolean(true);
 
         // If iterations takes more than the specified amount of milliseconds,
@@ -353,5 +354,9 @@ class TornadoExecutor {
 
         warmUpThread.join();
         controllerThread.join();
+    }
+
+    public void withWarmUpIterations(int iterations, ExecutorFrame executorFrame) {
+        IntStream.range(0, iterations).mapToObj(i -> executorFrame).forEach(this::execute);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -67,8 +67,8 @@ class TornadoExecutor {
         }
     }
 
-    void warmup(ExecutorFrame executorFrame) {
-        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.warmup(executorFrame));
+    void withAoTCompilation(ExecutorFrame executorFrame) {
+        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.withAoTCompilation(executorFrame));
     }
 
     void withBatch(String batchSize) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -20,6 +20,7 @@ package uk.ac.manchester.tornado.api;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
@@ -327,4 +328,30 @@ class TornadoExecutor {
         return false;
     }
 
+    public void withWarmUp(long milliseconds, ExecutorFrame executorFrame) throws InterruptedException {
+        AtomicBoolean run = new AtomicBoolean(true);
+
+        // If iterations takes more than the specified amount of milliseconds,
+        // the next run is stopped. This means that the amount if milliseconds
+        // specified is "at least" the time that the warm-up will take.
+        Thread warmUpThread = new Thread(() -> {
+            while (run.get()) {
+                execute(executorFrame);
+            }
+        });
+
+        Thread controllerThread = new Thread(() -> {
+            try {
+                Thread.sleep(milliseconds);
+            } catch (InterruptedException e) {
+                throw new TornadoRuntimeException(e);
+            }
+            run.set(false);
+        });
+        warmUpThread.start();
+        controllerThread.start();
+
+        warmUpThread.join();
+        controllerThread.join();
+    }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -82,7 +82,7 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void dump();
 
-    void withAoTCompilation(ExecutorFrame executionPackage);
+    void withPreCompilation(ExecutorFrame executionPackage);
 
     void freeDeviceMemory();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -82,7 +82,7 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void dump();
 
-    void warmup(ExecutorFrame executionPackage);
+    void withAoTCompilation(ExecutorFrame executionPackage);
 
     void freeDeviceMemory();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithAoTCompilation.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithAoTCompilation.java
@@ -20,14 +20,14 @@ package uk.ac.manchester.tornado.api.plan.types;
 import uk.ac.manchester.tornado.api.ExecutionPlanType;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 
-public final class WithWarmUp extends ExecutionPlanType {
+public final class WithAoTCompilation extends ExecutionPlanType {
 
-    public WithWarmUp(TornadoExecutionPlan parent) {
+    public WithAoTCompilation(TornadoExecutionPlan parent) {
         super(parent);
     }
 
     @Override
     public String toString() {
-        return super.toString() + "\n -> withWarmUp ";
+        return super.toString() + "\n -> withAoTCompilation ";
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithPreCompilation.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithPreCompilation.java
@@ -20,14 +20,14 @@ package uk.ac.manchester.tornado.api.plan.types;
 import uk.ac.manchester.tornado.api.ExecutionPlanType;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 
-public final class WithAoTCompilation extends ExecutionPlanType {
+public final class WithPreCompilation extends ExecutionPlanType {
 
-    public WithAoTCompilation(TornadoExecutionPlan parent) {
+    public WithPreCompilation(TornadoExecutionPlan parent) {
         super(parent);
     }
 
     @Override
     public String toString() {
-        return super.toString() + "\n -> withAoTCompilation ";
+        return super.toString() + "\n -> withPreCompilation ";
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithWarmUpIterations.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithWarmUpIterations.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.plan.types;
+
+import uk.ac.manchester.tornado.api.ExecutionPlanType;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+
+public final class WithWarmUpIterations extends ExecutionPlanType {
+
+    private final long iterations;
+
+    public WithWarmUpIterations(TornadoExecutionPlan parentNode, long iterations) {
+        super(parentNode);
+        this.iterations = iterations;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + "\n -> withWarmUpIterations( " + iterations + " ms)";
+    }
+
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithWarmUpTime.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithWarmUpTime.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.plan.types;
+
+import uk.ac.manchester.tornado.api.ExecutionPlanType;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+
+public final class WithWarmUpTime extends ExecutionPlanType {
+
+    private final long milliseconds;
+
+    public WithWarmUpTime(TornadoExecutionPlan parentNode, long milliseconds) {
+        super(parentNode);
+        this.milliseconds = milliseconds;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + "\n -> withWarmUpTime( " + milliseconds + " ms)";
+    }
+
+}

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -2,7 +2,7 @@
 # vim: set tasbstop=4
 
 #
-# Copyright (c) 2013-2023, APT Group, Department of Computer Science,
+# Copyright (c) 2013-2023, 2025, APT Group, Department of Computer Science,
 # The University of Manchester.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -162,6 +162,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.instances.TestInstances"),
     TestEntry("uk.ac.manchester.tornado.unittests.matrices.TestMatrixTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestAPI"),
+    TestEntry("uk.ac.manchester.tornado.unittests.warmup.TestWarmUp"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestInitDataTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.memory.TestMemoryLimit"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestIO"),

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/AddTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/AddTornado.java
@@ -76,7 +76,7 @@ public class AddTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
 
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/AddTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/AddTornado.java
@@ -76,7 +76,7 @@ public class AddTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
 
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/JMHAddImage.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/JMHAddImage.java
@@ -89,7 +89,7 @@ public class JMHAddImage {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/JMHAddImage.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/addImage/JMHAddImage.java
@@ -89,7 +89,7 @@ public class JMHAddImage {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/JMHBlackScholes.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/JMHBlackScholes.java
@@ -81,7 +81,7 @@ public class JMHBlackScholes {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/JMHBlackScholes.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blackscholes/JMHBlackScholes.java
@@ -81,7 +81,7 @@ public class JMHBlackScholes {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/BlurFilterTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/BlurFilterTornado.java
@@ -97,7 +97,7 @@ public class BlurFilterTornado extends BenchmarkDriver {
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
         executionPlan.withDefaultScheduler() //
-                .withWarmUp();
+                .withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/BlurFilterTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/BlurFilterTornado.java
@@ -97,7 +97,7 @@ public class BlurFilterTornado extends BenchmarkDriver {
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
         executionPlan.withDefaultScheduler() //
-                .withAoTCompilation();
+                .withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/JMHBlurFilter.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/JMHBlurFilter.java
@@ -111,7 +111,7 @@ public class JMHBlurFilter {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withDefaultScheduler().withWarmUp();
+            executor.withDefaultScheduler().withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/JMHBlurFilter.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/blurFilter/JMHBlurFilter.java
@@ -111,7 +111,7 @@ public class JMHBlurFilter {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withDefaultScheduler().withAoTCompilation();
+            executor.withDefaultScheduler().withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/ConvolveImageArrayTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/ConvolveImageArrayTornado.java
@@ -69,7 +69,7 @@ public class ConvolveImageArrayTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/ConvolveImageArrayTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/ConvolveImageArrayTornado.java
@@ -69,7 +69,7 @@ public class ConvolveImageArrayTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/JMHConvolveArray.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/JMHConvolveArray.java
@@ -84,7 +84,7 @@ public class JMHConvolveArray {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withDefaultScheduler().withWarmUp();
+            executor.withDefaultScheduler().withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/JMHConvolveArray.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolvearray/JMHConvolveArray.java
@@ -84,7 +84,7 @@ public class JMHConvolveArray {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withDefaultScheduler().withAoTCompilation();
+            executor.withDefaultScheduler().withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageTornado.java
@@ -70,7 +70,7 @@ public class ConvolveImageTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
 
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/ConvolveImageTornado.java
@@ -70,7 +70,7 @@ public class ConvolveImageTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
 
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/JMHConvolveImage.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/JMHConvolveImage.java
@@ -86,7 +86,7 @@ public class JMHConvolveImage {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/JMHConvolveImage.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/convolveimage/JMHConvolveImage.java
@@ -86,7 +86,7 @@ public class JMHConvolveImage {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTTornado.java
@@ -69,7 +69,7 @@ public class DFTTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override
@@ -79,7 +79,7 @@ public class DFTTornado extends BenchmarkDriver {
         FloatArray outImagTor = new FloatArray(size);
 
         executionPlan.withDevice(device) //
-                .withAoTCompilation() //
+                .withPreCompilation() //
                 .execute();
 
         ComputeKernels.computeDFT(inReal, inImag, outRealTor, outImagTor);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/DFTTornado.java
@@ -69,7 +69,7 @@ public class DFTTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override
@@ -79,7 +79,7 @@ public class DFTTornado extends BenchmarkDriver {
         FloatArray outImagTor = new FloatArray(size);
 
         executionPlan.withDevice(device) //
-                .withWarmUp() //
+                .withAoTCompilation() //
                 .execute();
 
         ComputeKernels.computeDFT(inReal, inImag, outRealTor, outImagTor);

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/JMHDFT.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/JMHDFT.java
@@ -84,7 +84,7 @@ public class JMHDFT {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/JMHDFT.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dft/JMHDFT.java
@@ -84,7 +84,7 @@ public class JMHDFT {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/DgemmTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/DgemmTornado.java
@@ -73,7 +73,7 @@ public class DgemmTornado extends BenchmarkDriver {
                 .task("dgemm", LinearAlgebraArrays::dgemm, m, n, n, a, b, c) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
         executionPlan = new TornadoExecutionPlan(taskGraph.snapshot());
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/DgemmTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/DgemmTornado.java
@@ -73,7 +73,7 @@ public class DgemmTornado extends BenchmarkDriver {
                 .task("dgemm", LinearAlgebraArrays::dgemm, m, n, n, a, b, c) //
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
         executionPlan = new TornadoExecutionPlan(taskGraph.snapshot());
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/JMHGemm.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/JMHGemm.java
@@ -88,7 +88,7 @@ public class JMHGemm {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/JMHGemm.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dgemm/JMHGemm.java
@@ -88,7 +88,7 @@ public class JMHGemm {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/DotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/DotTornado.java
@@ -74,7 +74,7 @@ public class DotTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/DotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/DotTornado.java
@@ -74,7 +74,7 @@ public class DotTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/JMHDotImage.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/JMHDotImage.java
@@ -86,7 +86,7 @@ public class JMHDotImage {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/JMHDotImage.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotimage/JMHDotImage.java
@@ -86,7 +86,7 @@ public class JMHDotImage {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/DotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/DotTornado.java
@@ -71,7 +71,7 @@ public class DotTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
 
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/DotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/DotTornado.java
@@ -71,7 +71,7 @@ public class DotTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
 
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/JMHDotVector.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/JMHDotVector.java
@@ -85,7 +85,7 @@ public class JMHDotVector {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/JMHDotVector.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/dotvector/JMHDotVector.java
@@ -85,7 +85,7 @@ public class JMHDotVector {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/EulerTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/EulerTornado.java
@@ -72,7 +72,7 @@ public class EulerTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/EulerTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/EulerTornado.java
@@ -72,7 +72,7 @@ public class EulerTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/JMHEuler.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/JMHEuler.java
@@ -89,7 +89,7 @@ public class JMHEuler {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/JMHEuler.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/euler/JMHEuler.java
@@ -89,7 +89,7 @@ public class JMHEuler {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/HilbertTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/HilbertTornado.java
@@ -53,7 +53,7 @@ public class HilbertTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/HilbertTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/HilbertTornado.java
@@ -53,7 +53,7 @@ public class HilbertTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/JMHHilbert.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/JMHHilbert.java
@@ -68,7 +68,7 @@ public class JMHHilbert {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, hilbertMatrix); //
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-            executionPlan.withAoTCompilation();
+            executionPlan.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/JMHHilbert.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/hilbert/JMHHilbert.java
@@ -68,7 +68,7 @@ public class JMHHilbert {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, hilbertMatrix); //
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-            executionPlan.withWarmUp();
+            executionPlan.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JMHJuliaSet.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JMHJuliaSet.java
@@ -73,7 +73,7 @@ public class JMHJuliaSet {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JMHJuliaSet.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JMHJuliaSet.java
@@ -73,7 +73,7 @@ public class JMHJuliaSet {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JuliaSetTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JuliaSetTornado.java
@@ -57,7 +57,7 @@ public class JuliaSetTornado extends BenchmarkDriver {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, hue, brightness);
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JuliaSetTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/juliaset/JuliaSetTornado.java
@@ -57,7 +57,7 @@ public class JuliaSetTornado extends BenchmarkDriver {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, hue, brightness);
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/JMHMandelbrot.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/JMHMandelbrot.java
@@ -69,7 +69,7 @@ public class JMHMandelbrot {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/JMHMandelbrot.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/JMHMandelbrot.java
@@ -69,7 +69,7 @@ public class JMHMandelbrot {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/MandelbrotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/MandelbrotTornado.java
@@ -50,7 +50,7 @@ public class MandelbrotTornado extends BenchmarkDriver {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/MandelbrotTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/mandelbrot/MandelbrotTornado.java
@@ -50,7 +50,7 @@ public class MandelbrotTornado extends BenchmarkDriver {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/JMHMontecarlo.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/JMHMontecarlo.java
@@ -70,7 +70,7 @@ public class JMHMontecarlo {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-            executionPlan.withAoTCompilation();
+            executionPlan.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/JMHMontecarlo.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/JMHMontecarlo.java
@@ -70,7 +70,7 @@ public class JMHMontecarlo {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-            executionPlan.withWarmUp();
+            executionPlan.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/MonteCarloTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/MonteCarloTornado.java
@@ -53,7 +53,7 @@ public class MonteCarloTornado extends BenchmarkDriver {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/MonteCarloTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/montecarlo/MonteCarloTornado.java
@@ -53,7 +53,7 @@ public class MonteCarloTornado extends BenchmarkDriver {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/JMHNBody.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/JMHNBody.java
@@ -101,7 +101,7 @@ public class JMHNBody {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, posSeq, velSeq);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/JMHNBody.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/JMHNBody.java
@@ -101,7 +101,7 @@ public class JMHNBody {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, posSeq, velSeq);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyTornado.java
@@ -85,7 +85,7 @@ public class NBodyTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override
@@ -133,9 +133,9 @@ public class NBodyTornado extends BenchmarkDriver {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
 
-        TornadoExecutionResult executionResult = executionPlan.withAoTCompilation() //
+        TornadoExecutionResult executionResult = executionPlan.withPreCompilation() //
                 .withDevice(device) //
                 .execute();
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/nbody/NBodyTornado.java
@@ -85,7 +85,7 @@ public class NBodyTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override
@@ -133,9 +133,9 @@ public class NBodyTornado extends BenchmarkDriver {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
 
-        TornadoExecutionResult executionResult = executionPlan.withWarmUp() //
+        TornadoExecutionResult executionResult = executionPlan.withAoTCompilation() //
                 .withDevice(device) //
                 .execute();
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/JMHRenderTrack.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/JMHRenderTrack.java
@@ -82,7 +82,7 @@ public class JMHRenderTrack {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/JMHRenderTrack.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/JMHRenderTrack.java
@@ -82,7 +82,7 @@ public class JMHRenderTrack {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/RenderTrackTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/RenderTrackTornado.java
@@ -67,7 +67,7 @@ public class RenderTrackTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/RenderTrackTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/renderTrack/RenderTrackTornado.java
@@ -67,7 +67,7 @@ public class RenderTrackTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/JMHRotateImage.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/JMHRotateImage.java
@@ -88,7 +88,7 @@ public class JMHRotateImage {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/JMHRotateImage.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/JMHRotateImage.java
@@ -88,7 +88,7 @@ public class JMHRotateImage {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateTornado.java
@@ -74,7 +74,7 @@ public class RotateTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotateimage/RotateTornado.java
@@ -74,7 +74,7 @@ public class RotateTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/JMHRotateVector.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/JMHRotateVector.java
@@ -85,7 +85,7 @@ public class JMHRotateVector {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/JMHRotateVector.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/JMHRotateVector.java
@@ -85,7 +85,7 @@ public class JMHRotateVector {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/RotateTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/RotateTornado.java
@@ -70,7 +70,7 @@ public class RotateTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/RotateTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/rotatevector/RotateTornado.java
@@ -70,7 +70,7 @@ public class RotateTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/JMHSaxpy.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/JMHSaxpy.java
@@ -81,7 +81,7 @@ public class JMHSaxpy {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/JMHSaxpy.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/JMHSaxpy.java
@@ -81,7 +81,7 @@ public class JMHSaxpy {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/SaxpyTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/SaxpyTornado.java
@@ -65,7 +65,7 @@ public class SaxpyTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/SaxpyTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/saxpy/SaxpyTornado.java
@@ -65,7 +65,7 @@ public class SaxpyTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/JMHSgemm.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/JMHSgemm.java
@@ -90,7 +90,7 @@ public class JMHSgemm {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
 
         }
     }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/JMHSgemm.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/JMHSgemm.java
@@ -90,7 +90,7 @@ public class JMHSgemm {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
 
         }
     }

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmTornado.java
@@ -89,7 +89,7 @@ public class SgemmTornado extends BenchmarkDriver {
         taskGraph.transferToHost(DataTransferMode.EVERY_EXECUTION, c);
 
         executionPlan = new TornadoExecutionPlan(taskGraph.snapshot());
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemm/SgemmTornado.java
@@ -89,7 +89,7 @@ public class SgemmTornado extends BenchmarkDriver {
         taskGraph.transferToHost(DataTransferMode.EVERY_EXECUTION, c);
 
         executionPlan = new TornadoExecutionPlan(taskGraph.snapshot());
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/JMHSgemV.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/JMHSgemV.java
@@ -89,7 +89,7 @@ public class JMHSgemV {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/JMHSgemV.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/JMHSgemV.java
@@ -89,7 +89,7 @@ public class JMHSgemV {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/SgemvTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/SgemvTornado.java
@@ -74,7 +74,7 @@ public class SgemvTornado extends BenchmarkDriver {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, y);
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/SgemvTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/sgemv/SgemvTornado.java
@@ -74,7 +74,7 @@ public class SgemvTornado extends BenchmarkDriver {
                 .transferToHost(DataTransferMode.EVERY_EXECUTION, y);
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/JMHSpmv.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/JMHSpmv.java
@@ -78,7 +78,7 @@ public class JMHSpmv {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, y);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/JMHSpmv.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/JMHSpmv.java
@@ -78,7 +78,7 @@ public class JMHSpmv {
                     .transferToHost(DataTransferMode.EVERY_EXECUTION, y);
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/SpmvTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/SpmvTornado.java
@@ -62,7 +62,7 @@ public class SpmvTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/SpmvTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/spmv/SpmvTornado.java
@@ -62,7 +62,7 @@ public class SpmvTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/JMHStencil.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/JMHStencil.java
@@ -96,7 +96,7 @@ public class JMHStencil {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/JMHStencil.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/JMHStencil.java
@@ -96,7 +96,7 @@ public class JMHStencil {
 
             ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
             executor = new TornadoExecutionPlan(immutableTaskGraph);
-            executor.withWarmUp();
+            executor.withAoTCompilation();
         }
     }
 

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/StencilTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/StencilTornado.java
@@ -78,7 +78,7 @@ public class StencilTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withWarmUp();
+        executionPlan.withAoTCompilation();
     }
 
     @Override

--- a/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/StencilTornado.java
+++ b/tornado-benchmarks/src/main/java/uk/ac/manchester/tornado/benchmarks/stencil/StencilTornado.java
@@ -78,7 +78,7 @@ public class StencilTornado extends BenchmarkDriver {
 
         immutableTaskGraph = taskGraph.snapshot();
         executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withAoTCompilation();
+        executionPlan.withPreCompilation();
     }
 
     @Override

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication1D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication1D.java
@@ -79,7 +79,7 @@ public class MatrixMultiplication1D {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph);
-        executor.withWarmUp();
+        executor.withAoTCompilation();
 
         // 1. Warm up Tornado
         for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication1D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication1D.java
@@ -79,7 +79,7 @@ public class MatrixMultiplication1D {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph);
-        executor.withAoTCompilation();
+        executor.withPreCompilation();
 
         // 1. Warm up Tornado
         for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication2D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication2D.java
@@ -110,7 +110,7 @@ public class MatrixMultiplication2D {
         long end;
         TornadoDeviceType deviceType;
         try (TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executor.withWarmUp();
+            executor.withAoTCompilation();
 
             // 1. Warm up Tornado
             for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication2D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication2D.java
@@ -110,7 +110,7 @@ public class MatrixMultiplication2D {
         long end;
         TornadoDeviceType deviceType;
         try (TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executor.withAoTCompilation();
+            executor.withPreCompilation();
 
             // 1. Warm up Tornado
             for (int i = 0; i < WARMING_UP_ITERATIONS; i++) {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixVector.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixVector.java
@@ -113,7 +113,7 @@ public class MatrixVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph);
-        executor.withWarmUp();
+        executor.withAoTCompilation();
 
         for (int i = 0; i < WARM_UP_ITERATIONS; i++) {
             computeMatrixVector(matrix2DFloat, vectorFloat, resultSeq);

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixVector.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixVector.java
@@ -113,7 +113,7 @@ public class MatrixVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph);
-        executor.withAoTCompilation();
+        executor.withPreCompilation();
 
         for (int i = 0; i < WARM_UP_ITERATIONS; i++) {
             computeMatrixVector(matrix2DFloat, vectorFloat, resultSeq);

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/NBody.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/NBody.java
@@ -154,7 +154,7 @@ public class NBody {
                 .transferToHost(DataTransferMode.UNDER_DEMAND, posTornadoVM, velTornadoVM);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph).withAoTCompilation();
+        TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph).withPreCompilation();
 
         resultsIterations = new StringBuffer();
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/NBody.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/NBody.java
@@ -154,7 +154,7 @@ public class NBody {
                 .transferToHost(DataTransferMode.UNDER_DEMAND, posTornadoVM, velTornadoVM);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
-        TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph).withWarmUp();
+        TornadoExecutionPlan executor = new TornadoExecutionPlan(immutableTaskGraph).withAoTCompilation();
 
         resultsIterations = new StringBuffer();
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/DFTVector.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/DFTVector.java
@@ -405,7 +405,7 @@ public class DFTVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withDevice(device).withWarmUp();
+            executionPlan.withDevice(device).withAoTCompilation();
 
             for (int i = 0; i < WARMUP; i++) {
                 executionPlan.execute();
@@ -451,7 +451,7 @@ public class DFTVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withDevice(device).withWarmUp();
+            executionPlan.withDevice(device).withAoTCompilation();
 
             for (int i = 0; i < WARMUP; i++) {
                 executionPlan.execute();
@@ -499,7 +499,7 @@ public class DFTVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withDevice(device).withWarmUp();
+            executionPlan.withDevice(device).withAoTCompilation();
 
             for (int i = 0; i < WARMUP; i++) {
                 executionPlan.execute();
@@ -547,7 +547,7 @@ public class DFTVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withDevice(device).withWarmUp();
+            executionPlan.withDevice(device).withAoTCompilation();
 
             for (int i = 0; i < WARMUP; i++) {
                 executionPlan.execute();
@@ -637,7 +637,7 @@ public class DFTVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp().withDevice(device);
+            executionPlan.withAoTCompilation().withDevice(device);
 
             for (int i = 0; i < WARMUP; i++) {
                 executionPlan.execute();

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/DFTVector.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/DFTVector.java
@@ -405,7 +405,7 @@ public class DFTVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withDevice(device).withAoTCompilation();
+            executionPlan.withDevice(device).withPreCompilation();
 
             for (int i = 0; i < WARMUP; i++) {
                 executionPlan.execute();
@@ -451,7 +451,7 @@ public class DFTVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withDevice(device).withAoTCompilation();
+            executionPlan.withDevice(device).withPreCompilation();
 
             for (int i = 0; i < WARMUP; i++) {
                 executionPlan.execute();
@@ -499,7 +499,7 @@ public class DFTVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withDevice(device).withAoTCompilation();
+            executionPlan.withDevice(device).withPreCompilation();
 
             for (int i = 0; i < WARMUP; i++) {
                 executionPlan.execute();
@@ -547,7 +547,7 @@ public class DFTVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withDevice(device).withAoTCompilation();
+            executionPlan.withDevice(device).withPreCompilation();
 
             for (int i = 0; i < WARMUP; i++) {
                 executionPlan.execute();
@@ -637,7 +637,7 @@ public class DFTVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation().withDevice(device);
+            executionPlan.withPreCompilation().withDevice(device);
 
             for (int i = 0; i < WARMUP; i++) {
                 executionPlan.execute();

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/MatrixVector.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/MatrixVector.java
@@ -26,13 +26,13 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoExecutionResult;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
-import uk.ac.manchester.tornado.api.types.vectors.Float4;
-import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
-import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat4;
-import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
-import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat;
+import uk.ac.manchester.tornado.api.types.collections.VectorFloat4;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat4;
+import uk.ac.manchester.tornado.api.types.vectors.Float4;
 import uk.ac.manchester.tornado.examples.utils.Utils;
 
 /**
@@ -108,7 +108,7 @@ public class MatrixVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withDevice(device).withWarmUp();
+        executionPlan.withDevice(device).withAoTCompilation();
 
         for (int i = 0; i < WARMUP; i++) {
             executionPlan.execute();
@@ -158,7 +158,7 @@ public class MatrixVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withDevice(device).withWarmUp();
+        executionPlan.withDevice(device).withAoTCompilation();
 
         for (int i = 0; i < WARMUP; i++) {
             executionPlan.execute();
@@ -186,7 +186,7 @@ public class MatrixVector {
         IntStream.range(0, size).parallel().forEach(i -> {
             float sum = 0.0f;
             for (int j = 0; j < matrix.getNumColumns(); j++) {
-                sum +=  matrix.get(i, j) * vector.get(j);
+                sum += matrix.get(i, j) * vector.get(j);
             }
             output.set(i, sum);
         });

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/MatrixVector.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/MatrixVector.java
@@ -108,7 +108,7 @@ public class MatrixVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withDevice(device).withAoTCompilation();
+        executionPlan.withDevice(device).withPreCompilation();
 
         for (int i = 0; i < WARMUP; i++) {
             executionPlan.execute();
@@ -158,7 +158,7 @@ public class MatrixVector {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withDevice(device).withAoTCompilation();
+        executionPlan.withDevice(device).withPreCompilation();
 
         for (int i = 0; i < WARMUP; i++) {
             executionPlan.execute();

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/VectorAddTest.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/VectorAddTest.java
@@ -104,7 +104,7 @@ public class VectorAddTest {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executorPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executorPlan.withDevice(device).withWarmUp();
+        executorPlan.withDevice(device).withAoTCompilation();
 
         ArrayList<Long> kernelTimers = new ArrayList<>();
         ArrayList<Long> totalTimers = new ArrayList<>();
@@ -142,7 +142,7 @@ public class VectorAddTest {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withDevice(device).withWarmUp();
+        executionPlan.withDevice(device).withAoTCompilation();
 
         ArrayList<Long> kernelTimers = new ArrayList<>();
         ArrayList<Long> totalTimers = new ArrayList<>();
@@ -180,7 +180,7 @@ public class VectorAddTest {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executorPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executorPlan.withDevice(device).withWarmUp();
+        executorPlan.withDevice(device).withAoTCompilation();
 
         ArrayList<Long> kernelTimers = new ArrayList<>();
         ArrayList<Long> totalTimers = new ArrayList<>();
@@ -217,7 +217,7 @@ public class VectorAddTest {
 
         ImmutableTaskGraph immutableTaskGraph2 = taskGraphNonVector.snapshot();
         TornadoExecutionPlan executorPlan = new TornadoExecutionPlan(immutableTaskGraph2);
-        executorPlan.withDevice(device).withWarmUp();
+        executorPlan.withDevice(device).withAoTCompilation();
 
         for (int i = 0; i < WARMUP; i++) {
             executorPlan.execute();

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/VectorAddTest.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/VectorAddTest.java
@@ -104,7 +104,7 @@ public class VectorAddTest {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executorPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executorPlan.withDevice(device).withAoTCompilation();
+        executorPlan.withDevice(device).withPreCompilation();
 
         ArrayList<Long> kernelTimers = new ArrayList<>();
         ArrayList<Long> totalTimers = new ArrayList<>();
@@ -142,7 +142,7 @@ public class VectorAddTest {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executionPlan.withDevice(device).withAoTCompilation();
+        executionPlan.withDevice(device).withPreCompilation();
 
         ArrayList<Long> kernelTimers = new ArrayList<>();
         ArrayList<Long> totalTimers = new ArrayList<>();
@@ -180,7 +180,7 @@ public class VectorAddTest {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         TornadoExecutionPlan executorPlan = new TornadoExecutionPlan(immutableTaskGraph);
-        executorPlan.withDevice(device).withAoTCompilation();
+        executorPlan.withDevice(device).withPreCompilation();
 
         ArrayList<Long> kernelTimers = new ArrayList<>();
         ArrayList<Long> totalTimers = new ArrayList<>();
@@ -217,7 +217,7 @@ public class VectorAddTest {
 
         ImmutableTaskGraph immutableTaskGraph2 = taskGraphNonVector.snapshot();
         TornadoExecutionPlan executorPlan = new TornadoExecutionPlan(immutableTaskGraph2);
-        executorPlan.withDevice(device).withAoTCompilation();
+        executorPlan.withDevice(device).withPreCompilation();
 
         for (int i = 0; i < WARMUP; i++) {
             executorPlan.execute();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -197,8 +197,8 @@ public class TornadoVM {
         executeActionOnInterpreters(TornadoVMInterpreter::printTimes);
     }
 
-    public void withAoTCompilation() {
-        executeActionOnInterpreters(TornadoVMInterpreter::withAoTCompilation);
+    public void withPreCompilation() {
+        executeActionOnInterpreters(TornadoVMInterpreter::withPreCompilation);
     }
 
     public void setGridScheduler(GridScheduler gridScheduler) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -181,10 +181,6 @@ public class TornadoVM {
         Arrays.stream(tornadoVMInterpreters).forEach(action::accept);
     }
 
-    public void clearInstalledCode() {
-        executeActionOnInterpreters(TornadoVMInterpreter::clearInstalledCode);
-    }
-
     public void dumpProfiles() {
         executeActionOnInterpreters(TornadoVMInterpreter::dumpProfiles);
     }
@@ -201,8 +197,8 @@ public class TornadoVM {
         executeActionOnInterpreters(TornadoVMInterpreter::printTimes);
     }
 
-    public void warmup() {
-        executeActionOnInterpreters(TornadoVMInterpreter::warmup);
+    public void withAoTCompilation() {
+        executeActionOnInterpreters(TornadoVMInterpreter::withAoTCompilation);
     }
 
     public void setGridScheduler(GridScheduler gridScheduler) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -253,7 +253,7 @@ public class TornadoVMInterpreter {
         }
     }
 
-    public void withAoTCompilation() {
+    public void withPreCompilation() {
         execute(true);
         finishedWarmup = true;
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -253,7 +253,7 @@ public class TornadoVMInterpreter {
         }
     }
 
-    public void warmup() {
+    public void withAoTCompilation() {
         execute(true);
         finishedWarmup = true;
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -945,7 +945,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     private void compileTaskToOpenCL() {
-        vm.warmup();
+        vm.withAoTCompilation();
     }
 
     /**
@@ -1234,7 +1234,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
-    public void warmup(ExecutorFrame executionPackage) {
+    public void withAoTCompilation(ExecutorFrame executionPackage) {
         setupProfiler();
         getDevice().getDeviceContext().setResetToFalse();
         timeProfiler.clean();
@@ -1242,7 +1242,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         compileComputeGraphToTornadoVMBytecode();
         executionPlanId = executionPackage.getExecutionPlanId();
         executionContext.setExecutionPlanId(executionPlanId);
-        vm.warmup();
+        vm.withAoTCompilation();
 
         if (TornadoOptions.isProfilerEnabled() && !TornadoOptions.PROFILER_LOGS_ACCUMULATE()) {
             timeProfiler.dumpJson(new StringBuilder(), this.getId());

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -945,7 +945,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     private void compileTaskToOpenCL() {
-        vm.withAoTCompilation();
+        vm.withPreCompilation();
     }
 
     /**
@@ -1234,7 +1234,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
-    public void withAoTCompilation(ExecutorFrame executionPackage) {
+    public void withPreCompilation(ExecutorFrame executionPackage) {
         setupProfiler();
         getDevice().getDeviceContext().setResetToFalse();
         timeProfiler.clean();
@@ -1242,7 +1242,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         compileComputeGraphToTornadoVMBytecode();
         executionPlanId = executionPackage.getExecutionPlanId();
         executionContext.setExecutionPlanId(executionPlanId);
-        vm.withAoTCompilation();
+        vm.withPreCompilation();
 
         if (TornadoOptions.isProfilerEnabled() && !TornadoOptions.PROFILER_LOGS_ACCUMULATE()) {
             timeProfiler.dumpJson(new StringBuilder(), this.getId());

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
@@ -330,7 +330,7 @@ public class TestAPI extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp() //
+            executionPlan.withAoTCompilation() //
                     .execute();
         }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
@@ -330,7 +330,7 @@ public class TestAPI extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation() //
+            executionPlan.withPreCompilation() //
                     .execute();
         }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestArrays.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestArrays.java
@@ -187,7 +187,7 @@ public class TestArrays extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation().execute();
+            executionPlan.withPreCompilation().execute();
         }
 
         for (int i = 0; i < N; i++) {
@@ -209,7 +209,7 @@ public class TestArrays extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation().execute();
+            executionPlan.withPreCompilation().execute();
         }
 
         for (int i = 0; i < N; i++) {
@@ -232,7 +232,7 @@ public class TestArrays extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation().execute();
+            executionPlan.withPreCompilation().execute();
         }
 
         for (int i = 0; i < N; i++) {
@@ -255,7 +255,7 @@ public class TestArrays extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation().execute();
+            executionPlan.withPreCompilation().execute();
         }
 
         for (int i = 0; i < N; i++) {
@@ -286,7 +286,7 @@ public class TestArrays extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation().execute();
+            executionPlan.withPreCompilation().execute();
         }
 
         for (int i = 0; i < N; i++) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestArrays.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestArrays.java
@@ -187,7 +187,7 @@ public class TestArrays extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp().execute();
+            executionPlan.withAoTCompilation().execute();
         }
 
         for (int i = 0; i < N; i++) {
@@ -209,7 +209,7 @@ public class TestArrays extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp().execute();
+            executionPlan.withAoTCompilation().execute();
         }
 
         for (int i = 0; i < N; i++) {
@@ -232,7 +232,7 @@ public class TestArrays extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp().execute();
+            executionPlan.withAoTCompilation().execute();
         }
 
         for (int i = 0; i < N; i++) {
@@ -255,7 +255,7 @@ public class TestArrays extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp().execute();
+            executionPlan.withAoTCompilation().execute();
         }
 
         for (int i = 0; i < N; i++) {
@@ -286,7 +286,7 @@ public class TestArrays extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp().execute();
+            executionPlan.withAoTCompilation().execute();
         }
 
         for (int i = 0; i < N; i++) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/CodeGenTest.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/CodeGenTest.java
@@ -296,7 +296,7 @@ public class CodeGenTest extends TornadoTestBase {
                 .task("t0", CodeGenTest::badCascadeKernel2);
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation();
+            executionPlan.withPreCompilation();
         }
     }
 
@@ -310,7 +310,7 @@ public class CodeGenTest extends TornadoTestBase {
                 .task("t0", CodeGenTest::badCascadeKernel3);
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation();
+            executionPlan.withPreCompilation();
         }
     }
 
@@ -325,7 +325,7 @@ public class CodeGenTest extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation();
+            executionPlan.withPreCompilation();
         }
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/CodeGenTest.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/CodeGenTest.java
@@ -136,19 +136,8 @@ public class CodeGenTest extends TornadoTestBase {
         context.localBarrier();
     }
 
-    public static void processHeadsFlashAttention(
-            KernelContext context,
-            FloatArray q,
-            FloatArray key_cache,
-            FloatArray value_cache,
-            FloatArray xb,
-            int nHeads,
-            int headSize,
-            int kvDim,
-            int kvMul,
-            IntArray positionHolder,
-            int layer,
-            int contextLength) {
+    public static void processHeadsFlashAttention(KernelContext context, FloatArray q, FloatArray key_cache, FloatArray value_cache, FloatArray xb, int nHeads, int headSize, int kvDim, int kvMul,
+            IntArray positionHolder, int layer, int contextLength) {
 
         // Thread and workgroup information
         int tid = context.localIdx;
@@ -158,7 +147,8 @@ public class CodeGenTest extends TornadoTestBase {
 
         // Early exit if this workgroup is beyond our head count
         // This relies on the kernel being launched with nHeads workgroups.
-        if (h >= nHeads) return;
+        if (h >= nHeads)
+            return;
 
         int pos = positionHolder.get(0);
         int loff = layer * contextLength * kvDim;
@@ -306,7 +296,7 @@ public class CodeGenTest extends TornadoTestBase {
                 .task("t0", CodeGenTest::badCascadeKernel2);
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp();
+            executionPlan.withAoTCompilation();
         }
     }
 
@@ -320,7 +310,7 @@ public class CodeGenTest extends TornadoTestBase {
                 .task("t0", CodeGenTest::badCascadeKernel3);
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp();
+            executionPlan.withAoTCompilation();
         }
     }
 
@@ -335,7 +325,7 @@ public class CodeGenTest extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp();
+            executionPlan.withAoTCompilation();
         }
     }
 
@@ -382,7 +372,7 @@ public class CodeGenTest extends TornadoTestBase {
 
     @Test
     public void testFlashAttention() throws TornadoExecutionPlanException {
-       assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
 
         final int dim = 2048;
         final int nHeads = 32;
@@ -429,20 +419,14 @@ public class CodeGenTest extends TornadoTestBase {
 
         KernelContext context = new KernelContext();
 
-        TaskGraph taskGraph = new TaskGraph("s0")
-                .transferToDevice(DataTransferMode.FIRST_EXECUTION,
-                        query, keyCache, valueCache, output, attentionWeights, positionAndLayer)
-                .task("t0", CodeGenTest::processHeadsFlashAttention,context,
-                        query, keyCache, valueCache, output,
-                        nHeads, headSize, kvDim, kvMul,
-                        positionAndLayer,0, 512)
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+        TaskGraph taskGraph = new TaskGraph("s0").transferToDevice(DataTransferMode.FIRST_EXECUTION, query, keyCache, valueCache, output, attentionWeights, positionAndLayer).task("t0",
+                CodeGenTest::processHeadsFlashAttention, context, query, keyCache, valueCache, output, nHeads, headSize, kvDim, kvMul, positionAndLayer, 0, 512).transferToHost(
+                        DataTransferMode.EVERY_EXECUTION, output);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
 
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withGridScheduler(gridScheduler)
-                    .execute();
+            executionPlan.withGridScheduler(gridScheduler).execute();
         }
 
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
@@ -85,7 +85,7 @@ public class TestExecutor extends TornadoTestBase {
 
             // 4. Add optimizations to the execution plan
             executionPlan.withProfiler(ProfilerMode.SILENT) //
-                    .withAoTCompilation() //
+                    .withPreCompilation() //
                     .withDevice(defaultDevice) //
                     .withDefaultScheduler();
 
@@ -278,7 +278,7 @@ public class TestExecutor extends TornadoTestBase {
             GridScheduler grid = new GridScheduler("s0.t0", workerGrid);
 
             // Testing multiple functions to invoke the print logic plan later
-            var trace = executionPlan.withAoTCompilation() //
+            var trace = executionPlan.withPreCompilation() //
                     .withDevice(device) //
                     .withGridScheduler(grid) //
                     .withThreadInfo() //

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/executor/TestExecutor.java
@@ -85,7 +85,7 @@ public class TestExecutor extends TornadoTestBase {
 
             // 4. Add optimizations to the execution plan
             executionPlan.withProfiler(ProfilerMode.SILENT) //
-                    .withWarmUp() //
+                    .withAoTCompilation() //
                     .withDevice(defaultDevice) //
                     .withDefaultScheduler();
 
@@ -278,7 +278,7 @@ public class TestExecutor extends TornadoTestBase {
             GridScheduler grid = new GridScheduler("s0.t0", workerGrid);
 
             // Testing multiple functions to invoke the print logic plan later
-            var trace = executionPlan.withWarmUp() //
+            var trace = executionPlan.withAoTCompilation() //
                     .withDevice(device) //
                     .withGridScheduler(grid) //
                     .withThreadInfo() //

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/TestFails.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/TestFails.java
@@ -79,7 +79,7 @@ public class TestFails extends TornadoTestBase {
         TornadoExecutionPlan executionPlanPlan = new TornadoExecutionPlan(immutableTaskGraph);
 
         // How to provoke the failure
-        executionPlanPlan.withAoTCompilation().execute();
+        executionPlanPlan.withPreCompilation().execute();
         reset();
         executionPlanPlan.execute();
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/TestFails.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fails/TestFails.java
@@ -79,7 +79,7 @@ public class TestFails extends TornadoTestBase {
         TornadoExecutionPlan executionPlanPlan = new TornadoExecutionPlan(immutableTaskGraph);
 
         // How to provoke the failure
-        executionPlanPlan.withWarmUp().execute();
+        executionPlanPlan.withAoTCompilation().execute();
         reset();
         executionPlanPlan.execute();
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/images/TestResizeImage.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/images/TestResizeImage.java
@@ -85,7 +85,7 @@ public class TestResizeImage extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp() //
+            executionPlan.withAoTCompilation() //
                     .execute();
         }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/images/TestResizeImage.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/images/TestResizeImage.java
@@ -85,7 +85,7 @@ public class TestResizeImage extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation() //
+            executionPlan.withPreCompilation() //
                     .execute();
         }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestVectorAdditionKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestVectorAdditionKernelContext.java
@@ -231,7 +231,7 @@ public class TestVectorAdditionKernelContext extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation() //
+            executionPlan.withPreCompilation() //
                     .withGridScheduler(gridScheduler) //
                     .execute();
         }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestVectorAdditionKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestVectorAdditionKernelContext.java
@@ -231,7 +231,7 @@ public class TestVectorAdditionKernelContext extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp() //
+            executionPlan.withAoTCompilation() //
                     .withGridScheduler(gridScheduler) //
                     .execute();
         }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
@@ -185,7 +185,7 @@ public class TestMatrices extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation().execute();
+            executionPlan.withPreCompilation().execute();
         }
 
         for (int i = 0; i < a.length; i++) {
@@ -229,7 +229,7 @@ public class TestMatrices extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation().execute();
+            executionPlan.withPreCompilation().execute();
         }
 
         for (int i = 0; i < a.length; i++) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/matrices/TestMatrices.java
@@ -185,7 +185,7 @@ public class TestMatrices extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp().execute();
+            executionPlan.withAoTCompilation().execute();
         }
 
         for (int i = 0; i < a.length; i++) {
@@ -229,7 +229,7 @@ public class TestMatrices extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp().execute();
+            executionPlan.withAoTCompilation().execute();
         }
 
         for (int i = 0; i < a.length; i++) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/neurocom/TestCase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/neurocom/TestCase.java
@@ -92,7 +92,7 @@ public class TestCase extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withWarmUp().execute();
+            executionPlan.withAoTCompilation().execute();
         }
 
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/neurocom/TestCase.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/neurocom/TestCase.java
@@ -92,7 +92,7 @@ public class TestCase extends TornadoTestBase {
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
-            executionPlan.withAoTCompilation().execute();
+            executionPlan.withPreCompilation().execute();
         }
 
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/warmup/TestWarmUp.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/warmup/TestWarmUp.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.warmup;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.ProfilerMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V --live uk.ac.manchester.tornado.unittests.warmup.TestWarmUp
+ * </code>
+ */
+public class TestWarmUp extends TornadoTestBase {
+
+    @Test
+    public void test01() throws TornadoExecutionPlanException, InterruptedException {
+        TaskGraph taskGraph = new TaskGraph("foo");
+
+        FloatArray input = new FloatArray(1024);
+        FloatArray output = new FloatArray(1024);
+        input.init(0.1f);
+
+        taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("bar", (FloatArray in, FloatArray out) -> {
+                    for (@Parallel int i = 0; i < in.getSize(); i++) {
+                        out.set(i, in.get(i) * 2);
+                    }
+                }, input, output).transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+
+            // Warmup for 1 second
+            long startTime = System.currentTimeMillis();
+            plan.withWarmUp(1000);
+            long endTime = System.currentTimeMillis();
+
+            // 5ms of tolerance 
+            Assert.assertTrue((endTime - startTime > 1000) && (endTime - startTime < 1005));
+
+            // Run one more time after the warmup
+            plan.withProfiler(ProfilerMode.CONSOLE).execute();
+        }
+    }
+
+}


### PR DESCRIPTION
#### Description

This PR extends the `TornadoExecutionPlan` API with two new calls for representing `warmup`. The current `warmup` functionality does not actually correspond to warmup. What it does it pre-compile a kernel from Java down to the selected backend (e.g., from Java bytecode to OpenCL C, or PTX). However, this call does not run the application, and it does not place data onto the accelerator. 

This PR tries to extend this functionality with two new calls:
- `withWarmUpWithTime(ms)`
- `withWarmUpIterations(numIterations)`

Besides, the old `withWarmUp` is set to `withPreCompilation()`, which only builds and install the generated code in the code-cache, with no data loading. 


#### Problem description

n/ a.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-test -V --live uk.ac.manchester.tornado.unittests.warmup.TestWarmUp
```
