### PR TITLE
[fix] API exceptions calling parent to not stop stack-trace

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoAPIException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoAPIException.java
@@ -19,16 +19,7 @@ package uk.ac.manchester.tornado.api.exceptions;
 
 public class TornadoAPIException extends RuntimeException {
 
-    private final String message;
-    private final Exception e;
-
     public TornadoAPIException(final String msg, Exception e) {
-        message = msg;
-        this.e = e;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(msg, e);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoBailoutRuntimeException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoBailoutRuntimeException.java
@@ -21,24 +21,12 @@ public class TornadoBailoutRuntimeException extends RuntimeException {
 
     static final String RESET = "\u001B[0m";
     static final String RED = "\u001B[31m";
-    private final String message;
-    private Exception e;
 
     public TornadoBailoutRuntimeException(final String msg) {
-        message = RED + msg + RESET;
+        super(RED + msg + RESET);
     }
 
     public TornadoBailoutRuntimeException(final String msg, Exception e) {
-        message = RED + msg + RESET;
-        this.e = e;
-    }
-
-    public Exception getException() {
-        return this.e;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(RED + msg + RESET, e);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoCompilationException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoCompilationException.java
@@ -17,18 +17,15 @@
  */
 package uk.ac.manchester.tornado.api.exceptions;
 
+import java.io.Serial;
+
 public class TornadoCompilationException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = -7515308573010965892L;
-    private final String message;
 
     public TornadoCompilationException(final String msg) {
-        message = msg;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(msg);
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoDeviceFP16NotSupported.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoDeviceFP16NotSupported.java
@@ -19,15 +19,8 @@ package uk.ac.manchester.tornado.api.exceptions;
 
 public class TornadoDeviceFP16NotSupported extends RuntimeException {
 
-    private final String message;
-
     public TornadoDeviceFP16NotSupported(final String msg) {
-        message = msg;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(msg);
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoDeviceFP64NotSupported.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoDeviceFP64NotSupported.java
@@ -19,14 +19,7 @@ package uk.ac.manchester.tornado.api.exceptions;
 
 public class TornadoDeviceFP64NotSupported extends RuntimeException {
 
-    private final String message;
-
     public TornadoDeviceFP64NotSupported(final String msg) {
-        message = msg;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(msg);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoDynamicReconfigurationException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoDynamicReconfigurationException.java
@@ -19,19 +19,11 @@ package uk.ac.manchester.tornado.api.exceptions;
 
 public class TornadoDynamicReconfigurationException extends RuntimeException {
 
-    private final String message;
-
     public TornadoDynamicReconfigurationException(final String msg) {
-        message = msg;
+        super(msg);
     }
 
     public TornadoDynamicReconfigurationException(Exception e) {
-        message = e.getMessage();
-        this.initCause(e.getCause());
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(e);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoExecutionPlanException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoExecutionPlanException.java
@@ -19,14 +19,11 @@ package uk.ac.manchester.tornado.api.exceptions;
 
 public class TornadoExecutionPlanException extends Exception {
 
-    private final String reason;
-
     public TornadoExecutionPlanException(String reason) {
-        this.reason = reason;
+        super(reason);
     }
 
-    public String getReason() {
-        return reason;
+    public TornadoExecutionPlanException(String message, Throwable cause) {
+        super(message, cause);
     }
-
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoFailureException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoFailureException.java
@@ -17,23 +17,19 @@
  */
 package uk.ac.manchester.tornado.api.exceptions;
 
+import java.io.Serial;
+
 public class TornadoFailureException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = -7515308573010965892L;
-    private final String message;
 
     public TornadoFailureException(final String msg) {
-        message = msg;
+        super(msg);
     }
 
     public TornadoFailureException(Exception e) {
-        message = e.getMessage();
-        this.initCause(e.getCause());
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(e);
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoMemoryException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoMemoryException.java
@@ -17,17 +17,14 @@
  */
 package uk.ac.manchester.tornado.api.exceptions;
 
+import java.io.Serial;
+
 public class TornadoMemoryException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 1609608023741117577L;
-    private final String message;
 
     public TornadoMemoryException(final String msg) {
-        message = msg;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(msg);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoNoOpenCLPlatformException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoNoOpenCLPlatformException.java
@@ -19,14 +19,7 @@ package uk.ac.manchester.tornado.api.exceptions;
 
 public class TornadoNoOpenCLPlatformException extends RuntimeException {
 
-    private final String message;
-
     public TornadoNoOpenCLPlatformException(final String msg) {
-        message = msg;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(msg);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoOutOfMemoryException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoOutOfMemoryException.java
@@ -17,17 +17,14 @@
  */
 package uk.ac.manchester.tornado.api.exceptions;
 
+import java.io.Serial;
+
 public class TornadoOutOfMemoryException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 8861358557469551291L;
-    private final String message;
 
     public TornadoOutOfMemoryException(final String msg) {
-        message = msg;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(msg);
     }
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoRuntimeException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoRuntimeException.java
@@ -17,23 +17,19 @@
  */
 package uk.ac.manchester.tornado.api.exceptions;
 
+import java.io.Serial;
+
 public class TornadoRuntimeException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = -7515308573010965892L;
-    private final String message;
 
     public TornadoRuntimeException(final String msg) {
-        message = msg;
+        super(msg);
     }
 
     public TornadoRuntimeException(Exception e) {
-        message = e.getMessage();
-        this.initCause(e.getCause());
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(e);
     }
 
 }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoTaskRuntimeException.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/exceptions/TornadoTaskRuntimeException.java
@@ -19,26 +19,14 @@ package uk.ac.manchester.tornado.api.exceptions;
 
 public class TornadoTaskRuntimeException extends RuntimeException {
 
-    private final String message;
-    private Exception e;
     static final String RESET = "\u001B[0m";
     static final String RED = "\u001B[31m";
 
     public TornadoTaskRuntimeException(final String msg) {
-        message = RED + msg + RESET;
+        super(RED + msg + RESET);
     }
 
     public TornadoTaskRuntimeException(final String msg, Exception e) {
-        message = RED + msg + RESET;
-        this.e = e;
-    }
-
-    public Exception getException() {
-        return this.e;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
+        super(RED + msg + RESET, e);
     }
 }


### PR DESCRIPTION
#### Description

Fix for the API exceptions calling parent to not stop stack-trace

#### Problem description

Stack trace can be lost if we do not call the parent constructor for the custom exceptions. 

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X} PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```bash
make
make tests
```
