### PR TITLE
Add `mvn test` configuration to ease unit-testing when porting TornadoVM to third-party projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,13 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
                         <version>3.3.0</version>
                         <configuration>

--- a/tornado-unittests/README.md
+++ b/tornado-unittests/README.md
@@ -5,6 +5,7 @@ It contains a set of unit tests that can be run with Maven or with a custom Torn
 
 
 ## Testing TornadoVM Unit Tests with Maven and JUnit Core
+Run any of the following commands from the `tornado-unittests` module.
 
 ```bash
 # Basic data types

--- a/tornado-unittests/README.md
+++ b/tornado-unittests/README.md
@@ -8,23 +8,23 @@ It contains a set of unit tests that can be run with Maven or with a custom Torn
 
 ```bash
 # Basic data types
-mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestFloats
-mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestIntegers
-mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestDoubles
-mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestLong
-mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestShorts
+mvn exec:exec -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestFloats
+mvn exec:exec -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestIntegers
+mvn exec:exec -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestDoubles
+mvn exec:exec -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestLong
+mvn exec:exec -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestShorts
 
 # Control flow and algorithms
-mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestIf
-mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestLinearAlgebra
-mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.MultipleRuns
+mvn exec:exec -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestIf
+mvn exec:exec -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestLinearAlgebra
+mvn exec:exec -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.MultipleRuns
 ```
 
 
 ### Debug and Profiling Options 
 
 ```bash
-mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestFloats \
+mvn exec:exec -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestFloats \
   -Dtornado.printKernel=True
 ```
 

--- a/tornado-unittests/README.md
+++ b/tornado-unittests/README.md
@@ -1,0 +1,171 @@
+# Testing TornadoVM
+
+TornadoVM Unit Tests are located in the `tornado-unittests` module.
+It contains a set of unit tests that can be run with Maven or with a custom TornadoRunner infrastructure.
+
+
+## Testing TornadoVM Unit Tests with Maven and JUnit Core
+
+```bash
+# Basic data types
+mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestFloats
+mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestIntegers
+mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestDoubles
+mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestLong
+mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestShorts
+
+# Control flow and algorithms
+mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestIf
+mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestLinearAlgebra
+mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.MultipleRuns
+```
+
+
+### Debug and Profiling Options 
+
+```bash
+mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestFloats \
+  -Dtornado.printKernel=True
+```
+
+#### Expected Output
+
+**Success** 
+
+```bash
+WARNING: Using incubator modules: jdk.incubator.vector
+JUnit version 4.13.2
+.....
+Time: 0.815
+
+OK (5 tests)
+```
+
+
+**Failure**
+```bash
+JUnit version 4.13.2
+.E
+Time: 0.001
+There was 1 failure:
+1) testMethod(TestClass)
+java.lang.AssertionError: Expected <expected> but was: <actual>
+    at org.junit.Assert.fail(Assert.java:XX)
+    ...
+
+FAILURES!!!
+Tests run: 1,  Failures: 1
+```
+
+
+## Testing TornadoVM Unit Tests with Custom TornadoRunner infrastructure    
+The TornadoVM project provides a specialized test infrastructure that offers enhanced reporting, backend-aware exception handling, and comprehensive test categorization. This approach provides more detailed output and better integration with TornadoVM's heterogeneous computing environment.
+
+**Prerequisites**
+
+* TornadoVM built and installed with TORNADO_SDK configured
+* Run from the TornadoVM root directory
+
+#### Basic Usage
+
+```bash
+# Run all unit tests
+make tests
+
+# Alternative test command
+tests:
+
+# Check available devices
+tornado --devices
+
+# Run tests with verbose output
+tornado-test --ea --verbose
+
+# Run all tests verbosely (short form)
+tornado-test -V
+```
+
+#### Running Specific Test Classes
+
+```bash
+# Run specific test class with verbose output
+tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.matrixvector.TestMatrixVectorMultiplication
+
+# Run specific test class from foundation package
+tornado-test -V uk.ac.manchester.tornado.unittests.foundation.TestFloats
+
+# Run compute tests
+tornado-test -V uk.ac.manchester.tornado.unittests.compute.ComputeTests
+```
+
+#### Running Specific Test Methods`
+```bash
+# Run specific test method
+tornado-test -V uk.ac.manchester.tornado.unittests.compute.ComputeTests#testNBody
+
+# Run with kernel printing enabled
+tornado-test -V --printKernel uk.ac.manchester.tornado.unittests.compute.ComputeTests#testNBody
+```
+
+#### Expected Output
+
+**Success**
+
+```bash
+Test: class uk.ac.manchester.tornado.unittests.foundation.TestFloats
+	Running test: testFloatsCopy             ................  [PASS] 
+	Running test: testVectorFloatAdd         ................  [PASS] 
+	Running test: testVectorFloatSub         ................  [PASS] 
+	Running test: testVectorFloatMul         ................  [PASS] 
+	Running test: testVectorFloatDiv         ................  [PASS] 
+Test ran: 5, Failed: 0, Unsupported: 0
+```
+
+
+**Failure**
+```bash
+Running test: testMethod                 ................  [FAILED] 
+		\_[REASON] Expected <10> but was: <20>
+```
+
+#### Test Options
+
+```bash
+╰─cmd ➜ tornado-test --help
+usage: tornado-test [-h] [--version] [--verbose] [--ea] [--threadInfo] [--printKernel] [--junit] [--igv] [--igvLowTier] [--printBytecodes] [--debug]
+                    [--fullDebug] [--live] [--quickPass] [--device DEVICE] [--printExec] [--jvm JVMFLAGS] [--enableProfiler ENABLE_PROFILER]
+                    [--monitorClass MONITORCLASS]
+                    [testClass]
+
+Tool to execute tests in Tornado
+
+positional arguments:
+  testClass             testClass#method
+
+options:
+  -h, --help            show this help message and exit
+  --version             Print version
+  --verbose, -V         Run test in verbose mode
+  --ea, --enableassertions
+                        Enable Tornado assertions
+  --threadInfo          Print thread information
+  --printKernel, -pk    Print OpenCL kernel
+  --junit               Run within JUnitCore main class
+  --igv                 Dump GraalIR into IGV
+  --igvLowTier          Dump OpenCL Low-TIER GraalIR into IGV
+  --printBytecodes, -pbc
+                        Print TornadoVM internal bytecodes
+  --debug, -d           Enable the Debug mode in Tornado
+  --fullDebug           Enable the Full Debug mode. This mode is more verbose compared to --debug only
+  --live, -l            Visualize output in live mode (no wait)
+  --quickPass, -qp      Quick pass without stress memory and output for logs in a file.
+  --device DEVICE       Set an specific device. E.g `s0.t0.device=0:1`
+  --printExec           Print OpenCL Kernel Execution Time
+  --jvm JVMFLAGS, -J JVMFLAGS
+                        Pass options to the JVM e.g. -J="-Ds0.t0.device=0:1"
+  --enableProfiler ENABLE_PROFILER
+                        Enable the profiler {silent|console}
+  --monitorClass MONITORCLASS
+                        Monitor class to monitor the JVM process. Options: outOfMemoryMonitor
+
+```

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -5,7 +5,8 @@
     <modelVersion>4.0.0</modelVersion>
     <properties>
         <tornado.sdk>${env.TORNADO_SDK}</tornado.sdk>
-        <test.class>uk.ac.manchester.tornado.unittests.foundation.TestFloats</test.class>
+        <test.class>uk.ac.manchester.tornado.unittests.foundation.FoundationTestSuite</test.class>
+        <maven.test.skip>true</maven.test.skip>
     </properties>
 
     <parent>
@@ -85,15 +86,6 @@
                         <argument>${test.class}</argument>
                     </arguments>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>run-tornado-tests</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -3,6 +3,11 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <tornado.sdk>${env.TORNADO_SDK}</tornado.sdk>
+        <test.class>uk.ac.manchester.tornado.unittests.foundation.TestFloats</test.class>
+    </properties>
+
     <parent>
         <groupId>tornado</groupId>
         <artifactId>tornado</artifactId>
@@ -32,4 +37,64 @@
             <artifactId>lucene-core</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Skip the default test phase since we'll use exec plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M9</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+
+            <!-- Use exec plugin to run the working Java command -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <executable>${env.JAVA_HOME}/bin/java</executable>
+                    <arguments>
+                        <argument>-server</argument>
+                        <argument>-XX:+UnlockExperimentalVMOptions</argument>
+                        <argument>-XX:+EnableJVMCI</argument>
+                        <argument>-XX:-UseCompressedClassPointers</argument>
+                        <argument>--enable-preview</argument>
+                        <argument>-Djava.library.path=${env.TORNADO_SDK}/lib</argument>
+                        <argument>--module-path=.:${env.TORNADO_SDK}/share/java/tornado</argument>
+                        <argument>-Dtornado.load.api.implementation=uk.ac.manchester.tornado.runtime.tasks.TornadoTaskGraph</argument>
+                        <argument>-Dtornado.load.runtime.implementation=uk.ac.manchester.tornado.runtime.TornadoCoreRuntime</argument>
+                        <argument>-Dtornado.load.tornado.implementation=uk.ac.manchester.tornado.runtime.common.Tornado</argument>
+                        <argument>-Dtornado.load.annotation.implementation=uk.ac.manchester.tornado.annotation.ASMClassVisitor</argument>
+                        <argument>-Dtornado.load.annotation.parallel=uk.ac.manchester.tornado.api.annotations.Parallel</argument>
+                        <argument>--upgrade-module-path</argument>
+                        <argument>${tornado.sdk}/share/java/graalJars</argument>
+                        <argument>-XX:+UseParallelGC</argument>
+                        <argument>@${tornado.sdk}/etc/exportLists/common-exports</argument>
+                        <argument>@${tornado.sdk}/etc/exportLists/opencl-exports</argument>
+                        <argument>--add-modules</argument>
+                        <argument>ALL-SYSTEM,tornado.runtime,tornado.annotation,tornado.drivers.common,tornado.drivers.opencl</argument>
+                        <argument>-cp</argument>
+                        <argument>${project.build.outputDirectory}</argument>
+                        <argument>-Xmx6g</argument>
+                        <argument>-Dtornado.recover.bailout=False</argument>
+                        <argument>org.junit.runner.JUnitCore</argument>
+                        <argument>${test.class}</argument>
+                    </arguments>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>run-tornado-tests</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/FoundationTestSuite.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/foundation/FoundationTestSuite.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.foundation;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        TestFloats.class,
+        TestIntegers.class,
+        TestDoubles.class,
+        TestLong.class,
+        TestShorts.class,
+        TestLinearAlgebra.class,
+        MultipleRuns.class
+})
+public class FoundationTestSuite {
+    // Empty class - just a holder for the annotations
+}


### PR DESCRIPTION
Added in unit-test package the option to run tests directly from mvn


#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [ ] No

#### How to test the new patch?

```bash 
mvn exec:exec 

or for single class:

mvn exec:exec -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestIntegers

```

```bash
Expected output:
╰─cmd ➜ mvn test -Dtest.class=uk.ac.manchester.tornado.unittests.foundation.TestIntegers
[INFO] Scanning for projects...
[INFO] 
[INFO] ---------------------< tornado:tornado-unittests >----------------------
[INFO] Building tornado-unittests 1.1.2-dev
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- buildnumber:1.4:create (default) @ tornado-unittests ---
[INFO] ShortRevision tag detected. The value is '7'.
[INFO] Executing: /bin/sh -c cd '/home/mikepapadim/manchester/TornadoVM/tornado-unittests' && 'git' 'rev-parse' '--verify' '--short=7' 'HEAD'
[INFO] Working directory: /home/mikepapadim/manchester/TornadoVM/tornado-unittests
[INFO] Storing buildNumber: 16a0c66 at timestamp: 1757939792394
[INFO] Storing buildScmBranch: tests/add_configureation_to_run_pure_junitcore
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ tornado-unittests ---
[INFO] skip non existing resourceDirectory /home/mikepapadim/manchester/TornadoVM/tornado-unittests/src/main/resources
[INFO] 
[INFO] --- compiler:3.11.0:compile (default-compile) @ tornado-unittests ---
[WARNING] *********************************************************************************************************************************************
[WARNING] * Required filename-based automodules detected: [lucene-core-8.2.0.jar]. Please don't publish this project to a public artifact repository! *
[WARNING] *********************************************************************************************************************************************
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ tornado-unittests ---
[INFO] skip non existing resourceDirectory /home/mikepapadim/manchester/TornadoVM/tornado-unittests/src/test/resources
[INFO] 
[INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ tornado-unittests ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.0.0-M9:test (default-test) @ tornado-unittests ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- exec:3.1.0:exec (run-tornado-tests) @ tornado-unittests ---
WARNING: Using incubator modules: jdk.incubator.vector
JUnit version 4.13.2
......#pragma OPENCL EXTENSION cl_khr_fp64 : enable  
#pragma OPENCL EXTENSION cl_khr_fp16 : enable  
#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable  
__kernel void init(__global long *_kernel_context, __constant uchar *_constant_region, __local uchar *_local_region, __global int *_atomics, __global uchar *a, __global uchar *b)
{
  long l_7, l_6; 
  ulong ul_1, ul_0, ul_9, ul_8; 
  int i_10, i_5, i_4, i_3, i_2; 

  // BLOCK 0
  ul_0  =  (ulong) a;
  ul_1  =  (ulong) b;
  i_2  =  get_global_size(0);
  i_3  =  get_global_id(0);
  // BLOCK 1 MERGES [0 2 ]
  i_4  =  i_3;
  for(;i_4 < 131072;)
  {
    // BLOCK 2
    i_5  =  i_4 + 6;
    l_6  =  (long) i_5;
    l_7  =  l_6 << 2;
    ul_8  =  ul_0 + l_7;
    *((__global int *) ul_8)  =  100;
    ul_9  =  ul_1 + l_7;
    *((__global int *) ul_9)  =  500;
    i_10  =  i_2 + i_4;
    i_4  =  i_10;
  }  // B2
  // BLOCK 3
  return;
}  //  kernel

.Task info: s0.t0
	Backend           : OPENCL
	Device            : NVIDIA GeForce RTX 3070 CL_DEVICE_TYPE_GPU (available)
	Dims              : 1
	Global work offset: [0]
	Global work size  : [131072]
	Local  work size  : [1024, 1, 1]
	Number of workgroups  : [128]


Time: 0.561

OK (7 tests)

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.253 s
[INFO] Finished at: 2025-09-15T15:36:33+03:00
[INFO] ------------------------------------------------------------------------

```
----------------------------------------------------------------------------
