### PR TITLE
Loop partial unroll fix

### DIFF
--- a/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/loops/TornadoPartialLoopUnrollPhase.java
+++ b/tornado-drivers/drivers-common/src/main/java/uk/ac/manchester/tornado/drivers/common/compiler/phases/loops/TornadoPartialLoopUnrollPhase.java
@@ -106,7 +106,7 @@ public class TornadoPartialLoopUnrollPhase extends BasePhase<MidTierContext> {
     private StructuredGraph checkStatus(StructuredGraph graph, StructuredGraph snapshot, OptimizationStatus status) {
         return status != OptimizationStatus.SUCCESS ? snapshot : graph;
     }
-    
+
     @Override
     protected void run(StructuredGraph graph, MidTierContext context) {
 


### PR DESCRIPTION
#### Description

This patch fixes the issue of TornadoVM inserting additional loop bodies after the loop that is partially unrolled.

#### Problem description

The issue is that when TornadoVM is partially unrolling a loop, it inserts duplicated loop bodies both within and after the loop that needs to be partially unrolled. It seems that all 3 backends have the same issue.

To reproduce the issue, using 1D matmul as an example (feel free to use different backends and unrolling factors):

tornado-test -V --jvm="-Ds0.t0.device=0:0 -Dtornado.experimental.partial.unroll=true -Dtornado.unroll.factor=8" -pk uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext#mxm1DKernelContext

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Using 1D matmul as an example:

tornado-test -V --jvm="-Ds0.t0.device=0:0 -Dtornado.experimental.partial.unroll=true -Dtornado.unroll.factor=8" -pk uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext#mxm1DKernelContext

Feel free to use different backends and unrolling factors. I have tested unrolling factors of 2, 4, 8, 16, and 32 with all 3 backends and 1D matmul, and it is working so far.

----------------------------------------------------------------------------
