### PR TITLE
[feat] Added streamlit python dependency (tornadoviz)

### DIFF
--- a/bin/install_python_modules.py
+++ b/bin/install_python_modules.py
@@ -55,5 +55,11 @@ def check_python_dependencies():
         subprocess.call(["pip3", "install", "packaging"], stderr=subprocess.DEVNULL)
         import packaging
 
+    try:
+        import streamlit
+    except:
+        subprocess.call(["pip3", "install", "streamlit"], stderr=subprocess.DEVNULL)
+        import streamlit
+
     return 0
     


### PR DESCRIPTION
#### Description

This patch adds the `streamlit` Python dependency in the TornadoVM installer. This is a new dependency required for launching the [`tornadoviz`](https://github.com/beehive-lab/tornadoviz) tool.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```
./bin/tornadovm-installer --jdk jdk21 --backend opencl
```

----------------------------------------------------------------------------
