### PR TITLE
[feat] Zero-copy TornadoNativeArray type instances with shallow memory segments

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ByteArray.java
@@ -151,7 +151,7 @@ public final class ByteArray extends TornadoNativeArray {
      * without copying its contents.
      *
      * @param segment
-     *      The {@link MemorySegment} containing *both* the off-heap byte *header* and *data*.
+     *     The {@link MemorySegment} containing *both* the off-heap byte *header* and *data*.
      * @return A new {@link ByteArray} instance that wraps the given segment.
      */
     public static ByteArray fromSegmentShallow(MemorySegment segment) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/CharArray.java
@@ -151,7 +151,7 @@ public final class CharArray extends TornadoNativeArray {
      * without copying its contents.
      *
      * @param segment
-     *      The {@link MemorySegment} containing *both* the off-heap char *header* and *data*.
+     *     The {@link MemorySegment} containing *both* the off-heap char *header* and *data*.
      * @return A new {@link CharArray} instance that wraps the given segment.
      */
     public static CharArray fromSegmentShallow(MemorySegment segment) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/DoubleArray.java
@@ -153,7 +153,7 @@ public final class DoubleArray extends TornadoNativeArray {
      * without copying its contents.
      *
      * @param segment
-     *      The {@link MemorySegment} containing *both* the off-heap double *header* and *data*.
+     *     The {@link MemorySegment} containing *both* the off-heap double *header* and *data*.
      * @return A new {@link DoubleArray} instance that wraps the given segment.
      */
     public static DoubleArray fromSegmentShallow(MemorySegment segment) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/FloatArray.java
@@ -153,7 +153,7 @@ public final class FloatArray extends TornadoNativeArray {
      * without copying its contents.
      *
      * @param segment
-     *      The {@link MemorySegment} containing *both* the off-heap float *header* and *data*.
+     *     The {@link MemorySegment} containing *both* the off-heap float *header* and *data*.
      * @return A new {@link FloatArray} instance that wraps the given segment.
      */
     public static FloatArray fromSegmentShallow(MemorySegment segment) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -154,7 +154,7 @@ public final class HalfFloatArray extends TornadoNativeArray {
      * without copying its contents.
      *
      * @param segment
-     *      The {@link MemorySegment} containing *both* the off-heap half-float *header* and *data*.
+     *     The {@link MemorySegment} containing *both* the off-heap half-float *header* and *data*.
      * @return A new {@link HalfFloatArray} instance that wraps the given segment.
      */
     public static HalfFloatArray fromSegmentShallow(MemorySegment segment) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/Int8Array.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/Int8Array.java
@@ -144,7 +144,7 @@ public final class Int8Array extends TornadoNativeArray {
      * without copying its contents.
      *
      * @param segment
-     *      The {@link MemorySegment} containing *both* the off-heap int8 *header* and *data*.
+     *     The {@link MemorySegment} containing *both* the off-heap int8 *header* and *data*.
      * @return A new {@link Int8Array} instance that wraps the given segment.
      */
     public static Int8Array fromSegmentShallow(MemorySegment segment) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/IntArray.java
@@ -150,7 +150,7 @@ public final class IntArray extends TornadoNativeArray {
      * without copying its contents.
      *
      * @param segment
-     *      The {@link MemorySegment} containing *both* the off-heap int *header* and *data*.
+     *     The {@link MemorySegment} containing *both* the off-heap int *header* and *data*.
      * @return A new {@link IntArray} instance that wraps the given segment.
      */
     public static IntArray fromSegmentShallow(MemorySegment segment) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/LongArray.java
@@ -151,7 +151,7 @@ public final class LongArray extends TornadoNativeArray {
      * without copying its contents.
      *
      * @param segment
-     *      The {@link MemorySegment} containing *both* the off-heap long *header* and *data*.
+     *     The {@link MemorySegment} containing *both* the off-heap long *header* and *data*.
      * @return A new {@link LongArray} instance that wraps the given segment.
      */
     public static LongArray fromSegmentShallow(MemorySegment segment) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/ShortArray.java
@@ -152,7 +152,7 @@ public final class ShortArray extends TornadoNativeArray {
      * without copying its contents.
      *
      * @param segment
-     *      The {@link MemorySegment} containing *both* the off-heap short *header* and *data*.
+     *     The {@link MemorySegment} containing *both* the off-heap short *header* and *data*.
      * @return A new {@link ShortArray} instance that wraps the given segment.
      */
     public static ShortArray fromSegmentShallow(MemorySegment segment) {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/TornadoNativeArrayInit.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/TornadoNativeArrayInit.java
@@ -134,13 +134,12 @@ public class TornadoNativeArrayInit {
         System.out.println("Testing FloatArray initialization methods\n");
 
         // Test different array sizes
-        int[] sizes = {1_000, 10_000, 100_000, 1_000_000};
+        int[] sizes = { 1_000, 10_000, 100_000, 1_000_000 };
         int iterations = 100;
 
         for (int size : sizes) {
             System.out.println("=".repeat(80));
-            System.out.printf("Performance Benchmark - Array Size: %,d elements (%s), Iterations: %,d\n",
-                    size, formatArraySize(size), iterations);
+            System.out.printf("Performance Benchmark - Array Size: %,d elements (%s), Iterations: %,d\n", size, formatArraySize(size), iterations);
             System.out.printf("Header Size: %d bytes\n", TornadoNativeArray.ARRAY_HEADER);
             System.out.println("=".repeat(80));
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAPI.java
@@ -57,7 +57,7 @@ public class TestAPI extends TornadoTestBase {
     @Test
     public void testSegmentsByte() {
         ByteArray dataA = ByteArray.fromElements((byte) 0, (byte) 1, (byte) 2, (byte) 3);
-        ByteArray dataB = ByteArray.fromArray(new byte[]{0, 1, 2, 3});
+        ByteArray dataB = ByteArray.fromArray(new byte[] { 0, 1, 2, 3 });
 
         for (int i = 0; i < dataA.getSize(); i++) {
             assertEquals(dataA.get(i), dataB.get(i));
@@ -76,7 +76,7 @@ public class TestAPI extends TornadoTestBase {
     @Test
     public void testSegmentsChar() {
         CharArray dataA = CharArray.fromElements((char) 0, (char) 1, (char) 2, (char) 3);
-        CharArray dataB = CharArray.fromArray(new char[]{0, 1, 2, 3});
+        CharArray dataB = CharArray.fromArray(new char[] { 0, 1, 2, 3 });
 
         for (int i = 0; i < dataA.getSize(); i++) {
             assertEquals(dataA.get(i), dataB.get(i));
@@ -95,7 +95,7 @@ public class TestAPI extends TornadoTestBase {
     @Test
     public void testSegmentsShort() {
         ShortArray dataA = ShortArray.fromElements((short) 0, (short) 1, (short) 2, (short) 3);
-        ShortArray dataB = ShortArray.fromArray(new short[]{0, 1, 2, 3});
+        ShortArray dataB = ShortArray.fromArray(new short[] { 0, 1, 2, 3 });
 
         for (int i = 0; i < dataA.getSize(); i++) {
             assertEquals(dataA.get(i), dataB.get(i));
@@ -114,7 +114,7 @@ public class TestAPI extends TornadoTestBase {
     @Test
     public void testSegmentsIntegers() {
         IntArray dataA = IntArray.fromElements(0, 1, 2, 3);
-        IntArray dataB = IntArray.fromArray(new int[]{0, 1, 2, 3});
+        IntArray dataB = IntArray.fromArray(new int[] { 0, 1, 2, 3 });
 
         for (int i = 0; i < dataA.getSize(); i++) {
             assertEquals(dataA.get(i), dataB.get(i));
@@ -133,7 +133,7 @@ public class TestAPI extends TornadoTestBase {
     @Test
     public void testSegmentsLong() {
         LongArray dataA = LongArray.fromElements(0, 1, 2, 3);
-        LongArray dataB = LongArray.fromArray(new long[]{0, 1, 2, 3});
+        LongArray dataB = LongArray.fromArray(new long[] { 0, 1, 2, 3 });
 
         for (int i = 0; i < dataA.getSize(); i++) {
             assertEquals(dataA.get(i), dataB.get(i));
@@ -152,7 +152,7 @@ public class TestAPI extends TornadoTestBase {
     @Test
     public void testSegmentsFloats() {
         FloatArray dataA = FloatArray.fromElements(0, 1, 2, 3);
-        FloatArray dataB = FloatArray.fromArray(new float[]{0, 1, 2, 3});
+        FloatArray dataB = FloatArray.fromArray(new float[] { 0, 1, 2, 3 });
 
         for (int i = 0; i < dataA.getSize(); i++) {
             assertEquals(dataA.get(i), dataB.get(i), 0.01f);
@@ -171,7 +171,7 @@ public class TestAPI extends TornadoTestBase {
     @Test
     public void testSegmentsDouble() {
         DoubleArray dataA = DoubleArray.fromElements(0, 1, 2, 3);
-        DoubleArray dataB = DoubleArray.fromArray(new double[]{0, 1, 2, 3});
+        DoubleArray dataB = DoubleArray.fromArray(new double[] { 0, 1, 2, 3 });
 
         for (int i = 0; i < dataA.getSize(); i++) {
             assertEquals(dataA.get(i), dataB.get(i), 0.001);
@@ -193,7 +193,7 @@ public class TestAPI extends TornadoTestBase {
     @Test
     public void testSegmentsHalfFloats() {
         HalfFloatArray dataA = HalfFloatArray.fromElements(new HalfFloat(0), new HalfFloat(1), new HalfFloat(2), new HalfFloat(3));
-        HalfFloatArray dataB = HalfFloatArray.fromArray(new HalfFloat[]{new HalfFloat(0), new HalfFloat(1), new HalfFloat(2), new HalfFloat(3)});
+        HalfFloatArray dataB = HalfFloatArray.fromArray(new HalfFloat[] { new HalfFloat(0), new HalfFloat(1), new HalfFloat(2), new HalfFloat(3) });
 
         for (int i = 0; i < dataA.getSize(); i++) {
             assertEquals(dataA.get(i).getFloat32(), dataB.get(i).getFloat32(), 0.01f);


### PR DESCRIPTION
#### Description
This patch adds a `fromSegmentShallow()` method for all `TornadoNativeArray` types that allows wrapping existing MemorySegments without memory allocation or data copying. This method is backed by a new package-private constructor (zero-copy constuctor) which automatically calculates the number of elements from the segment size, providing significant performance improvements for scenarios where `TornadoNativeArray`s need to be created from pre-existing memory regions.

The new constructor signature  i.e. for `FloatArray` is: `public FloatArray(MemorySegment existingSegment)`

#### Problem description
Previously, creating a `TornadoNativeArray` (i.e. a `FloatArray`) from existing memory required either:
1. Using `fromSegment()` which copies data from the source segment
2. Manual allocation and data copying operations

Both approaches incur significant performance overhead, especially for large arrays, due to memory allocation and data copying operations. This is particularly problematic in GPU computing scenarios where memory management efficiency is critical.

#### Backend/s tested
- [x] OpenCL
- [ ] PTX  
- [ ] SPIRV

#### OS tested
- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?
- [ ] Yes
- [x] No

#### How to test the new patch?

**Run unit tests:**
```bash
tornado-test -V uk.ac.manchester.tornado.unittests.api.TestAPI
```

**Run performance benchmark:**
```bash
tornado -m tornado.examples/uk.ac.manchester.tornado.examples.arrays.TornadoNativeArrayInit
```

The performance benchmark will demonstrate the speedup achieved by the `fromSegmentShallow()` methods and zero-copy constructor compared to regular constructor and `fromSegment()` methods across different array sizes (1K to 1M elements).