### PR TITLE
[test] Mark unsupported tests for SPIRV

### DIFF
--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/TestSignedComparisonsCodegen.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/TestSignedComparisonsCodegen.java
@@ -79,6 +79,7 @@ public class TestSignedComparisonsCodegen extends TornadoTestBase {
 
     @Test
     public void testSigned01() {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
         int size = 8;
         IntArray testArr = new IntArray(size);
         testArr.init(0);
@@ -103,6 +104,7 @@ public class TestSignedComparisonsCodegen extends TornadoTestBase {
 
     @Test
     public void testSigned02() {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
         int size = 8;
         IntArray testArr = new IntArray(size);
         testArr.init(0);
@@ -152,6 +154,7 @@ public class TestSignedComparisonsCodegen extends TornadoTestBase {
 
     @Test
     public void testSigned04() {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
         int size = 8;
         IntArray testArr = new IntArray(size);
 


### PR DESCRIPTION
#### Description

This PR marks as unsupported for `SPIRV` the TestSigned unit-tests that were introduced in #706. I noticed that this was missing due to the Jenkins pipeline failure.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

n/a

----------------------------------------------------------------------------
