### PR TITLE
[feat] Added non-interactive mode and restored backend and jdk console arguments

### DIFF
--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -631,7 +631,11 @@ class TornadoInstaller:
 
 def parseArguments():
     parser = argparse.ArgumentParser(description="TornadoVM Installer Tool.  It will install all software dependencies except the GPU/FPGA drivers")
-    parser.add_argument("--jdk", action="store", dest="jdk", default=None, help="Select one of the supported JDKs. Use --listJDKs option to see all supported ones")
+    parser.add_argument("--jdk", action="store", dest="jdk", default=None,
+                        help=(
+                            "Specify a JDK to install by its keyword (e.g., 'jdk21', 'graal-jdk-21'). "
+                            "Run with --listJDKs to view all available JDK keywords."
+                        ))
     parser.add_argument("--backend", action="store", dest="backend", default=None, help="Select the backend to install: { opencl, ptx, spirv }")
     parser.add_argument("--version", action="store_true", dest="version", default=False, help="Print version")
     parser.add_argument("--listJDKs", action="store_true", dest="listJDKs", default=False, help="List supported JDKs")
@@ -646,6 +650,7 @@ class UserInterface:
     """Handles user interactions."""
 
     def __init__(self, console: Console, system_info: SystemInfo):
+        self.args = args
         self.console = console
         self.system_info = system_info
 
@@ -756,9 +761,14 @@ class UserInterface:
             "Install TornadoVM with SapMachine OpenJDK 21",
             "Install TornadoVM with Liberica OpenJDK 21 (Only option for RISC-V 64)"
         ]
-        self.console.print(f"""List of supported JDKs for TornadoVM {__VERSION__}""", style="green")
+
+        self.console.print(f"List of supported JDKs for TornadoVM {__VERSION__}", style="green")
+
+        numbered = not getattr(args, "listJDKs", False)
+
         for idx, (jdk, desc) in enumerate(zip(__SUPPORTED_JDKS__, descriptions), start=1):
-            console.print(f"  [{idx}] {jdk:<18} : {desc}", style="green")
+            prefix = f"[{idx}] " if numbered else ""
+            self.console.print(f"  {prefix}{jdk:<18} : {desc}", style="green")
 
 if __name__ == "__main__":
     args = parseArguments()

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -538,6 +538,8 @@ class TornadoInstaller:
             config.java_home = java_home
             config.jdk_keyword = matched_jdk
             config.download_jdk = False
+        elif args.jdk:
+            config.download_jdk, config.jdk_keyword = self.ui.select_jdk_from_console(args)
         else:
             config.download_jdk, config.jdk_keyword = self._handle_jdk_selection()
 
@@ -547,17 +549,17 @@ class TornadoInstaller:
 
         # Check other dependencies
         config.download_maven = not self.validator.check_maven()
-        if config.download_maven:
+        if config.download_maven and not args.nonInteractive:
             if input("Maven not found. Download locally? (y/n): ").strip().lower() != "y":
                 raise ConfigurationError("Maven is required")
 
         config.download_cmake = not self.validator.check_cmake()
-        if config.download_cmake:
+        if config.download_cmake and not args.nonInteractive:
             if input("CMake not found or too old. Download locally? (y/n): ").strip().lower() != "y":
                 raise ConfigurationError("CMake is required")
 
         # Set other options
-        config.backends = self.ui.select_backends()
+        config.backends = self.ui.select_backends(args)
         config.polyglot = args.polyglot
         config.maven_single_threaded = args.mavenSingleThreaded
 
@@ -624,12 +626,15 @@ class TornadoInstaller:
 
 def parseArguments():
     parser = argparse.ArgumentParser(description="TornadoVM Installer Tool.  It will install all software dependencies except the GPU/FPGA drivers")
+    parser.add_argument("--jdk", action="store", dest="jdk", default=None, help="Select one of the supported JDKs. Use --listJDKs option to see all supported ones")
+    parser.add_argument("--backend", action="store", dest="backend", default=None, help="Select the backend to install: { opencl, ptx, spirv }")
     parser.add_argument("--version", action="store_true", dest="version", default=False, help="Print version")
     parser.add_argument("--listJDKs", action="store_true", dest="listJDKs", default=False, help="List supported JDKs")
     parser.add_argument("--polyglot", action="store_true", dest="polyglot", default=None,
                         help="Enable Truffle Interoperability with GraalVM")
     parser.add_argument("--mvn_single_threaded", action="store_true", dest="mavenSingleThreaded", default=None,
                         help="Run Maven in single-threaded mode")
+    parser.add_argument("--non-interactive", action="store_true", dest="nonInteractive", help="Download and install dependencies without user interaction")
     return parser.parse_args()
 
 class UserInterface:
@@ -638,6 +643,16 @@ class UserInterface:
     def __init__(self, console: Console, system_info: SystemInfo):
         self.console = console
         self.system_info = system_info
+
+    def select_jdk_from_console(self, args: argparse.Namespace) -> Tuple[bool, str]:
+        # If --jdk is provided
+        if getattr(args, "jdk", None):
+            selected_jdk = args.jdk.strip().lower()
+            if selected_jdk in __SUPPORTED_JDKS__:
+                return True, selected_jdk
+            else:
+                self.console.print(f"[ERROR] Unsupported JDK key '{selected_jdk}'. Supported options are: {', '.join(__SUPPORTED_JDKS__.keys())}", style="bold red")
+                sys.exit(1)
 
     def select_jdk(self) -> Tuple[bool, str]:
         """Let user select a JDK from the menu."""
@@ -653,8 +668,25 @@ class UserInterface:
             self.console.print("[ERROR] Invalid input. Exiting.", style="bold red")
             sys.exit(1)
 
-    def select_backends(self) -> List[str]:
-        """Let user select backend(s)."""
+    def select_backends(self, args: argparse.Namespace) -> List[str]:
+        """Select backend(s), using CLI args if provided, otherwise prompt interactively."""
+        # Check if --backend was provided
+        if getattr(args, "backend", None):
+            # Normalize and split the string
+            selected_backends = [b.strip() for b in args.backend.split(",") if b.strip()]
+
+            # Check if all provided backends are supported
+            unsupported = [b for b in selected_backends if b not in __SUPPORTED_BACKENDS__]
+            if unsupported:
+                self.console.print(f"[ERROR] Unsupported backends specified in --backend: {', '.join(unsupported)}", style="bold red")
+                sys.exit(1)
+
+            if self._validate_backend_selection(selected_backends):
+                return selected_backends
+
+            self.console.print("[WARNING] Backend selection via --backend failed validation for your system. Try again:", style="yellow")
+
+        # Interactive fallback
         while True:
             self.console.print("\n[bold]Select the backend(s) to install:[/bold]")
             for idx, backend in enumerate(__SUPPORTED_BACKENDS__, 1):
@@ -666,12 +698,16 @@ class UserInterface:
             )
 
             try:
-                choices = input("Your selection: ").strip()
-                selected_indices = {int(choice.strip()) for choice in choices.split(",")}
-                selected_backends = [
-                    __SUPPORTED_BACKENDS__[i - 1] for i in selected_indices
-                    if 1 <= i <= len(__SUPPORTED_BACKENDS__)
-                ]
+                choices = input("Your selection: ").strip().lower()
+
+                if choices == "all":
+                    selected_backends = __SUPPORTED_BACKENDS__
+                else:
+                    selected_indices = {int(choice.strip()) for choice in choices.split(",")}
+                    invalid_indices = [i for i in selected_indices if i < 1 or i > len(__SUPPORTED_BACKENDS__)]
+                    if invalid_indices:
+                        raise ValueError(f"Invalid index/indices: {', '.join(map(str, invalid_indices))}")
+                    selected_backends = [__SUPPORTED_BACKENDS__[i - 1] for i in selected_indices]
 
                 if not selected_backends:
                     raise ValueError("No valid backends selected")

--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -126,6 +126,7 @@ class InstallationConfig:
     polyglot: bool = False
     maven_single_threaded: bool = False
     java_home: Optional[str] = None
+    non_interactive: bool = False
 
     def __post_init__(self):
         if self.backends is None:
@@ -544,6 +545,7 @@ class TornadoInstaller:
             config.download_jdk, config.jdk_keyword = self._handle_jdk_selection()
 
         # Validate polyglot requirements
+        config.non_interactive = args.nonInteractive
         if args.polyglot:
             config = self._validate_polyglot_config(config)
 
@@ -596,31 +598,34 @@ class TornadoInstaller:
         """Validate and adjust configuration for polyglot support."""
         if not config.jdk_keyword or "graal" not in config.jdk_keyword.lower():
             self.console.print("[ERROR] Polyglot requires GraalVM. Please select the GraalVM JDK.", style="bold red")
-            self.console.print("You have two options to proceed:", style="yellow")
-            self.console.print("[1] Use an already installed GraalVM JDK by setting JAVA_HOME.", style="green")
-            self.console.print("[2] Let the installer automatically download and configure a compatible GraalVM JDK distribution.", style="green")
-            self.console.print("    Upon successful build, the installer will also generate an environment setup script", style="green")
-            self.console.print("    that configures JAVA_HOME and other necessary variables for future use.\n", style="green")
-
-            try:
-                choice = int(input("Enter the number of your choice (1 or 2): ").strip())
-                if choice == 1:
-                    self.console.print("👉 You selected option [1].", style="bold")
-                    self.console.print("Now you should either:", style="yellow")
-                    self.console.print("- export JAVA_HOME manually in your terminal", style="yellow")
-                    self.console.print("- OR set it permanently in your shell profile (e.g. ~/.bashrc, ~/.zshrc, or ~/.profile)", style="yellow")
-                    self.console.print("\nExample:", style="dim")
-                    self.console.print("export JAVA_HOME=/path/to/your/jdk", style="green")
-                    self.console.print("\nOnce JAVA_HOME is set correctly, re-run this installer.", style="yellow")
-                    sys.exit(0)
-                elif choice == 2:
-                    config.jdk_keyword = "graal-jdk-21"
-                    config.download_jdk = True
-                else:
-                    raise ValueError("Invalid choice")
-            except ValueError:
-                self.console.print("[ERROR] Invalid choice. Exiting.", style="bold red")
+            if config.non_interactive:
                 sys.exit(1)
+            else:
+                self.console.print("You have two options to proceed:", style="yellow")
+                self.console.print("[1] Use an already installed GraalVM JDK by setting JAVA_HOME.", style="green")
+                self.console.print("[2] Let the installer automatically download and configure a compatible GraalVM JDK distribution.", style="green")
+                self.console.print("    Upon successful build, the installer will also generate an environment setup script", style="green")
+                self.console.print("    that configures JAVA_HOME and other necessary variables for future use.\n", style="green")
+
+                try:
+                    choice = int(input("Enter the number of your choice (1 or 2): ").strip())
+                    if choice == 1:
+                        self.console.print("👉 You selected option [1].", style="bold")
+                        self.console.print("Now you should either:", style="yellow")
+                        self.console.print("- export JAVA_HOME manually in your terminal", style="yellow")
+                        self.console.print("- OR set it permanently in your shell profile (e.g. ~/.bashrc, ~/.zshrc, or ~/.profile)", style="yellow")
+                        self.console.print("\nExample:", style="dim")
+                        self.console.print("export JAVA_HOME=/path/to/your/jdk", style="green")
+                        self.console.print("\nOnce JAVA_HOME is set correctly, re-run this installer.", style="yellow")
+                        sys.exit(0)
+                    elif choice == 2:
+                        config.jdk_keyword = "graal-jdk-21"
+                        config.download_jdk = True
+                    else:
+                        raise ValueError("Invalid choice")
+                except ValueError:
+                    self.console.print("[ERROR] Invalid choice. Exiting.", style="bold red")
+                    sys.exit(1)
 
         return config
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -65,17 +65,20 @@ Additionally, this installation type will automatically trigger all dependencies
 .. code-block:: bash
 
     $ ./bin/tornadovm-installer --help
-      usage: tornadovm-installer [-h] [--version] [--listJDKs] [--polyglot] [--mvn_single_threaded]
+      usage: tornadovm-installer [-h] [--jdk JDK] [--backend BACKEND] [--version] [--listJDKs] [--polyglot] [--mvn_single_threaded] [--non-interactive]
 
       TornadoVM Installer Tool. It will install all software dependencies except the GPU/FPGA drivers
 
       options:
         -h, --help            show this help message and exit
+        --jdk JDK             Specify a JDK to install by its keyword (e.g., 'jdk21', 'graal-jdk-21'). Run with --listJDKs to view all available JDK keywords.
+        --backend BACKEND     Select the backend to install: { opencl, ptx, spirv }
         --version             Print version
         --listJDKs            List supported JDKs
         --polyglot            Enable Truffle Interoperability with GraalVM
         --mvn_single_threaded
                               Run Maven in single-threaded mode
+        --non-interactive     Download and install dependencies without user interaction
 
 
 Windows example: to build TornadoVM we recommend using a virtual Python environment (`venv`) to automatically install and import a missing ``wget`` Python module. Otherwise, the installer fails to install and import ``wget`` and reports an error. Although the installer works fine on the second try, using a `venv` from the start is the recommended approach:


### PR DESCRIPTION
#### Description

This PR reverts the `--jdk` and `--backend` arguments of the `tornadovm-installer` which were used in non-interactive mode to build docker images. Those arguments can now be used in both interactive and non-interactive modes.

Additionally, this PR adds a new argument that users can select to define the non-interactive modes. In this case, if user selects also the `--non-interactive` option, then no interactive menu will be displayed and all dependencies will be installed automatically by the script.

```bash
./bin/tornadovm-installer --help                                                                                                
usage: tornadovm-installer [-h] [--jdk JDK] [--backend BACKEND] [--version] [--listJDKs] [--polyglot] [--mvn_single_threaded] [--non-interactive]

TornadoVM Installer Tool. It will install all software dependencies except the GPU/FPGA drivers

options:
  -h, --help            show this help message and exit
  --jdk JDK             Specify a JDK to install by its keyword (e.g., 'jdk21', 'graal-jdk-21'). Run with --listJDKs to view all available JDK keywords.
  --backend BACKEND     Select the backend to install: { opencl, ptx, spirv }
  --version             Print version
  --listJDKs            List supported JDKs
  --polyglot            Enable Truffle Interoperability with GraalVM
  --mvn_single_threaded
                        Run Maven in single-threaded mode
  --non-interactive     Download and install dependencies without user interaction
```

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

Provide instructions about how to test the new patch. 

----------------------------------------------------------------------------
