### PR TITLE
[fix] Honour compile-time local work size in SPIR-V Level Zero launcher

### DIFF
--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVLevelZeroInstalledCode.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVLevelZeroInstalledCode.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2021, 2024, APT Group, Department of Computer Science,
+ * Copyright (c) 2021, 2024, 2026, APT Group, Department of Computer Science,
  * School of Engineering, The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -150,25 +150,14 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
     private ThreadBlockDispatcher suggestThreadSchedulingToLevelZeroDriver(DeviceThreadScheduling threadScheduling, LevelZeroKernel levelZeroKernel, ZeKernelHandle kernel, TaskDataContext meta) {
 
         // Prepare kernel for launch
-        // A) Suggest scheduling parameters to level-zero
         int[] groupSizeX = new int[] { (int) threadScheduling.localWork[0] };
         int[] groupSizeY = new int[] { (int) threadScheduling.localWork[1] };
         int[] groupSizeZ = new int[] { (int) threadScheduling.localWork[2] };
-
-        if (!meta.isWorkerGridAvailable()) {
-            int result = levelZeroKernel.zeKernelSuggestGroupSize(kernel.getPtrZeKernelHandle(), (int) threadScheduling.globalWork[0], (int) threadScheduling.globalWork[1],
-                    (int) threadScheduling.globalWork[2], groupSizeX, groupSizeY, groupSizeZ);
-            LevelZeroUtils.errorLog("zeKernelSuggestGroupSize", result);
-        }
 
         int result = levelZeroKernel.zeKernelSetGroupSize(kernel.getPtrZeKernelHandle(), groupSizeX, groupSizeY, groupSizeZ);
         LevelZeroUtils.errorLog("zeKernelSetGroupSize", result);
 
         if (result == ZeResult.ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION) {
-            // At this point, we can only get a ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION
-            // only when using the GridScheduler API to bypass the thread scheduler
-            // suggestions of Level Zero. In this case, we call the suggestions and set up
-            // the right thread block sizes.
             System.out.println(WARNING_THREAD_LOCAL);
             setThreadSuggestionFromLevelZero(levelZeroKernel, kernel, groupSizeX, groupSizeY, groupSizeZ);
         }
@@ -178,8 +167,8 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
             grid.setLocalWork(groupSizeX[0], groupSizeY[0], groupSizeZ[0]);
         }
 
-        long[] localWorkAfterSuggestion = new long[] { groupSizeX[0], groupSizeY[0], groupSizeZ[0] };
-        meta.setLocalWork(localWorkAfterSuggestion);
+        long[] localWorkUsed = new long[] { groupSizeX[0], groupSizeY[0], groupSizeZ[0] };
+        meta.setLocalWork(localWorkUsed);
 
         return new ThreadBlockDispatcher(groupSizeX, groupSizeY, groupSizeZ);
     }
@@ -226,14 +215,7 @@ public class SPIRVLevelZeroInstalledCode extends SPIRVInstalledCode {
             // if the worker grid is available, the user can update the number of threads to
             // run at any point during runtime.
             deviceThreadScheduling = calculateGlobalAndLocalBlockOfThreads(meta, batchThreads);
-            if (TornadoOptions.USE_LEVELZERO_THREAD_DISPATCHER_SUGGESTIONS) {
-                threadBlockDispatcher = suggestThreadSchedulingToLevelZeroDriver(deviceThreadScheduling, levelZeroKernel, kernel, meta);
-            } else {
-                int[] groupSizeX = new int[] { (int) deviceThreadScheduling.localWork[0] };
-                int[] groupSizeY = new int[] { (int) deviceThreadScheduling.localWork[1] };
-                int[] groupSizeZ = new int[] { (int) deviceThreadScheduling.localWork[2] };
-                threadBlockDispatcher = new ThreadBlockDispatcher(groupSizeX, groupSizeY, groupSizeZ);
-            }
+            threadBlockDispatcher = suggestThreadSchedulingToLevelZeroDriver(deviceThreadScheduling, levelZeroKernel, kernel, meta);
 
             if (meta.shouldResetThreadsBlock()) {
                 // If the device was updated for the same ExecutionPlan and same TornadoVM instance,

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -2,7 +2,7 @@
  * This file is part of Tornado: A heterogeneous programming framework:
  * https://github.com/beehive-lab/tornadovm
  *
- * Copyright (c) 2013-2025, APT Group, Department of Computer Science,
+ * Copyright (c) 2013-2026, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -301,10 +301,6 @@ public class TornadoOptions {
      */
     public static final boolean OPTIMIZE_LOAD_STORE_SPIRV = getBooleanValue("tornado.spirv.loadstore", TRUE);
     /**
-     * Use Level Zero Thread Suggestions for the Thread Dispatcher. True by default.
-     */
-    public static final boolean USE_LEVELZERO_THREAD_DISPATCHER_SUGGESTIONS = getBooleanValue("tornado.spirv.levelzero.thread.dispatcher", TRUE);
-    /**
      * Memory Alignment for the Level Zero buffers (shared memory and or device
      * memory).
      */
@@ -505,7 +501,7 @@ public class TornadoOptions {
      * resource is closed. This is False by default, since this area is global for all kernels. In near future,
      * we will change this to use a unique area per execution plan, and have the option to turn on and off
      * this flag as needed.
-     * 
+     *
      * @return boolean
      */
     public static boolean cleanUpAtomicsSpace() {


### PR DESCRIPTION
#### Description
There was a bug causing the CI/CD pipeline to break when running SPIR-V backend with the LevelZero runtime. This PR includes the following:

- Fix silent miscompare in SPIR-V Level Zero launcher caused by using the driver-suggested workgroup size instead of the size the kernel was compiled for.
- Drop the `USE_LEVELZERO_THREAD_DISPATCHER_SUGGESTIONS` option (`-Dtornado.spirv.levelzero.thread.dispatcher`). This was asking the driver to suggest local workgroup, but it was causing miscalculated items in case of reductions. This PR sets the compiled-for size and only falls back to `zeKernelSuggestGroupSize` if the driver rejects the GridScheduler-supplied size.

#### Problem description

`SPIRVLevelZeroInstalledCode#suggestThreadSchedulingToLevelZeroDriver` called `zeKernelSuggestGroupSize` and then handed the driver's suggestion to `zeKernelSetGroupSize`. On Intel Iris Xe (Level Zero) the suggestion for a 512-thread global is a single workgroup of 512.

The SPIR-V kernel, however, was compiled with statically-sized workgroup memory matching the local size TornadoVM picked at compile time (e.g. 128 floats for the auto-generated per-WG reduction kernel `testFloat`). Launching the same binary with `local=512` causes threads with `localId >= 128` to write out of bounds in `OpTypePointer Workgroup` arrays, corrupting adjacent kernel state and producing silently-wrong results with random sign.

The OpenCL runtime was unaffected: it has always launched with the compiled-for local size via `clEnqueueNDRangeKernel`.

## Fix

Always pass the local work size computed by `calculateGlobalAndLocalBlockOfThreads` to `zeKernelSetGroupSize`. The
`zeKernelSuggestGroupSize` fallback remains, but only fires when a user-supplied `GridScheduler` size is rejected by the driver with `ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION` - the original reason that branch existed.

Removes `USE_LEVELZERO_THREAD_DISPATCHER_SUGGESTIONS` entirely; the if/else it gated is gone and re-enabling driver-suggested sizes would just drive accidental problems.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [x] SPIRV
- [ ] Metal

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Reduction + matrix unit tests that previously failed only on `device=0:1` (SPIR-V / Level Zero) now pass:
```bash
make BACKEND=spirv
tornado-test --ea --verbose --jvm="-Dtornado.unittests.device=0:1" -qp
```

----------------------------------------------------------------------------
