### PR TITLE
[fix] Remove @ prefix from inline Truffle export flags

### DIFF
--- a/tornado-assembly/src/bin/tornado.py
+++ b/tornado-assembly/src/bin/tornado.py
@@ -1003,16 +1003,30 @@ class TornadoVMRunnerTool():
             ptx = self.truffleCompatibleExports(ptx)
             spirv = self.truffleCompatibleExports(spirv)
 
-        javaFlags = javaFlags + " @" + common + " "
-        if ("opencl-backend" in self.listOfBackends):
-            javaFlags = javaFlags + "@" + opencl + " "
-            tornadoAddModules = tornadoAddModules + "," + __OPENCL_MODULE__
-        if ("spirv-backend" in self.listOfBackends):
-            javaFlags = javaFlags + "@" + opencl + " @" + spirv + " "
-            tornadoAddModules = tornadoAddModules + "," + __OPENCL_MODULE__
-        if ("ptx-backend" in self.listOfBackends):
-            javaFlags = javaFlags + "@" + ptx + " "
-            tornadoAddModules = tornadoAddModules + "," + __PTX_MODULE__
+        # For Truffle, exports are already expanded inline (no @ prefix needed)
+        # For Java, use @ to read from file
+        if (self.isTruffleCommand):
+            javaFlags = javaFlags + " " + common + " "
+            if ("opencl-backend" in self.listOfBackends):
+                javaFlags = javaFlags + opencl + " "
+                tornadoAddModules = tornadoAddModules + "," + __OPENCL_MODULE__
+            if ("spirv-backend" in self.listOfBackends):
+                javaFlags = javaFlags + opencl + " " + spirv + " "
+                tornadoAddModules = tornadoAddModules + "," + __OPENCL_MODULE__
+            if ("ptx-backend" in self.listOfBackends):
+                javaFlags = javaFlags + ptx + " "
+                tornadoAddModules = tornadoAddModules + "," + __PTX_MODULE__
+        else:
+            javaFlags = javaFlags + " @" + common + " "
+            if ("opencl-backend" in self.listOfBackends):
+                javaFlags = javaFlags + "@" + opencl + " "
+                tornadoAddModules = tornadoAddModules + "," + __OPENCL_MODULE__
+            if ("spirv-backend" in self.listOfBackends):
+                javaFlags = javaFlags + "@" + opencl + " @" + spirv + " "
+                tornadoAddModules = tornadoAddModules + "," + __OPENCL_MODULE__
+            if ("ptx-backend" in self.listOfBackends):
+                javaFlags = javaFlags + "@" + ptx + " "
+                tornadoAddModules = tornadoAddModules + "," + __PTX_MODULE__
 
         javaFlags = javaFlags + tornadoAddModules + " "
 


### PR DESCRIPTION
### Fix description

This PR adds a fix that separates the logic:
  - For Truffle: Don't use @ prefix since arguments are already expanded inline
  - For Java: Keep @ prefix to read from files

**Disclaimer:** This fix is for Linux/macOS. For Windows, it may fail to run TornadoVM with Truffle languages.

### Problem description

I triggered a bug that was introduced when building TornadoVM with polyglot Truffle, after the changes we did in #738.

The bug was in `tornado-assembly/src/bin/tornado.py` in the `buildJavaCommand()` method (lines 1000-1015).

**Short description:** When running Truffle languages, the code was incorrectly mixing file reference syntax (@filepath) with inline argument strings.
```bash
graalpython: No such file or directory -- @--vm.-add-exports=jdk.internal.vm.compiler/org.graalvm.compiler.nodes.cfg=tornado.runtime
```

How It Worked Before (Correctly for Java)

#####  For normal Java execution:

  1. Export files (e.g., common-exports) contain JVM arguments like:
  --add-exports jdk.internal.vm.compiler/org.graalvm.compiler.nodes.cfg=tornado.runtime
  2. These are passed to Java using argfile syntax:
  java @/path/to/common-exports ...
  3. The @ tells the JVM to read arguments from that file.

##### What Went Wrong for Truffle

  For Truffle execution:
  1. Lines 1001-1004 called truffleCompatibleExports() which:
    - Reads the export file content
    - Converts --add-exports → --vm.-add-exports (Truffle format)
    - Replaces spaces with = for Truffle's argument format
    - Returns the expanded string, not a file path!
  2. Line 1006 then incorrectly added the @ prefix:
  javaFlags = javaFlags + " @" + common + " "
  3. This created: 
  @--vm.-add-exports=jdk.internal.vm.compiler/org.graalvm.compiler.nodes.cfg=tornado.ru
  ntime
  5. TruffleRuby interpreted @--vm.-add-exports=... as "read from a file named --vm.-add-exports=..." 

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

To test it, someone needs to either build the [docker-tornado](https://github.com/beehive-lab/docker-tornadovm) image and checkout to this branch in the Dockerfile ([line 51](https://github.com/beehive-lab/docker-tornadovm/blob/4f66e3faf20bdb0cf6ed9e32a7a9c7904523c522/polyglotImages/polyglot-graalpy/Dockerfile.nvidia.opencl.graalpy.jdk21#L51)), to run the test:
```bash
./polyglotImages/polyglot-graalpy/tornadovm-polyglot-nvidia.sh tornado --printKernel --truffle python /tornado-dev/tornado/bin/sdk/examples/polyglotTruffle/mxmWithTornadoVM.py
```

or have already built `GraalPython`:
```bash
export GRAALPY_HOME=/ssd-a/repositories/graalpy-dev/graal/sdk/mxbuild/linux-amd64/GRAALVM_03DCD25EA1_JAVA21/graalvm-03dcd25ea1-java21-23.1.0-dev
```

```bash
cd <path-to-tornado-root>
export JAVA_HOME=<point-to-graal-jdk21>
make graal-jdk-21
source setvars.sh
tornado --printKernel --truffle python $TORNADO_SDK/examples/polyglotTruffle/mxmWithTornadoVM.py
```

----------------------------------------------------------------------------
