### PR TITLE
Increase default memory size on device

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -99,7 +99,7 @@ public class TornadoOptions {
      */
     public static final boolean FPGA_EMULATION = isFPGAEmulation();
     /**
-     * Option to set the device maximum memory usage. It is set to 1GB by default.
+     * Option to set the device maximum memory usage. It is set to 4GB by default.
      */
     public static final long DEVICE_AVAILABLE_MEMORY = RuntimeUtilities.parseSize(System.getProperty("tornado.device.memory", "4GB"));
     /**


### PR DESCRIPTION
1GB as default is very low default value for modern GPUs.

This PR increases the default to 4GB. 