### PR TITLE
[cicd] Prevent workflows from running on forks

### DIFF
--- a/.github/workflows/build-test-with-graalvm-and-polyglot.yml
+++ b/.github/workflows/build-test-with-graalvm-and-polyglot.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-graalvm:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [ self-hosted, Linux, x64 ]
     timeout-minutes: 5
     strategy:
@@ -41,6 +42,7 @@ jobs:
           make graal-jdk-21 BACKEND=ptx,opencl,spirv
 
   tornadovm-graalvm-fast-tests:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [ self-hosted, Linux, x64 ]
     needs: build-graalvm
     timeout-minutes: 30
@@ -83,6 +85,7 @@ jobs:
           tornado-test --ea --verbose --jvm="-Dtornado.unittests.device=2:0" -qp
 
   tornadovm-graalvm-polyglot-tests:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [ self-hosted, Linux, x64 ]
     needs: tornadovm-graalvm-fast-tests
     timeout-minutes: 5

--- a/.github/workflows/build-test-with-jdks.yml
+++ b/.github/workflows/build-test-with-jdks.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-jdk-matrix:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [ self-hosted, Linux, x64 ]
     timeout-minutes: 180
     strategy:

--- a/.github/workflows/deploy-maven-central.yml
+++ b/.github/workflows/deploy-maven-central.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository == 'beehive-lab/TornadoVM'
     name: Deploy to Maven Central
     runs-on: [self-hosted, Linux, x64]
     timeout-minutes: 15

--- a/.github/workflows/fast-test.yml
+++ b/.github/workflows/fast-test.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   code-quality:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [self-hosted, Linux, x64]
     env:
       JAVA_HOME: /opt/jenkins/jdks/graal-23.1.0/jdk-21.0.3
@@ -26,6 +27,7 @@ jobs:
 
   # OpenCL first
   build-opencl:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [self-hosted, Linux, x64]
     needs: code-quality
     timeout-minutes: 20
@@ -66,6 +68,7 @@ jobs:
 
   # PTX after OpenCL
   build-ptx:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [self-hosted, Linux, x64]
     needs: build-opencl                      # Waits for OpenCL
     timeout-minutes: 20
@@ -105,6 +108,7 @@ jobs:
 
   # SPIRV parallel with OpenCL/PTX chain
   build-spirv:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [self-hosted, Linux, x64]
     needs: code-quality                      # Only waits for code-quality
     timeout-minutes: 20
@@ -142,6 +146,7 @@ jobs:
           source setvars.sh
           make fast-tests
   build-macOs-opencl:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [self-hosted, macOS, arm64]
     needs: code-quality
     timeout-minutes: 45

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -17,10 +17,11 @@ on:
 
 jobs:
   create-release-tag:
-    # Run when release PR merges OR manual trigger
+    # Run when release PR merges OR manual trigger (upstream repo only)
     if: |
-      (github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')) ||
-      github.event_name == 'workflow_dispatch'
+      github.repository == 'beehive-lab/TornadoVM' &&
+      ((github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')) ||
+      github.event_name == 'workflow_dispatch')
     runs-on: [self-hosted, Linux, x64]
     permissions:
       contents: write
@@ -107,6 +108,7 @@ jobs:
             console.log(`✅ Created release: ${release.html_url}`);
 
   update-develop:
+    if: github.repository == 'beehive-lab/TornadoVM'
     needs: create-release-tag
     runs-on: [self-hosted, Linux, x64]
     permissions:

--- a/.github/workflows/heavy-memory-tests.yml
+++ b/.github/workflows/heavy-memory-tests.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-full-test-openjdk:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [ self-hosted, Linux, x64 ]
     timeout-minutes: 200
     strategy:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   prepare-release:
+    if: github.repository == 'beehive-lab/TornadoVM'
     runs-on: [self-hosted, Linux, x64]
     permissions:
       contents: write

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -7,8 +7,9 @@ on:
 jobs:
   rerun:
     name: Rerun CI Workflows
-    # Only run on PR comments (not issue comments) with /rerun command
+    # Only run on PR comments (not issue comments) with /rerun command in upstream repo
     if: |
+      github.repository == 'beehive-lab/TornadoVM' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/rerun')
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Description

This PR adds repository checks to all GitHub workflows to prevent execution on forks. This avoids failures due to missing self-hosted runners, secrets, etc.

Workflows will now skip execution when triggered on forked repositories, improving the contributor experience and preventing resource waste.

----------------------------------------------------------------------------
