### PR TITLE
Increase sizes for auxiliary data structures related with the number of Tasks in a TaskGraph

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoGraph.java
@@ -36,7 +36,7 @@ import uk.ac.manchester.tornado.runtime.graph.nodes.AbstractNode;
  */
 public class TornadoGraph {
 
-    private static final int INITIAL_SIZE = 256;
+    private static final int INITIAL_SIZE = 1024;
 
     private AbstractNode[] nodes;
     private BitSet valid;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -159,7 +159,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     private static AtomicInteger offsetGlobalIndex = new AtomicInteger(0);
     private MetaReduceCodeAnalysis analysisTaskGraph;
     private TornadoExecutionContext executionContext;
-    private byte[] highLevelCode = new byte[2048];
+    private byte[] highLevelCode = new byte[8192];
     private ByteBuffer hlBuffer;
     private TornadoVMBytecodeBuilder bytecodeBuilder;
     private long batchSizeBytes = -1;


### PR DESCRIPTION
#### Description

It seems when having `TaskGraph` with more than 30 Tasks, it triggers a buffer overflow exception related with the two data structures updated in this PR.



#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?


----------------------------------------------------------------------------
