### PR TITLE
[fix] Handle Windows CRLF line endings in virtual device tests and native tests & Update Makefile.mak

### DIFF
--- a/Makefile.mak
+++ b/Makefile.mak
@@ -1,38 +1,38 @@
 all: build
 
-# Variable passed for the build process. It specifies which backend/s to use { opencl, ptx, spirv }. The default one is `opencl`.
+# Variable passed for the build process. List of backend/s to use { opencl, ptx, spirv }. The default one is `opencl`.
 # nmake BACKENDS="<comma_separated_backend_list>"
 BACKEND = opencl
 
-build jdk21:
-	python bin\compile --jdk jdk21 --backend $(BACKEND)
+build jdk25:
+	python bin\compile --jdk jdk25 --backend $(BACKEND)
 
-rebuild-deps:
-	python bin\compile --jdk graal-jdk-21 --rebuild --backend $(BACKEND)
+rebuild-deps-jdk25:
+	python bin\compile --jdk jdk25 --rebuild --backend $(BACKEND)
 
-graal-jdk-21:
-	python bin\compile --jdk graal-jdk-21 --backend $(BACKEND)
+graal-jdk-25:
+	python bin\compile --jdk graal-jdk-25 --backend $(BACKEND)
 
 polyglot:
-	python bin\compile --jdk graal-jdk-21 --backend $(BACKEND) --polyglot
+	python bin\compile --jdk graal-jdk-25 --backend $(BACKEND) --polyglot
 
-mvn-single-threaded-jdk21:
-	python bin/compile --jdk jdk21 --backend $(BACKEND) --mvn_single_threaded
+mvn-single-threaded-jdk25:
+	python bin/compile --jdk jdk25 --backend $(BACKEND) --mvn_single_threaded
 
-mvn-single-threaded-graal-jdk-21:
-	python bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded
+mvn-single-threaded-graal-jdk-25:
+	python bin/compile --jdk graal-jdk-25 --backend $(BACKEND) --mvn_single_threaded
 
 mvn-single-threaded-polyglot:
-	python bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded --polyglot
+	python bin/compile --jdk graal-jdk-25 --backend $(BACKEND) --mvn_single_threaded --polyglot
 
 ptx:
-	python bin\compile --jdk graal-jdk-21 --backend ptx,opencl
+	python bin\compile --jdk jdk25 --backend ptx,opencl
 
 spirv:
-	python bin\compile --jdk graal-jdk-21 --backend spirv,ptx,opencl
+	python bin\compile --jdk jdk25 --backend spirv,ptx,opencl
 
 sdk:
-	python bin\compile --jdk jdk21 --sdk --backend $(BACKEND)
+	python bin\compile --jdk jdk25 --sdk --backend $(BACKEND)
 
 # Variable passed for the preparation of the Xilinx FPGA emulated target device. The default device is `xilinx_u50_gen3x16_xdma_201920_3`.
 # make xilinx_emulation FPGA_PLATFORM=<platform_name> NUM_OF_FPGA_DEVICES=<number_of_devices>
@@ -54,19 +54,50 @@ example:
 tests:
 	del /f tornado_unittests.log
 	%TORNADOVM_HOME%\bin\tornado.exe --devices
-	%TORNADOVM_HOME%\bin\tornado-test.exe --ea --verbose
-	%TORNADOVM_HOME%\bin\tornado-test.exe --ea -V -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
+	%TORNADOVM_HOME%\bin\tornado-test.exe --verbose
+	%TORNADOVM_HOME%\bin\tornado-test.exe -V -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
+	%TORNADOVM_HOME%\bin\test-native.cmd
+
+fast-tests:
+	del /f tornado_unittests.log
+	%TORNADOVM_HOME%\bin\tornado.exe --devices
+	%TORNADOVM_HOME%\bin\tornado-test.exe --verbose --quickPass
+	%TORNADOVM_HOME%\bin\tornado-test.exe -V -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
 	%TORNADOVM_HOME%\bin\test-native.cmd
 
 tests-uncompressed:
 	del /f tornado_unittests.log
 	python %TORNADOVM_HOME%\bin\tornado --devices
-	python %TORNADOVM_HOME%\bin\tornado-test --ea --verbose --uncompressed
-	python %TORNADOVM_HOME%\bin\tornado-test --ea -V --uncompressed -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
+	python %TORNADOVM_HOME%\bin\tornado-test --verbose --uncompressed
+	python %TORNADOVM_HOME%\bin\tornado-test -V --uncompressed -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
+	%TORNADOVM_HOME%\bin\test-native.cmd
+
+fast-tests-uncompressed:
+	del /f tornado_unittests.log
+	python %TORNADOVM_HOME%\bin\tornado --devices
+	python %TORNADOVM_HOME%\bin\tornado-test --verbose --quickPass --uncompressed
+	python %TORNADOVM_HOME%\bin\tornado-test -V --uncompressed -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
+	%TORNADOVM_HOME%\bin\test-native.cmd
+
+tests-spirv-levelzero:
+	del /f tornado_unittests.log
+	%TORNADOVM_HOME%\bin\tornado.exe --jvm="-Dtornado.spirv.dispatcher=levelzero" uk.ac.manchester.tornado.drivers.TornadoDeviceQuery --params="verbose"
+	%TORNADOVM_HOME%\bin\tornado-test.exe --jvm="-Dtornado.spirv.dispatcher=levelzero" --verbose
+	%TORNADOVM_HOME%\bin\tornado-test.exe --jvm="-Dtornado.spirv.dispatcher=levelzero" -V -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
+	%TORNADOVM_HOME%\bin\test-native.cmd
+
+tests-spirv-opencl:
+	del /f tornado_unittests.log
+	%TORNADOVM_HOME%\bin\tornado.exe --jvm="-Dtornado.spirv.dispatcher=opencl" uk.ac.manchester.tornado.drivers.TornadoDeviceQuery --params="verbose"
+	%TORNADOVM_HOME%\bin\tornado-test.exe --jvm="-Dtornado.spirv.dispatcher=opencl" --verbose
+	%TORNADOVM_HOME%\bin\tornado-test.exe --jvm="-Dtornado.spirv.dispatcher=opencl" -V -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
 	%TORNADOVM_HOME%\bin\test-native.cmd
 
 test-slam:
 	%TORNADOVM_HOME%\bin\tornado-test.exe -V --fast uk.ac.manchester.tornado.unittests.slam.GraphicsTests
+
+docs:
+	sphinx-build -M html docs/source/ docs/build
 
 # Generate IntelliJ IDEA project files (developer-only)
 # Prerequisites: build TornadoVM first and run setvars.cmd

--- a/Makefile.mak
+++ b/Makefile.mak
@@ -7,8 +7,8 @@ BACKEND = opencl
 build jdk21:
 	python bin\compile --jdk jdk21 --backend $(BACKEND)
 
-rebuild-deps-jdk21:
-	python bin\compile --jdk jdk21 --rebuild --backend $(BACKEND)
+rebuild-deps:
+	python bin\compile --jdk graal-jdk-21 --rebuild --backend $(BACKEND)
 
 graal-jdk-21:
 	python bin\compile --jdk graal-jdk-21 --backend $(BACKEND)
@@ -26,10 +26,10 @@ mvn-single-threaded-polyglot:
 	python bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded --polyglot
 
 ptx:
-	python bin\compile --jdk jdk21 --backend ptx,opencl
+	python bin\compile --jdk graal-jdk-21 --backend ptx,opencl
 
 spirv:
-	python bin\compile --jdk jdk21 --backend spirv,ptx,opencl
+	python bin\compile --jdk graal-jdk-21 --backend spirv,ptx,opencl
 
 sdk:
 	python bin\compile --jdk jdk21 --sdk --backend $(BACKEND)

--- a/Makefile.mak
+++ b/Makefile.mak
@@ -4,35 +4,35 @@ all: build
 # nmake BACKENDS="<comma_separated_backend_list>"
 BACKEND = opencl
 
-build jdk25:
-	python bin\compile --jdk jdk25 --backend $(BACKEND)
+build jdk21:
+	python bin\compile --jdk jdk21 --backend $(BACKEND)
 
-rebuild-deps-jdk25:
-	python bin\compile --jdk jdk25 --rebuild --backend $(BACKEND)
+rebuild-deps-jdk21:
+	python bin\compile --jdk jdk21 --rebuild --backend $(BACKEND)
 
-graal-jdk-25:
-	python bin\compile --jdk graal-jdk-25 --backend $(BACKEND)
+graal-jdk-21:
+	python bin\compile --jdk graal-jdk-21 --backend $(BACKEND)
 
 polyglot:
-	python bin\compile --jdk graal-jdk-25 --backend $(BACKEND) --polyglot
+	python bin\compile --jdk graal-jdk-21 --backend $(BACKEND) --polyglot
 
-mvn-single-threaded-jdk25:
-	python bin/compile --jdk jdk25 --backend $(BACKEND) --mvn_single_threaded
+mvn-single-threaded-jdk21:
+	python bin/compile --jdk jdk21 --backend $(BACKEND) --mvn_single_threaded
 
-mvn-single-threaded-graal-jdk-25:
-	python bin/compile --jdk graal-jdk-25 --backend $(BACKEND) --mvn_single_threaded
+mvn-single-threaded-graal-jdk-21:
+	python bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded
 
 mvn-single-threaded-polyglot:
-	python bin/compile --jdk graal-jdk-25 --backend $(BACKEND) --mvn_single_threaded --polyglot
+	python bin/compile --jdk graal-jdk-21 --backend $(BACKEND) --mvn_single_threaded --polyglot
 
 ptx:
-	python bin\compile --jdk jdk25 --backend ptx,opencl
+	python bin\compile --jdk jdk21 --backend ptx,opencl
 
 spirv:
-	python bin\compile --jdk jdk25 --backend spirv,ptx,opencl
+	python bin\compile --jdk jdk21 --backend spirv,ptx,opencl
 
 sdk:
-	python bin\compile --jdk jdk25 --sdk --backend $(BACKEND)
+	python bin\compile --jdk jdk21 --sdk --backend $(BACKEND)
 
 # Variable passed for the preparation of the Xilinx FPGA emulated target device. The default device is `xilinx_u50_gen3x16_xdma_201920_3`.
 # make xilinx_emulation FPGA_PLATFORM=<platform_name> NUM_OF_FPGA_DEVICES=<number_of_devices>

--- a/tornado-assembly/src/bin/test-native.cmd
+++ b/tornado-assembly/src/bin/test-native.cmd
@@ -2,32 +2,32 @@
 
 for /f %%b in (%TORNADOVM_HOME%\etc\tornado.backend) do set backends=%%b
 
-echo %backends% | findstr "\<opencl\>" >nul 2>nul
+echo %backends% | findstr "opencl" >nul 2>nul
+if not errorlevel 1 (
+	echo:
+	echo Testing the native OpenCL API
+	echo:
+	%TORNADOVM_HOME%\bin\tornado.exe uk.ac.manchester.tornado.drivers.opencl.tests.TestOpenCLJITCompiler
+	%TORNADOVM_HOME%\bin\tornado.exe uk.ac.manchester.tornado.drivers.opencl.tests.TestOpenCLTornadoCompiler
+)
+echo %backends% | findstr "ptx" >nul 2>nul
 if not errorlevel 1 (
 	echo:
 	echo Testing the native PTX API
 	echo:
-	python %TORNADOVM_HOME%\bin\tornado uk.ac.manchester.tornado.drivers.ptx.tests.TestPTXJITCompiler
-	python %TORNADOVM_HOME%\bin\tornado uk.ac.manchester.tornado.drivers.ptx.tests.TestPTXTornadoCompiler
+	%TORNADOVM_HOME%\bin\tornado.exe uk.ac.manchester.tornado.drivers.ptx.tests.TestPTXJITCompiler
+	%TORNADOVM_HOME%\bin\tornado.exe uk.ac.manchester.tornado.drivers.ptx.tests.TestPTXTornadoCompiler
 )
-echo %backends% | findstr "\<ptx\>" >nul 2>nul
-if not errorlevel 1 (
-	echo:
-	echo Testing the native OpenCL API
-	echo:
-	python %TORNADOVM_HOME%\bin\tornado uk.ac.manchester.tornado.drivers.opencl.tests.TestOpenCLJITCompiler
-	python %TORNADOVM_HOME%\bin\tornado uk.ac.manchester.tornado.drivers.opencl.tests.TestOpenCLTornadoCompiler
-)
-echo %backends% | findstr "\<spirv\>" >nul 2>nul
+echo %backends% | findstr "spirv" >nul 2>nul
 if not errorlevel 1 (
 	echo:
 	echo Testing the native SPIR-V API
 	echo:
-	python %TORNADOVM_HOME%\bin\tornado uk.ac.manchester.tornado.drivers.spirv.tests.TestSPIRVJITCompiler
-	python %TORNADOVM_HOME%\bin\tornado uk.ac.manchester.tornado.drivers.spirv.tests.TestSPIRVTornadoCompiler
+	%TORNADOVM_HOME%\bin\tornado.exe uk.ac.manchester.tornado.drivers.spirv.tests.TestSPIRVJITCompiler
+	%TORNADOVM_HOME%\bin\tornado.exe uk.ac.manchester.tornado.drivers.spirv.tests.TestSPIRVTornadoCompiler
 	echo:
 	echo Testing the native OpenCL API
 	echo:
-	python %TORNADOVM_HOME%\bin\tornado uk.ac.manchester.tornado.drivers.opencl.tests.TestOpenCLJITCompiler
-	python %TORNADOVM_HOME%\bin\tornado uk.ac.manchester.tornado.drivers.opencl.tests.TestOpenCLTornadoCompiler
+	%TORNADOVM_HOME%\bin\tornado.exe uk.ac.manchester.tornado.drivers.opencl.tests.TestOpenCLJITCompiler
+	%TORNADOVM_HOME%\bin\tornado.exe uk.ac.manchester.tornado.drivers.opencl.tests.TestOpenCLTornadoCompiler
 )

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualJSONParser.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/virtual/VirtualJSONParser.java
@@ -40,7 +40,7 @@ import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEV
 
 public class VirtualJSONParser {
 
-    private static final Pattern pattern =  Pattern.compile(" |\",|\"|\t|]|\\[");
+    private static final Pattern pattern =  Pattern.compile(" |\",|\"|\t|\\r|]|\\[");
 
     private enum JsonKey {
         deviceName,
@@ -53,7 +53,7 @@ public class VirtualJSONParser {
     }
 
     public static VirtualDeviceDescriptor getDeviceDescriptor() {
-        String json = readVirtualDeviceJson();
+        String json = readVirtualDeviceJson().replace("\r", "");
         HashMap<JsonKey, String> jsonEntries = new HashMap<>();
         for (String line : json.split("\n")) {
             Matcher matcher = pattern.matcher(line);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceFeatureExtraction.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceFeatureExtraction.java
@@ -50,6 +50,7 @@ public class TestVirtualDeviceFeatureExtraction extends TornadoTestBase {
 
     private static final byte TAB = 0x9;
     private static final byte NEWLINE = 0xA;
+    private static final byte CARRIAGE_RETURN = 0xD;
     private static final byte WHITESPACE = 0x20;
 
     private static final String FEATURE_DUMP_DIR = System.getProperty("tornado.features.dump.dir");
@@ -64,7 +65,7 @@ public class TestVirtualDeviceFeatureExtraction extends TornadoTestBase {
     public static long getByteSum(byte[] bytes) {
         long sum = 0;
         for (byte entry : bytes) {
-            if (entry == TAB || entry == NEWLINE || entry == WHITESPACE) {
+            if (entry == TAB || entry == NEWLINE || entry == CARRIAGE_RETURN || entry == WHITESPACE) {
                 continue;
             }
             sum += entry;
@@ -81,9 +82,11 @@ public class TestVirtualDeviceFeatureExtraction extends TornadoTestBase {
     @After
     public void after() {
         // make sure the source file generated is deleted
-        File fileLog = new File(FEATURE_DUMP_DIR);
-        if (fileLog.exists()) {
-            fileLog.delete();
+        if (FEATURE_DUMP_DIR != null) {
+            File fileLog = new File(FEATURE_DUMP_DIR);
+            if (fileLog.exists()) {
+                fileLog.delete();
+            }
         }
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceKernel.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/virtual/TestVirtualDeviceKernel.java
@@ -61,9 +61,11 @@ public class TestVirtualDeviceKernel extends TornadoTestBase {
     @After
     public void after() {
         // make sure the source file generated is deleted
-        File fileLog = new File(SOURCE_DIR);
-        if (fileLog.exists()) {
-            fileLog.delete();
+        if (SOURCE_DIR != null) {
+            File fileLog = new File(SOURCE_DIR);
+            if (fileLog.exists()) {
+                fileLog.delete();
+            }
         }
     }
 


### PR DESCRIPTION
#### Description

This PR resolves some issues that caused the virtual devices and virtual features unit-tests to fail on Windows.
Additionally, it extended the `Makefile.mak` to include  the same rules of `Makefile`.

**Summary**
  - Fix virtual device tests (`TestVirtualDeviceKernel`, `TestVirtualDeviceFeatureExtraction`) failing on Windows due to CRLF (\r\n) line endings
  - `VirtualJSONParser` failed to parse the virtual device JSON file because `\r` characters prevented trailing comma stripping, causing NumberFormatException.
  - performComparison() in test assertions did not exclude `\r` (0x0D) from byte checksums, causing mismatches between Windows-generated output and Linux reference files
  - Added null guards in `@After` cleanup methods to prevent `NullPointerException` when system properties are not set

#### Problem description

If the patch provides a fix for a bug, please describe what was the issue and how to reproduce the issue.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [x] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
nmake -f Makefile.mak BACKEND=opencl
nmake -f Makefile.mak fast-tests
```

----------------------------------------------------------------------------
