### PR TITLE
Whitelist `TestInheritedFields` for non-OpenCL backends

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -327,6 +327,7 @@ __TORNADO_TESTS_WHITE_LIST__ = [
 
     ## Atomics
     "uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic12",
+    "uk.ac.manchester.tornado.unittests.fields.TestInheritedFields",
 
     ## Multi-backend
     "uk.ac.manchester.tornado.unittests.vm.concurrency.TestConcurrentBackends#testTwoBackendsSerial",

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fields/TestInheritedFields.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/fields/TestInheritedFields.java
@@ -62,6 +62,10 @@ public class TestInheritedFields extends TornadoTestBase {
 
     @Test
     public void testIncrementPrimitiveB() {
+        // only for opencl backend
+        assertNotBackend(TornadoVMBackendType.PTX);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+
         final int N = 1000;
         PrimitiveB b = new PrimitiveB(N);
 
@@ -81,6 +85,10 @@ public class TestInheritedFields extends TornadoTestBase {
 
     @Test
     public void testIncrementPrimitiveAB() {
+        // only for opencl backend
+        assertNotBackend(TornadoVMBackendType.PTX);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+
         final int N = 1000;
         PrimitiveB b = new PrimitiveB(N);
 
@@ -101,6 +109,10 @@ public class TestInheritedFields extends TornadoTestBase {
 
     @Test
     public void testIncrementTornadoB() {
+        // only for opencl backend
+        assertNotBackend(TornadoVMBackendType.PTX);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+
         final int N = 1000;
         TornadoB b = new TornadoB(N);
 
@@ -120,6 +132,10 @@ public class TestInheritedFields extends TornadoTestBase {
 
     @Test
     public void testIncrementTornadoAB() {
+        // only for opencl backend
+        assertNotBackend(TornadoVMBackendType.PTX);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+
         final int N = 1000;
         TornadoB b = new TornadoB(N);
 


### PR DESCRIPTION
#### Description

This PR whitelists the tests for InheritedFields for non-OpenCL backends

#### Problem description

InheritedFields is supported only by OpenCL consequently its unittests (`testInheritedFields`) should not run for non-OpenCL backends.

#### Backend/s tested

- [ ] OpenCL
- [X] PTX
- [X] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

```
make BACKEND=ptx
tornado-test --ea --verbose --quickPass
```

Expected Behavior: not to run `testInheritedFields` test.

----------------------------------------------------------------------------
