### PR TITLE
Same variable in single class

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -189,6 +189,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.logic.TestLogic"),
     TestEntry("uk.ac.manchester.tornado.unittests.fields.TestFields"),
     TestEntry("uk.ac.manchester.tornado.unittests.fields.TestInheritedFields"),
+    TestEntry("uk.ac.manchester.tornado.unittests.fields.TestSameVariableDifferentClass"),
     TestEntry("uk.ac.manchester.tornado.unittests.profiler.TestProfiler"),
     TestEntry("uk.ac.manchester.tornado.unittests.bitsets.BitSetTests"),
     TestEntry("uk.ac.manchester.tornado.unittests.quantization.QuantizationTests"),

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/FieldBuffer.java
@@ -99,4 +99,7 @@ public class FieldBuffer {
         return objectBuffer.getBufferOffset();
     }
 
+    public XPUBuffer getObjectBuffer() {
+        return objectBuffer;
+    }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fields/TestInheritedFields.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fields/TestInheritedFields.java
@@ -27,34 +27,36 @@ public class TestInheritedFields extends TornadoTestBase {
 
     public static class PrimitiveA {
         public final float[] valueA;
-        public PrimitiveA(int size){
+
+        public PrimitiveA(int size) {
             valueA = new float[size];
         }
     }
 
     public static class PrimitiveB extends PrimitiveA {
         public final float[] valueB;
-        public PrimitiveB(int size){
+
+        public PrimitiveB(int size) {
             super(size);
             valueB = new float[size];
         }
     }
 
-    public static void incrementPrimitiveA(PrimitiveA a, int size){
-        for(@Parallel int i = 0; i<size; i++){
+    public static void incrementPrimitiveA(PrimitiveA a, int size) {
+        for (@Parallel int i = 0; i < size; i++) {
             a.valueA[i] += 1f;
         }
     }
 
-    public static void incrementPrimitiveB(PrimitiveB b, int size){
-        for(@Parallel int i = 0; i<size; i++){
+    public static void incrementPrimitiveB(PrimitiveB b, int size) {
+        for (@Parallel int i = 0; i < size; i++) {
             b.valueA[i] += 1f;
             b.valueB[i] += 1f;
         }
     }
 
     @Test
-    public void testIncrementPrimitiveB(){
+    public void testIncrementPrimitiveB() {
         final int N = 1000;
         PrimitiveB b = new PrimitiveB(N);
 
@@ -63,17 +65,17 @@ public class TestInheritedFields extends TornadoTestBase {
         tg.task("t0", TestInheritedFields::incrementPrimitiveB, b, N);
         tg.transferToHost(DataTransferMode.EVERY_EXECUTION, b);
 
-        try(TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())){
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())) {
             executionPlan.execute();
             assertEquals(1f, b.valueA[0], 0.0);
             assertEquals(1f, b.valueB[0], 0.0);
-        } catch (TornadoExecutionPlanException e){
+        } catch (TornadoExecutionPlanException e) {
             e.printStackTrace();
         }
     }
 
     @Test
-    public void testIncrementPrimitiveAB(){
+    public void testIncrementPrimitiveAB() {
         final int N = 1000;
         PrimitiveB b = new PrimitiveB(N);
 
@@ -83,11 +85,11 @@ public class TestInheritedFields extends TornadoTestBase {
         tg.task("t1", TestInheritedFields::incrementPrimitiveB, b, N);
         tg.transferToHost(DataTransferMode.EVERY_EXECUTION, b);
 
-        try(TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())){
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())) {
             executionPlan.execute();
             assertEquals(2f, b.valueA[0], 0.0);
             assertEquals(1f, b.valueB[0], 0.0);
-        } catch (TornadoExecutionPlanException e){
+        } catch (TornadoExecutionPlanException e) {
             e.printStackTrace();
         }
     }
@@ -99,34 +101,36 @@ public class TestInheritedFields extends TornadoTestBase {
 
     public static class TornadoA {
         public final FloatArray valueA;
-        public TornadoA(int size){
+
+        public TornadoA(int size) {
             valueA = new FloatArray(size);
         }
     }
 
     public static class TornadoB extends TornadoA {
         public final FloatArray valueB;
-        public TornadoB(int size){
+
+        public TornadoB(int size) {
             super(size);
             valueB = new FloatArray(size);
         }
     }
 
-    public static void incrementTornadoA(TornadoA a, int size){
-        for(@Parallel int i = 0; i<size; i++){
+    public static void incrementTornadoA(TornadoA a, int size) {
+        for (@Parallel int i = 0; i < size; i++) {
             a.valueA.set(i, a.valueA.get(i) + 1f);
         }
     }
 
-    public static void incrementTornadoB(TornadoB b, int size){
-        for(@Parallel int i = 0; i<size; i++){
+    public static void incrementTornadoB(TornadoB b, int size) {
+        for (@Parallel int i = 0; i < size; i++) {
             b.valueA.set(i, b.valueA.get(i) + 1f);
             b.valueB.set(i, b.valueB.get(i) + 1f);
         }
     }
 
     @Test
-    public void testIncrementTornadoB(){
+    public void testIncrementTornadoB() {
         final int N = 1000;
         TornadoB b = new TornadoB(N);
 
@@ -135,17 +139,17 @@ public class TestInheritedFields extends TornadoTestBase {
         tg.task("t0", TestInheritedFields::incrementTornadoB, b, N);
         tg.transferToHost(DataTransferMode.EVERY_EXECUTION, b);
 
-        try(TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())){
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())) {
             executionPlan.execute();
             assertEquals(1f, b.valueA.get(0), 0.0);
             assertEquals(1f, b.valueB.get(0), 0.0);
-        } catch (TornadoExecutionPlanException e){
+        } catch (TornadoExecutionPlanException e) {
             e.printStackTrace();
         }
     }
 
     @Test
-    public void testIncrementTornadoAB(){
+    public void testIncrementTornadoAB() {
         final int N = 1000;
         TornadoB b = new TornadoB(N);
 
@@ -155,11 +159,69 @@ public class TestInheritedFields extends TornadoTestBase {
         tg.task("t1", TestInheritedFields::incrementTornadoB, b, N);
         tg.transferToHost(DataTransferMode.EVERY_EXECUTION, b);
 
-        try(TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())){
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())) {
             executionPlan.execute();
             assertEquals(2f, b.valueA.get(0), 0.0);
             assertEquals(1f, b.valueB.get(0), 0.0);
-        } catch (TornadoExecutionPlanException e){
+        } catch (TornadoExecutionPlanException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /*
+     * Same array referenced by inherited field and contained object
+     */
+
+    public abstract static class SuperClasse {
+        public final float[] x;
+
+        public SuperClasse(float[] x) {
+            this.x = x;
+        }
+    }
+
+    public static class Classe extends SuperClasse {
+        public final Oggetto oggetto;
+
+        public Classe() {
+            this(new Oggetto());
+        }
+
+        private Classe(Oggetto oggetto) {
+            super(oggetto.x);
+            this.oggetto = oggetto;
+        }
+    }
+
+    public static class Oggetto {
+        public final float[] x;
+
+        public Oggetto() {
+            this.x = new float[1000];
+        }
+    }
+
+    public static void increment(Classe a) {
+        for (@Parallel int i = 0; i < 1000; i++) {
+            a.oggetto.x[i] += 1f;
+            a.x[i] += 1f;
+        }
+    }
+
+    @Test
+    public void testIncrementSameVariable(){
+        Classe a = new Classe();
+
+        TaskGraph tg = new TaskGraph("tg");
+        tg.transferToDevice(DataTransferMode.FIRST_EXECUTION, a);
+        tg.task("t0", TestInheritedFields::increment, a);
+        tg.transferToHost(DataTransferMode.EVERY_EXECUTION, a);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())) {
+            executionPlan.execute();
+            assertEquals(2f, a.oggetto.x[0], 0.0);
+            assertEquals(2f, a.x[0], 0.0);
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fields/TestSameVariableDifferentClass.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fields/TestSameVariableDifferentClass.java
@@ -1,0 +1,64 @@
+package uk.ac.manchester.tornado.unittests.fields;
+
+import org.junit.Test;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * <p>
+ * How to test?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.fields.TestSameVariableDifferentClass
+ * </code>
+ */
+public class TestSameVariableDifferentClass extends TornadoTestBase {
+
+    public static class Classe {
+        public final Oggetto oggetto1;
+        public final Oggetto oggetto2;
+
+        public Classe(float[] x) {
+            oggetto1 = new Oggetto(x);
+            oggetto2 = new Oggetto(x);
+        }
+    }
+
+    public static class Oggetto {
+        public final float[] x;
+
+        public Oggetto(float[] x) {
+            this.x = x;
+        }
+    }
+
+    public static void increment(Classe a) {
+        for (@Parallel int i = 0; i < 1000; i++) {
+            a.oggetto1.x[i] += 1f;
+            a.oggetto2.x[i] += 1f;
+        }
+    }
+
+    @Test
+    public void testIncrementSameVariable(){
+        float[] x = new float[1000];
+        Classe a = new Classe(x);
+
+        TaskGraph tg = new TaskGraph("tg");
+        tg.transferToDevice(DataTransferMode.FIRST_EXECUTION, a);
+        tg.task("t0", TestSameVariableDifferentClass::increment, a);
+        tg.transferToHost(DataTransferMode.EVERY_EXECUTION, a);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())) {
+            executionPlan.execute();
+            if (a.oggetto1.x[0] != 2f || a.oggetto2.x[0] != 2f) {
+                throw new IllegalArgumentException("Non uguali! " + a.oggetto1.x[0] + " != " + a.oggetto2.x[0]);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Updated OCLFieldBuffer to correctly handle shared object references across multiple fields. The new implementation uses IdentityHashMap-based tracking and “unique buffer” sets to reuse wrappers and avoid duplicating device allocations, offsets, reads, and writes for the same underlying object.

#### Problem description

Previously, if two (or more) fields referenced the same array/object (e.g., inherited field and instance field pointing to the same float[]), TornadoVM would wrap and process them multiple times. This caused duplicated buffer mapping and repeated transfers (and could lead to wrong offsets / inconsistent device memory layout), breaking correctness and wasting memory/bandwidth.

#### Limitation

This deduplication works only for identical references discovered while walking the fields of the same class/object graph. If two distinct root objects reference the same nested object, they are still wrapped independently, resulting in two separate device buffers.

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [ ] OSx
- [X] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Implemented test cases
