### PR TITLE
Adopt jdk21 version suffix on develop and update release workflows 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,6 +54,7 @@ Mark the backends affected by this PR.
 - [ ] OpenCL
 - [ ] PTX
 - [ ] SPIRV
+- [ ] Metal
 
 #### OS tested
 

--- a/.github/workflows/1-prepare-release-jdk21.yml
+++ b/.github/workflows/1-prepare-release-jdk21.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g., 2.0.1)'
+        description: 'Release version (e.g., 4.0.1-jdk21)'
         required: true
         type: string
       previous_version:
-        description: 'Previous version for changelog (e.g., 2.0.0)'
+        description: 'Previous version for changelog (e.g., 4.0.0-jdk21)'
         required: true
         type: string
       dry_run:
@@ -36,8 +36,8 @@ jobs:
     steps:
       - name: Validate version format
         run: |
-          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ Invalid version format. Expected: X.Y.Z (e.g., 2.0.1)"
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-jdk21$ ]]; then
+            echo "❌ Invalid version format. Expected: X.Y.Z-jdk21 (e.g., 4.0.1-jdk21)"
             exit 1
           fi
           echo "✅ Version format valid: ${{ inputs.version }}"
@@ -81,21 +81,21 @@ jobs:
 
       - name: Update tornado-test version
         run: |
-          sed -i 's/__VERSION__ = "[0-9]\+\.[0-9]\+\.[0-9]\+\(-dev\)\?"/__VERSION__ = "${{ env.VERSION }}"/' tornado-assembly/src/bin/tornado-test
+          sed -i 's/__VERSION__ = "[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9-]*\)\?"/__VERSION__ = "${{ env.VERSION }}"/' tornado-assembly/src/bin/tornado-test
           echo "Updated tornado-assembly/src/bin/tornado-test:"
           grep -n "__VERSION__" tornado-assembly/src/bin/tornado-test
 
       - name: Update README.md
         run: |
           # Update version badge
-          sed -i 's/version-[0-9]\+\.[0-9]\+\.[0-9]\+-purple/version-${{ env.VERSION }}-purple/g' README.md
-          
+          sed -i 's/version-[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\?-purple/version-${{ env.VERSION }}-purple/g' README.md
+
           # Update "Latest Release" line with current date (DD/MM/YYYY format)
           RELEASE_DATE=$(date +"%d/%m/%Y")
-          sed -i "s|\*\*Latest Release:\*\* TornadoVM [0-9]\+\.[0-9]\+\.[0-9]\+ - [0-9/]\+|**Latest Release:** TornadoVM ${{ env.VERSION }} - ${RELEASE_DATE}|" README.md
-          
+          sed -i "s|\*\*Latest Release:\*\* TornadoVM [0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\? - [0-9/]\+|**Latest Release:** TornadoVM ${{ env.VERSION }} - ${RELEASE_DATE}|" README.md
+
           # Update Maven Central dependency versions (io.github.beehive-lab groupId)
-          sed -i 's|<version>[0-9]\+\.[0-9]\+\.[0-9]\+</version>|<version>${{ env.VERSION }}</version>|g' README.md
+          sed -i 's|<version>[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\?</version>|<version>${{ env.VERSION }}</version>|g' README.md
           
           echo "✅ Updated README.md"
 
@@ -103,8 +103,8 @@ jobs:
         run: |
           if [ -f docs/source/conf.py ]; then
             # conf.py uses "vX.Y.Z" format with double quotes
-            sed -i 's|release = "v[0-9]\+\.[0-9]\+\.[0-9]\+"|release = "v${{ env.VERSION }}"|' docs/source/conf.py
-            sed -i 's|version = "v[0-9]\+\.[0-9]\+\.[0-9]\+"|version = "v${{ env.VERSION }}"|' docs/source/conf.py
+            sed -i 's|release = "v[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\?"|release = "v${{ env.VERSION }}"|' docs/source/conf.py
+            sed -i 's|version = "v[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\?"|version = "v${{ env.VERSION }}"|' docs/source/conf.py
             echo "✅ Updated docs/source/conf.py"
             grep -E "(version|release) =" docs/source/conf.py
           fi
@@ -113,7 +113,7 @@ jobs:
         run: |
           if [ -f docs/source/installation.rst ]; then
             # Update Maven dependency versions in the XML examples
-            sed -i 's|<version>[0-9]\+\.[0-9]\+\.[0-9]\+</version>|<version>${{ env.VERSION }}</version>|g' docs/source/installation.rst
+            sed -i 's|<version>[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\?</version>|<version>${{ env.VERSION }}</version>|g' docs/source/installation.rst
             
             # Add new version to "Versions available" list (insert before previous version)
             sed -i "/^\* ${{ env.PREV_VERSION }}$/i\\ * ${{ env.VERSION }}" docs/source/installation.rst
@@ -296,7 +296,11 @@ jobs:
           script: |
             const version = process.env.VERSION;
             const prCount = '${{ steps.fetch_prs.outputs.pr_count }}';
-            
+
+            // Compute next dev version: strip -jdk21, bump patch, re-add suffix + -dev
+            const baseVersion = version.replace(/-jdk21$/, '');
+            const nextDev = baseVersion.replace(/(\d+)$/, m => parseInt(m) + 1) + '-jdk21-dev';
+
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -321,7 +325,7 @@ jobs:
             2. Run **deploy-maven-central** workflow manually
             3. Create GitHub Release with tag \`v${version}\`
             4. Merge master → develop
-            5. Bump develop to \`${version.replace(/(\d+)$/, m => parseInt(m)+1)}-dev\`
+            5. Bump develop to \`${nextDev}\`
             `
             });
             

--- a/.github/workflows/2-finalize-release-jdk21.yml
+++ b/.github/workflows/2-finalize-release-jdk21.yml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version to tag (e.g., 2.0.1)'
+        description: 'Release version to tag (e.g., 4.0.1-jdk21)'
         required: true
         type: string
       next_dev_version:
-        description: 'Next development version (e.g., 2.0.2-dev)'
+        description: 'Next development version (e.g., 4.0.2-jdk21-dev)'
         required: true
         type: string
 
@@ -55,28 +55,94 @@ jobs:
       - name: Create and push tag
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
-          git tag -a "v${VERSION}-jdk21" -m "Release ${VERSION} (JDK21)"
-          git push origin "v${VERSION}-jdk21"
-          echo "✅ Created tag v${VERSION}-jdk21"
+          git tag -a "v${VERSION}" -m "Release ${VERSION}"
+          git push origin "v${VERSION}"
+          echo "✅ Created tag v${VERSION}"
 
       - name: Extract changelog for release notes
         id: changelog
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
           CHANGELOG_FILE="docs/source/CHANGELOG.rst"
-          
+
           if [ -f "$CHANGELOG_FILE" ]; then
-            # Extract section for this version
+            # Extract RST section for this version (also skip the heading's underline)
             awk -v ver="TornadoVM ${VERSION}" '
-              $0 ~ ver { found=1; next }
-              found && /^TornadoVM [0-9]+\.[0-9]+\.[0-9]+$/ { exit }
+              $0 ~ ver { found=1; skip_next=1; next }
+              skip_next { skip_next=0; next }
+              found && /^TornadoVM [0-9]+\.[0-9]+\.[0-9]+/ { exit }
               found { print }
-            ' "$CHANGELOG_FILE" > /tmp/release_notes.txt
-            
+            ' "$CHANGELOG_FILE" > /tmp/release_notes_jdk21.rst
+
+            # Convert RST to Markdown for GitHub Release rendering:
+            #   `#NNN <url>`_                        -> #NNN  (GitHub auto-links issue refs)
+            #   text + ===/---/~~~ underline pair    -> #/##/### text
+            #   orphan underline lines               -> dropped
+            sed -E 's|`(#[0-9]+) <[^>]+>`_|\1|g' /tmp/release_notes_jdk21.rst | awk '
+              { lines[NR] = $0 }
+              END {
+                i = 1
+                while (i <= NR) {
+                  cur = lines[i]
+                  nxt = (i+1 <= NR) ? lines[i+1] : ""
+                  if (length(cur) > 0 && nxt ~ /^=+$/)      { print "# "  cur; i += 2 }
+                  else if (length(cur) > 0 && nxt ~ /^-+$/) { print "## " cur; i += 2 }
+                  else if (length(cur) > 0 && nxt ~ /^~+$/) { print "### " cur; i += 2 }
+                  else if (cur ~ /^[=~-]+$/)                { i += 1 }
+                  else                                       { print cur; i += 1 }
+                }
+              }
+            ' > /tmp/release_notes_jdk21.md
+
             echo "Found changelog section for ${VERSION}"
           else
-            echo "See CHANGELOG.rst for details." > /tmp/release_notes.txt
+            echo "See CHANGELOG.rst for details." > /tmp/release_notes_jdk21.md
           fi
+
+          # Append "How to use TornadoVM SDK" appendix.
+          # Heredoc is quoted so backticks, $(pwd), %PATH% etc. stay literal;
+          # @@VERSION@@ is substituted afterwards via sed.
+          cat >> /tmp/release_notes_jdk21.md <<'EOF'
+
+          ## How to use TornadoVM SDK
+
+          To use the TornadoVM SDK, ensure that the environment variable `JAVA_HOME` points to a valid JDK 21 installation. After that, select the appropriate sdk distribution for your target architecture and the accelerator backends you intend to use.
+
+          ### Linux Systems
+
+          ```bash
+          wget https://github.com/beehive-lab/TornadoVM/releases/download/v@@VERSION@@/tornadovm-@@VERSION@@-opencl-linux-amd64.zip
+          unzip tornadovm-@@VERSION@@-opencl-linux-amd64.zip
+          export TORNADOVM_HOME="$(pwd)/tornadovm-@@VERSION@@-opencl"
+          export PATH=$TORNADOVM_HOME/bin:$PATH
+          tornado --devices
+          tornado --version
+          ```
+
+          ### macOS Systems
+
+          ```bash
+          wget https://github.com/beehive-lab/TornadoVM/releases/download/v@@VERSION@@/tornadovm-@@VERSION@@-opencl-mac-aarch64.zip
+          unzip tornadovm-@@VERSION@@-opencl-mac-aarch64.zip
+          export TORNADOVM_HOME="$(pwd)/tornadovm-@@VERSION@@-opencl"
+          export PATH=$TORNADOVM_HOME/bin:$PATH
+          tornado --devices
+          tornado --version
+          ```
+
+          ### Windows (10+) Systems
+
+          ```bash
+          curl -L -o tornadovm-@@VERSION@@-opencl-windows-amd64.zip https://github.com/beehive-lab/TornadoVM/releases/download/v@@VERSION@@/tornadovm-@@VERSION@@-opencl-windows-amd64.zip
+          tar -xf tornadovm-@@VERSION@@-opencl-windows-amd64.zip
+          set TORNADOVM_HOME=%cd%\tornadovm-@@VERSION@@-opencl
+          set PATH=%TORNADOVM_HOME%\bin;%PATH%
+          tornado --devices
+          tornado --version
+          ```
+          EOF
+
+          sed -i "s|@@VERSION@@|${VERSION}|g" /tmp/release_notes_jdk21.md
 
       - name: Create GitHub Release
         uses: actions/github-script@v7
@@ -87,7 +153,7 @@ jobs:
             
             let releaseNotes;
             try {
-              releaseNotes = fs.readFileSync('/tmp/release_notes.txt', 'utf8').trim();
+              releaseNotes = fs.readFileSync('/tmp/release_notes_jdk21.md', 'utf8').trim();
               if (!releaseNotes) {
                 releaseNotes = `Release ${version}\n\nSee CHANGELOG.rst for details.`;
               }
@@ -98,8 +164,8 @@ jobs:
             const { data: release } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: `v${version}-jdk21`,
-              name: `TornadoVM ${version} (JDK21)`,
+              tag_name: `v${version}`,
+              name: `TornadoVM ${version}`,
               body: releaseNotes,
               draft: false,
               prerelease: false
@@ -148,8 +214,10 @@ jobs:
             echo "next_version=${{ inputs.next_dev_version }}" >> $GITHUB_OUTPUT
           else
             VERSION="${{ needs.create-release-tag.outputs.version }}"
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-            echo "next_version=${MAJOR}.${MINOR}.$((PATCH + 1))-dev" >> $GITHUB_OUTPUT
+            # Strip -jdk21 suffix, increment patch, re-add suffix + -dev
+            BASE_VERSION="${VERSION%-jdk21}"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+            echo "next_version=${MAJOR}.${MINOR}.$((PATCH + 1))-jdk21-dev" >> $GITHUB_OUTPUT
           fi
 
       - name: Bump to next dev version
@@ -158,7 +226,7 @@ jobs:
           
           ./mvnw versions:set -DnewVersion=${NEXT} -DgenerateBackupPoms=false
           
-          sed -i "s/__VERSION__ = \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/__VERSION__ = \"${NEXT}\"/" tornado-assembly/src/bin/tornado-test
+          sed -i "s/__VERSION__ = \"[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9-]*\)\?\"/__VERSION__ = \"${NEXT}\"/" tornado-assembly/src/bin/tornado-test
           
           git add -A
           
@@ -176,7 +244,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Tag created | ✅ v${{ needs.create-release-tag.outputs.version }}-jdk21 |" >> $GITHUB_STEP_SUMMARY
+          echo "| Tag created | ✅ v${{ needs.create-release-tag.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
           echo "| GitHub Release | ✅ Created |" >> $GITHUB_STEP_SUMMARY
           echo "| Develop bumped | ✅ ${{ steps.next_version.outputs.next_version }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/2-finalize-release-jdk25.yml
+++ b/.github/workflows/2-finalize-release-jdk25.yml
@@ -66,17 +66,83 @@ jobs:
           CHANGELOG_FILE="docs/source/CHANGELOG.rst"
 
           if [ -f "$CHANGELOG_FILE" ]; then
-            # Extract section for this version
+            # Extract RST section for this version (also skip the heading's underline)
             awk -v ver="TornadoVM ${VERSION}" '
-              $0 ~ ver { found=1; next }
+              $0 ~ ver { found=1; skip_next=1; next }
+              skip_next { skip_next=0; next }
               found && /^TornadoVM [0-9]+\.[0-9]+\.[0-9]+/ { exit }
               found { print }
-            ' "$CHANGELOG_FILE" > /tmp/release_notes.txt
+            ' "$CHANGELOG_FILE" > /tmp/release_notes_jdk25.rst
+
+            # Convert RST to Markdown for GitHub Release rendering:
+            #   `#NNN <url>`_                        -> #NNN  (GitHub auto-links issue refs)
+            #   text + ===/---/~~~ underline pair    -> #/##/### text
+            #   orphan underline lines               -> dropped
+            sed -E 's|`(#[0-9]+) <[^>]+>`_|\1|g' /tmp/release_notes_jdk25.rst | awk '
+              { lines[NR] = $0 }
+              END {
+                i = 1
+                while (i <= NR) {
+                  cur = lines[i]
+                  nxt = (i+1 <= NR) ? lines[i+1] : ""
+                  if (length(cur) > 0 && nxt ~ /^=+$/)      { print "# "  cur; i += 2 }
+                  else if (length(cur) > 0 && nxt ~ /^-+$/) { print "## " cur; i += 2 }
+                  else if (length(cur) > 0 && nxt ~ /^~+$/) { print "### " cur; i += 2 }
+                  else if (cur ~ /^[=~-]+$/)                { i += 1 }
+                  else                                       { print cur; i += 1 }
+                }
+              }
+            ' > /tmp/release_notes_jdk25.md
 
             echo "Found changelog section for ${VERSION}"
           else
-            echo "See CHANGELOG.rst for details." > /tmp/release_notes.txt
+            echo "See CHANGELOG.rst for details." > /tmp/release_notes_jdk25.md
           fi
+
+          # Append "How to use TornadoVM SDK" appendix.
+          # Heredoc is quoted so backticks, $(pwd), %PATH% etc. stay literal;
+          # @@VERSION@@ is substituted afterwards via sed.
+          cat >> /tmp/release_notes_jdk25.md <<'EOF'
+
+          ## How to use TornadoVM SDK
+
+          To use the TornadoVM SDK, ensure that the environment variable `JAVA_HOME` points to a valid JDK 25 installation. After that, select the appropriate sdk distribution for your target architecture and the accelerator backends you intend to use.
+
+          ### Linux Systems
+
+          ```bash
+          wget https://github.com/beehive-lab/TornadoVM/releases/download/v@@VERSION@@/tornadovm-@@VERSION@@-opencl-linux-amd64.zip
+          unzip tornadovm-@@VERSION@@-opencl-linux-amd64.zip
+          export TORNADOVM_HOME="$(pwd)/tornadovm-@@VERSION@@-opencl"
+          export PATH=$TORNADOVM_HOME/bin:$PATH
+          tornado --devices
+          tornado --version
+          ```
+
+          ### macOS Systems
+
+          ```bash
+          wget https://github.com/beehive-lab/TornadoVM/releases/download/v@@VERSION@@/tornadovm-@@VERSION@@-opencl-mac-aarch64.zip
+          unzip tornadovm-@@VERSION@@-opencl-mac-aarch64.zip
+          export TORNADOVM_HOME="$(pwd)/tornadovm-@@VERSION@@-opencl"
+          export PATH=$TORNADOVM_HOME/bin:$PATH
+          tornado --devices
+          tornado --version
+          ```
+
+          ### Windows (10+) Systems
+
+          ```bash
+          curl -L -o tornadovm-@@VERSION@@-opencl-windows-amd64.zip https://github.com/beehive-lab/TornadoVM/releases/download/v@@VERSION@@/tornadovm-@@VERSION@@-opencl-windows-amd64.zip
+          tar -xf tornadovm-@@VERSION@@-opencl-windows-amd64.zip
+          set TORNADOVM_HOME=%cd%\tornadovm-@@VERSION@@-opencl
+          set PATH=%TORNADOVM_HOME%\bin;%PATH%
+          tornado --devices
+          tornado --version
+          ```
+          EOF
+
+          sed -i "s|@@VERSION@@|${VERSION}|g" /tmp/release_notes_jdk25.md
 
       - name: Create GitHub Release
         uses: actions/github-script@v7
@@ -87,7 +153,7 @@ jobs:
 
             let releaseNotes;
             try {
-              releaseNotes = fs.readFileSync('/tmp/release_notes.txt', 'utf8').trim();
+              releaseNotes = fs.readFileSync('/tmp/release_notes_jdk25.md', 'utf8').trim();
               if (!releaseNotes) {
                 releaseNotes = `Release ${version}\n\nSee CHANGELOG.rst for details.`;
               }

--- a/.github/workflows/backport-pr-to-jdk25.yml
+++ b/.github/workflows/backport-pr-to-jdk25.yml
@@ -43,9 +43,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
+          # --no-maintainer-edit avoids "Fork collab can't be granted by
+          # someone without permission" when the source PR is from a fork:
+          # GITHUB_TOKEN cannot grant maintainer-edit on the contributor's
+          # fork, so the cross-fork PR creation fails unless we opt out.
           gh pr create \
             --repo "$REPO" \
             --base "jdk25" \
             --head "$HEAD_LABEL" \
             --title "$PR_TITLE" \
+            --no-maintainer-edit \
             --body "$(printf 'Auto-created because #%s was opened against `develop`.\n\nOriginal PR: %s\n\n---\n%s' "$PR_NUMBER" "$PR_URL" "$PR_BODY")"

--- a/.github/workflows/publish-archives-to-sdkman-jdk21.yml
+++ b/.github/workflows/publish-archives-to-sdkman-jdk21.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "GitHub release tag (e.g. v2.1.0)"
+        description: "GitHub release tag (e.g. v4.0.1-jdk21)"
         required: true
-        default: "v2.1.0"
+        default: "v4.0.1-jdk21"
       publish:
         description: "Actually publish to SDKMAN (true/false)"
         required: true
@@ -16,7 +16,13 @@ on:
 
 jobs:
   publish-to-sdkman:
-    if: github.repository == 'beehive-lab/TornadoVM'
+    # Only run for JDK 21 releases (tags ending with -jdk21)
+    if: |
+      github.repository == 'beehive-lab/TornadoVM' &&
+      (
+        (github.event_name == 'release' && endsWith(github.event.release.tag_name, '-jdk21')) ||
+        (github.event_name == 'workflow_dispatch' && endsWith(inputs.tag, '-jdk21'))
+      )
     name: Publish TornadoVM ${{ matrix.sdk_suffix }} / ${{ matrix.platform }} to SDKMAN
     runs-on: [ self-hosted, Linux, x64 ]
 
@@ -105,7 +111,10 @@ jobs:
 
     if: >
       github.repository == 'beehive-lab/TornadoVM' &&
-      (github.event_name == 'release' || inputs.publish == 'true')
+      (
+        (github.event_name == 'release' && endsWith(github.event.release.tag_name, '-jdk21')) ||
+        (github.event_name == 'workflow_dispatch' && inputs.publish == 'true' && endsWith(inputs.tag, '-jdk21'))
+      )
 
     steps:
       - name: Derive default version

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.beehive-lab</groupId>
     <artifactId>tornado</artifactId>
-    <version>4.0.1-dev</version>
+    <version>4.0.1-jdk21-dev</version>
     <packaging>pom</packaging>
     <name>tornado</name>
     <url>https://github.com/beehive-lab/tornadovm</url>

--- a/tornado-annotation/pom.xml
+++ b/tornado-annotation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
 
     <artifactId>tornado-annotation</artifactId>

--- a/tornado-api/pom.xml
+++ b/tornado-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>tornado</artifactId>
         <groupId>io.github.beehive-lab</groupId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <description>TornadoVM API: A high-level programming interface for accelerating Java applications on heterogeneous hardware</description>
     <groupId>io.github.beehive-lab</groupId>
     <artifactId>tornado-api</artifactId>
-    <version>4.0.1-dev</version>
+    <version>4.0.1-jdk21-dev</version>
     <name>tornado-api</name>
     <url>https://tornadovm.org</url>
     <licenses>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-assembly</artifactId>
     <packaging>pom</packaging>

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -397,7 +397,7 @@ else:
 
 ENABLE_ASSERTIONS = "-ea "
 
-__VERSION__ = "4.0.1-dev"
+__VERSION__ = "4.0.1-jdk21-dev"
 
 try:
     javaHome = os.environ["JAVA_HOME"]

--- a/tornado-benchmarks/pom.xml
+++ b/tornado-benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
 
     <artifactId>tornado-benchmarks</artifactId>

--- a/tornado-drivers/drivers-common/pom.xml
+++ b/tornado-drivers/drivers-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tornado-drivers/metal-jni/pom.xml
+++ b/tornado-drivers/metal-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-drivers-metal-jni</artifactId>
     <name>tornado-drivers-metal-jni</name>

--- a/tornado-drivers/metal/pom.xml
+++ b/tornado-drivers/metal/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-drivers-metal</artifactId>
     <name>tornado-drivers-metal</name>

--- a/tornado-drivers/opencl-jni/pom.xml
+++ b/tornado-drivers/opencl-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-drivers-opencl-jni</artifactId>
     <name>tornado-drivers-opencl-jni</name>

--- a/tornado-drivers/opencl/pom.xml
+++ b/tornado-drivers/opencl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-drivers-opencl</artifactId>
     <name>tornado-drivers-opencl</name>

--- a/tornado-drivers/pom.xml
+++ b/tornado-drivers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-drivers</artifactId>
     <name>tornado-drivers</name>

--- a/tornado-drivers/ptx-jni/pom.xml
+++ b/tornado-drivers/ptx-jni/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-drivers-ptx-jni</artifactId>
     <name>tornado-drivers-ptx-jni</name>

--- a/tornado-drivers/ptx/pom.xml
+++ b/tornado-drivers/ptx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-drivers-ptx</artifactId>
     <name>tornado-drivers-ptx</name>

--- a/tornado-drivers/spirv/pom.xml
+++ b/tornado-drivers/spirv/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado-drivers</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-drivers-spirv</artifactId>
     <name>tornado-drivers-spirv</name>

--- a/tornado-examples/pom.xml
+++ b/tornado-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <properties>
         <checkstyle.skip>true</checkstyle.skip>

--- a/tornado-matrices/pom.xml
+++ b/tornado-matrices/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-matrices</artifactId>
     <name>tornado-matrices</name>

--- a/tornado-runtime/pom.xml
+++ b/tornado-runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-runtime</artifactId>
     <name>tornado-runtime</name>

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.github.beehive-lab</groupId>
         <artifactId>tornado</artifactId>
-        <version>4.0.1-dev</version>
+        <version>4.0.1-jdk21-dev</version>
     </parent>
     <artifactId>tornado-unittests</artifactId>
     <name>tornado-unittests</name>


### PR DESCRIPTION
#### Description

Adopt the `X.Y.Z-jdk21` versioning convention on the `develop` branch, mirroring the `X.Y.Z-jdk25` convention already used on the `jdk25` branch. Makes the target JDK explicit in pom versions, Maven Central artifacts, GitHub release tags, and SDKMAN identifiers - disambiguating JDK 21 vs JDK 25 builds for downstream consumers.

Rolled in alongside the convention change are three related improvements to the release pipeline that surfaced while auditing the workflows:

1. **Release notes are now rendered as proper Markdown.** The 2-finalize workflows previously passed RST verbatim into the GitHub Release body; GitHub renders the body as Markdown so RST underlines, link syntax, and orphan dashes leaked through unrendered.                                                                                                                                                             
2. **A `## How to use TornadoVM SDK` appendix** with Linux / macOS / Windows install snippets is appended automatically, parameterized by the release version. Matches the format of the manually-authored  `v4.0.0-jdk21` and `v4.0.0-jdk25` notes.
 3. **A latent bug** in `publish-archives-to-sdkman-jdk21.yml` is fixed: it had no tag-suffix filter, so since the JDK 25 release line was introduced every `-jdk25` release was also firing the JDK 21 publish workflow, causing duplicate SDKMAN publishes and clobbering the SDKMAN default version.                                                                                                                                                                                  
                                                                                                                                                                                                              
  Plus an unrelated fork-PR fix:                                                                                                                                                                              
                  
  4. `backport-pr-to-jdk25.yml` failed for fork-sourced PRs with "Fork collab can't be granted by someone without permission"* because `GITHUB_TOKEN` cannot grant maintainer-edit collaboration on a contributor's fork. Added `--no-maintainer-edit` to `gh pr create`.

#### Problem description

The previous unsuffixed `4.0.1-dev` form on `develop` left release artifacts (Maven Central jars, GitHub tags, SDKMAN identifiers) without any indication of which JDK they target. Downstream users had to infer this from context, and the parallel `jdk25` branch had to live with an asymmetric naming scheme.                                                                                                                                                                                   

Concrete bugs the workflows hid:                                                                                                                                                                                              
 - `1-prepare-release-jdk21.yml` PR-body line 324 used `version.replace(/(\d+)$/, m => parseInt(m)+1)` to compute the next dev version — with `version = "4.0.1-jdk21"`, `(\d+)$` matches `21` and produces `4.0.1-jdk22-dev`. 
 - `2-finalize-release-jdk21.yml` `IFS='.' read MAJOR MINOR PATCH` would set `PATCH=1-jdk21` and break the arithmetic.
 - `2-finalize-release-jdk21.yml` tag creation did `v${VERSION}-jdk21`, producing `v4.0.1-jdk21-jdk21` if VERSION already carried the suffix.
 - End-of-section regex in the changelog extractor anchored on `$`, failing to match suffixed `TornadoVM 4.0.0-jdk21` headings.

All four are fixed in this PR.                                                                                                                      

#### Backend/s tested

n/a 

  - [ ] OpenCL                                                                                                                                                                                                
  - [ ] PTX
  - [ ] SPIRV                                                                                                                                                                                                 
  - [ ] Metal     

----------------------------------------------------------------------------
