### PR TITLE
Support for FMA by disabling fast math

### DIFF
--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssembler.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/asm/PTXAssembler.java
@@ -772,6 +772,7 @@ public class PTXAssembler extends Assembler {
     public static class PTXTernaryOp extends PTXOp {
         public static final PTXTernaryOp MAD_LO = new PTXTernaryOp("mad.lo");
         public static final PTXTernaryOp MAD = new PTXTernaryOp("mad");
+        public static final PTXTernaryOp FMA = new PTXTernaryOp("fma");
         public static final PTXTernaryOp SELP = new PTXTernaryOp("selp", false);
 
         private boolean needsRounding;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXArithmeticTool.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXArithmeticTool.java
@@ -10,7 +10,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -27,7 +27,6 @@ import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shoul
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXUnaryIntrinsic.RSQRT;
 
-import jdk.vm.ci.meta.JavaConstant;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.calc.FloatConvert;
 import org.graalvm.compiler.core.common.memory.MemoryExtendKind;
@@ -37,6 +36,7 @@ import org.graalvm.compiler.lir.LIRFrameState;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.ArithmeticLIRGenerator;
 
+import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.PlatformKind;
 import jdk.vm.ci.meta.Value;
 import jdk.vm.ci.meta.ValueKind;
@@ -47,6 +47,7 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler;
 import uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXBinaryOp;
 import uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXTernaryOp;
 import uk.ac.manchester.tornado.drivers.ptx.graal.compiler.PTXLIRGenerator;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public class PTXArithmeticTool extends ArithmeticLIRGenerator {
     @Override
@@ -357,11 +358,20 @@ public class PTXArithmeticTool extends ArithmeticLIRGenerator {
         return new PTXBinary.Expr(op, lirKind, x, y);
     }
 
+    private boolean isFastFMAEnabled() {
+        return TornadoOptions.ENABLE_FMA && TornadoOptions.FAST_MATH_OPTIMIZATIONS;
+    }
+
     public Value emitMultiplyAdd(Value op1, Value op2, Value op3) {
         Logger.traceBuildLIR(Logger.BACKEND.PTX, "emitMultiplyAdd op1=%s op2=%s op3=%s", op1, op2, op3);
         LIRKind resultKind = LIRKind.combine(op1, op2, op3);
         Variable result = getGen().newVariable(resultKind);
-        PTXTernaryOp op = ((PTXKind) resultKind.getPlatformKind()).isFloating() ? PTXTernaryOp.MAD : PTXTernaryOp.MAD_LO;
+        PTXTernaryOp op;
+        if (isFastFMAEnabled())
+            op = ((PTXKind) resultKind.getPlatformKind()).isFloating() ? PTXTernaryOp.MAD : PTXTernaryOp.MAD_LO;
+        else
+            op = PTXTernaryOp.FMA;
+
         getGen().append(new PTXLIRStmt.AssignStmt(result, new PTXTernary.Expr(op, resultKind, op1, op2, op3)));
         return result;
     }


### PR DESCRIPTION
#### Description

Support explicit  `FMA` operatons by disabling fast math (`mad` generated insted). 

#### Problem description

See issue #690 

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [X] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make BACKEND=ptx

## Enable `mad` 
tornado-test -V --jvm="-Ds0.t0.device=0:0 -Dtornado.enable.fma=true -Dtornado.enable.fastMathOptimizations=true " --enableProfiler console -pk uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext#mxm1DKernelContext

## Enable `fma` 

tornado-test -V --jvm="-Ds0.t0.device=0:0 -Dtornado.enable.fma=true -Dtornado.enable.fastMathOptimizations=false " --enableProfiler console -pk uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext#mxm1DKernelContext
```


