### PR TITLE
[feat] Add new action to push default tornadovm version

### DIFF
--- a/.github/workflows/publish-archives-to-sdkman.yml
+++ b/.github/workflows/publish-archives-to-sdkman.yml
@@ -95,7 +95,7 @@ jobs:
           url: ${{ steps.vars.outputs.url }}
   set-sdkman-default:
     name: Set TornadoVM default version on SDKMAN
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, Linux, x64 ]
     needs: publish-to-sdkman
 
     if: >


### PR DESCRIPTION
#### Description

This PR adds a final job in the `publish-archives-to-sdkman` GitHub workflow, that pushes the default version of the release. This job will have a dependency on the previous job that publishes the archives.

----------------------------------------------------------------------------
