### PR TITLE
[fix] Fix F16 miscompilation in PTX and Metal backends

### DIFF
--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/plugins/MetalGraphBuilderPlugins.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/plugins/MetalGraphBuilderPlugins.java
@@ -51,6 +51,7 @@ import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.PiNode;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.AddNode;
@@ -418,13 +419,16 @@ public class MetalGraphBuilderPlugins {
         // avoiding LoadField{TornadoMemorySegment#segment} nodes that break TornadoNativeTypeElimination.
         Registration r = new Registration(plugins, TornadoMemorySegment.class);
         for (JavaKind kind : JavaKind.values()) {
-            if (kind != JavaKind.Object && kind != JavaKind.Void && kind != JavaKind.Illegal) {
+            if (kind != JavaKind.Object && kind != JavaKind.Void && kind != JavaKind.Illegal && kind != JavaKind.Boolean) {
                 r.register(new InvocationPlugin("get" + kind.name() + "AtIndex", Receiver.class, int.class, int.class) {
                     @Override
                     public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode index, ValueNode baseIndex) {
-                        AddNode absoluteIndexNode = b.append(new AddNode(index, baseIndex));
-                        MulNode mulNode = b.append(new MulNode(absoluteIndexNode, ConstantNode.forInt(kind.getByteCount())));
-                        AddressNode addressNode = b.append(new OffsetAddressNode(receiver.get(true), mulNode));
+                        ValueNode receiverNode = receiver.get(true);
+                        ValueNode longIndex = b.append(SignExtendNode.create(index, 64, NodeView.DEFAULT));
+                        ValueNode longBaseIndex = b.append(SignExtendNode.create(baseIndex, 64, NodeView.DEFAULT));
+                        AddNode absoluteIndexNode = b.append(new AddNode(longIndex, longBaseIndex));
+                        MulNode mulNode = b.append(new MulNode(absoluteIndexNode, ConstantNode.forLong(kind.getByteCount())));
+                        AddressNode addressNode = b.append(new OffsetAddressNode(receiverNode, mulNode));
                         JavaReadNode readNode = new JavaReadNode(kind, addressNode, LocationIdentity.any(), BarrierType.NONE, MemoryOrderMode.PLAIN, false);
                         b.addPush(kind, readNode);
                         return true;
@@ -433,9 +437,12 @@ public class MetalGraphBuilderPlugins {
                 r.register(new InvocationPlugin("setAtIndex", Receiver.class, int.class, kind.toJavaClass(), int.class) {
                     @Override
                     public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode index, ValueNode value, ValueNode baseIndex) {
-                        AddNode absoluteIndexNode = b.append(new AddNode(index, baseIndex));
-                        MulNode mulNode = b.append(new MulNode(absoluteIndexNode, ConstantNode.forInt(kind.getByteCount())));
-                        AddressNode addressNode = b.append(new OffsetAddressNode(receiver.get(true), mulNode));
+                        ValueNode receiverNode = receiver.get(true);
+                        ValueNode longIndex = b.append(SignExtendNode.create(index, 64, NodeView.DEFAULT));
+                        ValueNode longBaseIndex = b.append(SignExtendNode.create(baseIndex, 64, NodeView.DEFAULT));
+                        AddNode absoluteIndexNode = b.append(new AddNode(longIndex, longBaseIndex));
+                        MulNode mulNode = b.append(new MulNode(absoluteIndexNode, ConstantNode.forLong(kind.getByteCount())));
+                        AddressNode addressNode = b.append(new OffsetAddressNode(receiverNode, mulNode));
                         JavaWriteNode writeNode = new JavaWriteNode(kind, addressNode, LocationIdentity.any(), value, BarrierType.NONE, false);
                         b.add(writeNode);
                         return true;

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/plugins/MetalHalfFloatPlugins.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/plugins/MetalHalfFloatPlugins.java
@@ -53,9 +53,10 @@ public class MetalHalfFloatPlugins {
         ps.appendNodePlugin(new NodePlugin() {
             @Override
             public boolean handleInvoke(GraphBuilderContext b, ResolvedJavaMethod method, ValueNode[] args) {
-                if (method.getName().equals("<init>") && (method.toString().contains("HalfFloat.<init>"))) {
-                    NewHalfFloatInstance newHalfFloatInstance = b.append(new NewHalfFloatInstance(args[1]));
+                if (method.getName().equals("<init>") && method.toString().contains("HalfFloat.<init>")) {
+                    NewHalfFloatInstance newHalfFloatInstance = new NewHalfFloatInstance(args[1]);
                     b.add(newHalfFloatInstance);
+                    args[0].replaceAtUsages(newHalfFloatInstance);
                     return true;
                 }
                 return false;
@@ -65,7 +66,8 @@ public class MetalHalfFloatPlugins {
         r.register(new InvocationPlugin("add", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                AddHalfFloatNode addNode = b.append(new AddHalfFloatNode(halfFloat1, halfFloat2));
+                AddHalfFloatNode addNode = new AddHalfFloatNode(halfFloat1, halfFloat2);
+                b.getGraph().addOrUnique(addNode);
                 b.push(JavaKind.Object, addNode);
                 return true;
             }
@@ -74,8 +76,8 @@ public class MetalHalfFloatPlugins {
         r.register(new InvocationPlugin("sub", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                SubHalfFloatNode subNode = b.append(new SubHalfFloatNode(halfFloat1, halfFloat2));
-                b.push(JavaKind.Object, subNode);
+                SubHalfFloatNode subNode = new SubHalfFloatNode(halfFloat1, halfFloat2);
+                b.addPush(JavaKind.Object, subNode);
                 return true;
             }
         });
@@ -83,7 +85,8 @@ public class MetalHalfFloatPlugins {
         r.register(new InvocationPlugin("mult", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                MultHalfFloatNode multNode = b.append(new MultHalfFloatNode(halfFloat1, halfFloat2));
+                MultHalfFloatNode multNode = new MultHalfFloatNode(halfFloat1, halfFloat2);
+                b.getGraph().addOrUnique(multNode);
                 b.push(JavaKind.Object, multNode);
                 return true;
             }
@@ -92,7 +95,8 @@ public class MetalHalfFloatPlugins {
         r.register(new InvocationPlugin("div", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                DivHalfFloatNode divNode = b.append(new DivHalfFloatNode(halfFloat1, halfFloat2));
+                DivHalfFloatNode divNode = new DivHalfFloatNode(halfFloat1, halfFloat2);
+                b.getGraph().addOrUnique(divNode);
                 b.push(JavaKind.Object, divNode);
                 return true;
             }
@@ -101,7 +105,9 @@ public class MetalHalfFloatPlugins {
         r.register(new InvocationPlugin("getHalfFloatValue", InvocationPlugin.Receiver.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
-                b.push(JavaKind.Short, b.append(new HalfFloatPlaceholder(receiver.get())));
+                HalfFloatPlaceholder placeholder = new HalfFloatPlaceholder(receiver.get(true));
+                b.getGraph().addOrUnique(placeholder);
+                b.push(JavaKind.Short, placeholder);
                 return true;
             }
         });

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXHalfFloatPlugin.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXHalfFloatPlugin.java
@@ -53,9 +53,10 @@ public class PTXHalfFloatPlugin {
         ps.appendNodePlugin(new NodePlugin() {
             @Override
             public boolean handleInvoke(GraphBuilderContext b, ResolvedJavaMethod method, ValueNode[] args) {
-                if (method.getName().equals("<init>") && (method.toString().contains("HalfFloat.<init>"))) {
-                    NewHalfFloatInstance newHalfFloatInstance = b.append(new NewHalfFloatInstance(args[1]));
+                if (method.getName().equals("<init>") && method.toString().contains("HalfFloat.<init>")) {
+                    NewHalfFloatInstance newHalfFloatInstance = new NewHalfFloatInstance(args[1]);
                     b.add(newHalfFloatInstance);
+                    args[0].replaceAtUsages(newHalfFloatInstance);
                     return true;
                 }
                 return false;
@@ -65,7 +66,8 @@ public class PTXHalfFloatPlugin {
         r.register(new InvocationPlugin("add", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                AddHalfFloatNode addNode = b.append(new AddHalfFloatNode(halfFloat1, halfFloat2));
+                AddHalfFloatNode addNode = new AddHalfFloatNode(halfFloat1, halfFloat2);
+                b.getGraph().addOrUnique(addNode);
                 b.push(JavaKind.Object, addNode);
                 return true;
             }
@@ -74,8 +76,8 @@ public class PTXHalfFloatPlugin {
         r.register(new InvocationPlugin("sub", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                SubHalfFloatNode subNode = b.append(new SubHalfFloatNode(halfFloat1, halfFloat2));
-                b.push(JavaKind.Object, subNode);
+                SubHalfFloatNode subNode = new SubHalfFloatNode(halfFloat1, halfFloat2);
+                b.addPush(JavaKind.Object, subNode);
                 return true;
             }
         });
@@ -83,7 +85,8 @@ public class PTXHalfFloatPlugin {
         r.register(new InvocationPlugin("mult", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                MultHalfFloatNode multNode = b.append(new MultHalfFloatNode(halfFloat1, halfFloat2));
+                MultHalfFloatNode multNode = new MultHalfFloatNode(halfFloat1, halfFloat2);
+                b.getGraph().addOrUnique(multNode);
                 b.push(JavaKind.Object, multNode);
                 return true;
             }
@@ -92,7 +95,8 @@ public class PTXHalfFloatPlugin {
         r.register(new InvocationPlugin("div", HalfFloat.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode halfFloat1, ValueNode halfFloat2) {
-                DivHalfFloatNode divNode = b.append(new DivHalfFloatNode(halfFloat1, halfFloat2));
+                DivHalfFloatNode divNode = new DivHalfFloatNode(halfFloat1, halfFloat2);
+                b.getGraph().addOrUnique(divNode);
                 b.push(JavaKind.Object, divNode);
                 return true;
             }


### PR DESCRIPTION
#### Description

This PR applies the fixes that were applied in OpenCL backend in PR #829 for the Metal and PTX backends.

More specifically, the backport of the HalfFloat plugin IR insertion fixes and 32-bit address arithmetic overflow fix to the PTX and Metal backends.

#### Problem description

Two bugs in the Graal compiler invocation plugins cause silent miscompilation of HalfFloat (F16) operations on PTX and Metal:                                                                                                                                                                                                             
  1. **Incorrect IR node insertion**: `AddHalfFloatNode`, `SubHalfFloatNode`, `MultHalfFloatNode`, `DivHalfFloatNode`, and `HalfFloatPlaceholder` extend `ValueNode` directly (floating nodes) but were inserted using `b.append()`, which is intended for fixed nodes. Additionally, the `<init>` handler used both `b.append()` and `b.add()` (double insertion)  and did not call `replaceAtUsages()` to redirect the `NewInstance` node. They produce correct results on the first invocation but garbage on subsequent runs.                                                                                                                                                                                        
                                                                                                                                                                                                             
  2. **32-bit address overflow (Metal only)**: `registerMemoryAccessPlugins` computed GPU memory addresses using `ConstantNode.forInt()` and 32-bit  `AddNode`/`MulNode`. When `(baseIndex + index) * elementSize` exceeds `Integer.MAX_VALUE`, the address silently wraps around, causing the GPU to read/write from wrong memory locations.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [x] PTX
- [ ] SPIRV
- [x] Metal

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [x] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Requires a built https://github.com/beehive-lab/GPULlama3.java and an F16 GGUF model:                                                                                              

Update the pom file to use the current TornadoVM version of this branch (`4.0.1-dev`) and then build it using **metal**:
```bash
make BACKEND=metal
```

and run it:

```bash
  ./llama-tornado --gpu --metal \                                                                                                                                                   
      --model /path/to/Llama-3.2-1B-Instruct-F16.gguf \                                                                                                                              
      --prompt "Tell me a joke"                                                                                                                                                      
```

build it using **ptx**:
```bash
make BACKEND=ptx
```

and run it:

```bash
  ./llama-tornado --gpu --ptx \                                                                                                                                                   
      --model /path/to/Llama-3.2-1B-Instruct-F16.gguf \                                                                                                                              
      --prompt "Tell me a joke"                                                                                                                                                      
```

- Before this PR: Either a SchedulePhase NPE during compilation, or (depending on which bug is hit first) the model runs and produces unrelated/garbage tokens.
- After this PR: Model produces a coherent joke, identical to OpenCL behavior.

----------------------------------------------------------------------------
