### PR TITLE
[fix] Backport jdk25 OCL plugin fixes: 64-bit address arithmetic, node insertion, and atomics

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024-2025, APT Group, Department of Computer Science,
+ * Copyright (c) 2022, 2024-2026, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * Copyright (c) 2018, 2020, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
@@ -23,19 +23,13 @@
  */
 package uk.ac.manchester.tornado.drivers.opencl.graal.compiler.plugins;
 
-import jdk.vm.ci.hotspot.HotSpotMetaAccessProvider;
-import jdk.vm.ci.meta.JavaConstant;
-import jdk.vm.ci.meta.JavaKind;
-import jdk.vm.ci.meta.MetaAccessProvider;
-import jdk.vm.ci.meta.RawConstant;
-import jdk.vm.ci.meta.ResolvedJavaMethod;
-import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.compiler.core.common.memory.BarrierType;
 import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.PiNode;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.AddNode;
@@ -57,6 +51,13 @@ import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.nodes.memory.address.OffsetAddressNode;
 import org.graalvm.compiler.nodes.util.GraphUtil;
 import org.graalvm.compiler.replacements.InlineDuringParsingPlugin;
+import jdk.vm.ci.hotspot.HotSpotMetaAccessProvider;
+import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.MetaAccessProvider;
+import jdk.vm.ci.meta.RawConstant;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.word.LocationIdentity;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.exceptions.Debug;
@@ -89,7 +90,7 @@ import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 import java.util.function.Supplier;
 
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
+import static org.graalvm.compiler.debug.GraalError.unimplemented;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPBinaryIntrinsicNode.Operation.ATAN2;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPBinaryIntrinsicNode.Operation.FMAX;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPBinaryIntrinsicNode.Operation.FMIN;
@@ -131,12 +132,14 @@ public class OCLGraphBuilderPlugins {
         OCLHalfFloatPlugins.registerPlugins(ps, plugins);
         registerMemoryAccessPlugins(plugins, metaAccessProvider);
         registerQuantizationUtilsPlugins(plugins);
-
     }
 
     private static boolean isMethodFromAtomicClass(ResolvedJavaMethod method) {
-        return method.getDeclaringClass().toJavaName().equals("uk.ac.manchester.tornado.api.atomics.TornadoAtomicInteger") || method.getDeclaringClass().toJavaName()
-                .equals("java.util.concurrent.atomic.AtomicInteger");
+        return method.getDeclaringClass() //
+        .toJavaName() //
+            .equals("uk.ac.manchester.tornado.api.atomics.TornadoAtomicInteger")  //
+            || method.getDeclaringClass().toJavaName() //
+            .equals("java.util.concurrent.atomic.AtomicInteger");
     }
 
     private static void registerAtomicCall(Registration r, JavaKind returnedJavaKind) {
@@ -144,7 +147,9 @@ public class OCLGraphBuilderPlugins {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
                 receiver.get(true);
-                b.addPush(returnedJavaKind, b.append(new IncAtomicNode(receiver.get(), OCLUnary.AtomicOperator.INCREMENT_AND_GET)));
+                IncAtomicNode atomicNode = new IncAtomicNode(receiver.get(true), OCLUnary.AtomicOperator.INCREMENT_AND_GET);
+                b.getGraph().addOrUnique(atomicNode);
+                b.addPush(returnedJavaKind, atomicNode);
                 return true;
             }
         });
@@ -153,7 +158,7 @@ public class OCLGraphBuilderPlugins {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
                 receiver.get(true);
-                b.addPush(returnedJavaKind, b.append(new IncAtomicNode(receiver.get(), OCLUnary.AtomicOperator.GET_AND_INCREMENT)));
+                b.addPush(returnedJavaKind, b.append(new IncAtomicNode(receiver.get(true), OCLUnary.AtomicOperator.GET_AND_INCREMENT)));
                 return true;
             }
         });
@@ -205,7 +210,7 @@ public class OCLGraphBuilderPlugins {
                             if (value == 0) {
                                 atomic.setInitialValue(constantNode);
                             } else {
-                                atomic.setInitialValueAtUsages(constantNode);
+                                atomic.setInitialValueAtUsages(initialValue);
                             }
                         }
                         return true;
@@ -223,11 +228,11 @@ public class OCLGraphBuilderPlugins {
 
     private static TornadoAtomicIntegerNode resolveReceiverAtomic(ValueNode thisObject) {
         TornadoAtomicIntegerNode atomicNode = null;
-        if (thisObject instanceof PiNode piNode) {
-            thisObject = piNode.getOriginalNode();
+        if (thisObject instanceof PiNode objectAsPiNode) {
+            thisObject = objectAsPiNode.getOriginalNode();
         }
-        if (thisObject instanceof TornadoAtomicIntegerNode tornadoAtomicIntegerNode) {
-            atomicNode = tornadoAtomicIntegerNode;
+        if (thisObject instanceof TornadoAtomicIntegerNode returnedAtomicNode) {
+            atomicNode = returnedAtomicNode;
         }
         return atomicNode;
     }
@@ -274,18 +279,18 @@ public class OCLGraphBuilderPlugins {
         registerAtomicAddPlugin(r, "atomicAdd", int[].class, OCLKind.UINT, intHeaderSupplier);
         registerAtomicAddPlugin(r, "atomicAdd", LongArray.class, OCLKind.ULONG, longHeaderSupplier);
         registerUnsupportedAtomicAddPlugin(r);
-        registerUnsupportedAtomicAddPlugin(r);
     }
 
     private static void registerAtomicAddPlugin(Registration r, String methodName, Class<?> arrayType, OCLKind kind, Supplier<Integer> headerSupplier) {
         r.register(new InvocationPlugin(methodName, InvocationPlugin.Receiver.class, arrayType, Integer.TYPE, kind.asJavaKind().toJavaClass()) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode segment, ValueNode index, ValueNode inc) {
+                receiver.get(true);
                 JavaKind javaKind = kind.asJavaKind();
                 int header = headerSupplier.get();
                 AddressNode address = computeAddress(b, segment, index, header, javaKind);
                 AtomAddNodeTemplate atomicAddNode = new AtomAddNodeTemplate(address, inc, javaKind);
-                b.add(b.append(atomicAddNode));
+                b.add(atomicAddNode);
                 return true;
             }
         });
@@ -295,6 +300,7 @@ public class OCLGraphBuilderPlugins {
         r.register(new InvocationPlugin("atomicAdd", InvocationPlugin.Receiver.class, FloatArray.class, Integer.TYPE, Float.TYPE) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode segment, ValueNode index, ValueNode inc) {
+                receiver.get(true);
                 unimplemented("In OpenCL, the atom_add function does not support floating point operations.");
                 return false;
             }
@@ -302,6 +308,7 @@ public class OCLGraphBuilderPlugins {
         r.register(new InvocationPlugin("atomicAdd", InvocationPlugin.Receiver.class, DoubleArray.class, Integer.TYPE, Double.TYPE) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode segment, ValueNode index, ValueNode inc) {
+                receiver.get(true);
                 unimplemented("In OpenCL, the atom_add function does not support floating point operations.");
                 return false;
             }
@@ -322,6 +329,7 @@ public class OCLGraphBuilderPlugins {
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
                 receiver.get(true);
                 LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, size);
+                b.getGraph().addOrUnique(localArrayNode);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -334,6 +342,7 @@ public class OCLGraphBuilderPlugins {
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
                 receiver.get(true);
                 LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, size);
+                b.getGraph().addOrUnique(localArrayNode);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -346,6 +355,7 @@ public class OCLGraphBuilderPlugins {
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
                 receiver.get(true);
                 LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, size);
+                b.getGraph().addOrUnique(localArrayNode);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -358,6 +368,7 @@ public class OCLGraphBuilderPlugins {
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
                 receiver.get(true);
                 LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, elementType, size);
+                b.getGraph().addOrUnique(localArrayNode);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -369,10 +380,10 @@ public class OCLGraphBuilderPlugins {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
                 receiver.get(true);
-                // if we do not pass the resolved type, the compiler cannot deduct if the type is char or byte
                 MetaAccessProvider metaAccess = b.getMetaAccess();
                 ResolvedJavaType resolvedElementType = metaAccess.lookupJavaType(byte.class);
                 LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, resolvedElementType, size);
+                b.getGraph().addOrUnique(localArrayNode);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -387,6 +398,7 @@ public class OCLGraphBuilderPlugins {
                 MetaAccessProvider metaAccess = b.getMetaAccess();
                 ResolvedJavaType resolvedElementType = metaAccess.lookupJavaType(short.class);
                 LocalArrayNode localArrayNode = new LocalArrayNode(OCLArchitecture.localSpace, resolvedElementType, size, OCLKind.HALF);
+                b.getGraph().addOrUnique(localArrayNode);
                 b.push(returnedJavaKind, localArrayNode);
                 return true;
             }
@@ -423,37 +435,6 @@ public class OCLGraphBuilderPlugins {
         registerAtomicAddOperation(r);
     }
 
-    private static void registerMemoryAccessPlugins(InvocationPlugins plugins, HotSpotMetaAccessProvider metaAccessProvider) {
-        Registration r = new Registration(plugins, TornadoMemorySegment.class);
-
-        for (JavaKind kind : JavaKind.values()) {
-            if (kind != JavaKind.Object && kind != JavaKind.Void && kind != JavaKind.Illegal) {
-                r.register(new InvocationPlugin("get" + kind.name() + "AtIndex", Receiver.class, int.class, int.class) {
-                    @Override
-                    public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode index, ValueNode baseIndex) {
-                        AddNode absoluteIndexNode = b.append(new AddNode(index, baseIndex));
-                        MulNode mulNode = b.append(new MulNode(absoluteIndexNode, ConstantNode.forInt(kind.getByteCount())));
-                        AddressNode addressNode = b.append(new OffsetAddressNode(receiver.get(true), mulNode));
-                        JavaReadNode readNode = new JavaReadNode(kind, addressNode, LocationIdentity.any(), BarrierType.NONE, MemoryOrderMode.PLAIN, false);
-                        b.addPush(kind, readNode);
-                        return true;
-                    }
-                });
-                r.register(new InvocationPlugin("setAtIndex", Receiver.class, int.class, kind.toJavaClass(), int.class) {
-                    @Override
-                    public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode index, ValueNode value, ValueNode baseIndex) {
-                        AddNode absoluteIndexNode = b.append(new AddNode(index, baseIndex));
-                        MulNode mulNode = b.append(new MulNode(absoluteIndexNode, ConstantNode.forInt(kind.getByteCount())));
-                        AddressNode addressNode = b.append(new OffsetAddressNode(receiver.get(true), mulNode));
-                        JavaWriteNode writeNode = new JavaWriteNode(kind, addressNode, LocationIdentity.any(), value, BarrierType.NONE, false);
-                        b.add(writeNode);
-                        return true;
-                    }
-                });
-            }
-        }
-    }
-
     private static void registerFP16ConversionPlugins(InvocationPlugins plugins) {
         Registration r = new Registration(plugins, Float.class);
 
@@ -461,7 +442,8 @@ public class OCLGraphBuilderPlugins {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfValue) {
                 OCLConvertHalfToFloat convertHalfToFloat = new OCLConvertHalfToFloat(halfValue);
-                b.addPush(JavaKind.Float, convertHalfToFloat);
+                b.getGraph().addOrUnique(convertHalfToFloat);
+                b.push(JavaKind.Float, convertHalfToFloat);
                 return true;
             }
         });
@@ -559,10 +541,49 @@ public class OCLGraphBuilderPlugins {
 
     }
 
+    private static void registerMemoryAccessPlugins(InvocationPlugins plugins, HotSpotMetaAccessProvider metaAccessProvider) {
+        Registration r = new Registration(plugins, TornadoMemorySegment.class);
+
+        for (JavaKind kind : JavaKind.values()) {
+            if (kind != JavaKind.Object && kind != JavaKind.Void && kind != JavaKind.Illegal && kind != JavaKind.Boolean) {
+                r.register(new InvocationPlugin("get" + kind.name() + "AtIndex", Receiver.class, int.class, int.class) {
+                    @Override
+                    public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode index, ValueNode baseIndex) {
+                        ValueNode receiverNode = receiver.get(true);  // Get receiver first (this adds null check)
+                        // Sign-extend int indices to long for 64-bit address arithmetic
+                        ValueNode longIndex = b.append(SignExtendNode.create(index, 64, NodeView.DEFAULT));
+                        ValueNode longBaseIndex = b.append(SignExtendNode.create(baseIndex, 64, NodeView.DEFAULT));
+                        AddNode absoluteIndexNode = b.append(new AddNode(longIndex, longBaseIndex));
+                        MulNode mulNode = b.append(new MulNode(absoluteIndexNode, ConstantNode.forLong(kind.getByteCount())));
+                        AddressNode addressNode = b.append(new OffsetAddressNode(receiverNode, mulNode));
+                        JavaReadNode readNode = new JavaReadNode(kind, addressNode, LocationIdentity.any(), BarrierType.NONE, MemoryOrderMode.PLAIN, false);
+                        b.addPush(kind, readNode);
+                        return true;
+                    }
+                });
+                r.register(new InvocationPlugin("setAtIndex", Receiver.class, int.class, kind.toJavaClass(), int.class) {
+                    @Override
+                    public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode index, ValueNode value, ValueNode baseIndex) {
+                        ValueNode receiverNode = receiver.get(true);  // Get receiver first (this adds null check)
+                        // Sign-extend int indices to long for 64-bit address arithmetic
+                        ValueNode longIndex = b.append(SignExtendNode.create(index, 64, NodeView.DEFAULT));
+                        ValueNode longBaseIndex = b.append(SignExtendNode.create(baseIndex, 64, NodeView.DEFAULT));
+                        AddNode absoluteIndexNode = b.append(new AddNode(longIndex, longBaseIndex));
+                        MulNode mulNode = b.append(new MulNode(absoluteIndexNode, ConstantNode.forLong(kind.getByteCount())));
+                        AddressNode addressNode = b.append(new OffsetAddressNode(receiverNode, mulNode));
+                        JavaWriteNode writeNode = new JavaWriteNode(kind, addressNode, LocationIdentity.any(), value, BarrierType.NONE, false);
+                        b.add(writeNode);
+                        return true;
+                    }
+                });
+            }
+        }
+    }
+
     private static void registerOpenCLBuiltinPlugins(InvocationPlugins plugins) {
 
         Registration r = new Registration(plugins, java.lang.Math.class);
-        // We have to overwrite some of the standard math plugins
+        // We have to overwrite some standard math plugins
         r.setAllowOverwrite(true);
         registerOpenCLOverridesForType(r, Float.TYPE, JavaKind.Float);
         registerOpenCLOverridesForType(r, Double.TYPE, JavaKind.Double);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
@@ -90,7 +90,7 @@ import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 import java.util.function.Supplier;
 
-import static org.graalvm.compiler.debug.GraalError.unimplemented;
+import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPBinaryIntrinsicNode.Operation.ATAN2;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPBinaryIntrinsicNode.Operation.FMAX;
 import static uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLFPBinaryIntrinsicNode.Operation.FMIN;

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLHalfFloatPlugins.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLHalfFloatPlugins.java
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2022, 2025, 2026 APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2018, 2020, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -27,16 +29,15 @@ import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderContext;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugins;
 import org.graalvm.compiler.nodes.graphbuilderconf.NodePlugin;
-
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.runtime.graal.nodes.AddHalfFloatNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.DivHalfFloatNode;
-import uk.ac.manchester.tornado.runtime.graal.nodes.MultHalfFloatNode;
-import uk.ac.manchester.tornado.runtime.graal.nodes.SubHalfFloatNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.HalfFloatPlaceholder;
+import uk.ac.manchester.tornado.runtime.graal.nodes.MultHalfFloatNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.NewHalfFloatInstance;
+import uk.ac.manchester.tornado.runtime.graal.nodes.SubHalfFloatNode;
 
 public class OCLHalfFloatPlugins {
 
@@ -51,9 +52,17 @@ public class OCLHalfFloatPlugins {
         ps.appendNodePlugin(new NodePlugin() {
             @Override
             public boolean handleInvoke(GraphBuilderContext b, ResolvedJavaMethod method, ValueNode[] args) {
-                if (method.getName().equals("<init>") && (method.toString().contains("HalfFloat.<init>"))) {
-                    NewHalfFloatInstance newHalfFloatInstance = b.append(new NewHalfFloatInstance(args[1]));
+                if (method.getName().equals("<init>") && method.toString().contains("HalfFloat.<init>")) {
+                    NewHalfFloatInstance newHalfFloatInstance = new NewHalfFloatInstance(args[1]);
+
+                    // Use b.add() to properly insert this FixedWithNextNode into the control flow
                     b.add(newHalfFloatInstance);
+
+                    // Replace usages of the NewInstanceNode (args[0]) with our node
+                    args[0].replaceAtUsages(newHalfFloatInstance);
+
+                    // Return false to let normal <init> processing continue
+                    // This avoids frame state issues
                     return true;
                 }
                 return false;
@@ -63,7 +72,8 @@ public class OCLHalfFloatPlugins {
         r.register(new InvocationPlugin("add", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                AddHalfFloatNode addNode = b.append(new AddHalfFloatNode(halfFloat1, halfFloat2));
+                AddHalfFloatNode addNode = new AddHalfFloatNode(halfFloat1, halfFloat2);
+                b.getGraph().addOrUnique(addNode);
                 b.push(JavaKind.Object, addNode);
                 return true;
             }
@@ -72,8 +82,8 @@ public class OCLHalfFloatPlugins {
         r.register(new InvocationPlugin("sub", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                SubHalfFloatNode subNode = b.append(new SubHalfFloatNode(halfFloat1, halfFloat2));
-                b.push(JavaKind.Object, subNode);
+                SubHalfFloatNode subNode = new SubHalfFloatNode(halfFloat1, halfFloat2);
+                b.addPush(JavaKind.Object, subNode);
                 return true;
             }
         });
@@ -81,7 +91,8 @@ public class OCLHalfFloatPlugins {
         r.register(new InvocationPlugin("mult", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                MultHalfFloatNode multNode = b.append(new MultHalfFloatNode(halfFloat1, halfFloat2));
+                MultHalfFloatNode multNode = new MultHalfFloatNode(halfFloat1, halfFloat2);
+                b.getGraph().addOrUnique(multNode);
                 b.push(JavaKind.Object, multNode);
                 return true;
             }
@@ -90,7 +101,8 @@ public class OCLHalfFloatPlugins {
         r.register(new InvocationPlugin("div", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                DivHalfFloatNode divNode = b.append(new DivHalfFloatNode(halfFloat1, halfFloat2));
+                DivHalfFloatNode divNode = new DivHalfFloatNode(halfFloat1, halfFloat2);
+                b.getGraph().addOrUnique(divNode);
                 b.push(JavaKind.Object, divNode);
                 return true;
             }
@@ -99,7 +111,9 @@ public class OCLHalfFloatPlugins {
         r.register(new InvocationPlugin("getHalfFloatValue", InvocationPlugin.Receiver.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
-                b.push(JavaKind.Short, b.append(new HalfFloatPlaceholder(receiver.get(true))));
+                HalfFloatPlaceholder placeholder = new HalfFloatPlaceholder(receiver.get(true));
+                b.getGraph().addOrUnique(placeholder);
+                b.push(JavaKind.Short, placeholder);
                 return true;
             }
         });

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVHalfFloatPlugins.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVHalfFloatPlugins.java
@@ -102,7 +102,7 @@ public class SPIRVHalfFloatPlugins {
         r.register(new InvocationPlugin("getHalfFloatValue", InvocationPlugin.Receiver.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
-                b.push(JavaKind.Short, b.append(new HalfFloatPlaceholder(receiver.get())));
+                b.push(JavaKind.Short, b.append(new HalfFloatPlaceholder(receiver.get(true))));
                 return true;
             }
         });


### PR DESCRIPTION
#### Description

Fixes silent F16 (half-precision) miscompilation and a related compilation failure in the OpenCL backend's Graal parser plugins (#828), and adds a null-check guard in the SPIR-V half-float plugin for consistency.
                                                                                                                                                                                     
The OpenCL backend produces incorrect output (no exception, no bailout) when running F16 LLM inference workloads such as https://github.com/beehive-lab/GPULlama3.java on `develop`  (for any version after `v2.2.0`). The same workloads work on `v2.2.0` and on the `jdk25` branch - the fixes already exist on jdk25 but were never backported to develop.

#### Problem description

##### Bug 1 - silent miscompilation (OpenCL r`egisterMemoryAccessPlugins`)

The `TornadoMemorySegment.get*AtIndex / setAtIndex` invocation plugins computed the byte offset in 32-bit int:

```java
AddNode absoluteIndexNode = b.append(new AddNode(index, baseIndex));
MulNode mulNode = b.append(new MulNode(absoluteIndexNode, ConstantNode.forInt(kind.getByteCount())));
AddressNode addressNode = b.append(new OffsetAddressNode(receiver.get(true), mulNode));
```
                                                                                                                                                                        
For an F16 weight tensor at the scale of a 1B-parameter Llama model (~2 GB byte offset range), (baseIndex + index) * elementSize exceeds 2³¹ and wraps to a negative byte offset.

The `OffsetAddressNode` then reads from the wrong GPU address. The kernel compiles cleanly and runs to completion — the only symptom is that the model produces unrelated tokens. Unit tests miss this because they use small arrays where the offset fits in 32 bits.                                                                                               

PTX (PTXGraphBuilderPlugins) and SPIR-V (SPIRVGraphBuilderPlugins) already do 64-bit address arithmetic via the same SignExtendNode pattern; only OpenCL lost it during the TornadoMemorySegment interception rewrite in PR #787.
                                                                                                                                                                                     
##### Bug 2 — compilation failure (OpenCL `OCLHalfFloatPlugins`)                                                                                                                           
  
After fixing bug 1, F16 kernels failed earlier in the pipeline with a SchedulePhase NPE inside PartialEscapePhase:                                                                                   
```bash
  java.lang.NullPointerException
    at org.graalvm.compiler.graph.NodeIdAccessor.getNodeId(NodeIdAccessor.java:64)
    at org.graalvm.compiler.graph.NodeMap.get(NodeMap.java:54) 
    at org.graalvm.compiler.phases.schedule.SchedulePhase$Instance.processNodes(SchedulePhase.java:963)
```
                                                                                                                                                                                
  Two causes in OCLHalfFloatPlugins:                                                                                                                                                 

1. The `HalfFloat.<init> NodePlugin` did both `b.append()` and `b.add()` on the same `NewHalfFloatInstance`, then returned `true` to suppress Graal's normal init processing. This left the  frame state inconsistent and inserted the node twice.
2. The `add/sub/mult/div/getHalfFloatValue` invocation plugins called `b.append(new XxxHalfFloatNode(...))` for nodes whose class extends `ValueNode` directly (not `FixedNode` or `FloatingNode`). The corrected pattern is `b.getGraph().addOrUnique(node)` followed by `b.push(kind, node)`, capturing the return value of `addOrUnique` so the unique instance ends up referenced - the local `new` instance may not be the one actually in the graph.

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [ ] PTX
- [ ] SPIRV

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Requires a built https://github.com/beehive-lab/GPULlama3.java and an F16 GGUF model:                                                                                              

Update the pom file to use the current TornadoVM version of this branch (`4.0.1-dev`) and then build it using:
```bash
make
```

and run it:

```bash
  ./llama-tornado --gpu --opencl \                                                                                                                                                   
      --model /path/to/Llama-3.2-1B-Instruct-F16.gguf \                                                                                                                              
      --prompt "Tell me a joke"                                                                                                                                                      
```

- Before this PR: Either a SchedulePhase NPE during compilation, or (depending on which bug is hit first) the model runs and produces unrelated/garbage tokens.
- After this PR: Model produces a coherent joke, identical to `v2.2.0` / `jdk25` behavior.

----------------------------------------------------------------------------
