### PR TITLE
[refactor] Update function to select make rules and build with mvn-single-threaded

### DIFF
--- a/bin/tornadovm-installer
+++ b/bin/tornadovm-installer
@@ -388,16 +388,19 @@ class BuildManager:
         os.system(cmd)
 
     def _determine_make_options(self, config: InstallationConfig) -> Tuple[str, str]:
-        """Determine make target and polyglot option."""
+        # Common prefix for single-threaded Maven runs
+        prefix = "mvn-single-threaded-" if config.maven_single_threaded else ""
+
+        # Decide the suffix make target and polyglot option.
         if config.jdk_keyword and "graal" in config.jdk_keyword.lower():
             if config.polyglot:
-                if config.maven_single_threaded:
-                    return "mvn-single-threaded-polyglot"
-                else:
-                    return "polyglot"
+                suffix = "polyglot"
             else:
-                return "graal-jdk-21"
-        return "jdk21"
+                suffix = "graal-jdk-21"
+        else:
+            suffix = "jdk21"
+
+        return f"{prefix}{suffix}"
 
     def _get_backend_option(self, backends: List[str]) -> str:
         """Get backend option string."""


### PR DESCRIPTION
#### Description

This PR offers a fix in the installer for building with mvn in single thread mode (using the `--mvn_single_threaded`) argument, when `graal-jdk-21` or `jdk21` is selected as jdk_keyword. In essence, this option was working only if `polyglot` was selected.

This issue was observed while building the [polyglot-graaljs docker image](https://github.com/beehive-lab/docker-tornadovm/blob/master/polyglotImages/polyglot-graaljs/Dockerfile.nvidia.opencl.graaljs.jdk21) that combines GraalJS with TornadoVM.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash
rm -rf etd/dependencies/*
./bin/tornadovm-installer --jdk graal-jdk-21 --backend opencl --auto-deps --mvn_single_threaded

rm -rf etd/dependencies/*
./bin/tornadovm-installer --backend opencl --auto-deps --mvn_single_threaded
```
----------------------------------------------------------------------------
