### PR TITLE
[fix] Make cmake to always set CMAKE_OSX_SYSROOT explicitly, making i…

### DIFF
--- a/tornado-drivers/metal-jni/src/main/cpp/CMakeLists.txt
+++ b/tornado-drivers/metal-jni/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.6)
+
+if(APPLE)
+    execute_process(COMMAND xcrun --show-sdk-path OUTPUT_VARIABLE CMAKE_OSX_SYSROOT OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
 project(TornadoMetal)
 
 find_package(JNI REQUIRED)


### PR DESCRIPTION
## Template to be used in the PR description (remove this part when submitted the PR)

#### Description

I encountered the following issue when I built the `develop` branch with the `metal` backend: 
 
cmake was not passing -isysroot to the compiler, relying on Xcode's automatic SDK detection instead. A macOS 26 beta/Xcode update broke that auto-detection, so clang could no longer find Metal/Metal.h. The metal branch appeared to work because the prebuilt libtornado-objc-metal.dylib was still in the target/ directory and cmake skipped recompilation.                                                                                                                                                                     
                                                                                                                                                                                     
The fix is to add `execute_process(COMMAND xcrun --show-sdk-path ...)` before `project()` in `CMakeLists.txt` so cmake always sets CMAKE_OSX_SYSROOT explicitly, making it pass -isysroot to the compiler regardless of Xcode's environment state.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [ ] SPIRV
- [x] Metal

#### OS tested

Mark the OS where this PR is tested.

- [ ] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
## Pass unittests using the SPIRV backend
$ make BACKEND=metal
$ make fast-tests
```
----------------------------------------------------------------------------
