### PR TITLE
[feat] Update tornadovm-installer script to be interactive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ mvn-single-threaded-jdk21:
 mvn-single-threaded-graal-jdk-21:
 	bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded
 
+mvn-single-threaded-polyglot:
+	bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded --polyglot
+
 ptx:
 	bin/compile --jdk jdk21 --backend ptx,opencl
 

--- a/Makefile.mak
+++ b/Makefile.mak
@@ -22,6 +22,9 @@ mvn-single-threaded-jdk21:
 mvn-single-threaded-graal-jdk-21:
 	python bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded
 
+mvn-single-threaded-polyglot:
+	python bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded --polyglot
+
 ptx:
 	python bin\compile --jdk graal-jdk-21 --backend ptx,opencl
 

--- a/bin/tornadoDepModules.txt
+++ b/bin/tornadoDepModules.txt
@@ -6,3 +6,4 @@ black
 sphinx_rtd_theme
 pyinstaller
 psutil
+rich

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -17,27 +17,27 @@
 # limitations under the License.
 #
 
+jdk_keyword = None
+
 import argparse
 import os
 import platform
 import sys
 import tarfile
 import zipfile
-
+import subprocess
+from shutil import which
+import wget
 import install_python_modules as tornadoReq
 import config_utils as cutils
+import installer_config as config
+from packaging import version
 
 tornadoReq.check_python_dependencies()
 
-import wget
-import installer_config as config
-
-## ################################################################
-## Configuration
-## ################################################################
+# Configuration
 __DIRECTORY_DEPENDENCIES__ = os.path.join("etc", "dependencies")
 __VERSION__ = "v1.1.0"
-
 __SUPPORTED_JDKS__ = [
     config.__JDK21__,
     config.__GRAALVM21__,
@@ -49,445 +49,314 @@ __SUPPORTED_JDKS__ = [
     config.__SAPMACHINE21__,
     config.__LIBERICA21__,
 ]
-
 __SUPPORTED_BACKENDS__ = ["opencl", "spirv", "ptx"]
-## ################################################################
 
 class TornadoInstaller:
-
     def __init__(self):
         self.workDirName = ""
         self.dependenciesDirName = ""
-        self.osPlatform = self.getOSPlatform()
+        self.osPlatform = platform.system().lower()
         self.hardware = self.getMachineArc()
-        self.env = {}
-        self.env["PATH"] = [os.path.join(self.getCurrentDirectory(), "bin", "bin")]
-        self.env["TORNADO_SDK"] = os.path.join(self.getCurrentDirectory(), "bin", "sdk")
-
-    def getOSPlatform(self):
-        return platform.system().lower()
+        self.env = {
+            "PATH": [os.path.join(os.getcwd(), "bin", "bin")],
+            "TORNADO_SDK": os.path.join(os.getcwd(), "bin", "sdk")
+        }
 
     def getMachineArc(self):
-        compatibleMachineTypes = {
-            "x86_64"  : "x86_64",
-            "amd64"   : "x86_64",
-            "arm64"   : "arm64",
-            "aarch64" : "arm64",
-            "riscv64" : "riscv64"
-        }
-        machine = platform.machine().lower()
-        return compatibleMachineTypes[machine]
+        types = {"x86_64": "x86_64", "amd64": "x86_64", "arm64": "arm64", "aarch64": "arm64", "riscv64": "riscv64"}
+        return types[platform.machine().lower()]
 
-    def processFileName(self, url):
-        return os.path.basename(url)
+    def processFileName(self, url): return os.path.basename(url)
 
     def setWorkDir(self, jdk):
-        tornadoDir = "TornadoVM-" + jdk
-        self.workDirName = os.path.join(__DIRECTORY_DEPENDENCIES__, tornadoDir)
-        if not os.path.exists(self.workDirName):
-            os.makedirs(self.workDirName)
+        self.workDirName = os.path.join(__DIRECTORY_DEPENDENCIES__, f"TornadoVM-{jdk}")
+        os.makedirs(self.workDirName, exist_ok=True)
 
     def setDependenciesDir(self):
         self.dependenciesDirName = os.path.join(__DIRECTORY_DEPENDENCIES__)
-        if not os.path.exists(self.dependenciesDirName):
-            os.makedirs(self.dependenciesDirName)
+        os.makedirs(self.dependenciesDirName, exist_ok=True)
 
-    def getCurrentDirectory(self):
-        return os.getcwd()
+    def getCurrentDirectory(self): return os.getcwd()
+
+    def getTLDName(self, ar):
+        names = ar.namelist() if os.name == 'nt' else ar.getnames()
+        parts = names[1].split("/")
+        return parts[1] if parts[0] == "." else parts[0]
 
     def downloadCMake(self):
         url = config.CMAKE[self.osPlatform][self.hardware]
-        if url == None:
-            ## When using the RISC-V installer, CMAKE will be None
-            ## Only for this case, we can use the system cmake instead.
-            if (self.hardware == "riscv64"):
-                return
-            else:
-                print("CMake not configured for this OS/ machine configuration: {self.osPlatform}/ {self.hardware}")
-                sys.exit(0)
+        if url is None:
+            if self.hardware == "riscv64": return
+            print(f"CMake not configured for {self.osPlatform}/{self.hardware}"); sys.exit(0)
 
         fileName = self.processFileName(url)
-        print("\nChecking dependency: " + fileName)
         fullPath = os.path.join(self.dependenciesDirName, fileName)
-
-        if not os.path.exists(fullPath):
-            wget.download(url, fullPath)
-
-        ## Uncompress file
+        if not os.path.exists(fullPath): wget.download(url, fullPath)
         try:
-            if os.name == 'nt':
-                ar = zipfile.ZipFile(fullPath, 'r')
-                cmakeTLD = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
-                if not os.path.exists(cmakeTLD):
-                    ar.extractall(self.dependenciesDirName)
-            else:
-                ar = tarfile.open(fullPath, "r:gz")
-                cmakeTLD = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
-                if not os.path.exists(cmakeTLD):
-                    ar.extractall(self.dependenciesDirName, numeric_owner=True)
-        except:
-            print(f"Unpacking failed for CMake {url}")
-            sys.exit(0)
-
-        ar.close()
-
-        extraPath = ""
-        if self.osPlatform == config.__APPLE__:
-            extraPath = os.path.join("CMake.app", "Contents")
-
-        ## Update env-variables
-        extraPath = os.path.join(extraPath, "bin")
-        self.env["PATH"].append(os.path.join(cmakeTLD, extraPath))
+            ar = zipfile.ZipFile(fullPath, 'r') if os.name == 'nt' else tarfile.open(fullPath, "r:gz")
+            tld = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
+            if not os.path.exists(tld):
+                ar.extractall(self.dependenciesDirName, numeric_owner=(os.name != 'nt'))
+            ar.close()
+            extraPath = os.path.join("CMake.app", "Contents") if self.osPlatform == config.__APPLE__ else ""
+            self.env["PATH"].append(os.path.join(tld, extraPath, "bin"))
+        except Exception as e:
+            print(f"Unpacking failed for CMake: {e}"); sys.exit(0)
 
     def downloadMaven(self):
         url = config.MAVEN[self.osPlatform][self.hardware]
-        if url == None:
-            print("Maven not configured for this OS/ machine configuration: {self.osPlatform}/ {self.hardware}")
-            sys.exit(0)
-
+        if url is None: print(f"Maven not configured for {self.osPlatform}/{self.hardware}"); sys.exit(0)
         fileName = self.processFileName(url)
-        print("\nChecking dependency: " + fileName)
         fullPath = os.path.join(self.dependenciesDirName, fileName)
-
-        if not os.path.exists(fullPath):
-            wget.download(url, fullPath)
-
-        ## Uncompress file
+        if not os.path.exists(fullPath): wget.download(url, fullPath)
         try:
-            if os.name == 'nt':
-                ar = zipfile.ZipFile(fullPath, 'r')
-                mavenTLD = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
-                if not os.path.exists(mavenTLD):
-                    ar.extractall(self.dependenciesDirName)
-            else:
-                ar = tarfile.open(fullPath, "r:gz")
-                mavenTLD = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
-                if not os.path.exists(mavenTLD):
-                    ar.extractall(self.dependenciesDirName, numeric_owner=True)
-        except:
-            print(f"Unpacking failed for Maven {url}")
-            sys.exit(0)
-
-        ar.close()
-
-        ## Update env-variables
-        self.env["PATH"].append(os.path.join(mavenTLD, "bin"))
-
-
-    def getTLDName(self, ar):
-        if os.name == 'nt':
-            extractedNames = ar.namelist()[1].split("/")
-        else:
-            extractedNames = ar.getnames()[1].split("/")
-        if extractedNames[0] == ".":
-            extractedDirectory = extractedNames[1]
-        else:
-            extractedDirectory = extractedNames[0]
-        return extractedDirectory
+            ar = zipfile.ZipFile(fullPath, 'r') if os.name == 'nt' else tarfile.open(fullPath, "r:gz")
+            tld = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
+            if not os.path.exists(tld):
+                ar.extractall(self.dependenciesDirName, numeric_owner=(os.name != 'nt'))
+            ar.close()
+            self.env["PATH"].append(os.path.join(tld, "bin"))
+        except Exception as e:
+            print(f"Unpacking failed for Maven: {e}"); sys.exit(0)
 
     def downloadJDK(self, jdk):
         url = config.JDK[jdk][self.osPlatform][self.hardware]
-        if url == None:
-            print("JDK {jdk} not configured for this OS/ machine configuration: {self.osPlatform}/ {self.hardware}")
-            sys.exit(0)
-
+        if url is None: print(f"JDK {jdk} not configured"); sys.exit(0)
         fileName = self.processFileName(url)
-        print("\nChecking dependency: " + fileName)
         fullPath = os.path.join(self.workDirName, fileName)
-
         if not os.path.exists(fullPath):
-            try:
-                wget.download(url, fullPath)
+            try: wget.download(url, fullPath)
             except:
                 import urllib3
-                http = urllib3.PoolManager()
-                response = http.request('GET', url)
-                jdkImage = response.data
-                with open(fullPath, 'wb') as file:
-                    file.write(jdkImage)
-
+                r = urllib3.PoolManager().request('GET', url)
+                with open(fullPath, 'wb') as f: f.write(r.data)
         try:
-            if os.name == 'nt':
-                ar = zipfile.ZipFile(fullPath, 'r')
-                jdkTLD = os.path.join(self.getCurrentDirectory(), self.workDirName, self.getTLDName(ar))
-                if not os.path.exists(jdkTLD):
-                    ar.extractall(self.workDirName)
-            else:
-                ar = tarfile.open(fullPath, "r:gz")
-                jdkTLD = os.path.join(self.getCurrentDirectory(), self.workDirName, self.getTLDName(ar))
-                if not os.path.exists(jdkTLD):
-                    ar.extractall(self.workDirName, numeric_owner=True)
-        except:
-            print(f"Unpacking failed for JDK {url}")
-            sys.exit(0)
-
-        ar.close()
-
-        extraPath = ""
-        if self.osPlatform == config.__APPLE__ and "zulu" not in jdk:
-            extraPath = os.path.join("Contents", "Home")
-
-        ## Update env-variables
-        self.env["JAVA_HOME"] = os.path.join(jdkTLD, extraPath)
+            ar = zipfile.ZipFile(fullPath, 'r') if os.name == 'nt' else tarfile.open(fullPath, "r:gz")
+            tld = os.path.join(self.getCurrentDirectory(), self.workDirName, self.getTLDName(ar))
+            if not os.path.exists(tld):
+                ar.extractall(self.workDirName, numeric_owner=(os.name != 'nt'))
+            ar.close()
+            suffix = os.path.join("Contents", "Home") if self.osPlatform == config.__APPLE__ and "zulu" not in jdk else ""
+            self.env["JAVA_HOME"] = os.path.join(tld, suffix)
+        except Exception as e:
+            print(f"Unpacking failed for JDK: {e}"); sys.exit(0)
 
     def setEnvironmentVariables(self):
-        ## 1. PATH
-        paths = self.env["PATH"]
-        allPaths = ""
-        for p in paths:
-            allPaths = allPaths + p + os.pathsep
-        allPaths = allPaths + os.environ["PATH"]
-        os.environ["PATH"] = allPaths
-
-        ## 2. JAVA_HOME
+        os.environ["PATH"] = os.pathsep.join(self.env["PATH"]) + os.pathsep + os.environ["PATH"]
         os.environ["JAVA_HOME"] = self.env["JAVA_HOME"]
-
-        ## 3. TORNADO_SDK
         os.environ["TORNADO_SDK"] = self.env["TORNADO_SDK"]
 
-    def compileTornadoVM(self, makeJDK, backend, polyglotOption, mavenSingleThreadedOption):
-        if os.name == 'nt':
-            if all(s == "" for s in [polyglotOption, mavenSingleThreadedOption]):
-                command = "nmake /f Makefile.mak " + makeJDK + " " + backend
-            else:
-                if polyglotOption:
-                    command = "nmake /f Makefile.mak " + polyglotOption
-                if mavenSingleThreadedOption:
-                    command = "nmake /f Makefile.mak " + mavenSingleThreadedOption + " " + backend 
+    def compileTornadoVM(self, makeJDK, backend, polyglot, mvnOpt):
+        cmd = "nmake /f Makefile.mak " if os.name == 'nt' else "make "
+        if all(x == "" for x in [polyglot, mvnOpt]):
+            cmd += f"{makeJDK} {backend}"
         else:
-            if all(s == "" for s in [polyglotOption, mavenSingleThreadedOption]):
-                command = "make " + makeJDK + " " + backend
-            else:
-                if polyglotOption:
-                    command = "make " + polyglotOption
-                if mavenSingleThreadedOption:
-                    command = "make " + mavenSingleThreadedOption + " " + backend
-        os.system(command)
+            if polyglot: cmd += polyglot
+            if mvnOpt: cmd += f" {mvnOpt} {backend}"
+        os.system(cmd)
 
     def createSourceFile(self):
-        print(" ------------------------------------------")
-        print("        TornadoVM installation done        ")
-        print(" ------------------------------------------")
-        print("Creating source file ......................")
-
-        paths = self.env["PATH"]
-        allPaths = ""
-        for p in paths:
-            allPaths = allPaths + p + os.pathsep
-
+        print("Creating environment setup script...")
+        allPaths = os.pathsep.join(self.env["PATH"])
         if os.name == 'nt':
-            binariesDistribution = os.path.join(os.environ["TORNADO_SDK"], "bin", "dist")
-            cutils.runPyInstaller(os.getcwd(), os.environ["TORNADO_SDK"])
-            fileContent = "set JAVA_HOME=" + os.environ["JAVA_HOME"] + "\n"
-            levelZeroPath = os.path.join(os.getcwd(), "level-zero", "build", "bin", "Release")
-            fileContent = fileContent + "set PATH=" + allPaths + levelZeroPath + os.pathsep + binariesDistribution + os.pathsep + "%PATH%" + "\n"
-            fileContent = (
-                    fileContent + "set TORNADO_SDK=" + os.environ["TORNADO_SDK"] + "\n"
+            path = os.path.join(os.getcwd(), "level-zero", "build", "bin", "Release")
+            dist = os.path.join(os.environ["TORNADO_SDK"], "bin", "dist")
+            content = (
+                f"set JAVA_HOME={os.environ['JAVA_HOME']}\n"
+                f"set PATH={allPaths}{path}{os.pathsep}{dist}{os.pathsep}%PATH%\n"
+                f"set TORNADO_SDK={os.environ['TORNADO_SDK']}\n"
             )
-            f = open("setvars.cmd", "w")
-            f.write(fileContent)
-            f.close()
-
-            print("........................................[ok]")
-            print(" ")
-            print(" ")
-            print("To run TornadoVM, first run `setvars.cmd`")
+            with open("setvars.cmd", "w") as f: f.write(content)
+            print("Run with: setvars.cmd")
         else:
-            fileContent = "export JAVA_HOME=" + os.environ["JAVA_HOME"] + "\n"
-            fileContent = fileContent + "export PATH=" + allPaths + "$PATH" + "\n"
-            fileContent = (
-                    fileContent + "export TORNADO_SDK=" + os.environ["TORNADO_SDK"] + "\n"
+            content = (
+                f"export JAVA_HOME={os.environ['JAVA_HOME']}\n"
+                f"export PATH={allPaths}:$PATH\n"
+                f"export TORNADO_SDK={os.environ['TORNADO_SDK']}\n"
             )
-            f = open("setvars.sh", "w")
-            f.write(fileContent)
-            f.close()
+            with open("setvars.sh", "w") as f: f.write(content)
+            print("Run with: source setvars.sh")
 
-            print("........................................[ok]")
-            print(" ")
-            print(" ")
-            print("To run TornadoVM, first run `source setvars.sh`")
-
-    def checkJDKOption(self, args):
-        if args.jdk == None:
-            print("[Error] Define one JDK to install TornadoVM. ")
-            sys.exit(0)
-
-        if args.jdk not in __SUPPORTED_JDKS__:
-            print(
-                "JDK not supported. Please install with one of the JDKs from the supported list"
-            )
-            for jdk in __SUPPORTED_JDKS__:
-                print("\t" + jdk)
-            sys.exit(0)
-
-    def composeBackendOption(sekf, args):
-        backend = args.backend.replace(" ", "").lower()
-        for b in backend.split(","):
+    def composeBackendOption(self, args):
+        backends = args.backend.replace(" ", "").lower().split(",")
+        for b in backends:
             if b not in __SUPPORTED_BACKENDS__:
-                print(b + " is not a supported backend")
+                print(f"[Error] Unsupported backend: {b}")
                 sys.exit(0)
-        backend = "BACKEND=" + backend
-        return backend
+        return "BACKEND=" + ",".join(backends)
 
-    def composePolyglotOption(self, args):
-        if args.polyglot:
-            polyglotOption = "polyglot"
-        else:
-            polyglotOption = ""
-        return polyglotOption
+    def check_or_install_python_modules(self): os.system("pip3 install -r bin/tornadoDepModules.txt")
 
-    def composeMavenSingleThreadedOption(self, args, makeJDK):
-        if args.mavenSingleThreaded:
-            mavenSingleThreadedOption = "mvn-single-threaded-" + makeJDK
-        else:
-            mavenSingleThreadedOption = ""
-        return mavenSingleThreadedOption
-
-    def check_or_install_python_modules(self):
-        command = "pip3 install -r bin/tornadoDepModules.txt"
-        os.system(command)
-
-    def install(self, args):
-
+    def downloadDependencies(self, download_jdk, jdk_keyword, download_cmake, download_mvn):
         self.check_or_install_python_modules()
-
-        if args.javaHome == None:
-            self.checkJDKOption(args)
-
-        if args.backend == None:
-            print("[Error] Specify at least one backend { opencl,ptx,spirv } ")
-            sys.exit(0)
-
-        backend = self.composeBackendOption(args)
-
-        makeJDK = "jdk21"
-        polyglotOption = ""
-        if (args.javaHome != None and "graal" in args.javaHome) or (args.jdk != None and "graal" in args.jdk):
-            makeJDK = "graal-jdk-21"
-            polyglotOption = self.composePolyglotOption(args)
-
-        mavenSingleThreadedOption = self.composeMavenSingleThreadedOption(args, makeJDK)
-        if args.javaHome != None:
-            directoryPostfix = args.javaHome.split(os.sep)[-1]
-        else:
-            directoryPostfix = args.jdk
-
         self.setDependenciesDir()
-        self.setWorkDir(directoryPostfix)
+        self.setWorkDir(jdk_keyword)
 
-        self.downloadCMake()
-        self.downloadMaven()
+        if download_cmake:
+            self.downloadCMake()
 
-        ## If JAVA_HOME is provided, there is no need to download a JDK
-        if args.javaHome == None:
-            self.downloadJDK(args.jdk)
-        else:
-            self.env["JAVA_HOME"] = args.javaHome
+        if download_mvn:
+            self.downloadMaven()
 
+        if download_jdk:
+            self.downloadJDK(jdk_keyword)
+
+    def install(self, args, makeJDK, polyglotOption, mavenSingleThreadedOption):
+        backend = self.composeBackendOption(args)
         self.setEnvironmentVariables()
         self.compileTornadoVM(makeJDK, backend, polyglotOption, mavenSingleThreadedOption)
         self.createSourceFile()
 
+    def selectJDKFromMenu(self):
+        download_jdk = False
+        listSupportedJDKs()
+        try:
+            choice = int(input("Enter the number of your choice: ").strip())
+            if 1 <= choice <= len(__SUPPORTED_JDKS__):
+                jdk_keyword = __SUPPORTED_JDKS__[choice - 1]
+                download_jdk = True
+            else:
+                print(f"Invalid choice. Exiting."); sys.exit(1)
+        except ValueError:
+            print(f"Invalid input. Exiting."); sys.exit(1)
+        return download_jdk, jdk_keyword
+
+    def checkDownloadJDK(self, args):
+        java_home = os.environ.get("JAVA_HOME")
+        self.env["JAVA_HOME"] = java_home
+        if not java_home:
+            print("[INFO] JAVA_HOME is not set.")
+            download_jdk, jdk_keyword = self.selectJDKFromMenu()
+        else:
+            print(f"[INFO] JAVA_HOME is set to: {java_home}")
+            matched_jdk = None
+            java_exec = os.path.join(java_home, "bin", "java")
+            if os.path.exists(java_exec):
+                try:
+                    output = subprocess.check_output([java_exec, "-version"], stderr=subprocess.STDOUT, text=True)
+                    if "21" in output:
+                        matched_jdk = "graal-jdk-21" if "GraalVM" in output else "jdk21"
+                except Exception as e:
+                    print(f"[WARN] Could not determine JDK version: {e}")
+            if matched_jdk:
+                print(f"[INFO] Detected JDK match: {matched_jdk}")
+                jdk_keyword = matched_jdk
+                download_jdk = False
+
+                # Check if polyglot was requested but the JDK is not GraalVM
+                if args.polyglot and "graal" not in matched_jdk.lower():
+                    print("[WARN] Polyglot option requested, but JAVA_HOME is not a GraalVM JDK.")
+                    response = input("Do you want to switch to GraalVM and download it? (y/n): ").strip().lower()
+                    if response == "y":
+                        jdk_keyword = "graal-jdk-21"
+                        download_jdk = True
+                    else:
+                        print("Polyglot requires GraalVM. Exiting.")
+                        sys.exit(1)
+            else:
+                print("[WARN] JAVA_HOME does not match a supported JDK.")
+                download_jdk, jdk_keyword = self.selectJDKFromMenu()
+        return download_jdk, jdk_keyword
+
+    def checkDownloadMaven(self):
+        download_mvn = False
+        mvn_path = which("mvn")
+        if not mvn_path:
+            if input("Maven not found. Download locally? (y/n): ").strip().lower() == "y":
+                download_mvn = True
+            else:
+                print("Maven required. Exiting."); sys.exit(1)
+        else:
+            print(f"[INFO] Maven found at: {mvn_path}")
+        return download_mvn
+
+    def checkDownloadCmake(self):
+        download_cmake = False
+        cmake_valid = False
+        cmake_path = which("cmake")
+        if cmake_path:
+            try:
+                out = subprocess.check_output(["cmake", "--version"], text=True)
+                if version.parse(out.splitlines()[0].split()[-1]) >= version.parse("3.25.2"):
+                    cmake_valid = True
+            except Exception as e:
+                print(f"[WARN] Could not determine CMake version: {e}")
+        if not cmake_valid:
+            if input("CMake not found or too old. Download locally? (y/n): ").strip().lower() == "y":
+                download_cmake = True
+            else:
+                print("CMake required. Exiting."); sys.exit(1)
+        else:
+            print(f"[INFO] CMake found at: {cmake_path}")
+        return download_cmake
+
+def composePolyglotOption(args): return "polyglot" if args.polyglot else ""
+
+def composeMavenSingleThreadedOption(args, jdk): return f"mvn-single-threaded-{jdk}" if args.mavenSingleThreaded else ""
+
+def checkBackends():
+    valid_backends = {"opencl", "ptx", "spirv"}
+    args.backend = input("Enter backends (opencl, ptx, spirv): ").strip().lower()
+
+    # Remove whitespace and split by comma
+    selected_backends = {b.strip() for b in args.backend.split(",")}
+
+    if not selected_backends.issubset(valid_backends):
+        print("[Error] Invalid backend(s) specified. Choose from: opencl, ptx, spirv")
+        sys.exit(1)
 
 def listSupportedJDKs():
-    print(
-    """
-    TornadoVM Installer - Select a JDK implementation to install with TornadoVM:
+    descriptions = [
+        "Install TornadoVM with OpenJDK 21 (Oracle OpenJDK)",
+        "Install TornadoVM with GraalVM and JDK 21 (GraalVM 23.1.0)",
+        "Install TornadoVM with Mandrel and JDK 21 (GraalVM 23.1.0)",
+        "Install TornadoVM with Corretto JDK 21",
+        "Install TornadoVM with Microsoft JDK 21",
+        "Install TornadoVM with Azul Zulu JDK 21",
+        "Install TornadoVM with Eclipse Temurin JDK 21",
+        "Install TornadoVM with SapMachine OpenJDK 21",
+        "Install TornadoVM with Liberica OpenJDK 21 (Only option for RISC-V 64)"
+    ]
+    print(f"""
+  List of supported JDKs for TornadoVM {__VERSION__}
+  """)
+    for idx, (jdk, desc) in enumerate(zip(__SUPPORTED_JDKS__, descriptions), start=1):
+        print(f"  [{idx}] {jdk:<18} : {desc}")
 
-    jdk21             : Install TornadoVM with OpenJDK 21 (Oracle OpenJDK)
-    graal-jdk-21      : Install TornadoVM with GraalVM and JDK 21 (GraalVM 23.1.0)
-    mandrel-jdk-21    : Install TornadoVM with Mandrel and JDK 21 (GraalVM 23.1.0)
-    corretto-jdk-21   : Install TornadoVM with Corretto JDK 21
-    microsoft-jdk-21  : Install TornadoVM with Microsoft JDK 21
-    zulu-jdk-21       : Install TornadoVM with Azul Zulu JDK 21
-    temurin-jdk-21    : Install TornadoVM with Eclipse Temurin JDK 21
-    sapmachine-jdk-21 : Install TornadoVM with SapMachine OpenJDK 21
-    liberica-jdk-21   : Install TornadoVM with Liberica OpenJDK 21 (Only option for RISC-V 64)
-
-    Usage:
-      $ ./bin/tornadovm-installer  --jdk <JDK_VERSION> --backend <BACKEND>
-
-    If you want to select another version of OpenJDK, you can use --javaHome <pathToJavaHome> and install as follows:
-      $ ./bin/tornadovm-installer --backend <BACKEND> --javaHome <pathToJavaHome>
-    """
-    )
-
+def determine_make_jdk(args):
+    if (jdk_keyword and "graal" in jdk_keyword.lower()):
+        polyglot_option = composePolyglotOption(args)
+        return "graal-jdk-21", polyglot_option
+    else:
+        return "jdk21", ""
 
 def parseArguments():
-    """
-    Parse command line arguments.
-    """
-    parser = argparse.ArgumentParser(
-        description="""TornadoVM Installer Tool. It will install all software dependencies except the GPU/FPGA drivers"""
-    )
-    parser.add_argument(
-        "--version",
-        action="store_true",
-        dest="version",
-        default=False,
-        help="Print version of TornadoVM",
-    )
-    parser.add_argument(
-        "--jdk",
-        action="store",
-        dest="jdk",
-        default=None,
-        help="Select one of the supported JDKs. Use --listJDKs option to see all supported ones.",
-    )
-    parser.add_argument(
-        "--backend",
-        action="store",
-        dest="backend",
-        default=None,
-        help="Select the backend to install: { opencl, ptx, spirv }",
-    )
-    parser.add_argument(
-        "--listJDKs",
-        action="store_true",
-        dest="listJDKs",
-        default=False,
-        help="List all JDK supported versions",
-    )
-    parser.add_argument(
-        "--javaHome",
-        action="store",
-        dest="javaHome",
-        default=None,
-        help="Use a JDK from a user directory",
-    )
-    parser.add_argument(
-        "--polyglot",
-        action="store_true",
-        dest="polyglot",
-        default=None,
-        help="To enable interoperability with Truffle Programming Languages.",
-    )
-    parser.add_argument(
-        "--mvn_single_threaded",
-        action="store_true",
-        dest="mavenSingleThreaded",
-        default=None,
-        help="To build with maven while using one thread.",
-    )
-    args = parser.parse_args()
-
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(0)
-
-    return args
-
+    parser = argparse.ArgumentParser(description="TornadoVM Installer Tool")
+    parser.add_argument("--version", action="store_true", dest="version", default=False, help="Print version")
+    parser.add_argument("--listJDKs", action="store_true", dest="listJDKs", default=False, help="List supported JDKs")
+    parser.add_argument("--polyglot", action="store_true", dest="polyglot", default=None, help="Enable Truffle Interoperability with GraalVM")
+    parser.add_argument("--mvn_single_threaded", action="store_true", dest="mavenSingleThreaded", default=None, help="Use Maven with one thread")
+    return parser.parse_args()
 
 if __name__ == "__main__":
     args = parseArguments()
-
     if args.version:
-        print(__VERSION__)
-        sys.exit(0)
-
+        print(__VERSION__); sys.exit(0)
     if args.listJDKs:
-        listSupportedJDKs()
-        sys.exit(0)
+        listSupportedJDKs(); sys.exit(0)
+
+    if sys.version_info < (3, 6):
+        print("[ERROR] Python 3.6+ is required."); sys.exit(1)
 
     installer = TornadoInstaller()
-    installer.install(args)
+    download_jdk, jdk_keyword = installer.checkDownloadJDK(args)
+    download_mvn = installer.checkDownloadMaven()
+    download_cmake = installer.checkDownloadCmake()
+
+    checkBackends()
+    makeJDK, polyglotOption = determine_make_jdk(args)
+    mavenSingleThreadedOption = composeMavenSingleThreadedOption(args, makeJDK)
+
+
+    installer.downloadDependencies(download_jdk, jdk_keyword, download_cmake, download_mvn)
+    installer.install(args, makeJDK, polyglotOption, mavenSingleThreadedOption)

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -623,13 +623,13 @@ class TornadoInstaller:
         return config
 
 def parseArguments():
-    parser = argparse.ArgumentParser(description="TornadoVM Installer Tool")
+    parser = argparse.ArgumentParser(description="TornadoVM Installer Tool.  It will install all software dependencies except the GPU/FPGA drivers")
     parser.add_argument("--version", action="store_true", dest="version", default=False, help="Print version")
     parser.add_argument("--listJDKs", action="store_true", dest="listJDKs", default=False, help="List supported JDKs")
     parser.add_argument("--polyglot", action="store_true", dest="polyglot", default=None,
                         help="Enable Truffle Interoperability with GraalVM")
     parser.add_argument("--mvn_single_threaded", action="store_true", dest="mavenSingleThreaded", default=None,
-                        help="Use Maven with one thread")
+                        help="Run Maven in single-threaded mode")
     return parser.parse_args()
 
 class UserInterface:

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -21,7 +21,17 @@ try:
     from rich.console import Console
 except ImportError:
     import subprocess
-    subprocess.check_call(["pip", "install", "rich"])
+    import sys
+
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "rich"])
+    except subprocess.CalledProcessError:
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip3", "install", "rich"])
+        except subprocess.CalledProcessError:
+            print("[ERROR] Could not install 'rich'. Please install it manually.")
+            sys.exit(1)
+
     from rich.console import Console
 
 console = Console()
@@ -96,7 +106,7 @@ class TornadoInstaller:
         url = config.CMAKE[self.osPlatform][self.hardware]
         if url is None:
             if self.hardware == "riscv64": return
-            console.print(f"[MISSING DEPENDENCY] CMake not configured for {self.osPlatform}/{self.hardware}", style="bold orange"); sys.exit(0)
+            console.print(f"[MISSING DEPENDENCY] CMake not configured for {self.osPlatform}/{self.hardware}", style="yellow"); sys.exit(0)
 
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.dependenciesDirName, fileName)
@@ -114,7 +124,7 @@ class TornadoInstaller:
 
     def downloadMaven(self):
         url = config.MAVEN[self.osPlatform][self.hardware]
-        if url is None: console.print(f"[MISSING DEPENDENCY] Maven not configured for {self.osPlatform}/{self.hardware}", style="bold orange"); sys.exit(0)
+        if url is None: console.print(f"[MISSING DEPENDENCY] Maven not configured for {self.osPlatform}/{self.hardware}", style="yellow"); sys.exit(0)
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.dependenciesDirName, fileName)
         if not os.path.exists(fullPath): wget.download(url, fullPath)
@@ -130,7 +140,7 @@ class TornadoInstaller:
 
     def downloadJDK(self, jdk):
         url = config.JDK[jdk][self.osPlatform][self.hardware]
-        if url is None: console.print(f"[MISSING DEPENDENCY] The url of JDK {jdk} is not configured", style="bold orange"); sys.exit(0)
+        if url is None: console.print(f"[MISSING DEPENDENCY] The url of JDK {jdk} is not configured", style="yellow"); sys.exit(0)
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.workDirName, fileName)
         if not os.path.exists(fullPath):
@@ -257,7 +267,7 @@ class TornadoInstaller:
                     if "21" in output:
                         matched_jdk = "graal-jdk-21" if "GraalVM" in output else "jdk21"
                 except Exception as e:
-                    console.print(f"[WARNING] Could not determine JDK version: {e}", style="orange")
+                    console.print(f"[WARNING] Could not determine JDK version: {e}", style="yellow")
             if matched_jdk:
                 console.print(f"[INFO] Detected JDK match: {matched_jdk}", style="green")
                 jdk_keyword = matched_jdk
@@ -265,16 +275,16 @@ class TornadoInstaller:
 
                 # Check if polyglot was requested but the JDK is not GraalVM
                 if args.polyglot and "graal" not in matched_jdk.lower():
-                    console.print(f"[WARNING] Polyglot option requested, but JAVA_HOME is not a GraalVM JDK.", style="orange")
+                    console.print(f"[WARNING] Polyglot option requested, but JAVA_HOME is not a GraalVM JDK.", style="yellow")
                     response = input("Do you want to switch to GraalVM and download it? (y/n): ").strip().lower()
                     if response == "y":
                         jdk_keyword = "graal-jdk-21"
                         download_jdk = True
                     else:
-                        console.print(f"[WARNING] Polyglot requires GraalVM. Exiting.", style="orange")
+                        console.print(f"[WARNING] Polyglot requires GraalVM. Exiting.", style="yellow")
                         sys.exit(1)
             else:
-                console.print(f"[WARNING] JAVA_HOME does not match a supported JDK.", style="orange")
+                console.print(f"[WARNING] JAVA_HOME does not match a supported JDK.", style="yellow")
                 download_jdk, jdk_keyword = self.selectJDKFromMenu()
         return download_jdk, jdk_keyword
 
@@ -285,7 +295,7 @@ class TornadoInstaller:
             if input("Maven not found. Download locally? (y/n): ").strip().lower() == "y":
                 download_mvn = True
             else:
-                console.print(f"[WARNING] Maven required. Exiting.", style="orange"); sys.exit(1)
+                console.print(f"[WARNING] Maven required. You can add Maven in your PATH and try again.", style="yellow"); sys.exit(1)
         else:
             console.print(f"[INFO] Maven found at: {mvn_path}", style="green")
         return download_mvn
@@ -300,12 +310,12 @@ class TornadoInstaller:
                 if version.parse(out.splitlines()[0].split()[-1]) >= version.parse("3.25.2"):
                     cmake_valid = True
             except Exception as e:
-                console.print(f"[WARNING] Could not determine CMake version: {e}", style="orange")
+                console.print(f"[WARNING] Could not determine CMake version: {e}", style="yellow")
         if not cmake_valid:
             if input("CMake not found or too old. Download locally? (y/n): ").strip().lower() == "y":
                 download_cmake = True
             else:
-                console.print(f"[WARNING] CMake required. Exiting.", style="orange"); sys.exit(1)
+                console.print(f"[WARNING] CMake required. You can add CMake in your PATH and try again.", style="yellow"); sys.exit(1)
         else:
             console.print(f"[INFO] CMake found at: {cmake_path}", style="green")
         return download_cmake

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (c) 2013-2024, APT Group, Department of Computer Science,
+# Copyright (c) 2013-2025, APT Group, Department of Computer Science,
 # The University of Manchester.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,17 +45,22 @@ import sys
 import tarfile
 import zipfile
 import subprocess
+from dataclasses import dataclass
+from pathlib import Path
 from shutil import which
+from typing import Dict, List, Optional, Tuple, Union
+from abc import ABC, abstractmethod
 import wget
 import install_python_modules as tornadoReq
 import config_utils as cutils
 import installer_config as config
 from packaging import version
+import textwrap
 
 tornadoReq.check_python_dependencies()
 
 # Configuration
-__DIRECTORY_DEPENDENCIES__ = os.path.join("etc", "dependencies")
+__DIRECTORY_DEPENDENCIES__ = (Path("etc") / "dependencies").resolve()
 __VERSION__ = "v1.1.0"
 __SUPPORTED_JDKS__ = [
     config.__JDK21__,
@@ -70,382 +75,552 @@ __SUPPORTED_JDKS__ = [
 ]
 __SUPPORTED_BACKENDS__ = ["opencl", "spirv", "ptx"]
 
+# Custom Exceptions
+class TornadoInstallerError(Exception):
+    """Base exception for TornadoVM installer errors."""
+    pass
+
+
+class DownloadError(TornadoInstallerError):
+    """Raised when download operations fail."""
+    pass
+
+
+class ExtractionError(TornadoInstallerError):
+    """Raised when extraction operations fail."""
+    pass
+
+
+class ConfigurationError(TornadoInstallerError):
+    """Raised when configuration is invalid."""
+    pass
+
+# Data Classes
+@dataclass
+class SystemInfo:
+    """System information container."""
+    platform: str
+    architecture: str
+    is_windows: bool
+
+    @classmethod
+    def detect(cls) -> 'SystemInfo':
+        """Detect current system information."""
+        platform_name = platform.system().lower()
+        arch_mapping = {
+            "x86_64": "x86_64", "amd64": "x86_64",
+            "arm64": "arm64", "aarch64": "arm64",
+            "riscv64": "riscv64"
+        }
+        arch = arch_mapping.get(platform.machine().lower(), platform.machine().lower())
+        return cls(platform_name, arch, os.name == 'nt')
+
+@dataclass
+class InstallationConfig:
+    """Installation configuration container."""
+    jdk_keyword: Optional[str] = None
+    download_jdk: bool = False
+    download_maven: bool = False
+    download_cmake: bool = False
+    backends: List[str] = None
+    polyglot: bool = False
+    maven_single_threaded: bool = False
+    java_home: Optional[str] = None
+
+    def __post_init__(self):
+        if self.backends is None:
+            self.backends = ["opencl"]
+
+@dataclass
+class Environment:
+    """Environment variables container."""
+    paths: List[str]
+    java_home: str
+    tornado_sdk: str
+
+    def __init__(self):
+        self.paths = [str(Path.cwd() / "bin" / "bin")]
+        self.tornado_sdk = str(Path.cwd() / "bin" / "sdk")
+        self.java_home = ""
+
+# Abstract Base Classes
+class Downloader(ABC):
+    """Abstract base class for downloaders."""
+
+    def __init__(self, console: Console, system_info: SystemInfo):
+        self.console = console
+        self.system_info = system_info
+
+    @abstractmethod
+    def download(self, dependencies_dir: Path) -> str:
+        """Download the component and return the path to the extracted directory."""
+        pass
+
+    def _download_file(self, url: str, destination: Path) -> None:
+        """Download a file from URL to destination."""
+        if destination.exists():
+            return
+
+        try:
+            wget.download(url, str(destination))
+        except Exception as e:
+            try:
+                import urllib3
+                r = urllib3.PoolManager().request('GET', url)
+                with open(destination, 'wb') as f:
+                    f.write(r.data)
+            except Exception as fallback_error:
+                raise DownloadError(f"Failed to download {url}: {e}, fallback: {fallback_error}")
+
+    def _extract_archive(self, archive_path: Path, extract_to: Path) -> str:
+        """Extract archive and return the top-level directory name."""
+        try:
+            if self.system_info.is_windows:
+                with zipfile.ZipFile(archive_path, 'r') as ar:
+                    tld = self._get_top_level_dir(ar.namelist())
+                    if not (extract_to / tld).exists():
+                        ar.extractall(extract_to)
+            else:
+                with tarfile.open(archive_path, "r:gz") as ar:
+                    tld = self._get_top_level_dir(ar.getnames())
+                    if not (extract_to / tld).exists():
+                        ar.extractall(extract_to, numeric_owner=False)
+            return tld
+        except Exception as e:
+            raise ExtractionError(f"Failed to extract {archive_path}: {e}")
+
+    def _get_top_level_dir(self, names: List[str]) -> str:
+        """Get the top-level directory name from archive contents."""
+        if not names:
+            raise ExtractionError("Empty archive")
+
+        first_entry = names[1] if len(names) > 1 else names[0]
+        parts = first_entry.split("/")
+        return parts[1] if parts[0] == "." else parts[0]
+
+
+class CMakeDownloader(Downloader):
+    """CMake downloader and extractor."""
+
+    def download(self, dependencies_dir: Path) -> str:
+        url = config.CMAKE.get(self.system_info.platform, {}).get(self.system_info.architecture)
+        if not url:
+            if self.system_info.architecture == "riscv64":
+                return ""
+            raise ConfigurationError(
+                f"CMake not configured for {self.system_info.platform}/{self.system_info.architecture}"
+            )
+
+        filename = Path(url).name
+        archive_path = Path(dependencies_dir) / filename
+
+        self._download_file(url, archive_path)
+        tld = self._extract_archive(archive_path, dependencies_dir)
+
+        extra_path = Path("CMake.app") / "Contents" if self.system_info.platform == config.__APPLE__ else Path()
+        bin_path = Path(dependencies_dir) / tld / extra_path / "bin"
+
+        return bin_path
+
+class MavenDownloader(Downloader):
+    """Maven downloader and extractor."""
+
+    def download(self, dependencies_dir: Path) -> str:
+        url = config.MAVEN.get(self.system_info.platform, {}).get(self.system_info.architecture)
+        if not url:
+            raise ConfigurationError(
+                f"Maven not configured for {self.system_info.platform}/{self.system_info.architecture}"
+            )
+
+        filename = Path(url).name
+        archive_path = Path(dependencies_dir) / filename
+
+        self._download_file(url, archive_path)
+        tld = self._extract_archive(archive_path, dependencies_dir)
+
+        bin_path = Path(dependencies_dir) / tld / "bin"
+        return bin_path
+
+class JDKDownloader(Downloader):
+    """JDK downloader and extractor."""
+
+    def download(self, dependencies_dir: Path, jdk_keyword: str) -> str:
+        url = config.JDK.get(jdk_keyword, {}).get(self.system_info.platform, {}).get(self.system_info.architecture)
+        if not url:
+            raise ConfigurationError(f"JDK {jdk_keyword} not configured for this platform")
+
+        filename = Path(url).name
+        archive_path = Path(dependencies_dir) / filename
+
+        self._download_file(url, archive_path)
+        tld = self._extract_archive(archive_path, dependencies_dir)
+
+        suffix = Path("Contents") / "Home" if (
+                self.system_info.platform == config.__APPLE__ and "zulu" not in jdk_keyword.lower() and "liberica" not in jdk_keyword.lower()
+        ) else Path()
+
+        java_home = Path(dependencies_dir) / tld / suffix
+        return str(java_home)
+
+class DependencyManager:
+    """Manages downloading and setup of dependencies."""
+
+    def __init__(self, console: Console, system_info: SystemInfo):
+        self.console = console
+        self.system_info = system_info
+        self.cmake_downloader = CMakeDownloader(console, system_info)
+        self.maven_downloader = MavenDownloader(console, system_info)
+        self.jdk_downloader = JDKDownloader(console, system_info)
+
+    def setup_dependencies(self, config: InstallationConfig, env: Environment) -> None:
+        """Set up all required dependencies."""
+        self._install_python_modules()
+        path_of_dependencies_dir = self._create_dependencies_dir()
+
+        if config.download_cmake:
+            cmake_path = self.cmake_downloader.download(path_of_dependencies_dir)
+            if cmake_path:
+                env.paths.append(cmake_path)
+
+        if config.download_maven:
+            maven_path = self.maven_downloader.download(path_of_dependencies_dir)
+            env.paths.append(maven_path)
+
+        if config.download_jdk:
+            java_home = self.jdk_downloader.download(self._create_jdk_dependencies_dir(path_of_dependencies_dir, config.jdk_keyword), config.jdk_keyword)
+            env.java_home = java_home
+        elif config.java_home:
+            env.java_home = config.java_home
+
+    def _install_python_modules(self) -> None:
+        """Install required Python modules."""
+        tornadoReq.check_python_dependencies()
+        os.system("pip3 install -r bin/tornadoDepModules.txt")
+
+    def _create_dependencies_dir(self) -> Path:
+        """Create and return the dependencies directory."""
+        work_dir = __DIRECTORY_DEPENDENCIES__
+
+        os.makedirs(work_dir, exist_ok=True)
+        return Path(work_dir)
+
+    def _create_jdk_dependencies_dir(self, path_of_dependencies_dir, jdk_keyword: Optional[str]) -> Path:
+        """Create and return the dependencies directory."""
+        if jdk_keyword:
+            work_dir = path_of_dependencies_dir / f"TornadoVM-{jdk_keyword}"
+            os.makedirs(work_dir, exist_ok=True)
+            return Path(work_dir)
+        else:
+            self.console.print(f"[ERROR] There was no TornadoVM JDK profile matching the selected JDK", style="bold red")
+            sys.exit(0)
+
+class EnvironmentManager:
+    """Manages environment variables and setup."""
+
+    def __init__(self, console: Console, system_info: SystemInfo):
+        self.console = console
+        self.system_info = system_info
+
+    def apply_environment(self, env: Environment) -> None:
+        """Apply environment variables to current process."""
+        os.environ["PATH"] = os.pathsep.join(str(p) for p in env.paths) + os.pathsep + os.environ["PATH"]
+        os.environ["JAVA_HOME"] = env.java_home
+        os.environ["TORNADO_SDK"] = env.tornado_sdk
+
+    def create_setup_script(self, env: Environment) -> None:
+        """Create environment setup script."""
+        self.console.print("[INFO] Creating environment setup script...", style="green")
+
+        if self.system_info.is_windows:
+            self._create_windows_script(env)
+        else:
+            self._create_unix_script(env)
+
+    def _create_windows_script(self, env: Environment) -> None:
+        """Create Windows batch script."""
+        binaries_dist = Path(env.tornado_sdk) / "bin" / "dist"
+        level_zero_path = Path.cwd() / "level-zero" / "build" / "bin" / "Release"
+
+        cutils.runPyInstaller(str(Path.cwd()), env.tornado_sdk)
+
+        content = f"""set JAVA_HOME={env.java_home}
+set PATH={os.pathsep.join(env.paths)}{os.pathsep}{level_zero_path}{os.pathsep}{binaries_dist}{os.pathsep}%PATH%
+set TORNADO_SDK={env.tornado_sdk}
+"""
+
+        with open("setvars.cmd", "w") as f:
+            f.write(content)
+
+        self.console.print("[INFO] Run with: setvars.cmd", style="green")
+
+    def _create_unix_script(self, env: Environment) -> None:
+        path_str = os.pathsep.join(str(p) for p in env.paths)
+
+        content = textwrap.dedent(f"""\
+            export JAVA_HOME={env.java_home}
+            export PATH={path_str}:$PATH
+            export TORNADO_SDK={env.tornado_sdk}
+        """)
+
+        with open("setvars.sh", "w") as f:
+            f.write(content)
+
+        self.console.print("[INFO] Run with: source setvars.sh", style="green")
+
+
+class BuildManager:
+    """Manages the build process."""
+
+    def __init__(self, console: Console, system_info: SystemInfo):
+        self.console = console
+        self.system_info = system_info
+
+    def build(self, config: InstallationConfig) -> None:
+        """Build TornadoVM with the specified configuration."""
+        make_rule = self._determine_make_options(config)
+        backend_option = self._get_backend_option(config.backends)
+
+        cmd = self._build_command(make_rule, backend_option)
+
+        self.console.print(f"[INFO] Building with command:", style="green")
+        self.console.print(f"{cmd}", style="cyan")
+        os.system(cmd)
+
+    def _determine_make_options(self, config: InstallationConfig) -> Tuple[str, str]:
+        """Determine make target and polyglot option."""
+        if config.jdk_keyword and "graal" in config.jdk_keyword.lower():
+            if config.polyglot:
+                if config.maven_single_threaded:
+                    return "mvn-single-threaded-polyglot"
+                else:
+                    return "polyglot"
+            else:
+                return "graal-jdk-21"
+        return "jdk21"
+
+    def _get_backend_option(self, backends: List[str]) -> str:
+        """Get backend option string."""
+        return f"BACKEND={','.join(backends)}"
+
+    def _build_command(self, make_rule: str, backend_option: str) -> str:
+        """Build the complete command string."""
+        base_cmd = "nmake /f Makefile.mak " if self.system_info.is_windows else "make "
+        return f"{base_cmd}{make_rule} {backend_option}"
+
+class SystemValidator:
+    """Validates system requirements."""
+
+    def __init__(self, console: Console, system_info: SystemInfo):
+        self.console = console
+        self.system_info = system_info
+
+    def check_java_home(self) -> Tuple[bool, Optional[str], Optional[str]]:
+        """Check if JAVA_HOME is set and valid."""
+        java_home = os.environ.get("JAVA_HOME")
+
+        if not java_home:
+            self.console.print("[INFO] JAVA_HOME is not set.", style="yellow")
+            return False, None, None
+
+        self.console.print(f"[INFO] JAVA_HOME is set to: {java_home}", style="green")
+
+        java_exec = self._get_java_executable(java_home)
+        if not java_exec.exists():
+            self.console.print("[WARN] Java executable not found in JAVA_HOME.", style="yellow")
+            return False, java_home, None
+
+        try:
+            output = subprocess.check_output([str(java_exec), "-version"],
+                                             stderr=subprocess.STDOUT, text=True)
+            self.console.print(output, style="yellow")
+
+            matched_jdk = self._match_jdk_version(output)
+            if matched_jdk:
+                self.console.print(f"[INFO] Detected JDK: {matched_jdk}", style="green")
+                return True, java_home, matched_jdk
+            else:
+                self.console.print("[WARN] JDK version not compatible.", style="yellow")
+                return False, java_home, None
+
+        except Exception as e:
+            self.console.print(f"[WARNING] Could not determine JDK version: {e}", style="yellow")
+            return False, java_home, None
+
+    def check_maven(self) -> bool:
+        """Check if Maven is available."""
+        mvn_path = which("mvn")
+        if mvn_path:
+            self.console.print(f"[INFO] Maven found at: {mvn_path}", style="green")
+            return True
+        return False
+
+    def check_cmake(self) -> bool:
+        """Check if CMake is available and meets version requirements."""
+        cmake_path = which("cmake")
+        if not cmake_path:
+            return False
+
+        try:
+            cmd = "cmake.exe" if self.system_info.is_windows else "cmake"
+            output = subprocess.check_output([cmd, "--version"], text=True)
+            raw_version = output.splitlines()[0].split()[-1].split("-")[0]
+
+            if version.parse(raw_version) >= version.parse("3.25.2"):
+                self.console.print(f"[INFO] CMake found at: {cmake_path}", style="green")
+                return True
+            else:
+                self.console.print("[WARN] CMake version too old.", style="yellow")
+                return False
+
+        except Exception as e:
+            self.console.print(f"[WARNING] Could not determine CMake version: {e}", style="yellow")
+            return False
+
+    def _get_java_executable(self, java_home: str) -> Path:
+        """Get the Java executable path."""
+        if self.system_info.is_windows:
+            return Path(java_home) / "bin" / "java.exe"
+        return Path(java_home) / "bin" / "java"
+
+    def _match_jdk_version(self, output: str) -> Optional[str]:
+        """Match JDK version output to supported JDK profiles."""
+        output_lower = output.lower()
+
+        if "21" in output and "graalvm" in output_lower:
+            return "graal-jdk-21"
+        elif "21" in output:
+            return "jdk21"
+
+        return None
 
 class TornadoInstaller:
     def __init__(self):
-        self.workDirName = ""
-        self.dependenciesDirName = ""
-        self.osPlatform = platform.system().lower()
-        self.hardware = self.getMachineArc()
-        self.env = {
-            "PATH": [os.path.join(os.getcwd(), "bin", "bin")],
-            "TORNADO_SDK": os.path.join(os.getcwd(), "bin", "sdk")
-        }
+        self.console = Console()
+        self.system_info = SystemInfo.detect()
+        self.ui = UserInterface(self.console, self.system_info)
+        self.validator = SystemValidator(self.console, self.system_info)
+        self.dependency_manager = DependencyManager(self.console, self.system_info)
+        self.env_manager = EnvironmentManager(self.console, self.system_info)
+        self.build_manager = BuildManager(self.console, self.system_info)
 
-    def getMachineArc(self):
-        types = {"x86_64": "x86_64", "amd64": "x86_64", "arm64": "arm64", "aarch64": "arm64", "riscv64": "riscv64"}
-        return types[platform.machine().lower()]
-
-    def processFileName(self, url):
-        return os.path.basename(url)
-
-    def setWorkDir(self, jdk):
-        self.workDirName = os.path.join(__DIRECTORY_DEPENDENCIES__, f"TornadoVM-{jdk}")
-        os.makedirs(self.workDirName, exist_ok=True)
-
-    def setDependenciesDir(self):
-        self.dependenciesDirName = os.path.join(__DIRECTORY_DEPENDENCIES__)
-        os.makedirs(self.dependenciesDirName, exist_ok=True)
-
-    def getCurrentDirectory(self):
-        return os.getcwd()
-
-    def getTLDName(self, ar):
-        names = ar.namelist() if os.name == 'nt' else ar.getnames()
-        parts = names[1].split("/")
-        return parts[1] if parts[0] == "." else parts[0]
-
-    def downloadCMake(self):
-        url = config.CMAKE[self.osPlatform][self.hardware]
-        if url is None:
-            if self.hardware == "riscv64": return
-            console.print(f"[ERROR] CMake not configured for {self.osPlatform}/{self.hardware}. Try to install it in your PATH",
-                          style="bold red");
-            sys.exit(0)
-
-        fileName = self.processFileName(url)
-        fullPath = os.path.join(self.dependenciesDirName, fileName)
-        if not os.path.exists(fullPath): wget.download(url, fullPath)
+    def install(self, args: argparse.Namespace) -> None:
+        """Main installation method."""
         try:
-            ar = zipfile.ZipFile(fullPath, 'r') if os.name == 'nt' else tarfile.open(fullPath, "r:gz")
-            tld = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
-            if not os.path.exists(tld):
-                ar.extractall(self.dependenciesDirName, numeric_owner=(os.name != 'nt'))
-            ar.close()
-            extraPath = os.path.join("CMake.app", "Contents") if self.osPlatform == config.__APPLE__ else ""
-            self.env["PATH"].append(os.path.join(tld, extraPath, "bin"))
-        except Exception as e:
-            console.print(f"[ERROR] Unpacking failed for CMake: {e}", style="bold red");
-            sys.exit(0)
+            config = self._build_configuration(args)
+            env = Environment()
 
-    def downloadMaven(self):
-        url = config.MAVEN[self.osPlatform][self.hardware]
-        if url is None: console.print(
-            f"[ERROR] Maven not configured for {self.osPlatform}/{self.hardware}. Try to install it in your PATH",
-            style="bold red"); sys.exit(0)
-        fileName = self.processFileName(url)
-        fullPath = os.path.join(self.dependenciesDirName, fileName)
-        if not os.path.exists(fullPath): wget.download(url, fullPath)
-        try:
-            ar = zipfile.ZipFile(fullPath, 'r') if os.name == 'nt' else tarfile.open(fullPath, "r:gz")
-            tld = os.path.join(self.getCurrentDirectory(), self.dependenciesDirName, self.getTLDName(ar))
-            if not os.path.exists(tld):
-                ar.extractall(self.dependenciesDirName, numeric_owner=(os.name != 'nt'))
-            ar.close()
-            self.env["PATH"].append(os.path.join(tld, "bin"))
-        except Exception as e:
-            console.print(f"[ERROR] Unpacking failed for Maven: {e}", style="bold red");
-            sys.exit(0)
+            self.dependency_manager.setup_dependencies(config, env)
+            self.env_manager.apply_environment(env)
 
-    def downloadJDK(self, jdk):
-        url = config.JDK[jdk][self.osPlatform][self.hardware]
-        if url is None: console.print(f"[ERROR] The url of JDK {jdk} is not configured in TornadoVM. Try to set JAVA_HOME.",
-                                      style="bold red"); sys.exit(0)
-        fileName = self.processFileName(url)
-        fullPath = os.path.join(self.workDirName, fileName)
-        if not os.path.exists(fullPath):
-            try:
-                wget.download(url, fullPath)
-            except:
-                import urllib3
-                r = urllib3.PoolManager().request('GET', url)
-                with open(fullPath, 'wb') as f:
-                    f.write(r.data)
-        try:
-            ar = zipfile.ZipFile(fullPath, 'r') if os.name == 'nt' else tarfile.open(fullPath, "r:gz")
-            tld = os.path.join(self.getCurrentDirectory(), self.workDirName, self.getTLDName(ar))
-            if not os.path.exists(tld):
-                ar.extractall(self.workDirName, numeric_owner=(os.name != 'nt'))
-            ar.close()
-            suffix = os.path.join("Contents",
-                                  "Home") if self.osPlatform == config.__APPLE__ and "zulu" not in jdk else ""
-            self.env["JAVA_HOME"] = os.path.join(tld, suffix)
-        except Exception as e:
-            console.print(f"[ERROR] Unpacking failed for JDK: {e}", style="bold red");
-            sys.exit(0)
+            self.build_manager.build(config)
+            self.env_manager.create_setup_script(env)
 
-    def setEnvironmentVariables(self):
-        os.environ["PATH"] = os.pathsep.join(self.env["PATH"]) + os.pathsep + os.environ["PATH"]
-        os.environ["JAVA_HOME"] = self.env["JAVA_HOME"]
-        os.environ["TORNADO_SDK"] = self.env["TORNADO_SDK"]
+            self.console.print("[SUCCESS] Installation completed!", style="bold green")
 
-    def compileTornadoVM(self, makeJDK, backend, polyglot, mvnOpt):
-        cmd = "nmake /f Makefile.mak " if os.name == 'nt' else "make "
-        if all(x == "" for x in [polyglot, mvnOpt]):
-            cmd += f"{makeJDK} {backend}"
-        else:
-            if polyglot: cmd += polyglot
-            if mvnOpt: cmd += f" {mvnOpt} {backend}"
-        os.system(cmd)
-
-    def createSourceFile(self):
-        console.print(f"[INFO] Creating environment setup script...", style="green")
-        paths = self.env["PATH"]
-        allPaths = ""
-        for p in paths:
-            allPaths = allPaths + p + os.pathsep
-
-        if os.name == 'nt':
-            binariesDistribution = os.path.join(os.environ["TORNADO_SDK"], "bin", "dist")
-            cutils.runPyInstaller(os.getcwd(), os.environ["TORNADO_SDK"])
-            fileContent = "set JAVA_HOME=" + os.environ["JAVA_HOME"] + "\n"
-            levelZeroPath = os.path.join(os.getcwd(), "level-zero", "build", "bin", "Release")
-            fileContent = fileContent + "set PATH=" + allPaths + levelZeroPath + os.pathsep + binariesDistribution + os.pathsep + "%PATH%" + "\n"
-            fileContent = (
-                    fileContent + "set TORNADO_SDK=" + os.environ["TORNADO_SDK"] + "\n"
-            )
-            f = open("setvars.cmd", "w")
-            f.write(fileContent)
-            f.close()
-
-            print("........................................[ok]")
-            print(" ")
-            console.print(f"[INFO] Run with: setvars.cmd", style="green")
-        else:
-            content = (
-                f"export JAVA_HOME={os.environ['JAVA_HOME']}\n"
-                f"export PATH={allPaths}:$PATH\n"
-                f"export TORNADO_SDK={os.environ['TORNADO_SDK']}\n"
-            )
-            with open("setvars.sh", "w") as f:
-                f.write(content)
-            print("........................................[ok]")
-            print(" ")
-            console.print(f"[INFO] Run with: source setvars.sh", style="green")
-
-    def composeBackendOption(self, args):
-        backends = checkValidBackends(args.backend)
-        return "BACKEND=" + ",".join(backends)
-
-    def check_or_install_python_modules(self):
-        os.system("pip3 install -r bin/tornadoDepModules.txt")
-
-    def downloadDependencies(self, download_jdk, jdk_keyword, download_cmake, download_mvn):
-        self.check_or_install_python_modules()
-        self.setDependenciesDir()
-        self.setWorkDir(jdk_keyword)
-
-        if download_cmake:
-            self.downloadCMake()
-
-        if download_mvn:
-            self.downloadMaven()
-
-        if download_jdk:
-            self.downloadJDK(jdk_keyword)
-
-    def install(self, args, makeJDK, polyglotOption, mavenSingleThreadedOption):
-        backend = self.composeBackendOption(args)
-        self.setEnvironmentVariables()
-        self.compileTornadoVM(makeJDK, backend, polyglotOption, mavenSingleThreadedOption)
-        self.createSourceFile()
-
-    def selectJDKFromMenu(self):
-        download_jdk = False
-        listSupportedJDKs()
-        try:
-            choice = int(input("Enter the number of your choice (1-9): ").strip())
-            if 1 <= choice <= len(__SUPPORTED_JDKS__):
-                jdk_keyword = __SUPPORTED_JDKS__[choice - 1]
-                download_jdk = True
-            else:
-                console.print(f"[ERROR] Invalid choice. Exiting.", style="bold red");
-                sys.exit(1)
-        except ValueError:
-            console.print(f"[ERROR] Invalid input. Exiting.", style="bold red");
+        except TornadoInstallerError as e:
+            self.console.print(f"[ERROR] {e}", style="bold red")
             sys.exit(1)
-        return download_jdk, jdk_keyword
+        except Exception as e:
+            import traceback
+            self.console.print(f"[ERROR] Unexpected error: {e}", style="bold red")
+            tb_str = ''.join(traceback.format_exception(type(e), e, e.__traceback__))
+            self.console.print(tb_str, style="red")
+            sys.exit(1)
 
-    def checkJDKForPolyglot(self, args, download_jdk, jdk_keyword):
+    def _build_configuration(self, args: argparse.Namespace) -> InstallationConfig:
+        """Build installation configuration from arguments and user input."""
+        config = InstallationConfig()
+
+        # Check system requirements and get JDK info
+        has_valid_java, java_home, matched_jdk = self.validator.check_java_home()
+
+        if has_valid_java:
+            config.java_home = java_home
+            config.jdk_keyword = matched_jdk
+            config.download_jdk = False
+        else:
+            config.download_jdk, config.jdk_keyword = self._handle_jdk_selection()
+
+        # Validate polyglot requirements
         if args.polyglot:
-            if not jdk_keyword or "graal" not in jdk_keyword.lower():
-                console.print("[ERROR] Polyglot requires GraalVM. Please select the GraalVM JDK.", style="bold red")
-                print(" ")
-                console.print(f"You have two options to proceed:", style="yellow")
-                console.print(f"[1] Use an already installed GraalVM JDK by setting JAVA_HOME.", style="yellow")
-                console.print(f"[2] Automatically download and install a GraalVM JDK distribution.", style="yellow")
-                print(" ")
-                choice = int(input("Enter the number of your choice (1 or 2): ").strip())
-                if choice == 1:
-                    sys.exit(1)
-                elif choice == 2:
-                    jdk_keyword = "graal-jdk-21"
-                    download_jdk = True
-                else:
-                    console.print("[ERROR] GraalVM required for polyglot. Exiting.", style="bold red")
-                    sys.exit(1)
-        return download_jdk, jdk_keyword
+            config = self._validate_polyglot_config(config)
 
-    def checkDownloadJDK(self, args):
-        java_home = os.environ.get("JAVA_HOME")
-        self.env["JAVA_HOME"] = java_home
-        if not java_home:
-            console.print(f"[INFO] JAVA_HOME is not set.", style="yellow")
-            print(" ")
-            console.print(f"You have two options to proceed:", style="yellow")
-            console.print(f"[1] Use an already installed compatible JDK by setting JAVA_HOME.", style="yellow")
-            console.print(f"[2] Automatically download and install a supported JDK distribution.", style="yellow")
-            print(" ")
+        # Check other dependencies
+        config.download_maven = not self.validator.check_maven()
+        if config.download_maven:
+            if input("Maven not found. Download locally? (y/n): ").strip().lower() != "y":
+                raise ConfigurationError("Maven is required")
+
+        config.download_cmake = not self.validator.check_cmake()
+        if config.download_cmake:
+            if input("CMake not found or too old. Download locally? (y/n): ").strip().lower() != "y":
+                raise ConfigurationError("CMake is required")
+
+        # Set other options
+        config.backends = self.ui.select_backends()
+        config.polyglot = args.polyglot
+        config.maven_single_threaded = args.mavenSingleThreaded
+
+        return config
+
+    def _handle_jdk_selection(self) -> Tuple[bool, str]:
+        """Handle JDK selection when JAVA_HOME is not set or invalid."""
+        self.console.print("You have two options to proceed:", style="yellow")
+        self.console.print("[1] Use an already installed compatible JDK by setting JAVA_HOME.", style="green")
+        self.console.print("[2] Let the installer automatically download and configure a compatible JDK distribution.", style="green")
+        self.console.print("    Upon successful build, the installer will also generate an environment setup script", style="green")
+        self.console.print("    that configures JAVA_HOME and other necessary variables for future use.\n", style="green")
+
+        try:
             choice = int(input("Enter the number of your choice (1 or 2): ").strip())
             if choice == 1:
-                sys.exit(1)
+                self.console.print("👉 You selected option [1].", style="bold")
+                self.console.print("Now you should either:", style="yellow")
+                self.console.print("- export JAVA_HOME manually in your terminal", style="yellow")
+                self.console.print("- OR set it permanently in your shell profile (e.g. ~/.bashrc, ~/.zshrc, or ~/.profile)", style="yellow")
+                self.console.print("\nExample:", style="dim")
+                self.console.print("export JAVA_HOME=/path/to/your/jdk", style="bold green")
+                self.console.print("\nOnce JAVA_HOME is set correctly, re-run this installer.", style="yellow")
+                sys.exit(0)
             elif choice == 2:
-                download_jdk, jdk_keyword = self.selectJDKFromMenu()
-                download_jdk, jdk_keyword = self.checkJDKForPolyglot(args, download_jdk, jdk_keyword)
+                return self.ui.select_jdk()
             else:
-                console.print(f"[ERROR] Invalid choice. Exiting.", style="bold red");
-                sys.exit(1)
-        else:
-            console.print(f"[INFO] JAVA_HOME is set to: {java_home}", style="green")
-            matched_jdk = None
-            if self.osPlatform == config.__WINDOWS__:
-                java_exec = os.path.join(java_home, "bin", "java.exe")
-            else:
-                java_exec = os.path.join(java_home, "bin", "java")
-            if os.path.exists(java_exec):
-                try:
-                    output = subprocess.check_output([java_exec, "-version"], stderr=subprocess.STDOUT, text=True)
-                    console.print(output, style="yellow")
-                    output_lower = output.lower()
-                    if "21" in output and "graalvm" in output_lower:
-                        matched_jdk = "graal-jdk-21"
-                        console.print("[INFO] Detected GraalVM JDK 21 from JAVA_HOME.", style="yellow")
-                    elif "21" in output:
-                        matched_jdk = "jdk21"
-                        console.print("[INFO] Detected standard JDK 21 from JAVA_HOME.", style="yellow")
-                    else:
-                        console.print("[WARN] Detected JDK is not compatible with TornadoVM.", style="yellow")
-                except Exception as e:
-                    console.print(f"[WARNING] Could not determine JDK version: {e}", style="yellow")
-            if matched_jdk:
-                console.print(f"[INFO] Detected match to a TornadoVM JDK profile: {matched_jdk}", style="green")
-                jdk_keyword = matched_jdk.lower()
-                download_jdk = False
-
-                download_jdk, jdk_keyword = self.checkJDKForPolyglot(args, download_jdk, jdk_keyword)
-            else:
-                console.print(f"[WARNING] JAVA_HOME does not match a supported JDK.", style="yellow")
-                download_jdk, jdk_keyword = self.selectJDKFromMenu()
-        return download_jdk, jdk_keyword
-
-    def checkDownloadMaven(self):
-        download_mvn = False
-        mvn_path = which("mvn")
-        if not mvn_path:
-            if input("Maven not found. Download locally? (y/n): ").strip().lower() == "y":
-                download_mvn = True
-            else:
-                console.print(f"[ERROR] Maven required. You can add Maven in your PATH and try again.",
-                              style="bold red");
-                sys.exit(1)
-        else:
-            console.print(f"[INFO] Maven found at: {mvn_path}", style="green")
-        return download_mvn
-
-    def checkDownloadCmake(self):
-        download_cmake = False
-        cmake_valid = False
-        cmake_path = which("cmake")
-        if cmake_path:
-            try:
-                if self.osPlatform == config.__WINDOWS__:
-                    out = subprocess.check_output(["cmake.exe", "--version"], text=True)
-                else:
-                    out = subprocess.check_output(["cmake", "--version"], text=True)
-                raw_version = out.splitlines()[0].split()[-1].split("-")[0]
-                if version.parse(raw_version) >= version.parse("3.25.2"):
-                    cmake_valid = True
-            except Exception as e:
-                console.print(f"[WARNING] Could not determine CMake version: {e}", style="yellow")
-        if not cmake_valid:
-            if input("CMake not found or too old. Download locally? (y/n): ").strip().lower() == "y":
-                download_cmake = True
-            else:
-                console.print(f"[ERROR] CMake required. You can add CMake in your PATH and try again.",
-                              style="bold red");
-                sys.exit(1)
-        else:
-            console.print(f"[INFO] CMake found at: {cmake_path}", style="green")
-        return download_cmake
-
-
-def composePolyglotOption(args): return "polyglot" if args.polyglot else ""
-
-
-def composeMavenSingleThreadedOption(args, jdk): return f"mvn-single-threaded-{jdk}" if args.mavenSingleThreaded else ""
-
-def checkValidBackends(backends):
-    for b in backends:
-        if b not in __SUPPORTED_BACKENDS__:
-            console.print("[ERROR] Invalid backend(s) specified. Choose from: opencl, ptx, spirv", style="bold red")
+                raise ValueError("Invalid choice")
+        except ValueError:
+            self.console.print("[ERROR] Invalid choice. Exiting.", style="bold red")
             sys.exit(1)
 
-    return backends
+    def _validate_polyglot_config(self, config: InstallationConfig) -> InstallationConfig:
+        """Validate and adjust configuration for polyglot support."""
+        if not config.jdk_keyword or "graal" not in config.jdk_keyword.lower():
+            self.console.print("[ERROR] Polyglot requires GraalVM. Please select the GraalVM JDK.", style="bold red")
+            self.console.print("You have two options to proceed:", style="yellow")
+            self.console.print("[1] Use an already installed GraalVM JDK by setting JAVA_HOME.", style="green")
+            self.console.print("[2] Let the installer automatically download and configure a compatible GraalVM JDK distribution.", style="green")
+            self.console.print("    Upon successful build, the installer will also generate an environment setup script", style="green")
+            self.console.print("    that configures JAVA_HOME and other necessary variables for future use.\n", style="green")
 
-def selectBackends():
-    while True:
-        console.print("\n[bold]Select the backend(s) to install:[/bold]")
-        for idx, backend in enumerate(__SUPPORTED_BACKENDS__, 1):
-            console.print(f"  {idx}. {backend}")
+            try:
+                choice = int(input("Enter the number of your choice (1 or 2): ").strip())
+                if choice == 1:
+                    self.console.print("👉 You selected option [1].", style="bold")
+                    self.console.print("Now you should either:", style="yellow")
+                    self.console.print("- export JAVA_HOME manually in your terminal", style="yellow")
+                    self.console.print("- OR set it permanently in your shell profile (e.g. ~/.bashrc, ~/.zshrc, or ~/.profile)", style="yellow")
+                    self.console.print("\nExample:", style="dim")
+                    self.console.print("export JAVA_HOME=/path/to/your/jdk", style="green")
+                    self.console.print("\nOnce JAVA_HOME is set correctly, re-run this installer.", style="yellow")
+                    sys.exit(0)
+                elif choice == 2:
+                    config.jdk_keyword = "graal-jdk-21"
+                    config.download_jdk = True
+                else:
+                    raise ValueError("Invalid choice")
+            except ValueError:
+                self.console.print("[ERROR] Invalid choice. Exiting.", style="bold red")
+                sys.exit(1)
 
-        console.print("You can select more than one by typing the numbers separated by commas (e.g., 1, 2, 3).", style="cyan")
-
-        try:
-            choices = input("Your selection: ").strip()
-            selected_backend_indices = {int(choice.strip()) for choice in choices.split(",")}
-            selected_backends = {__SUPPORTED_BACKENDS__[i - 1] for i in selected_backend_indices if 1 <= i <= len(__SUPPORTED_BACKENDS__)}
-            if not selected_backends:
-                raise ValueError
-        except (ValueError, IndexError):
-            console.print("[ERROR] Invalid selection. Please enter valid number(s) from the list.", style="bold red")
-            continue
-
-        # Handle macOS-specific warning
-        if platform.system().lower() == config.__APPLE__ and (len(selected_backends) > 1 or selected_backends != {"opencl"}):
-            console.print("[WARNING] Multiple backends on macOS may cause issues. OpenCL is the only tested backend.", style="yellow")
-            confirm = input(f"Are you sure you want to proceed with the selected backends: ({', '.join(selected_backends)})? (y/n): ").strip().lower()
-            if confirm != "y":
-                continue  # Loop again for re-selection
-
-        return selected_backends
-
-
-def listSupportedJDKs():
-    descriptions = [
-        "Install TornadoVM with OpenJDK 21 (Oracle OpenJDK)",
-        "Install TornadoVM with GraalVM and JDK 21 (GraalVM 23.1.0)",
-        "Install TornadoVM with Mandrel and JDK 21 (GraalVM 23.1.0)",
-        "Install TornadoVM with Corretto JDK 21",
-        "Install TornadoVM with Microsoft JDK 21",
-        "Install TornadoVM with Azul Zulu JDK 21",
-        "Install TornadoVM with Eclipse Temurin JDK 21",
-        "Install TornadoVM with SapMachine OpenJDK 21",
-        "Install TornadoVM with Liberica OpenJDK 21 (Only option for RISC-V 64)"
-    ]
-    console.print(f"""
-List of supported JDKs for TornadoVM {__VERSION__}
-  """, style="green")
-    for idx, (jdk, desc) in enumerate(zip(__SUPPORTED_JDKS__, descriptions), start=1):
-        console.print(f"  [{idx}] {jdk:<18} : {desc}", style="green")
-
-
-def determine_make_jdk(args):
-    if (jdk_keyword and "graal" in jdk_keyword.lower()):
-        polyglot_option = composePolyglotOption(args)
-        return "graal-jdk-21", polyglot_option
-    else:
-        return "jdk21", ""
-
+        return config
 
 def parseArguments():
     parser = argparse.ArgumentParser(description="TornadoVM Installer Tool")
@@ -457,6 +632,92 @@ def parseArguments():
                         help="Use Maven with one thread")
     return parser.parse_args()
 
+class UserInterface:
+    """Handles user interactions."""
+
+    def __init__(self, console: Console, system_info: SystemInfo):
+        self.console = console
+        self.system_info = system_info
+
+    def select_jdk(self) -> Tuple[bool, str]:
+        """Let user select a JDK from the menu."""
+        self._list_supported_jdks()
+
+        try:
+            choice = int(input("Enter the number of your choice (1-9): ").strip())
+            if 1 <= choice <= len(__SUPPORTED_JDKS__):
+                return True, __SUPPORTED_JDKS__[choice - 1]
+            else:
+                raise ValueError("Invalid choice")
+        except ValueError:
+            self.console.print("[ERROR] Invalid input. Exiting.", style="bold red")
+            sys.exit(1)
+
+    def select_backends(self) -> List[str]:
+        """Let user select backend(s)."""
+        while True:
+            self.console.print("\n[bold]Select the backend(s) to install:[/bold]")
+            for idx, backend in enumerate(__SUPPORTED_BACKENDS__, 1):
+                self.console.print(f"  {idx}. {backend}")
+
+            self.console.print(
+                "You can select more than one by typing the numbers separated by commas (e.g., 1, 2, 3).",
+                style="cyan"
+            )
+
+            try:
+                choices = input("Your selection: ").strip()
+                selected_indices = {int(choice.strip()) for choice in choices.split(",")}
+                selected_backends = [
+                    __SUPPORTED_BACKENDS__[i - 1] for i in selected_indices
+                    if 1 <= i <= len(__SUPPORTED_BACKENDS__)
+                ]
+
+                if not selected_backends:
+                    raise ValueError("No valid backends selected")
+
+                if self._validate_backend_selection(selected_backends):
+                    return selected_backends
+
+            except (ValueError, IndexError):
+                self.console.print(
+                    "[ERROR] Invalid selection. Please enter valid number(s).",
+                    style="bold red"
+                )
+
+    def _validate_backend_selection(self, backends: List[str]) -> bool:
+        """Validate backend selection, especially for macOS."""
+        if (self.system_info.platform == config.__APPLE__ and
+                (len(backends) > 1 or backends != ["opencl"])):
+
+            self.console.print(
+                "[WARNING] Multiple backends on macOS may cause issues. OpenCL is the only tested backend.",
+                style="yellow"
+            )
+
+            confirm = input(
+                f"Proceed with selected backends ({', '.join(backends)})? (y/n): "
+            ).strip().lower()
+
+            return confirm == "y"
+
+        return True
+
+    def _list_supported_jdks(self) -> None:
+        descriptions = [
+            "Install TornadoVM with OpenJDK 21 (Oracle OpenJDK)",
+            "Install TornadoVM with GraalVM and JDK 21 (GraalVM 23.1.0)",
+            "Install TornadoVM with Mandrel and JDK 21 (GraalVM 23.1.0)",
+            "Install TornadoVM with Corretto JDK 21",
+            "Install TornadoVM with Microsoft JDK 21",
+            "Install TornadoVM with Azul Zulu JDK 21",
+            "Install TornadoVM with Eclipse Temurin JDK 21",
+            "Install TornadoVM with SapMachine OpenJDK 21",
+            "Install TornadoVM with Liberica OpenJDK 21 (Only option for RISC-V 64)"
+        ]
+        self.console.print(f"""List of supported JDKs for TornadoVM {__VERSION__}""", style="green")
+        for idx, (jdk, desc) in enumerate(zip(__SUPPORTED_JDKS__, descriptions), start=1):
+            console.print(f"  [{idx}] {jdk:<18} : {desc}", style="green")
 
 if __name__ == "__main__":
     args = parseArguments()
@@ -464,7 +725,8 @@ if __name__ == "__main__":
         console.print(__VERSION__, style="green");
         sys.exit(0)
     if args.listJDKs:
-        listSupportedJDKs();
+        ui = UserInterface(Console(), SystemInfo.detect())
+        ui._list_supported_jdks()
         sys.exit(0)
 
     if sys.version_info < (3, 6):
@@ -472,13 +734,4 @@ if __name__ == "__main__":
         sys.exit(1)
 
     installer = TornadoInstaller()
-    download_jdk, jdk_keyword = installer.checkDownloadJDK(args)
-    download_mvn = installer.checkDownloadMaven()
-    download_cmake = installer.checkDownloadCmake()
-
-    args.backend = selectBackends()
-    makeJDK, polyglotOption = determine_make_jdk(args)
-    mavenSingleThreadedOption = composeMavenSingleThreadedOption(args, makeJDK)
-
-    installer.downloadDependencies(download_jdk, jdk_keyword, download_cmake, download_mvn)
-    installer.install(args, makeJDK, polyglotOption, mavenSingleThreadedOption)
+    installer.install(args)

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -109,8 +109,8 @@ class TornadoInstaller:
         url = config.CMAKE[self.osPlatform][self.hardware]
         if url is None:
             if self.hardware == "riscv64": return
-            console.print(f"[MISSING DEPENDENCY] CMake not configured for {self.osPlatform}/{self.hardware}",
-                          style="yellow");
+            console.print(f"[ERROR] CMake not configured for {self.osPlatform}/{self.hardware}. Try to install it in your PATH",
+                          style="bold red");
             sys.exit(0)
 
         fileName = self.processFileName(url)
@@ -131,8 +131,8 @@ class TornadoInstaller:
     def downloadMaven(self):
         url = config.MAVEN[self.osPlatform][self.hardware]
         if url is None: console.print(
-            f"[MISSING DEPENDENCY] Maven not configured for {self.osPlatform}/{self.hardware}",
-            style="yellow"); sys.exit(0)
+            f"[ERROR] Maven not configured for {self.osPlatform}/{self.hardware}. Try to install it in your PATH",
+            style="bold red"); sys.exit(0)
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.dependenciesDirName, fileName)
         if not os.path.exists(fullPath): wget.download(url, fullPath)
@@ -149,8 +149,8 @@ class TornadoInstaller:
 
     def downloadJDK(self, jdk):
         url = config.JDK[jdk][self.osPlatform][self.hardware]
-        if url is None: console.print(f"[MISSING DEPENDENCY] The url of JDK {jdk} is not configured",
-                                      style="yellow"); sys.exit(0)
+        if url is None: console.print(f"[ERROR] The url of JDK {jdk} is not configured in TornadoVM. Try to set JAVA_HOME.",
+                                      style="bold red"); sys.exit(0)
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.workDirName, fileName)
         if not os.path.exists(fullPath):
@@ -345,8 +345,8 @@ class TornadoInstaller:
             if input("Maven not found. Download locally? (y/n): ").strip().lower() == "y":
                 download_mvn = True
             else:
-                console.print(f"[WARNING] Maven required. You can add Maven in your PATH and try again.",
-                              style="yellow");
+                console.print(f"[ERROR] Maven required. You can add Maven in your PATH and try again.",
+                              style="bold red");
                 sys.exit(1)
         else:
             console.print(f"[INFO] Maven found at: {mvn_path}", style="green")
@@ -371,8 +371,8 @@ class TornadoInstaller:
             if input("CMake not found or too old. Download locally? (y/n): ").strip().lower() == "y":
                 download_cmake = True
             else:
-                console.print(f"[WARNING] CMake required. You can add CMake in your PATH and try again.",
-                              style="yellow");
+                console.print(f"[ERROR] CMake required. You can add CMake in your PATH and try again.",
+                              style="bold red");
                 sys.exit(1)
         else:
             console.print(f"[INFO] CMake found at: {cmake_path}", style="green")
@@ -385,29 +385,39 @@ def composePolyglotOption(args): return "polyglot" if args.polyglot else ""
 def composeMavenSingleThreadedOption(args, jdk): return f"mvn-single-threaded-{jdk}" if args.mavenSingleThreaded else ""
 
 def checkValidBackends(backends):
-    # Remove whitespace and split by comma
-    selected_backends = {b.strip() for b in backends.split(",")}
-
-    for b in selected_backends:
+    for b in backends:
         if b not in __SUPPORTED_BACKENDS__:
             console.print("[ERROR] Invalid backend(s) specified. Choose from: opencl, ptx, spirv", style="bold red")
             sys.exit(1)
 
-    return selected_backends
-
-def assertBackendsForApple(selected_backends):
-    if platform.system().lower() == config.__APPLE__ and len(selected_backends) > 1:
-        console.print("[WARNING] Multiple backends on macOS may cause an issue. Note that OpenCL is the only backend tested on macOS, though it has been deprecated by Apple.", style="yellow")
-        if input(f"Are you sure you want to proceed with the selected backends: ({selected_backends})? (y/n): ").strip().lower() != "y":
-            args.backend = input("Enter backends (opencl, ptx, spirv): ").strip().lower()
-        checkValidBackends(args.backend)
+    return backends
 
 def selectBackends():
-    args.backend = input("Enter backends (opencl, ptx, spirv): ").strip().lower()
+    while True:
+        console.print("\n[bold]Select the backend(s) to install:[/bold]")
+        for idx, backend in enumerate(__SUPPORTED_BACKENDS__, 1):
+            console.print(f"  {idx}. {backend}")
 
-    # Remove whitespace and split by comma
-    selected_backends = checkValidBackends(args.backend)
-    assertBackendsForApple(selected_backends)
+        console.print("You can select more than one by typing the numbers separated by commas (e.g., 1, 2, 3).", style="cyan")
+
+        try:
+            choices = input("Your selection: ").strip()
+            selected_backend_indices = {int(choice.strip()) for choice in choices.split(",")}
+            selected_backends = {__SUPPORTED_BACKENDS__[i - 1] for i in selected_backend_indices if 1 <= i <= len(__SUPPORTED_BACKENDS__)}
+            if not selected_backends:
+                raise ValueError
+        except (ValueError, IndexError):
+            console.print("[ERROR] Invalid selection. Please enter valid number(s) from the list.", style="bold red")
+            continue
+
+        # Handle macOS-specific warning
+        if platform.system().lower() == config.__APPLE__ and (len(selected_backends) > 1 or selected_backends != {"opencl"}):
+            console.print("[WARNING] Multiple backends on macOS may cause issues. OpenCL is the only tested backend.", style="yellow")
+            confirm = input(f"Are you sure you want to proceed with the selected backends: ({', '.join(selected_backends)})? (y/n): ").strip().lower()
+            if confirm != "y":
+                continue  # Loop again for re-selection
+
+        return selected_backends
 
 
 def listSupportedJDKs():
@@ -466,7 +476,7 @@ if __name__ == "__main__":
     download_mvn = installer.checkDownloadMaven()
     download_cmake = installer.checkDownloadCmake()
 
-    selectBackends()
+    args.backend = selectBackends()
     makeJDK, polyglotOption = determine_make_jdk(args)
     mavenSingleThreadedOption = composeMavenSingleThreadedOption(args, makeJDK)
 

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -17,7 +17,13 @@
 # limitations under the License.
 #
 
-from rich.console import Console
+try:
+    from rich.console import Console
+except ImportError:
+    import subprocess
+    subprocess.check_call(["pip", "install", "rich"])
+    from rich.console import Console
+
 console = Console()
 
 jdk_keyword = None

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -224,11 +224,7 @@ class TornadoInstaller:
             console.print(f"[INFO] Run with: source setvars.sh", style="green")
 
     def composeBackendOption(self, args):
-        backends = args.backend.replace(" ", "").lower().split(",")
-        for b in backends:
-            if b not in __SUPPORTED_BACKENDS__:
-                console.print(f"[ERROR] Unsupported backend: {b}", style="bold red")
-                sys.exit(0)
+        backends = checkValidBackends(args.backend)
         return "BACKEND=" + ",".join(backends)
 
     def check_or_install_python_modules(self):
@@ -273,9 +269,16 @@ class TornadoInstaller:
     def checkJDKForPolyglot(self, args, download_jdk, jdk_keyword):
         if args.polyglot:
             if not jdk_keyword or "graal" not in jdk_keyword.lower():
-                console.print("[ERROR] Polyglot requires GraalVM. Please select GraalVM JDK.", style="bold red")
-                download = input("Download and use GraalVM JDK? (y/n): ").strip().lower()
-                if download == "y":
+                console.print("[ERROR] Polyglot requires GraalVM. Please select the GraalVM JDK.", style="bold red")
+                print(" ")
+                console.print(f"You have two options to proceed:", style="yellow")
+                console.print(f"[1] Use an already installed GraalVM JDK by setting JAVA_HOME.", style="yellow")
+                console.print(f"[2] Automatically download and install a GraalVM JDK distribution.", style="yellow")
+                print(" ")
+                choice = int(input("Enter the number of your choice (1 or 2): ").strip())
+                if choice == 1:
+                    sys.exit(1)
+                elif choice == 2:
                     jdk_keyword = "graal-jdk-21"
                     download_jdk = True
                 else:
@@ -325,7 +328,7 @@ class TornadoInstaller:
                 except Exception as e:
                     console.print(f"[WARNING] Could not determine JDK version: {e}", style="yellow")
             if matched_jdk:
-                console.print(f"[INFO] Detected JDK match: {matched_jdk}", style="green")
+                console.print(f"[INFO] Detected match to a TornadoVM JDK profile: {matched_jdk}", style="green")
                 jdk_keyword = matched_jdk.lower()
                 download_jdk = False
 
@@ -381,17 +384,30 @@ def composePolyglotOption(args): return "polyglot" if args.polyglot else ""
 
 def composeMavenSingleThreadedOption(args, jdk): return f"mvn-single-threaded-{jdk}" if args.mavenSingleThreaded else ""
 
+def checkValidBackends(backends):
+    # Remove whitespace and split by comma
+    selected_backends = {b.strip() for b in backends.split(",")}
 
-def checkBackends():
-    valid_backends = {"opencl", "ptx", "spirv"}
+    for b in selected_backends:
+        if b not in __SUPPORTED_BACKENDS__:
+            console.print("[ERROR] Invalid backend(s) specified. Choose from: opencl, ptx, spirv", style="bold red")
+            sys.exit(1)
+
+    return selected_backends
+
+def assertBackendsForApple(selected_backends):
+    if platform.system().lower() == config.__APPLE__ and len(selected_backends) > 1:
+        console.print("[WARNING] Multiple backends on macOS may cause an issue. Note that OpenCL is the only backend tested on macOS, though it has been deprecated by Apple.", style="yellow")
+        if input(f"Are you sure you want to proceed with the selected backends: ({selected_backends})? (y/n): ").strip().lower() != "y":
+            args.backend = input("Enter backends (opencl, ptx, spirv): ").strip().lower()
+        checkValidBackends(args.backend)
+
+def selectBackends():
     args.backend = input("Enter backends (opencl, ptx, spirv): ").strip().lower()
 
     # Remove whitespace and split by comma
-    selected_backends = {b.strip() for b in args.backend.split(",")}
-
-    if not selected_backends.issubset(valid_backends):
-        console.print("[ERROR] Invalid backend(s) specified. Choose from: opencl, ptx, spirv", style="bold red")
-        sys.exit(1)
+    selected_backends = checkValidBackends(args.backend)
+    assertBackendsForApple(selected_backends)
 
 
 def listSupportedJDKs():
@@ -450,7 +466,7 @@ if __name__ == "__main__":
     download_mvn = installer.checkDownloadMaven()
     download_cmake = installer.checkDownloadCmake()
 
-    checkBackends()
+    selectBackends()
     makeJDK, polyglotOption = determine_make_jdk(args)
     mavenSingleThreadedOption = composeMavenSingleThreadedOption(args, makeJDK)
 

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+from rich.console import Console
+console = Console()
+
 jdk_keyword = None
 
 import argparse
@@ -87,7 +90,7 @@ class TornadoInstaller:
         url = config.CMAKE[self.osPlatform][self.hardware]
         if url is None:
             if self.hardware == "riscv64": return
-            print(f"CMake not configured for {self.osPlatform}/{self.hardware}"); sys.exit(0)
+            console.print(f"[MISSING DEPENDENCY] CMake not configured for {self.osPlatform}/{self.hardware}", style="bold orange"); sys.exit(0)
 
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.dependenciesDirName, fileName)
@@ -101,11 +104,11 @@ class TornadoInstaller:
             extraPath = os.path.join("CMake.app", "Contents") if self.osPlatform == config.__APPLE__ else ""
             self.env["PATH"].append(os.path.join(tld, extraPath, "bin"))
         except Exception as e:
-            print(f"Unpacking failed for CMake: {e}"); sys.exit(0)
+            console.print(f"[ERROR] Unpacking failed for CMake: {e}", style="bold red"); sys.exit(0)
 
     def downloadMaven(self):
         url = config.MAVEN[self.osPlatform][self.hardware]
-        if url is None: print(f"Maven not configured for {self.osPlatform}/{self.hardware}"); sys.exit(0)
+        if url is None: console.print(f"[MISSING DEPENDENCY] Maven not configured for {self.osPlatform}/{self.hardware}", style="bold orange"); sys.exit(0)
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.dependenciesDirName, fileName)
         if not os.path.exists(fullPath): wget.download(url, fullPath)
@@ -117,11 +120,11 @@ class TornadoInstaller:
             ar.close()
             self.env["PATH"].append(os.path.join(tld, "bin"))
         except Exception as e:
-            print(f"Unpacking failed for Maven: {e}"); sys.exit(0)
+            console.print(f"[ERROR] Unpacking failed for Maven: {e}", style="bold red"); sys.exit(0)
 
     def downloadJDK(self, jdk):
         url = config.JDK[jdk][self.osPlatform][self.hardware]
-        if url is None: print(f"JDK {jdk} not configured"); sys.exit(0)
+        if url is None: console.print(f"[MISSING DEPENDENCY] The url of JDK {jdk} is not configured", style="bold orange"); sys.exit(0)
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.workDirName, fileName)
         if not os.path.exists(fullPath):
@@ -139,7 +142,7 @@ class TornadoInstaller:
             suffix = os.path.join("Contents", "Home") if self.osPlatform == config.__APPLE__ and "zulu" not in jdk else ""
             self.env["JAVA_HOME"] = os.path.join(tld, suffix)
         except Exception as e:
-            print(f"Unpacking failed for JDK: {e}"); sys.exit(0)
+            console.print(f"[ERROR] Unpacking failed for JDK: {e}", style="bold red"); sys.exit(0)
 
     def setEnvironmentVariables(self):
         os.environ["PATH"] = os.pathsep.join(self.env["PATH"]) + os.pathsep + os.environ["PATH"]
@@ -156,7 +159,7 @@ class TornadoInstaller:
         os.system(cmd)
 
     def createSourceFile(self):
-        print("Creating environment setup script...")
+        console.print(f"[INFO] Creating environment setup script...", style="green")
         allPaths = os.pathsep.join(self.env["PATH"])
         if os.name == 'nt':
             path = os.path.join(os.getcwd(), "level-zero", "build", "bin", "Release")
@@ -167,7 +170,7 @@ class TornadoInstaller:
                 f"set TORNADO_SDK={os.environ['TORNADO_SDK']}\n"
             )
             with open("setvars.cmd", "w") as f: f.write(content)
-            print("Run with: setvars.cmd")
+            console.print(f"[INFO] Run with: setvars.cmd", style="green")
         else:
             content = (
                 f"export JAVA_HOME={os.environ['JAVA_HOME']}\n"
@@ -175,13 +178,13 @@ class TornadoInstaller:
                 f"export TORNADO_SDK={os.environ['TORNADO_SDK']}\n"
             )
             with open("setvars.sh", "w") as f: f.write(content)
-            print("Run with: source setvars.sh")
+            console.print(f"[INFO] Run with: source setvars.sh", style="green")
 
     def composeBackendOption(self, args):
         backends = args.backend.replace(" ", "").lower().split(",")
         for b in backends:
             if b not in __SUPPORTED_BACKENDS__:
-                print(f"[Error] Unsupported backend: {b}")
+                console.print(f"[ERROR] Unsupported backend: {b}", style="bold red")
                 sys.exit(0)
         return "BACKEND=" + ",".join(backends)
 
@@ -211,35 +214,35 @@ class TornadoInstaller:
         download_jdk = False
         listSupportedJDKs()
         try:
-            choice = int(input("Enter the number of your choice: ").strip())
+            choice = int(input("Enter the number of your choice (1-9): ").strip())
             if 1 <= choice <= len(__SUPPORTED_JDKS__):
                 jdk_keyword = __SUPPORTED_JDKS__[choice - 1]
                 download_jdk = True
             else:
-                print(f"Invalid choice. Exiting."); sys.exit(1)
+                console.print(f"[ERROR] Invalid choice. Exiting.", style="bold red"); sys.exit(1)
         except ValueError:
-            print(f"Invalid input. Exiting."); sys.exit(1)
+            console.print(f"[ERROR] Invalid input. Exiting.", style="bold red"); sys.exit(1)
         return download_jdk, jdk_keyword
 
     def checkDownloadJDK(self, args):
         java_home = os.environ.get("JAVA_HOME")
         self.env["JAVA_HOME"] = java_home
         if not java_home:
-            print(f"[INFO] JAVA_HOME is not set.")
+            console.print(f"[INFO] JAVA_HOME is not set.", style="yellow")
             print()
-            print(f"You have two options to proceed:")
-            print(f"[1] Use an already installed compatible JDK by setting JAVA_HOME.")
-            print(f"[2] Automatically download and install a supported JDK distribution.")
+            console.print(f"You have two options to proceed:", style="yellow")
+            console.print(f"[1] Use an already installed compatible JDK by setting JAVA_HOME.", style="yellow")
+            console.print(f"[2] Automatically download and install a supported JDK distribution.", style="yellow")
             print()
             choice = int(input("Enter the number of your choice (1 or 2): ").strip())
             if choice == 1:
                 sys.exit(1)
             elif choice == 2:
-                self.selectJDKFromMenu()
+                download_jdk, jdk_keyword = self.selectJDKFromMenu()
             else:
-                print(f"Invalid choice. Exiting."); sys.exit(1)
+                console.print(f"[ERROR] Invalid choice. Exiting.", style="bold red"); sys.exit(1)
         else:
-            print(f"[INFO] JAVA_HOME is set to: {java_home}")
+            console.print(f"[INFO] JAVA_HOME is set to: {java_home}", style="green")
             matched_jdk = None
             java_exec = os.path.join(java_home, "bin", "java")
             if os.path.exists(java_exec):
@@ -248,24 +251,24 @@ class TornadoInstaller:
                     if "21" in output:
                         matched_jdk = "graal-jdk-21" if "GraalVM" in output else "jdk21"
                 except Exception as e:
-                    print(f"[WARN] Could not determine JDK version: {e}")
+                    console.print(f"[WARNING] Could not determine JDK version: {e}", style="orange")
             if matched_jdk:
-                print(f"[INFO] Detected JDK match: {matched_jdk}")
+                console.print(f"[INFO] Detected JDK match: {matched_jdk}", style="green")
                 jdk_keyword = matched_jdk
                 download_jdk = False
 
                 # Check if polyglot was requested but the JDK is not GraalVM
                 if args.polyglot and "graal" not in matched_jdk.lower():
-                    print("[WARN] Polyglot option requested, but JAVA_HOME is not a GraalVM JDK.")
+                    console.print(f"[WARNING] Polyglot option requested, but JAVA_HOME is not a GraalVM JDK.", style="orange")
                     response = input("Do you want to switch to GraalVM and download it? (y/n): ").strip().lower()
                     if response == "y":
                         jdk_keyword = "graal-jdk-21"
                         download_jdk = True
                     else:
-                        print("Polyglot requires GraalVM. Exiting.")
+                        console.print(f"[WARNING] Polyglot requires GraalVM. Exiting.", style="orange")
                         sys.exit(1)
             else:
-                print("[WARN] JAVA_HOME does not match a supported JDK.")
+                console.print(f"[WARNING] JAVA_HOME does not match a supported JDK.", style="orange")
                 download_jdk, jdk_keyword = self.selectJDKFromMenu()
         return download_jdk, jdk_keyword
 
@@ -276,9 +279,9 @@ class TornadoInstaller:
             if input("Maven not found. Download locally? (y/n): ").strip().lower() == "y":
                 download_mvn = True
             else:
-                print("Maven required. Exiting."); sys.exit(1)
+                console.print(f"[WARNING] Maven required. Exiting.", style="orange"); sys.exit(1)
         else:
-            print(f"[INFO] Maven found at: {mvn_path}")
+            console.print(f"[INFO] Maven found at: {mvn_path}", style="green")
         return download_mvn
 
     def checkDownloadCmake(self):
@@ -291,14 +294,14 @@ class TornadoInstaller:
                 if version.parse(out.splitlines()[0].split()[-1]) >= version.parse("3.25.2"):
                     cmake_valid = True
             except Exception as e:
-                print(f"[WARN] Could not determine CMake version: {e}")
+                console.print(f"[WARNING] Could not determine CMake version: {e}", style="orange")
         if not cmake_valid:
             if input("CMake not found or too old. Download locally? (y/n): ").strip().lower() == "y":
                 download_cmake = True
             else:
-                print("CMake required. Exiting."); sys.exit(1)
+                console.print(f"[WARNING] CMake required. Exiting.", style="orange"); sys.exit(1)
         else:
-            print(f"[INFO] CMake found at: {cmake_path}")
+            console.print(f"[INFO] CMake found at: {cmake_path}", style="green")
         return download_cmake
 
 def composePolyglotOption(args): return "polyglot" if args.polyglot else ""
@@ -313,7 +316,7 @@ def checkBackends():
     selected_backends = {b.strip() for b in args.backend.split(",")}
 
     if not selected_backends.issubset(valid_backends):
-        print("[Error] Invalid backend(s) specified. Choose from: opencl, ptx, spirv")
+        console.print("[ERROR] Invalid backend(s) specified. Choose from: opencl, ptx, spirv", style="bold red")
         sys.exit(1)
 
 def listSupportedJDKs():
@@ -328,11 +331,11 @@ def listSupportedJDKs():
         "Install TornadoVM with SapMachine OpenJDK 21",
         "Install TornadoVM with Liberica OpenJDK 21 (Only option for RISC-V 64)"
     ]
-    print(f"""
-  List of supported JDKs for TornadoVM {__VERSION__}
-  """)
+    console.print(f"""
+List of supported JDKs for TornadoVM {__VERSION__}
+  """, style="green")
     for idx, (jdk, desc) in enumerate(zip(__SUPPORTED_JDKS__, descriptions), start=1):
-        print(f"  [{idx}] {jdk:<18} : {desc}")
+        console.print(f"  [{idx}] {jdk:<18} : {desc}", style="green")
 
 def determine_make_jdk(args):
     if (jdk_keyword and "graal" in jdk_keyword.lower()):
@@ -352,19 +355,12 @@ def parseArguments():
 if __name__ == "__main__":
     args = parseArguments()
     if args.version:
-        print(__VERSION__); sys.exit(0)
+        console.print(__VERSION__, style="green"); sys.exit(0)
     if args.listJDKs:
         listSupportedJDKs(); sys.exit(0)
 
     if sys.version_info < (3, 6):
-        print("[ERROR] Python 3.6+ is required."); sys.exit(1)
-
-    from rich.console import Console
-    console = Console()
-
-    console.print("[INFO] Installation started", style="green")
-    console.print("[WARN] Missing optional dependency", style="yellow")
-    console.print("[ERROR] Installation failed", style="bold red")
+        console.print("[ERROR] Python 3.6+ is required.", style="bold red"); sys.exit(1)
 
     installer = TornadoInstaller()
     download_jdk, jdk_keyword = installer.checkDownloadJDK(args)

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -70,6 +70,7 @@ __SUPPORTED_JDKS__ = [
 ]
 __SUPPORTED_BACKENDS__ = ["opencl", "spirv", "ptx"]
 
+
 class TornadoInstaller:
     def __init__(self):
         self.workDirName = ""
@@ -85,7 +86,8 @@ class TornadoInstaller:
         types = {"x86_64": "x86_64", "amd64": "x86_64", "arm64": "arm64", "aarch64": "arm64", "riscv64": "riscv64"}
         return types[platform.machine().lower()]
 
-    def processFileName(self, url): return os.path.basename(url)
+    def processFileName(self, url):
+        return os.path.basename(url)
 
     def setWorkDir(self, jdk):
         self.workDirName = os.path.join(__DIRECTORY_DEPENDENCIES__, f"TornadoVM-{jdk}")
@@ -95,7 +97,8 @@ class TornadoInstaller:
         self.dependenciesDirName = os.path.join(__DIRECTORY_DEPENDENCIES__)
         os.makedirs(self.dependenciesDirName, exist_ok=True)
 
-    def getCurrentDirectory(self): return os.getcwd()
+    def getCurrentDirectory(self):
+        return os.getcwd()
 
     def getTLDName(self, ar):
         names = ar.namelist() if os.name == 'nt' else ar.getnames()
@@ -106,7 +109,9 @@ class TornadoInstaller:
         url = config.CMAKE[self.osPlatform][self.hardware]
         if url is None:
             if self.hardware == "riscv64": return
-            console.print(f"[MISSING DEPENDENCY] CMake not configured for {self.osPlatform}/{self.hardware}", style="yellow"); sys.exit(0)
+            console.print(f"[MISSING DEPENDENCY] CMake not configured for {self.osPlatform}/{self.hardware}",
+                          style="yellow");
+            sys.exit(0)
 
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.dependenciesDirName, fileName)
@@ -120,11 +125,14 @@ class TornadoInstaller:
             extraPath = os.path.join("CMake.app", "Contents") if self.osPlatform == config.__APPLE__ else ""
             self.env["PATH"].append(os.path.join(tld, extraPath, "bin"))
         except Exception as e:
-            console.print(f"[ERROR] Unpacking failed for CMake: {e}", style="bold red"); sys.exit(0)
+            console.print(f"[ERROR] Unpacking failed for CMake: {e}", style="bold red");
+            sys.exit(0)
 
     def downloadMaven(self):
         url = config.MAVEN[self.osPlatform][self.hardware]
-        if url is None: console.print(f"[MISSING DEPENDENCY] Maven not configured for {self.osPlatform}/{self.hardware}", style="yellow"); sys.exit(0)
+        if url is None: console.print(
+            f"[MISSING DEPENDENCY] Maven not configured for {self.osPlatform}/{self.hardware}",
+            style="yellow"); sys.exit(0)
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.dependenciesDirName, fileName)
         if not os.path.exists(fullPath): wget.download(url, fullPath)
@@ -136,29 +144,35 @@ class TornadoInstaller:
             ar.close()
             self.env["PATH"].append(os.path.join(tld, "bin"))
         except Exception as e:
-            console.print(f"[ERROR] Unpacking failed for Maven: {e}", style="bold red"); sys.exit(0)
+            console.print(f"[ERROR] Unpacking failed for Maven: {e}", style="bold red");
+            sys.exit(0)
 
     def downloadJDK(self, jdk):
         url = config.JDK[jdk][self.osPlatform][self.hardware]
-        if url is None: console.print(f"[MISSING DEPENDENCY] The url of JDK {jdk} is not configured", style="yellow"); sys.exit(0)
+        if url is None: console.print(f"[MISSING DEPENDENCY] The url of JDK {jdk} is not configured",
+                                      style="yellow"); sys.exit(0)
         fileName = self.processFileName(url)
         fullPath = os.path.join(self.workDirName, fileName)
         if not os.path.exists(fullPath):
-            try: wget.download(url, fullPath)
+            try:
+                wget.download(url, fullPath)
             except:
                 import urllib3
                 r = urllib3.PoolManager().request('GET', url)
-                with open(fullPath, 'wb') as f: f.write(r.data)
+                with open(fullPath, 'wb') as f:
+                    f.write(r.data)
         try:
             ar = zipfile.ZipFile(fullPath, 'r') if os.name == 'nt' else tarfile.open(fullPath, "r:gz")
             tld = os.path.join(self.getCurrentDirectory(), self.workDirName, self.getTLDName(ar))
             if not os.path.exists(tld):
                 ar.extractall(self.workDirName, numeric_owner=(os.name != 'nt'))
             ar.close()
-            suffix = os.path.join("Contents", "Home") if self.osPlatform == config.__APPLE__ and "zulu" not in jdk else ""
+            suffix = os.path.join("Contents",
+                                  "Home") if self.osPlatform == config.__APPLE__ and "zulu" not in jdk else ""
             self.env["JAVA_HOME"] = os.path.join(tld, suffix)
         except Exception as e:
-            console.print(f"[ERROR] Unpacking failed for JDK: {e}", style="bold red"); sys.exit(0)
+            console.print(f"[ERROR] Unpacking failed for JDK: {e}", style="bold red");
+            sys.exit(0)
 
     def setEnvironmentVariables(self):
         os.environ["PATH"] = os.pathsep.join(self.env["PATH"]) + os.pathsep + os.environ["PATH"]
@@ -176,16 +190,26 @@ class TornadoInstaller:
 
     def createSourceFile(self):
         console.print(f"[INFO] Creating environment setup script...", style="green")
-        allPaths = os.pathsep.join(self.env["PATH"])
+        paths = self.env["PATH"]
+        allPaths = ""
+        for p in paths:
+            allPaths = allPaths + p + os.pathsep
+
         if os.name == 'nt':
-            path = os.path.join(os.getcwd(), "level-zero", "build", "bin", "Release")
-            dist = os.path.join(os.environ["TORNADO_SDK"], "bin", "dist")
-            content = (
-                f"set JAVA_HOME={os.environ['JAVA_HOME']}\n"
-                f"set PATH={allPaths}{path}{os.pathsep}{dist}{os.pathsep}%PATH%\n"
-                f"set TORNADO_SDK={os.environ['TORNADO_SDK']}\n"
+            binariesDistribution = os.path.join(os.environ["TORNADO_SDK"], "bin", "dist")
+            cutils.runPyInstaller(os.getcwd(), os.environ["TORNADO_SDK"])
+            fileContent = "set JAVA_HOME=" + os.environ["JAVA_HOME"] + "\n"
+            levelZeroPath = os.path.join(os.getcwd(), "level-zero", "build", "bin", "Release")
+            fileContent = fileContent + "set PATH=" + allPaths + levelZeroPath + os.pathsep + binariesDistribution + os.pathsep + "%PATH%" + "\n"
+            fileContent = (
+                    fileContent + "set TORNADO_SDK=" + os.environ["TORNADO_SDK"] + "\n"
             )
-            with open("setvars.cmd", "w") as f: f.write(content)
+            f = open("setvars.cmd", "w")
+            f.write(fileContent)
+            f.close()
+
+            print("........................................[ok]")
+            print(" ")
             console.print(f"[INFO] Run with: setvars.cmd", style="green")
         else:
             content = (
@@ -193,7 +217,10 @@ class TornadoInstaller:
                 f"export PATH={allPaths}:$PATH\n"
                 f"export TORNADO_SDK={os.environ['TORNADO_SDK']}\n"
             )
-            with open("setvars.sh", "w") as f: f.write(content)
+            with open("setvars.sh", "w") as f:
+                f.write(content)
+            print("........................................[ok]")
+            print(" ")
             console.print(f"[INFO] Run with: source setvars.sh", style="green")
 
     def composeBackendOption(self, args):
@@ -204,7 +231,8 @@ class TornadoInstaller:
                 sys.exit(0)
         return "BACKEND=" + ",".join(backends)
 
-    def check_or_install_python_modules(self): os.system("pip3 install -r bin/tornadoDepModules.txt")
+    def check_or_install_python_modules(self):
+        os.system("pip3 install -r bin/tornadoDepModules.txt")
 
     def downloadDependencies(self, download_jdk, jdk_keyword, download_cmake, download_mvn):
         self.check_or_install_python_modules()
@@ -235,9 +263,24 @@ class TornadoInstaller:
                 jdk_keyword = __SUPPORTED_JDKS__[choice - 1]
                 download_jdk = True
             else:
-                console.print(f"[ERROR] Invalid choice. Exiting.", style="bold red"); sys.exit(1)
+                console.print(f"[ERROR] Invalid choice. Exiting.", style="bold red");
+                sys.exit(1)
         except ValueError:
-            console.print(f"[ERROR] Invalid input. Exiting.", style="bold red"); sys.exit(1)
+            console.print(f"[ERROR] Invalid input. Exiting.", style="bold red");
+            sys.exit(1)
+        return download_jdk, jdk_keyword
+
+    def checkJDKForPolyglot(self, args, download_jdk, jdk_keyword):
+        if args.polyglot:
+            if not jdk_keyword or "graal" not in jdk_keyword.lower():
+                console.print("[ERROR] Polyglot requires GraalVM. Please select GraalVM JDK.", style="bold red")
+                download = input("Download and use GraalVM JDK? (y/n): ").strip().lower()
+                if download == "y":
+                    jdk_keyword = "graal-jdk-21"
+                    download_jdk = True
+                else:
+                    console.print("[ERROR] GraalVM required for polyglot. Exiting.", style="bold red")
+                    sys.exit(1)
         return download_jdk, jdk_keyword
 
     def checkDownloadJDK(self, args):
@@ -245,44 +288,48 @@ class TornadoInstaller:
         self.env["JAVA_HOME"] = java_home
         if not java_home:
             console.print(f"[INFO] JAVA_HOME is not set.", style="yellow")
-            print()
+            print(" ")
             console.print(f"You have two options to proceed:", style="yellow")
             console.print(f"[1] Use an already installed compatible JDK by setting JAVA_HOME.", style="yellow")
             console.print(f"[2] Automatically download and install a supported JDK distribution.", style="yellow")
-            print()
+            print(" ")
             choice = int(input("Enter the number of your choice (1 or 2): ").strip())
             if choice == 1:
                 sys.exit(1)
             elif choice == 2:
                 download_jdk, jdk_keyword = self.selectJDKFromMenu()
+                download_jdk, jdk_keyword = self.checkJDKForPolyglot(args, download_jdk, jdk_keyword)
             else:
-                console.print(f"[ERROR] Invalid choice. Exiting.", style="bold red"); sys.exit(1)
+                console.print(f"[ERROR] Invalid choice. Exiting.", style="bold red");
+                sys.exit(1)
         else:
             console.print(f"[INFO] JAVA_HOME is set to: {java_home}", style="green")
             matched_jdk = None
-            java_exec = os.path.join(java_home, "bin", "java")
+            if self.osPlatform == config.__WINDOWS__:
+                java_exec = os.path.join(java_home, "bin", "java.exe")
+            else:
+                java_exec = os.path.join(java_home, "bin", "java")
             if os.path.exists(java_exec):
                 try:
                     output = subprocess.check_output([java_exec, "-version"], stderr=subprocess.STDOUT, text=True)
-                    if "21" in output:
-                        matched_jdk = "graal-jdk-21" if "GraalVM" in output else "jdk21"
+                    console.print(output, style="yellow")
+                    output_lower = output.lower()
+                    if "21" in output and "graalvm" in output_lower:
+                        matched_jdk = "graal-jdk-21"
+                        console.print("[INFO] Detected GraalVM JDK 21 from JAVA_HOME.", style="yellow")
+                    elif "21" in output:
+                        matched_jdk = "jdk21"
+                        console.print("[INFO] Detected standard JDK 21 from JAVA_HOME.", style="yellow")
+                    else:
+                        console.print("[WARN] Detected JDK is not compatible with TornadoVM.", style="yellow")
                 except Exception as e:
                     console.print(f"[WARNING] Could not determine JDK version: {e}", style="yellow")
             if matched_jdk:
                 console.print(f"[INFO] Detected JDK match: {matched_jdk}", style="green")
-                jdk_keyword = matched_jdk
+                jdk_keyword = matched_jdk.lower()
                 download_jdk = False
 
-                # Check if polyglot was requested but the JDK is not GraalVM
-                if args.polyglot and "graal" not in matched_jdk.lower():
-                    console.print(f"[WARNING] Polyglot option requested, but JAVA_HOME is not a GraalVM JDK.", style="yellow")
-                    response = input("Do you want to switch to GraalVM and download it? (y/n): ").strip().lower()
-                    if response == "y":
-                        jdk_keyword = "graal-jdk-21"
-                        download_jdk = True
-                    else:
-                        console.print(f"[WARNING] Polyglot requires GraalVM. Exiting.", style="yellow")
-                        sys.exit(1)
+                download_jdk, jdk_keyword = self.checkJDKForPolyglot(args, download_jdk, jdk_keyword)
             else:
                 console.print(f"[WARNING] JAVA_HOME does not match a supported JDK.", style="yellow")
                 download_jdk, jdk_keyword = self.selectJDKFromMenu()
@@ -295,7 +342,9 @@ class TornadoInstaller:
             if input("Maven not found. Download locally? (y/n): ").strip().lower() == "y":
                 download_mvn = True
             else:
-                console.print(f"[WARNING] Maven required. You can add Maven in your PATH and try again.", style="yellow"); sys.exit(1)
+                console.print(f"[WARNING] Maven required. You can add Maven in your PATH and try again.",
+                              style="yellow");
+                sys.exit(1)
         else:
             console.print(f"[INFO] Maven found at: {mvn_path}", style="green")
         return download_mvn
@@ -306,8 +355,12 @@ class TornadoInstaller:
         cmake_path = which("cmake")
         if cmake_path:
             try:
-                out = subprocess.check_output(["cmake", "--version"], text=True)
-                if version.parse(out.splitlines()[0].split()[-1]) >= version.parse("3.25.2"):
+                if self.osPlatform == config.__WINDOWS__:
+                    out = subprocess.check_output(["cmake.exe", "--version"], text=True)
+                else:
+                    out = subprocess.check_output(["cmake", "--version"], text=True)
+                raw_version = out.splitlines()[0].split()[-1].split("-")[0]
+                if version.parse(raw_version) >= version.parse("3.25.2"):
                     cmake_valid = True
             except Exception as e:
                 console.print(f"[WARNING] Could not determine CMake version: {e}", style="yellow")
@@ -315,14 +368,19 @@ class TornadoInstaller:
             if input("CMake not found or too old. Download locally? (y/n): ").strip().lower() == "y":
                 download_cmake = True
             else:
-                console.print(f"[WARNING] CMake required. You can add CMake in your PATH and try again.", style="yellow"); sys.exit(1)
+                console.print(f"[WARNING] CMake required. You can add CMake in your PATH and try again.",
+                              style="yellow");
+                sys.exit(1)
         else:
             console.print(f"[INFO] CMake found at: {cmake_path}", style="green")
         return download_cmake
 
+
 def composePolyglotOption(args): return "polyglot" if args.polyglot else ""
 
+
 def composeMavenSingleThreadedOption(args, jdk): return f"mvn-single-threaded-{jdk}" if args.mavenSingleThreaded else ""
+
 
 def checkBackends():
     valid_backends = {"opencl", "ptx", "spirv"}
@@ -334,6 +392,7 @@ def checkBackends():
     if not selected_backends.issubset(valid_backends):
         console.print("[ERROR] Invalid backend(s) specified. Choose from: opencl, ptx, spirv", style="bold red")
         sys.exit(1)
+
 
 def listSupportedJDKs():
     descriptions = [
@@ -353,6 +412,7 @@ List of supported JDKs for TornadoVM {__VERSION__}
     for idx, (jdk, desc) in enumerate(zip(__SUPPORTED_JDKS__, descriptions), start=1):
         console.print(f"  [{idx}] {jdk:<18} : {desc}", style="green")
 
+
 def determine_make_jdk(args):
     if (jdk_keyword and "graal" in jdk_keyword.lower()):
         polyglot_option = composePolyglotOption(args)
@@ -360,23 +420,30 @@ def determine_make_jdk(args):
     else:
         return "jdk21", ""
 
+
 def parseArguments():
     parser = argparse.ArgumentParser(description="TornadoVM Installer Tool")
     parser.add_argument("--version", action="store_true", dest="version", default=False, help="Print version")
     parser.add_argument("--listJDKs", action="store_true", dest="listJDKs", default=False, help="List supported JDKs")
-    parser.add_argument("--polyglot", action="store_true", dest="polyglot", default=None, help="Enable Truffle Interoperability with GraalVM")
-    parser.add_argument("--mvn_single_threaded", action="store_true", dest="mavenSingleThreaded", default=None, help="Use Maven with one thread")
+    parser.add_argument("--polyglot", action="store_true", dest="polyglot", default=None,
+                        help="Enable Truffle Interoperability with GraalVM")
+    parser.add_argument("--mvn_single_threaded", action="store_true", dest="mavenSingleThreaded", default=None,
+                        help="Use Maven with one thread")
     return parser.parse_args()
+
 
 if __name__ == "__main__":
     args = parseArguments()
     if args.version:
-        console.print(__VERSION__, style="green"); sys.exit(0)
+        console.print(__VERSION__, style="green");
+        sys.exit(0)
     if args.listJDKs:
-        listSupportedJDKs(); sys.exit(0)
+        listSupportedJDKs();
+        sys.exit(0)
 
     if sys.version_info < (3, 6):
-        console.print("[ERROR] Python 3.6+ is required.", style="bold red"); sys.exit(1)
+        console.print("[ERROR] Python 3.6+ is required.", style="bold red");
+        sys.exit(1)
 
     installer = TornadoInstaller()
     download_jdk, jdk_keyword = installer.checkDownloadJDK(args)
@@ -386,7 +453,6 @@ if __name__ == "__main__":
     checkBackends()
     makeJDK, polyglotOption = determine_make_jdk(args)
     mavenSingleThreadedOption = composeMavenSingleThreadedOption(args, makeJDK)
-
 
     installer.downloadDependencies(download_jdk, jdk_keyword, download_cmake, download_mvn)
     installer.install(args, makeJDK, polyglotOption, mavenSingleThreadedOption)

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -225,8 +225,19 @@ class TornadoInstaller:
         java_home = os.environ.get("JAVA_HOME")
         self.env["JAVA_HOME"] = java_home
         if not java_home:
-            print("[INFO] JAVA_HOME is not set.")
-            download_jdk, jdk_keyword = self.selectJDKFromMenu()
+            print(f"[INFO] JAVA_HOME is not set.")
+            print()
+            print(f"You have two options to proceed:")
+            print(f"[1] Use an already installed compatible JDK by setting JAVA_HOME.")
+            print(f"[2] Automatically download and install a supported JDK distribution.")
+            print()
+            choice = int(input("Enter the number of your choice (1 or 2): ").strip())
+            if choice == 1:
+                sys.exit(1)
+            elif choice == 2:
+                self.selectJDKFromMenu()
+            else:
+                print(f"Invalid choice. Exiting."); sys.exit(1)
         else:
             print(f"[INFO] JAVA_HOME is set to: {java_home}")
             matched_jdk = None
@@ -347,6 +358,13 @@ if __name__ == "__main__":
 
     if sys.version_info < (3, 6):
         print("[ERROR] Python 3.6+ is required."); sys.exit(1)
+
+    from rich.console import Console
+    console = Console()
+
+    console.print("[INFO] Installation started", style="green")
+    console.print("[WARN] Missing optional dependency", style="yellow")
+    console.print("[ERROR] Installation failed", style="bold red")
 
     installer = TornadoInstaller()
     download_jdk, jdk_keyword = installer.checkDownloadJDK(args)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@
 sphinx==5.3.0
 sphinx_rtd_theme==1.1.1
 readthedocs-sphinx-search==0.3.2
+rich>=13.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx==5.3.0
 sphinx_rtd_theme==1.1.1
 readthedocs-sphinx-search==0.3.2
 rich>=13.0
+pyinstaller>=6.6.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,3 @@
 sphinx==5.3.0
 sphinx_rtd_theme==1.1.1
 readthedocs-sphinx-search==0.3.2
-rich>=13.0
-pyinstaller>=6.6.0

--- a/docs/source/cloud.rst
+++ b/docs/source/cloud.rst
@@ -35,14 +35,14 @@ Pre-requisites:
       $ cd /home/centos
       $ git clone https://github.com/aws/aws-fpga.git $AWS_FPGA_REPO_DIR
 
-1. Install TornadoVM as a CentOS user. The Xilinx FPGA is not exposed to simple users.
+1. Install TornadoVM with the OpenCL backend, as a CentOS user. The Xilinx FPGA is not exposed to simple users.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: bash
 
    $ git clone https://github.com/beehive-lab/TornadoVM.git
    $ cd TornadoVM
-   $ ./bin/tornadovm-installer --jdk jdk21 --backend opencl
+   $ ./bin/tornadovm-installer
    $ source setvars.env
 
 2. Follow these steps to get access to the Xilinx FPGA.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -64,44 +64,21 @@ Additionally, this installation type will automatically trigger all dependencies
 
 .. code-block:: bash
 
-    $ ./bin/tornadovm-installer
-      usage: tornadovm-installer [-h] [--version] [--jdk JDK] [--backend BACKEND] [--listJDKs] [--javaHome JAVAHOME]
-                           [--polyglot]
+    $ ./bin/tornadovm-installer --help
+      usage: tornadovm-installer [-h] [--version] [--listJDKs] [--polyglot] [--mvn_single_threaded]
 
       TornadoVM Installer Tool. It will install all software dependencies except the GPU/FPGA drivers
 
       options:
-        -h, --help           show this help message and exit
-        --version            Print version of TornadoVM
-        --jdk JDK            Select one of the supported JDKs. Use --listJDKs option to see all supported ones.
-        --backend BACKEND    Select the backend to install: { opencl, ptx, spirv }
-        --listJDKs           List all JDK supported versions
-        --javaHome JAVAHOME  Use a JDK from a user directory
-        --polyglot           To enable interoperability with Truffle Programming Languages.
+        -h, --help            show this help message and exit
+        --version             Print version
+        --listJDKs            List supported JDKs
+        --polyglot            Enable Truffle Interoperability with GraalVM
+        --mvn_single_threaded
+                              Run Maven in single-threaded mode
 
 
-**Note:** Select the desired backend with the ``--backend`` option:
-  * ``opencl``: Enables the OpenCL backend (it requires OpenCL drivers and OpenCL SDK installed)
-  * ``ptx``: Enables the PTX backend (it requires NVIDIA Driver and the CUDA SDK)
-  * ``spirv``: Enables the SPIRV backend (it requires Intel Level Zero drivers)
-
-
-For example, to build TornadoVM with GraalVM (JDK21) for all backends:
-
-.. code-block:: bash
-
-  ## Install with Graal for JDK 21 using PTX, OpenCL and SPIRV backends
-  ./bin/tornadovm-installer --jdk graal-jdk-21  --backend opencl,ptx,spirv
-
-
-Another example: to build TornadoVM with OpenJDK 21 for the OpenCL and PTX backends:
-
-.. code-block:: bash
-
-  ./bin/tornadovm-installer --jdk jdk21 --backend opencl,ptx
-
-
-Windows example: to build TornadoVM with GraalVM and all supported backends (mind backslash and quotes):
+Windows example: to build TornadoVM we recommend using a virtual Python environment (`venv`) to automatically install and import a missing ``wget`` Python module. Otherwise, the installer fails to install and import ``wget`` and reports an error. Although the installer works fine on the second try, using a `venv` from the start is a smarter approach:
 
 .. code-block:: bash
 
@@ -113,12 +90,7 @@ Windows example: to build TornadoVM with GraalVM and all supported backends (min
   python -m venv .venv
   .venv\Scripts\activate.bat
 
-  python bin\tornadovm-installer --jdk graal-jdk-21 --backend opencl,ptx,spirv
-
-
-**Notes on Windows:**
-
-- The installer must run in a virtual Python environment (`venv`) to automatically install and import a missing ``wget`` Python module. Otherwise, the installer fails to install and import ``wget`` and reports an error. Although the installer works fine on the second try, using a `venv` from the start is a smarter approach.
+  python bin\tornadovm-installer
 
 - Running the TornadoVM test suite on Windows requires using ``nmake`` which is part of Visual Studio:
 
@@ -172,7 +144,13 @@ For example, using JDK 21 for all backends:
 
    git clone https://github.com/beehive-lab/TornadoVM.git
    cd TornadoVM
-   bin/tornadovm-installer --jdk jdk21 --backend opencl,ptx,spirv
+   bin/tornadovm-installer
+   Select the backend(s) to install:
+     1. opencl
+     2. spirv
+     3. ptx
+   You can select more than one by typing the numbers separated by commas (e.g., 1, 2, 3).
+   Your selection: 1, 2, 3
    source setvars.sh
 
 
@@ -220,7 +198,13 @@ Download and install TornadoVM. Note that, in OSx Apple M1/M2/M3 chip, the only 
 
    git clone https://github.com/beehive-lab/TornadoVM.git
    cd TornadoVM
-   bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl
+   bin/tornadovm-installer
+   Select the backend(s) to install:
+     1. opencl
+     2. spirv
+     3. ptx
+   You can select more than one by typing the numbers separated by commas (e.g., 1, 2, 3).
+   Your selection: 1
    source setvars.sh
 
 
@@ -338,14 +322,14 @@ The installation script downloads the following dependencies:
 
 - Java
 - Maven
-- cmake
+- CMake
 
 .. code:: bash
 
    python -m venv .venv
    .venv\Scripts\activate.bat
    .\bin\windowsMicrosoftStudioTools2022.cmd
-   python bin\tornadovm-installer --jdk jdk21 --backend=opencl 
+   python bin\tornadovm-installer
    setvars.cmd
 
 
@@ -510,14 +494,7 @@ Clone and build TornadoVM:
    git clone https://github.com/beehive-lab/TornadoVM.git tornado
    cd tornado
 
-  ## Install OpenCL only
-   ./bin/tornadovm-installer --jdk jdk21 --backend=opencl
-
-   ## Install OpenCL and PTX
-   ./bin/tornadovm-installer --jdk jdk21 --backend=opencl,ptx
-
-   ## Install All backends:
-   ./bin/tornadovm-installer --jdk jdk21 --backend=opencl,ptx,spirv
+   ./bin/tornadovm-installer
 
 
 Finally enable environment:

--- a/docs/source/spirv-backend.rst
+++ b/docs/source/spirv-backend.rst
@@ -23,7 +23,13 @@ To build the SPIR-V Backend, enable the backend as follows:
 .. code:: bash
 
    $ cd <tornadovm-directory>
-   $ ./bin/tornadovm-installer --jdk jdk21 --backend=spirv
+   $ ./bin/tornadovm-installer
+   $ Select the backend(s) to install:
+   $   1. opencl
+   $   2. spirv
+   $   3. ptx
+   $ You can select more than one by typing the numbers separated by commas (e.g., 1, 2, 3).
+   $ Your selection: 2
    $ . setvars.sh
 
 Running examples with the SPIR-V backend


### PR DESCRIPTION
#### Description

This PR extends the `tornadovm-installer` script to be interactive. In essence, if user has already a `JDK 21` distribution, and `mvn` and `cmake` already installed in the system, there is no need to download the dependencies. This option is still valid in case `JAVA_HOME` is not set.

1. The list of available JDKs to be downloaded is enumerated so that user can give a choice:
```bash ./bin/tornadovm-installer --listJDKs
List of supported JDKs for TornadoVM v1.1.0
  [1] jdk21              : Install TornadoVM with OpenJDK 21 (Oracle OpenJDK)
  [2] graal-jdk-21       : Install TornadoVM with GraalVM and JDK 21 (GraalVM 23.1.0)
  [3] corretto-jdk-21    : Install TornadoVM with Mandrel and JDK 21 (GraalVM 23.1.0)
  [4] microsoft-jdk-21   : Install TornadoVM with Corretto JDK 21
  [5] mandrel-jdk-21     : Install TornadoVM with Microsoft JDK 21
  [6] zulu-jdk-21        : Install TornadoVM with Azul Zulu JDK 21
  [7] temurin-jdk-21     : Install TornadoVM with Eclipse Temurin JDK 21
  [8] sapmachine-jdk-21  : Install TornadoVM with SapMachine OpenJDK 21
  [9] liberica-jdk-21    : Install TornadoVM with Liberica OpenJDK 21 (Only option for RISC-V 64)
```

2. There are several safe-guards added in this version. For instance, if a user has not GraalVM JDK distribution and wants to build with the `polyglot` flag, the system will detect this issue and interact if users want to update `JAVA_HOME` or wishes the script to download a GraalVM distribution, which will be downloaded in `etc/dependencies` path and the environmental variables will be automatically generated upon successful build.

```bash
./bin/tornadovm-installer --polyglot
```

3. Additionally, the installation script has been re-organized to use classes in order to facilitate maintenance and it outputs coloured message to make the interaction with users more friendly.

4. The Makefile has been extended with a new rule that enables the `--polyglot` option to be combined with the `--mvn_single_threaded` option.

5. Finally, the documentation has also been updated.

Example of the help message:
```bash
./bin/tornadovm-installer --help
usage: tornadovm-installer [-h] [--version] [--listJDKs] [--polyglot] [--mvn_single_threaded]

TornadoVM Installer Tool. It will install all software dependencies except the GPU/FPGA drivers

options:
  -h, --help            show this help message and exit
  --version             Print version
  --listJDKs            List supported JDKs
  --polyglot            Enable Truffle Interoperability with GraalVM
  --mvn_single_threaded
                        Run Maven in single-threaded mode
```

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
./bin/tornadovm-installer
```

----------------------------------------------------------------------------
