### PR TITLE
[fix]  Integer overflow in TornadoNativeArray implementations that caused `IllegalArgumentException` when allocating large arrays

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -55,7 +55,7 @@ public final class ByteArray extends TornadoNativeArray {
         this.numberOfElements = numberOfElements;
         arrayHeaderSize = (int) TornadoNativeArray.ARRAY_HEADER;
         baseIndex = arrayHeaderSize / BYTE_BYTES;
-        segmentByteSize = numberOfElements * BYTE_BYTES + arrayHeaderSize;
+        segmentByteSize = (long) numberOfElements * BYTE_BYTES + arrayHeaderSize;
 
         segment = Arena.ofAuto().allocate(segmentByteSize, 1);
         segment.setAtIndex(JAVA_INT, 0, numberOfElements);
@@ -120,7 +120,7 @@ public final class ByteArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / BYTE_BYTES);
         ensureMultipleOfElementSize(byteSize, BYTE_BYTES);
         ByteArray byteArray = new ByteArray(numElements);
-        MemorySegment.copy(segment, 0, byteArray.segment, byteArray.baseIndex * BYTE_BYTES, byteSize);
+        MemorySegment.copy(segment, 0, byteArray.segment, (long) byteArray.baseIndex * BYTE_BYTES, byteSize);
         return byteArray;
     }
 
@@ -300,8 +300,8 @@ public final class ByteArray extends TornadoNativeArray {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
-        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * BYTE_BYTES;
-        long sliceByteLength = length * BYTE_BYTES;
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + (long) offset * BYTE_BYTES;
+        long sliceByteLength = (long) length * BYTE_BYTES;
         MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         ByteArray slice = fromSegment(sliceSegment);
         return slice;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -55,7 +55,7 @@ public final class CharArray extends TornadoNativeArray {
         this.numberOfElements = numberOfElements;
         arrayHeaderSize = (int) TornadoNativeArray.ARRAY_HEADER;
         baseIndex = arrayHeaderSize / CHAR_BYTES;
-        segmentByteSize = numberOfElements * CHAR_BYTES + arrayHeaderSize;
+        segmentByteSize = (long) numberOfElements * CHAR_BYTES + arrayHeaderSize;
 
         segment = Arena.ofAuto().allocate(segmentByteSize, 1);
         segment.setAtIndex(JAVA_INT, 0, numberOfElements);
@@ -120,7 +120,7 @@ public final class CharArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / CHAR_BYTES);
         ensureMultipleOfElementSize(byteSize, CHAR_BYTES);
         CharArray charArray = new CharArray(numElements);
-        MemorySegment.copy(segment, 0, charArray.segment, charArray.baseIndex * CHAR_BYTES, byteSize);
+        MemorySegment.copy(segment, 0, charArray.segment, (long) charArray.baseIndex * CHAR_BYTES, byteSize);
         return charArray;
     }
 
@@ -301,8 +301,8 @@ public final class CharArray extends TornadoNativeArray {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
-        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * CHAR_BYTES;
-        long sliceByteLength = length * CHAR_BYTES;
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + (long) offset * CHAR_BYTES;
+        long sliceByteLength = (long) length * CHAR_BYTES;
         MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         CharArray slice = fromSegment(sliceSegment);
         return slice;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -57,7 +57,7 @@ public final class DoubleArray extends TornadoNativeArray {
         arrayHeaderSize = (int) TornadoNativeArray.ARRAY_HEADER;
         assert arrayHeaderSize >= 8;
         baseIndex = arrayHeaderSize / DOUBLE_BYTES;
-        segmentByteSize = numberOfElements * DOUBLE_BYTES + arrayHeaderSize;
+        segmentByteSize = (long) numberOfElements * DOUBLE_BYTES + arrayHeaderSize;
 
         segment = Arena.ofAuto().allocate(segmentByteSize, 1);
         segment.setAtIndex(JAVA_INT, 0, numberOfElements);
@@ -122,7 +122,7 @@ public final class DoubleArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / DOUBLE_BYTES);
         ensureMultipleOfElementSize(byteSize, DOUBLE_BYTES);
         DoubleArray doubleArray = new DoubleArray(numElements);
-        MemorySegment.copy(segment, 0, doubleArray.segment, doubleArray.baseIndex * DOUBLE_BYTES, byteSize);
+        MemorySegment.copy(segment, 0, doubleArray.segment, (long) doubleArray.baseIndex * DOUBLE_BYTES, byteSize);
         return doubleArray;
     }
 
@@ -303,8 +303,8 @@ public final class DoubleArray extends TornadoNativeArray {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
-        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * DOUBLE_BYTES;
-        long sliceByteLength = length * DOUBLE_BYTES;
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + (long) offset * DOUBLE_BYTES;
+        long sliceByteLength = (long) length * DOUBLE_BYTES;
         MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         DoubleArray slice = fromSegment(sliceSegment);
         return slice;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -57,7 +57,7 @@ public final class FloatArray extends TornadoNativeArray {
         this.numberOfElements = numberOfElements;
         arrayHeaderSize = (int) TornadoNativeArray.ARRAY_HEADER;
         baseIndex = arrayHeaderSize / FLOAT_BYTES;
-        segmentByteSize = numberOfElements * FLOAT_BYTES + arrayHeaderSize;
+        segmentByteSize = (long) numberOfElements * FLOAT_BYTES + arrayHeaderSize;
 
         segment = Arena.ofAuto().allocate(segmentByteSize, 1);
         segment.setAtIndex(JAVA_INT, 0, numberOfElements);
@@ -122,7 +122,7 @@ public final class FloatArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / FLOAT_BYTES);
         ensureMultipleOfElementSize(byteSize, FLOAT_BYTES);
         FloatArray floatArray = new FloatArray(numElements);
-        MemorySegment.copy(segment, 0, floatArray.segment, floatArray.baseIndex * FLOAT_BYTES, byteSize);
+        MemorySegment.copy(segment, 0, floatArray.segment, (long) floatArray.baseIndex * FLOAT_BYTES, byteSize);
         return floatArray;
     }
 
@@ -303,8 +303,8 @@ public final class FloatArray extends TornadoNativeArray {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
-        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * FLOAT_BYTES;
-        long sliceByteLength = length * FLOAT_BYTES;
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + (long) offset * FLOAT_BYTES;
+        long sliceByteLength = (long) length * FLOAT_BYTES;
         MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         FloatArray slice = fromSegment(sliceSegment);
         return slice;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -58,7 +58,7 @@ public final class HalfFloatArray extends TornadoNativeArray {
         this.numberOfElements = numberOfElements;
         arrayHeaderSize = (int) TornadoNativeArray.ARRAY_HEADER;
         baseIndex = arrayHeaderSize / HALF_FLOAT_BYTES;
-        segmentByteSize = numberOfElements * HALF_FLOAT_BYTES + arrayHeaderSize;
+        segmentByteSize = (long) numberOfElements * HALF_FLOAT_BYTES + arrayHeaderSize;
 
         segment = Arena.ofAuto().allocate(segmentByteSize, 1);
         segment.setAtIndex(JAVA_INT, 0, numberOfElements);
@@ -306,8 +306,8 @@ public final class HalfFloatArray extends TornadoNativeArray {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
-        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * HALF_FLOAT_BYTES;
-        long sliceByteLength = length * HALF_FLOAT_BYTES;
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + (long) offset * HALF_FLOAT_BYTES;
+        long sliceByteLength = (long) length * HALF_FLOAT_BYTES;
         MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         HalfFloatArray slice = fromSegment(sliceSegment);
         return slice;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -54,7 +54,7 @@ public final class IntArray extends TornadoNativeArray {
         this.numberOfElements = numberOfElements;
         arrayHeaderSize = (int) TornadoNativeArray.ARRAY_HEADER;
         baseIndex = arrayHeaderSize / INT_BYTES;
-        segmentByteSize = numberOfElements * INT_BYTES + arrayHeaderSize;
+        segmentByteSize = (long) numberOfElements * INT_BYTES + arrayHeaderSize;
 
         segment = Arena.ofAuto().allocate(segmentByteSize, 1);
         segment.setAtIndex(JAVA_INT, 0, numberOfElements);
@@ -119,7 +119,7 @@ public final class IntArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / INT_BYTES);
         ensureMultipleOfElementSize(byteSize, INT_BYTES);
         IntArray intArray = new IntArray(numElements);
-        MemorySegment.copy(segment, 0, intArray.segment, intArray.baseIndex * INT_BYTES, byteSize);
+        MemorySegment.copy(segment, 0, intArray.segment, (long) intArray.baseIndex * INT_BYTES, byteSize);
         return intArray;
     }
 
@@ -300,8 +300,8 @@ public final class IntArray extends TornadoNativeArray {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
-        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * INT_BYTES;
-        long sliceByteLength = length * INT_BYTES;
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + (long) offset * INT_BYTES;
+        long sliceByteLength = (long) length * INT_BYTES;
         MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         IntArray slice = fromSegment(sliceSegment);
         return slice;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -56,7 +56,7 @@ public final class LongArray extends TornadoNativeArray {
         arrayHeaderSize = (int) TornadoNativeArray.ARRAY_HEADER;
         baseIndex = arrayHeaderSize / LONG_BYTES;
 
-        segmentByteSize = numberOfElements * LONG_BYTES + arrayHeaderSize;
+        segmentByteSize = (long) numberOfElements * LONG_BYTES + arrayHeaderSize;
         segment = Arena.ofAuto().allocate(segmentByteSize, 1);
         segment.setAtIndex(JAVA_INT, 0, numberOfElements);
     }
@@ -120,7 +120,7 @@ public final class LongArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / LONG_BYTES);
         ensureMultipleOfElementSize(byteSize, LONG_BYTES);
         LongArray longArray = new LongArray(numElements);
-        MemorySegment.copy(segment, 0, longArray.segment, longArray.baseIndex * LONG_BYTES, byteSize);
+        MemorySegment.copy(segment, 0, longArray.segment, (long) longArray.baseIndex * LONG_BYTES, byteSize);
         return longArray;
     }
 
@@ -301,8 +301,8 @@ public final class LongArray extends TornadoNativeArray {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
-        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * LONG_BYTES;
-        long sliceByteLength = length * LONG_BYTES;
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + (long) offset * LONG_BYTES;
+        long sliceByteLength = (long) length * LONG_BYTES;
         MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         LongArray slice = fromSegment(sliceSegment);
         return slice;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -56,7 +56,7 @@ public final class ShortArray extends TornadoNativeArray {
         arrayHeaderSize = (int) TornadoNativeArray.ARRAY_HEADER;
         assert arrayHeaderSize >= 4;
         baseIndex = arrayHeaderSize / SHORT_BYTES;
-        segmentByteSize = numberOfElements * SHORT_BYTES + arrayHeaderSize;
+        segmentByteSize = (long) numberOfElements * SHORT_BYTES + arrayHeaderSize;
 
         segment = Arena.ofAuto().allocate(segmentByteSize, 1);
         segment.setAtIndex(JAVA_INT, 0, numberOfElements);
@@ -121,7 +121,7 @@ public final class ShortArray extends TornadoNativeArray {
         int numElements = (int) (byteSize / SHORT_BYTES);
         ensureMultipleOfElementSize(byteSize, SHORT_BYTES);
         ShortArray shortArray = new ShortArray(numElements);
-        MemorySegment.copy(segment, 0, shortArray.segment, shortArray.baseIndex * SHORT_BYTES, byteSize);
+        MemorySegment.copy(segment, 0, shortArray.segment, (long) shortArray.baseIndex * SHORT_BYTES, byteSize);
         return shortArray;
     }
 
@@ -301,8 +301,8 @@ public final class ShortArray extends TornadoNativeArray {
             throw new IllegalArgumentException("Slice out of bounds");
         }
 
-        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + offset * SHORT_BYTES;
-        long sliceByteLength = length * SHORT_BYTES;
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + (long) offset * SHORT_BYTES;
+        long sliceByteLength = (long) length * SHORT_BYTES;
         MemorySegment sliceSegment = segment.asSlice(sliceOffsetInBytes, sliceByteLength);
         ShortArray slice = fromSegment(sliceSegment);
         return slice;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestLargeArrays.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestLargeArrays.java
@@ -1,20 +1,40 @@
+/*
+ * Copyright (c) 2025 APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package uk.ac.manchester.tornado.unittests.arrays;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.stream.IntStream;
 
 import org.junit.Assume;
 import org.junit.Test;
+
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoMemoryException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
-
-import java.util.stream.IntStream;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * How to test?
@@ -27,22 +47,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestLargeArrays extends TornadoTestBase {
 
-    @Override
-    public void before() {
-        boolean hasRequiredDeviceMemory = checkDeviceMemory();
-        System.out.println("TestLargeArrays 1");
-
-        // Skip all tests if device memory requirement not met
-        Assume.assumeTrue(
-                "Skipping TestLargeArrays: requires > 3GB global memory",
-                hasRequiredDeviceMemory
-        );
-    }
-
     public static boolean checkDeviceMemory() {
-        long mem = TornadoRuntimeProvider.getTornadoRuntime()
-                .getDefaultDevice()
-                .getMaxGlobalMemory();
+        long mem = TornadoRuntimeProvider.getTornadoRuntime().getDefaultDevice().getMaxGlobalMemory();
 
         return mem > 3L * 1024 * 1024 * 1024;
     }
@@ -53,16 +59,27 @@ public class TestLargeArrays extends TornadoTestBase {
         }
     }
 
+    @Override
+    public void before() {
+        boolean hasRequiredDeviceMemory = checkDeviceMemory();
+
+        // Skip all tests if device memory requirement not met
+        Assume.assumeTrue("Skipping TestLargeArrays: requires > 3GB global memory", hasRequiredDeviceMemory);
+    }
+
     @Test
-    public void testLargeFloatArray() throws TornadoExecutionPlanException {
-        //final int numElements = Integer.MAX_VALUE; // last overflow
-        //final int numElements = 600000000; // overflow
-        //final int numElements = 550000000; // overflow
-        final int numElements = 540000000; // overflow
-        //final int numElements = 535000000; // safe
-        //final int numElements = 530000000; // safe
-        //final int numElements = 525000000; // safe
-        //final int numElements = 500500000; // safe
+    public void testLargeFloatArraySafe() throws TornadoExecutionPlanException {
+        final int numElements = 510_000_000; // Known safe size
+        testFloatArrayWithSize(numElements);
+    }
+
+    @Test(expected = TornadoOutOfMemoryException.class)
+    public void testLargeFloatArrayOverflow() throws TornadoExecutionPlanException {
+        final int numElements = 540_000_000; // Known to overflow
+        testFloatArrayWithSize(numElements);
+    }
+
+    private void testFloatArrayWithSize(int numElements) throws TornadoExecutionPlanException {
         FloatArray a = new FloatArray(numElements);
 
         IntStream.range(0, numElements).sequential().forEach(i -> {
@@ -72,10 +89,8 @@ public class TestLargeArrays extends TornadoTestBase {
         FloatArray b = FloatArray.fromSegment(a.getSegment());
         float accumulator = 1.0f;
 
-        TaskGraph taskGraph = new TaskGraph("s0") //
-                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a) //
-                .task("t0", TestLargeArrays::addAccumulator, a, accumulator) //
-                .transferToHost(DataTransferMode.EVERY_EXECUTION, a);
+        TaskGraph taskGraph = new TaskGraph("s0").transferToDevice(DataTransferMode.EVERY_EXECUTION, a).task("t0", TestLargeArrays::addAccumulator, a, accumulator).transferToHost(
+                DataTransferMode.EVERY_EXECUTION, a);
 
         ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
         try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestLargeArrays.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestLargeArrays.java
@@ -1,0 +1,89 @@
+package uk.ac.manchester.tornado.unittests.arrays;
+
+import org.junit.Assume;
+import org.junit.Test;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * How to test?
+ *
+ * <p>
+ * <code>
+ * tornado-test -V -J"-Dtornado.device.memory=3GB" uk.ac.manchester.tornado.unittests.arrays.TestLargeArrays
+ * </code>
+ * </p>
+ */
+public class TestLargeArrays extends TornadoTestBase {
+
+    @Override
+    public void before() {
+        boolean hasRequiredDeviceMemory = checkDeviceMemory();
+        System.out.println("TestLargeArrays 1");
+
+        // Skip all tests if device memory requirement not met
+        Assume.assumeTrue(
+                "Skipping TestLargeArrays: requires > 3GB global memory",
+                hasRequiredDeviceMemory
+        );
+    }
+
+    public static boolean checkDeviceMemory() {
+        long mem = TornadoRuntimeProvider.getTornadoRuntime()
+                .getDefaultDevice()
+                .getMaxGlobalMemory();
+
+        return mem > 3L * 1024 * 1024 * 1024;
+    }
+
+    public static void addAccumulator(FloatArray a, float value) {
+        for (@Parallel int i = 0; i < a.getSize(); i++) {
+            a.set(i, a.get(i) + value);
+        }
+    }
+
+    @Test
+    public void testLargeFloatArray() throws TornadoExecutionPlanException {
+        //final int numElements = Integer.MAX_VALUE; // last overflow
+        //final int numElements = 600000000; // overflow
+        //final int numElements = 550000000; // overflow
+        final int numElements = 540000000; // overflow
+        //final int numElements = 535000000; // safe
+        //final int numElements = 530000000; // safe
+        //final int numElements = 525000000; // safe
+        //final int numElements = 500500000; // safe
+        FloatArray a = new FloatArray(numElements);
+
+        IntStream.range(0, numElements).sequential().forEach(i -> {
+            a.set(i, (float) Math.random());
+        });
+
+        FloatArray b = FloatArray.fromSegment(a.getSegment());
+        float accumulator = 1.0f;
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a) //
+                .task("t0", TestLargeArrays::addAccumulator, a, accumulator) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, a);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < a.getSize(); i++) {
+            assertEquals(b.get(i) + accumulator, a.get(i), 0.01f);
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Fix integer overflow in TornadoNativeArray implementations that caused `IllegalArgumentException` when allocating large arrays. The issue occurred when calculating `segmentByteSize` using integer arithmetic, causing overflow for arrays requiring more than ~2GB of memory.

#### Problem description

When creating large arrays (e.g., FloatArray with ~>540M elements), the calculation `numberOfElements * ELEMENT_BYTES + arrayHeaderSize` would overflow the integer range, resulting in negative values being passed to `Arena.allocate()`. This caused the following exception:

```java
Exception in thread "main" java.lang.IllegalArgumentException: Invalid allocation size : -1805647848
at java.base/jdk.internal.foreign.Utils.checkAllocationSizeAndAlign(Utils.java:206)
at java.base/jdk.internal.foreign.MemorySessionImpl.allocate(MemorySessionImpl.java:157)
at java.base/java.lang.foreign.Arena.allocate(Arena.java:273)
at [tornado.api@1.1.2-dev](mailto:tornado.api@1.1.2-dev)/uk.ac.manchester.tornado.api.types.arrays.FloatArray.<init>(FloatArray.java:62)
```

The fix involves casting `numberOfElements` to `long` before multiplication to ensure the calculation is performed using long arithmetic, preventing integer overflow.

In addition, it provides a new test class for large arrays (`uk.ac.manchester.tornado.unittests.arrays.TestLargeArrays`) along with a test for FloatArrays (`testLargeFloatArray()`).

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

To reproduce the original issue and verify the fix:

run the test with and without the fix:
```java
tornado-test -V -J"-Dtornado.device.memory=3GB" uk.ac.manchester.tornado.unittests.arrays.TestLargeArrays
```
----------------------------------------------------------------------------
