### PR TITLE
change the memory access pattern in matmul1D from stride-size to stride-1 for better performance

### DIFF
--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestMatrixMultiplicationKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestMatrixMultiplicationKernelContext.java
@@ -72,7 +72,7 @@ public class TestMatrixMultiplicationKernelContext extends TornadoTestBase {
         for (int jdx = 0; jdx < size; jdx++) {
             float sum = 0.0f;
             for (int k = 0; k < size; k++) {
-                sum += a.get((idx * size) + k) * b.get((k * size) + jdx);
+                sum += a.get((jdx * size) + k) * b.get((k * size) + idx);
             }
             c.set((idx * size) + jdx, sum);
         }


### PR DESCRIPTION
#### Description

This patch changes the memory access pattern for the 1D matmul in the unit test from stride-size to stride-1, which should provide better performance due to better memory access coalescing.

#### Problem description

N/A, it is for performance improvement, not a bug.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

tornado-test -V --jvm="-Ds0.t0.device=0:0" uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext#mxm1DKernelContext
----------------------------------------------------------------------------
