### PR TITLE
[fix] Fix state after warmup phase

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -359,12 +359,13 @@ class TornadoExecutor {
     private void runForWarmUp(ExecutorFrame executorFrame) {
         immutableTaskGraphList.forEach(immutableTaskGraph -> {
             immutableTaskGraph.execute(executorFrame);
+            // Update state for all task-graphs within the execution plan
             ImmutableTaskGraph last = immutableTaskGraphList.getLast();
             immutableTaskGraphList.forEach(itg -> itg.setLastExecutedTaskGraph(last));
         });
     }
 
     public void withWarmUpIterations(int iterations, ExecutorFrame executorFrame) {
-        IntStream.range(0, iterations).mapToObj(_ -> executorFrame).forEach(this::runForWarmUp);
+        IntStream.range(0, iterations).forEach(_ -> runForWarmUp(executorFrame));
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -337,7 +337,7 @@ class TornadoExecutor {
         // specified is "at least" the time that the warm-up will take.
         Thread warmUpThread = new Thread(() -> {
             while (run.get()) {
-                execute(executorFrame);
+                runForWarmUp(executorFrame);
             }
         });
 
@@ -356,7 +356,15 @@ class TornadoExecutor {
         controllerThread.join();
     }
 
+    private void runForWarmUp(ExecutorFrame executorFrame) {
+        immutableTaskGraphList.forEach(immutableTaskGraph -> {
+            immutableTaskGraph.execute(executorFrame);
+            ImmutableTaskGraph last = immutableTaskGraphList.getLast();
+            immutableTaskGraphList.forEach(itg -> itg.setLastExecutedTaskGraph(last));
+        });
+    }
+
     public void withWarmUpIterations(int iterations, ExecutorFrame executorFrame) {
-        IntStream.range(0, iterations).mapToObj(i -> executorFrame).forEach(this::execute);
+        IntStream.range(0, iterations).mapToObj(_ -> executorFrame).forEach(this::runForWarmUp);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -366,6 +366,6 @@ class TornadoExecutor {
     }
 
     public void withWarmUpIterations(int iterations, ExecutorFrame executorFrame) {
-        IntStream.range(0, iterations).forEach(_ -> runForWarmUp(executorFrame));
+        IntStream.range(0, iterations).forEach(iteration -> runForWarmUp(executorFrame));
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/warmup/TestWarmUp.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/warmup/TestWarmUp.java
@@ -61,8 +61,8 @@ public class TestWarmUp extends TornadoTestBase {
             plan.withWarmUpTime(1000);
             long endTime = System.currentTimeMillis();
 
-            // 5ms of tolerance 
-            Assert.assertTrue((endTime - startTime > 1000) && (endTime - startTime < 1005));
+            // 7 ms of tolerance
+            Assert.assertTrue((endTime - startTime > 1000) && (endTime - startTime < 1008));
 
             // Run one more time after the warmup
             plan.withProfiler(ProfilerMode.CONSOLE).execute();


### PR DESCRIPTION
#### Description

Fix state after warmup 

#### Problem description

The problem was that we need to update the `last to execute` graph after the execution plan runs, even after warmup. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
tornado-test -V --live uk.ac.manchester.tornado.unittests.warmup.TestWarmUp
```