### PR TITLE
[jdk25] Add swizzled local memory accessors for FP16 and INT8 on the PTX backend

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
@@ -312,4 +312,206 @@ public class KernelContext implements ExecutionContext {
     @Override
     public void atomicAdd(DoubleArray array, int index, double val) {
     }
+
+    /**
+     * Loads a half-float from a swizzled shared-memory tile (stride-32 layout).
+     *
+     * <p>Applies an XOR permutation to the logical {@code (row, col)} coordinate so that
+     * the resulting shared-memory access pattern avoids bank conflicts. On NVIDIA GPUs, shared memory has
+     * 32 banks of 4 bytes each; a naive row-major tile layout causes many threads in a warp
+     * to hit the same bank, serializing the access. The XOR rotates each row's bank
+     * assignment so consecutive rows spread across distinct banks.
+     *
+     * <p>The swizzle is computed on the <em>byte</em> offset:
+     * <pre>{@code
+     *   byteOffset = (row * stride + col) * 2          // fp16 = 2 bytes per element
+     *   swizzled   = byteOffset ^ (((byteOffset >> 7) & 0b111) << 4)
+     * }</pre>
+     *
+     * <p>The three constants:
+     * <ul>
+     *   <li><b>7</b> (shift-right / source position): isolates the row-group bits to
+     *       permute. The 32-bank * 4-byte layout means the bank pattern repeats every
+     *       128 bytes (2<sup>7</sup>); shifting right by 7 yields the row group.</li>
+     *   <li><b>0b111</b> (mask): three bits participate, giving 8 distinct row rotations.</li>
+     *   <li><b>4</b> (shift-left / target position): the permutation lands at the 16-byte
+     *       boundary (2<sup>4</sup>). Bits below 4 pass through untouched, so each 16-byte
+     *       chunk stays contiguous.</li>
+     * </ul>
+     *
+     * <p>The XOR is involutive, so {@link #swizzleStoreFp16Stride32} with the same
+     * coordinate writes to exactly the position this method reads from.
+     *
+     * <p>The specific constants (a 16-byte permutation granularity over groups of 8 rows)
+     * match the access pattern of NVIDIA Tensor Core matrix loads, so this layout is
+     * intended for staging matrix tiles for future MMA support. It is, however, a general
+     * bank-conflict-free layout usable by any kernel with the same access shape.
+     *
+     * <p><b>Note:</b> Currently lowered on the PTX backend only.
+     *
+     * @param arr    the shared-memory tile, addressed in logical element coordinates
+     * @param row    the row index within the tile
+     * @param col    the column index within the row
+     * @param stride the number of fp16 elements per row (16 for a 32-byte row)
+     * @return the half-float stored at the swizzled position
+     */
+    public HalfFloat swizzleLoadFp16Stride32(HalfFloat[] arr, int row, int col, int stride) {
+        int byteOffset = (row * stride + col) * 2;
+        int swizzledByte = byteOffset ^ (((byteOffset >> 7) & 0b111) << 4);
+        return arr[swizzledByte / 2];
+    }
+
+    /**
+     * Stores a half-float into a swizzled shared-memory tile (stride-32 layout).
+     *
+     * <p>The inverse of {@link #swizzleLoadFp16Stride32}: applies the identical XOR
+     * permutation {@code byteOffset ^ (((byteOffset >> 7) & 0b111) << 4)} so a value written
+     * at a given {@code (row, col)} is later read back from the same coordinate. See
+     * {@link #swizzleLoadFp16Stride32} for the full derivation of the constants
+     * (7 = source bits, 0b111 = mask, 4 = 16-byte target boundary).
+     *
+     * <p><b>Note:</b> Currently lowered on the PTX backend only.
+     *
+     * @param arr    the shared-memory tile, addressed in logical element coordinates
+     * @param row    the row index within the tile
+     * @param col    the column index within the row
+     * @param stride the number of fp16 elements per row (16 for a 32-byte row)
+     * @param v      the half-float to store at the swizzled position
+     */
+    public void swizzleStoreFp16Stride32(HalfFloat[] arr, int row, int col, int stride, HalfFloat v) {
+        int byteOffset = (row * stride + col) * 2;
+        int swizzledByte = byteOffset ^ (((byteOffset >> 7) & 0b111) << 4);
+        arr[swizzledByte / 2] = v;
+    }
+
+    /**
+     * Loads a half-float from a swizzled shared-memory tile (stride-16 layout).
+     *
+     * <p>Variant of {@link #swizzleLoadFp16Stride32} for a narrower tile (8 fp16 cols =
+     * 16 bytes per row). Applies the same kind of bank-conflict-avoiding XOR permutation,
+     * but with constants shifted down one bit because the row stride is halved:
+     * <pre>{@code
+     *   byteOffset = (row * stride + col) * 2          // fp16 = 2 bytes per element
+     *   swizzled   = byteOffset ^ (((byteOffset >> 6) & 0b111) << 3)
+     * }</pre>
+     *
+     * <p>The three constants:
+     * <ul>
+     *   <li><b>6</b> (shift-right / source position): row-group bits for a 16-byte row
+     *       stride. The bank pattern spans half as many rows as the 32-byte case, so the
+     *       group bits sit one position lower, at 2<sup>6</sup> = 64 bytes.</li>
+     *   <li><b>0b111</b> (mask): three bits participate, giving 8 distinct row rotations.</li>
+     *   <li><b>3</b> (shift-left / target position): the permutation lands at the 8-byte
+     *       boundary (2<sup>3</sup>). Bits below 3 pass through untouched.</li>
+     * </ul>
+     *
+     * <p>The XOR is involutive, so {@link #swizzleStoreFp16Stride16} with the same
+     * coordinate writes to exactly the position this method reads from.
+     *
+     * <p>This narrower layout is intended for transposed matrix tiles in future MMA work.
+     * The constants follow the same derivation as the stride-32 case, shifted down one bit
+     * for the halved row stride, but have not yet been validated against a live consumer,
+     * treat as provisional.
+     *
+     * <p><b>Note:</b> Currently lowered on the PTX backend only.
+     *
+     * @param arr    the shared-memory tile, addressed in logical element coordinates
+     * @param row    the row index within the tile
+     * @param col    the column index within the row
+     * @param stride the number of fp16 elements per row (8 for a 16-byte row)
+     * @return the half-float stored at the swizzled position
+     */
+    public HalfFloat swizzleLoadFp16Stride16(HalfFloat[] arr, int row, int col, int stride) {
+        int byteOffset = (row * stride + col) * 2;
+        int swizzledByte = byteOffset ^ (((byteOffset >> 6) & 0b111) << 3);
+        return arr[swizzledByte / 2];
+    }
+
+    /**
+     * Stores a half-float into a swizzled shared-memory tile (stride-16 layout).
+     *
+     * <p>The inverse of {@link #swizzleLoadFp16Stride16}: applies the identical XOR
+     * permutation {@code byteOffset ^ (((byteOffset >> 6) & 0b111) << 3)}. See
+     * {@link #swizzleLoadFp16Stride16} for the constant derivation (6 = source bits,
+     * 0b111 = mask, 3 = 8-byte target boundary) and the validation caveat.
+     *
+     * <p><b>Note:</b> Currently lowered on the PTX backend only.
+     *
+     * @param arr    the shared-memory tile, addressed in logical element coordinates
+     * @param row    the row index within the tile
+     * @param col    the column index within the row
+     * @param stride the number of fp16 elements per row (8 for a 16-byte row)
+     * @param v      the half-float to store at the swizzled position
+     */
+    public void swizzleStoreFp16Stride16(HalfFloat[] arr, int row, int col, int stride, HalfFloat v) {
+        int byteOffset = (row * stride + col) * 2;
+        int swizzledByte = byteOffset ^ (((byteOffset >> 6) & 0b111) << 3);
+        arr[swizzledByte / 2] = v;
+    }
+
+    /**
+     * Loads an int8 value from a swizzled shared-memory tile.
+     *
+     * <p>Applies the same bank-conflict-avoiding XOR permutation as
+     * {@link #swizzleLoadFp16Stride32}, with identical constants. The permutation operates
+     * on a 16-byte granularity, which is independent of the element type, so the int8 and
+     * fp16 stride-32 swizzles share the same math.
+     *
+     * <p>Because int8 elements are one byte, the logical element index <em>is</em> the byte
+     * offset; there is no {@code * 2} conversion:
+     * <pre>{@code
+     *   byteOffset = row * stride + col
+     *   swizzled   = byteOffset ^ (((byteOffset >> 7) & 0b111) << 4)
+     * }</pre>
+     *
+     * <p>Constants (see {@link #swizzleLoadFp16Stride32} for the full derivation):
+     * <ul>
+     *   <li><b>7</b> (source): row-group bits; the 32-bank * 4-byte layout repeats every
+     *       128 bytes (2<sup>7</sup>).</li>
+     *   <li><b>0b111</b> (mask): 8 distinct row rotations.</li>
+     *   <li><b>4</b> (target): permutation at the 16-byte boundary (2<sup>4</sup>).</li>
+     * </ul>
+     *
+     * <p>This single method serves both tile layouts; the caller selects via the
+     * {@code stride} argument: 32 (bytes) for a wide tile, 16 (bytes) for a narrow one.
+     * The swizzle math is identical for both. The layout is intended for staging matrix
+     * tiles for future MMA support, but is a general bank-conflict-free layout usable by
+     * any kernel with the same access shape.
+     *
+     * <p><b>Note:</b> Currently lowered on the PTX backend only.
+     *
+     * @param arr    the shared-memory tile, addressed in logical element coordinates
+     * @param row    the row index within the tile
+     * @param col    the column index within the row
+     * @param stride the number of int8 elements (= bytes) per row
+     * @return the int8 value stored at the swizzled position
+     */
+    public byte swizzleLoadInt8(byte[] arr, int row, int col, int stride) {
+        int byteOffset = row * stride + col;   // int8: element index == byte offset
+        int swizzledByte = byteOffset ^ (((byteOffset >> 7) & 0b111) << 4);
+        return arr[swizzledByte];
+    }
+
+    /**
+     * Stores an int8 value into a swizzled shared-memory tile.
+     *
+     * <p>The inverse of {@link #swizzleLoadInt8}: applies the identical XOR permutation
+     * {@code byteOffset ^ (((byteOffset >> 7) & 0b111) << 4)}, where for int8 the element
+     * index is the byte offset directly. See {@link #swizzleLoadInt8} for the constant
+     * derivation and the dual-stride (32 / 16) usage.
+     *
+     * <p><b>Note:</b> Currently lowered on the PTX backend only.
+     *
+     * @param arr    the shared-memory tile, addressed in logical element coordinates
+     * @param row    the row index within the tile
+     * @param col    the column index within the row
+     * @param stride the number of int8 elements (= bytes) per row
+     * @param v      the int8 value to store at the swizzled position
+     */
+    public void swizzleStoreInt8(byte[] arr, int row, int col, int stride, byte v) {
+        int byteOffset = row * stride + col;
+        int swizzledByte = byteOffset ^ (((byteOffset >> 7) & 0b111) << 4);
+        arr[swizzledByte] = v;
+    }
+
 }

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -175,6 +175,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestCombinedTaskGraph"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestVectorAdditionKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.KernelContextWorkGroupTests"),
+    TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.local.memory.TestSwizzledLocalArrays"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsIntegersKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsFloatsKernelContext"),

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/plugins/MetalGraphBuilderPlugins.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/plugins/MetalGraphBuilderPlugins.java
@@ -23,6 +23,7 @@
  */
 package uk.ac.manchester.tornado.drivers.metal.graal.compiler.plugins;
 
+import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 import static uk.ac.manchester.tornado.drivers.common.code.CodeUtil.getJavaKindFromValueLayoutClass;
 import static uk.ac.manchester.tornado.drivers.common.code.CodeUtil.getValueLayoutClass;
 import static uk.ac.manchester.tornado.drivers.metal.graal.nodes.MetalFPBinaryIntrinsicNode.Operation.ATAN2;
@@ -82,6 +83,7 @@ import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.exceptions.Debug;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.Int8Array;
@@ -426,6 +428,61 @@ public class MetalGraphBuilderPlugins {
         localArraysPlugins(r);
         registerAtomicAddOperation(r);
         registerSIMDPlugins(r);
+        registerSwizzledLocalAccessesPlugins(r);
+    }
+
+    private static void registerSwizzledLocalAccessesPlugins(Registration r) {
+        r.register(new InvocationPlugin("swizzleLoadFp16Stride32", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreFp16Stride32", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class, HalfFloat.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleLoadFp16Stride16", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreFp16Stride16", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class, HalfFloat.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleLoadInt8", InvocationPlugin.Receiver.class,
+                byte[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver,
+                                 ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreInt8", InvocationPlugin.Receiver.class,
+                byte[].class, int.class, int.class, int.class, byte.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver,
+                                 ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
     }
 
     private static void registerMemoryAccessPlugins(final Plugins ps, InvocationPlugins plugins) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/plugins/OCLGraphBuilderPlugins.java
@@ -61,6 +61,7 @@ import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.word.LocationIdentity;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.exceptions.Debug;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.Int8Array;
@@ -433,6 +434,61 @@ public class OCLGraphBuilderPlugins {
         registerGlobalBarrier(r);
         localArraysPlugins(r);
         registerAtomicAddOperation(r);
+        registerSwizzledLocalAccessesPlugins(r);
+    }
+
+    private static void registerSwizzledLocalAccessesPlugins(Registration r) {
+        r.register(new InvocationPlugin("swizzleLoadFp16Stride32", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreFp16Stride32", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class, HalfFloat.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleLoadFp16Stride16", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreFp16Stride16", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class, HalfFloat.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleLoadInt8", InvocationPlugin.Receiver.class,
+                byte[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver,
+                                 ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreInt8", InvocationPlugin.Receiver.class,
+                byte[].class, int.class, int.class, int.class, byte.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver,
+                                 ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
     }
 
     private static void registerFP16ConversionPlugins(InvocationPlugins plugins) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
@@ -58,6 +58,7 @@ import jdk.graal.compiler.replacements.InlineDuringParsingPlugin;
 import org.graalvm.word.LocationIdentity;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.exceptions.Debug;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.Int8Array;
@@ -81,6 +82,12 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXIntBinaryIntrinsicNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXIntUnaryIntrinsicNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PrintfNode;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SwizzledLoadFP16Stride16Node;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SwizzledLoadFP16Stride32Node;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SwizzledLoadInt8Node;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SwizzledStoreFP16Stride16Node;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SwizzledStoreFP16Stride32Node;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SwizzledStoreInt8Node;
 import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
@@ -434,6 +441,61 @@ public class PTXGraphBuilderPlugins {
         localArraysPlugins(r);
         registerAtomicAddOperation(r);
         registerSIMDPlugins(r);
+        registerSwizzledLocalAccessesPlugins(r);
+    }
+
+    private static void registerSwizzledLocalAccessesPlugins(Registration r) {
+        r.register(new InvocationPlugin("swizzleLoadFp16Stride32", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                b.addPush(JavaKind.Short, new SwizzledLoadFP16Stride32Node(local_array, row, column, stride));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreFp16Stride32", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class, HalfFloat.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                b.addPush(JavaKind.Short, new SwizzledStoreFP16Stride32Node(local_array, row, column, stride, value));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleLoadFp16Stride16", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                b.addPush(JavaKind.Short, new SwizzledLoadFP16Stride16Node(local_array, row, column, stride));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreFp16Stride16", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class, HalfFloat.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                b.addPush(JavaKind.Short, new SwizzledStoreFP16Stride16Node(local_array, row, column, stride, value));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleLoadInt8", InvocationPlugin.Receiver.class,
+                byte[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver,
+                                 ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                b.addPush(JavaKind.Byte, new SwizzledLoadInt8Node(local_array, row, column, stride));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreInt8", InvocationPlugin.Receiver.class,
+                byte[].class, int.class, int.class, int.class, byte.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver,
+                                 ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                b.addPush(JavaKind.Byte, new SwizzledStoreInt8Node(local_array, row, column, stride, value));
+                return true;
+            }
+        });
     }
 
     private static void registerSIMDPlugins(Registration r) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
@@ -448,7 +448,8 @@ public class PTXGraphBuilderPlugins {
         r.register(new InvocationPlugin("swizzleLoadFp16Stride32", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
-                b.addPush(JavaKind.Short, new SwizzledLoadFP16Stride32Node(local_array, row, column, stride));
+                receiver.get(true);
+                b.addPush(JavaKind.Object, new SwizzledLoadFP16Stride32Node(local_array, row, column, stride));
                 return true;
             }
         });
@@ -456,7 +457,8 @@ public class PTXGraphBuilderPlugins {
         r.register(new InvocationPlugin("swizzleStoreFp16Stride32", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
-                b.addPush(JavaKind.Short, new SwizzledStoreFP16Stride32Node(local_array, row, column, stride, value));
+                receiver.get(true);
+                b.add(new SwizzledStoreFP16Stride32Node(local_array, row, column, stride, value));
                 return true;
             }
         });
@@ -464,7 +466,8 @@ public class PTXGraphBuilderPlugins {
         r.register(new InvocationPlugin("swizzleLoadFp16Stride16", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
-                b.addPush(JavaKind.Short, new SwizzledLoadFP16Stride16Node(local_array, row, column, stride));
+                receiver.get(true);
+                b.addPush(JavaKind.Object, new SwizzledLoadFP16Stride16Node(local_array, row, column, stride));
                 return true;
             }
         });
@@ -472,27 +475,27 @@ public class PTXGraphBuilderPlugins {
         r.register(new InvocationPlugin("swizzleStoreFp16Stride16", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class, HalfFloat.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
-                b.addPush(JavaKind.Short, new SwizzledStoreFP16Stride16Node(local_array, row, column, stride, value));
+                receiver.get(true);
+                b.add(new SwizzledStoreFP16Stride16Node(local_array, row, column, stride, value));
                 return true;
             }
         });
 
-        r.register(new InvocationPlugin("swizzleLoadInt8", InvocationPlugin.Receiver.class,
-                byte[].class, int.class, int.class, int.class) {
+        r.register(new InvocationPlugin("swizzleLoadInt8", InvocationPlugin.Receiver.class, byte[].class, int.class, int.class, int.class) {
             @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver,
-                                 ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                receiver.get(true);
                 b.addPush(JavaKind.Byte, new SwizzledLoadInt8Node(local_array, row, column, stride));
                 return true;
             }
         });
 
-        r.register(new InvocationPlugin("swizzleStoreInt8", InvocationPlugin.Receiver.class,
-                byte[].class, int.class, int.class, int.class, byte.class) {
+        // STORE int8 — returns void → add
+        r.register(new InvocationPlugin("swizzleStoreInt8", InvocationPlugin.Receiver.class, byte[].class, int.class, int.class, int.class, byte.class) {
             @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver,
-                                 ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
-                b.addPush(JavaKind.Byte, new SwizzledStoreInt8Node(local_array, row, column, stride, value));
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                receiver.get(true);
+                b.add(new SwizzledStoreInt8Node(local_array, row, column, stride, value));
                 return true;
             }
         });

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
@@ -1716,4 +1716,775 @@ public class PTXLIRStmt {
             asm.eol();
         }
     }
+
+    @Opcode("SWIZZLED_LOAD_FP16_STRIDE_32")
+    public static class SwizzledLoadFP16Stride32Stmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<SwizzledLoadFP16Stride32Stmt> TYPE
+                = LIRInstructionClass.create(SwizzledLoadFP16Stride32Stmt.class);
+
+        @Def protected Value result;
+        @Use protected Value localArray;
+        @Use protected Value row;
+        @Use protected Value column;
+        @Use protected Value stride;
+        @Def protected Value linIdx;
+        @Def protected Value byteOff;
+        @Def protected Value shifted;
+        @Def protected Value masked;
+        @Def protected Value xorTerm;
+        @Def protected Value swzByte;
+
+        public SwizzledLoadFP16Stride32Stmt(Value result, Value localArray, Value row, Value column, Value stride,
+                                            Value linIdx, Value byteOff, Value shifted, Value masked,
+                                            Value xorTerm, Value swzByte) {
+            super(TYPE);
+            this.result = result;
+            this.localArray = localArray;
+            this.row = row;
+            this.column = column;
+            this.stride = stride;
+            this.linIdx = linIdx;
+            this.byteOff = byteOff;
+            this.shifted = shifted;
+            this.masked = masked;
+            this.xorTerm = xorTerm;
+            this.swzByte = swzByte;
+        }
+
+        @Override
+        public void emitCode(PTXCompilationResultBuilder crb, PTXAssembler asm) {
+            // ----------------------------------------------------------------------------
+            // Swizzled FP16 load, stride-32 layout (16 fp16 cols = 32 bytes per row).
+            //
+            // Computes:  swzByte = byteOff ^ (((byteOff >> 7) & 0b111) << 4)
+            //            result  = sharedMem[swzByte]
+            //
+            // Constants (CUTLASS Swizzle<3,4,3>-equivalent for ldmatrix.x4.b16):
+            //   element size = 2 bytes (fp16) -> linIdx << 1 gives the byte offset
+            //   7  (S, shift-right amount): selects the row-index bits to permute.
+            //       byteOff >> 7 isolates bits [9:7], i.e. which group of 8 rows
+            //       (a 32-byte row * 4 = 128-byte = 2^7 boundary).
+            //   0b111 (MASK): 3 bits participate in the permutation (8 distinct rows).
+            //   4  (T, shift-left amount): where the XOR lands. 2^4 = 16 bytes, i.e.
+            //       the ldmatrix.x4 access granularity. Bits below 4 pass through
+            //       untouched, so the bottom 16 bytes move as a unit.
+            // ----------------------------------------------------------------------------
+
+            // linIdx = row * stride + column   (logical element index within the tile)
+            asm.emitSymbol(TAB);
+            asm.emit("mad.lo.s32 ");
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(row);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(stride);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(column);
+            asm.delimiter();
+            asm.eol();
+
+            // byteOff = linIdx << 1   (element index -> byte offset; fp16 = 2 bytes)
+            asm.emitSymbol(TAB);
+            asm.emit("shl.b32 ");
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("1");
+            asm.delimiter();
+            asm.eol();
+
+            // shifted = byteOff >> 7   (7 = S: isolate the row-group bits to permute)
+            asm.emitSymbol(TAB);
+            asm.emit("shr.b32 ");
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("7");
+            asm.delimiter();
+            asm.eol();
+
+            // masked = shifted & 0b111   (0b111 = MASK: keep 3 bits = 8 distinct rows)
+            asm.emitSymbol(TAB);
+            asm.emit("and.b32 ");
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("7");
+            asm.delimiter();
+            asm.eol();
+
+            // xorTerm = masked << 4   (4 = T: place the permutation at the 16-byte boundary)
+            asm.emitSymbol(TAB);
+            asm.emit("shl.b32 ");
+            asm.emitValue(xorTerm);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("4");
+            asm.delimiter();
+            asm.eol();
+
+            // swzByte = byteOff ^ xorTerm   (apply the swizzle)
+            asm.emitSymbol(TAB);
+            asm.emit("xor.b32 ");
+            asm.emitValue(swzByte);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(xorTerm);
+            asm.delimiter();
+            asm.eol();
+
+            // result = ld.shared.b16 sharedMem[swzByte]   (16-bit load = one fp16)
+            asm.emitSymbol(TAB);
+            asm.emit("ld.shared.b16 ");
+            asm.emitValue(result);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(localArray);
+            asm.emitSymbol("[");
+            asm.emitValue(swzByte);
+            asm.emitSymbol("]");
+            asm.delimiter();
+            asm.eol();
+        }
+    }
+
+    @Opcode("SWIZZLED_LOAD_FP16_STRIDE_16")
+    public static class SwizzledLoadFP16Stride16Stmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<SwizzledLoadFP16Stride16Stmt> TYPE
+                = LIRInstructionClass.create(SwizzledLoadFP16Stride16Stmt.class);
+
+        @Def protected Value result;
+        @Use protected Value localArray;
+        @Use protected Value row;
+        @Use protected Value column;
+        @Use protected Value stride;
+        @Def protected Value linIdx;
+        @Def protected Value byteOff;
+        @Def protected Value shifted;
+        @Def protected Value masked;
+        @Def protected Value xorTerm;
+        @Def protected Value swzByte;
+
+        public SwizzledLoadFP16Stride16Stmt(Value result, Value localArray, Value row, Value column, Value stride,
+                                            Value linIdx, Value byteOff, Value shifted, Value masked,
+                                            Value xorTerm, Value swzByte) {
+            super(TYPE);
+            this.result = result;
+            this.localArray = localArray;
+            this.row = row;
+            this.column = column;
+            this.stride = stride;
+            this.linIdx = linIdx;
+            this.byteOff = byteOff;
+            this.shifted = shifted;
+            this.masked = masked;
+            this.xorTerm = xorTerm;
+            this.swzByte = swzByte;
+        }
+
+        @Override
+        public void emitCode(PTXCompilationResultBuilder crb, PTXAssembler asm) {
+            // ----------------------------------------------------------------------------
+            // Swizzled FP16 load, stride-16 layout (8 fp16 cols = 16 bytes per row).
+            // Used for the transposed B operand consumed by ldmatrix.x2.trans.b16.
+            //
+            // Computes:  swzByte = byteOff ^ (((byteOff >> 6) & 0b111) << 3)
+            //            result  = sharedMem[swzByte]
+            //
+            // Constants (same swizzle shape as stride-32, shifted down one bit because
+            // the row stride is halved: 16 bytes/row instead of 32):
+            //   element size = 2 bytes (fp16) -> linIdx << 1 gives the byte offset
+            //   6  (S): isolate the row-group bits. byteOff >> 6 selects bits [8:6]
+            //       (16-byte row * 4 = 64-byte = 2^6 boundary).
+            //   0b111 (MASK): 3 bits participate (8 distinct rows).
+            //   3  (T): XOR lands at 2^3 = 8 bytes, the ldmatrix.x2 access granularity
+            //       for this narrower tile.
+            //
+            // ----------------------------------------------------------------------------
+
+            // linIdx = row * stride + column   (logical element index within the tile)
+            asm.emitSymbol(TAB);
+            asm.emit("mad.lo.s32 ");
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(row);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(stride);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(column);
+            asm.delimiter();
+            asm.eol();
+
+            // byteOff = linIdx << 1   (element index -> byte offset; fp16 = 2 bytes)
+            asm.emitSymbol(TAB);
+            asm.emit("shl.b32 ");
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("1");
+            asm.delimiter();
+            asm.eol();
+
+            // shifted = byteOff >> 6   (6 = S: row-group bits for the 16-byte stride)
+            asm.emitSymbol(TAB);
+            asm.emit("shr.b32 ");
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("6");
+            asm.delimiter();
+            asm.eol();
+
+            // masked = shifted & 0b111   (0b111 = MASK: keep 3 bits = 8 distinct rows)
+            asm.emitSymbol(TAB);
+            asm.emit("and.b32 ");
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("7");
+            asm.delimiter();
+            asm.eol();
+
+            // xorTerm = masked << 3   (3 = T: place permutation at the 8-byte boundary)
+            asm.emitSymbol(TAB);
+            asm.emit("shl.b32 ");
+            asm.emitValue(xorTerm);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("3");
+            asm.delimiter();
+            asm.eol();
+
+            // swzByte = byteOff ^ xorTerm   (apply the swizzle)
+            asm.emitSymbol(TAB);
+            asm.emit("xor.b32 ");
+            asm.emitValue(swzByte);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(xorTerm);
+            asm.delimiter();
+            asm.eol();
+
+            // result = ld.shared.b16 sharedMem[swzByte]   (16-bit load = one fp16)
+            asm.emitSymbol(TAB);
+            asm.emit("ld.shared.b16 ");
+            asm.emitValue(result);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(localArray);
+            asm.emitSymbol("[");
+            asm.emitValue(swzByte);
+            asm.emitSymbol("]");
+            asm.delimiter();
+            asm.eol();
+        }
+    }
+
+    @Opcode("SWIZZLED_LOAD_INT8")
+    public static class SwizzledLoadInt8Stmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<SwizzledLoadInt8Stmt> TYPE
+                = LIRInstructionClass.create(SwizzledLoadInt8Stmt.class);
+
+        @Def protected Value result;
+        @Use protected Value localArray;
+        @Use protected Value row;
+        @Use protected Value column;
+        @Use protected Value stride;
+        @Def protected Value linIdx;
+        @Def protected Value shifted;
+        @Def protected Value masked;
+        @Def protected Value xorTerm;
+        @Def protected Value swzByte;
+
+        public SwizzledLoadInt8Stmt(Value result, Value localArray, Value row, Value column, Value stride,
+                                    Value linIdx, Value shifted, Value masked, Value xorTerm, Value swzByte) {
+            super(TYPE);
+            this.result = result;
+            this.localArray = localArray;
+            this.row = row;
+            this.column = column;
+            this.stride = stride;
+            this.linIdx = linIdx;
+            this.shifted = shifted;
+            this.masked = masked;
+            this.xorTerm = xorTerm;
+            this.swzByte = swzByte;
+        }
+
+        @Override
+        public void emitCode(PTXCompilationResultBuilder crb, PTXAssembler asm) {
+            // ----------------------------------------------------------------------------
+            // Swizzled INT8 load. Same swizzle as FP16 stride-32 because ldmatrix moves
+            // 16 bytes per lane regardless of element type (int8 packs 2-per-.b16 lane,
+            // so the access granularity is still 16 bytes).
+            //
+            // Computes:  swzByte = linIdx ^ (((linIdx >> 7) & 0b111) << 4)
+            //            result  = sharedMem[swzByte]
+            //
+            // Constants (identical to FP16 stride-32):
+            //   element size = 1 byte (int8) -> linIdx is the byte offset, no <<1 needed.
+            //   7  (S): isolate the row-group bits (128-byte = 2^7 boundary).
+            //   0b111 (MASK): 3 bits participate (8 distinct rows).
+            //   4  (T): XOR lands at 2^4 = 16 bytes, the ldmatrix access granularity.
+            //
+            // The caller chooses the row stride: 32 (bytes) for the A operand,
+            // 16 (bytes) for the B operand staged at ldmatrix granularity. The swizzle
+            // math is the same for both; only the stride argument differs.
+            // ----------------------------------------------------------------------------
+
+            // linIdx = row * stride + column   (int8: this is the byte offset directly)
+            asm.emitSymbol(TAB);
+            asm.emit("mad.lo.s32 ");
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(row);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(stride);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(column);
+            asm.delimiter();
+            asm.eol();
+
+            // shifted = linIdx >> 7   (7 = S: isolate the row-group bits to permute)
+            asm.emitSymbol(TAB);
+            asm.emit("shr.b32 ");
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("7");
+            asm.delimiter();
+            asm.eol();
+
+            // masked = shifted & 0b111   (0b111 = MASK: keep 3 bits = 8 distinct rows)
+            asm.emitSymbol(TAB);
+            asm.emit("and.b32 ");
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("7");
+            asm.delimiter();
+            asm.eol();
+
+            // xorTerm = masked << 4   (4 = T: place permutation at the 16-byte boundary)
+            asm.emitSymbol(TAB);
+            asm.emit("shl.b32 ");
+            asm.emitValue(xorTerm);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("4");
+            asm.delimiter();
+            asm.eol();
+
+            // swzByte = linIdx ^ xorTerm   (apply the swizzle)
+            asm.emitSymbol(TAB);
+            asm.emit("xor.b32 ");
+            asm.emitValue(swzByte);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(xorTerm);
+            asm.delimiter();
+            asm.eol();
+
+            // result = ld.shared.s8 sharedMem[swzByte]   (8-bit load = one int8)
+            asm.emitSymbol(TAB);
+            asm.emit("ld.shared.s8 ");
+            asm.emitValue(result);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(localArray);
+            asm.emitSymbol("[");
+            asm.emitValue(swzByte);
+            asm.emitSymbol("]");
+            asm.delimiter();
+            asm.eol();
+        }
+    }
+
+    @Opcode("SWIZZLED_STORE_FP16_STRIDE_32")
+    public static class SwizzledStoreFP16Stride32Stmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<SwizzledStoreFP16Stride32Stmt> TYPE
+                = LIRInstructionClass.create(SwizzledStoreFP16Stride32Stmt.class);
+
+        @Use protected Value localArray;
+        @Use protected Value row;
+        @Use protected Value column;
+        @Use protected Value stride;
+        @Use protected Value value;
+        @Def protected Value linIdx;
+        @Def protected Value byteOff;
+        @Def protected Value shifted;
+        @Def protected Value masked;
+        @Def protected Value xorTerm;
+        @Def protected Value swzByte;
+
+        public SwizzledStoreFP16Stride32Stmt(Value localArray, Value row, Value column, Value stride, Value value,
+                                             Value linIdx, Value byteOff, Value shifted, Value masked,
+                                             Value xorTerm, Value swzByte) {
+            super(TYPE);
+            this.localArray = localArray;
+            this.row = row;
+            this.column = column;
+            this.stride = stride;
+            this.value = value;
+            this.linIdx = linIdx;
+            this.byteOff = byteOff;
+            this.shifted = shifted;
+            this.masked = masked;
+            this.xorTerm = xorTerm;
+            this.swzByte = swzByte;
+        }
+
+        @Override
+        public void emitCode(PTXCompilationResultBuilder crb, PTXAssembler asm) {
+            // ----------------------------------------------------------------------------
+            // Swizzled FP16 store, stride-32 layout. Mirror of SwizzledLoadFP16Stride32:
+            // identical address computation, ends in a store instead of a load.
+            //
+            // Computes:  swzByte = byteOff ^ (((byteOff >> 7) & 0b111) << 4)
+            //            sharedMem[swzByte] = value
+            //
+            // Constants: 2 bytes/elem (<<1), 7 = S, 0b111 = MASK, 4 = T (16-byte boundary).
+            // ----------------------------------------------------------------------------
+
+            // linIdx = row * stride + column   (logical element index within the tile)
+            asm.emitSymbol(TAB);
+            asm.emit("mad.lo.s32 ");
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(row);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(stride);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(column);
+            asm.delimiter();
+            asm.eol();
+
+            // byteOff = linIdx << 1   (element index -> byte offset; fp16 = 2 bytes)
+            asm.emitSymbol(TAB);
+            asm.emit("shl.b32 ");
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("1");
+            asm.delimiter();
+            asm.eol();
+
+            // shifted = byteOff >> 7   (7 = S: isolate the row-group bits to permute)
+            asm.emitSymbol(TAB);
+            asm.emit("shr.b32 ");
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("7");
+            asm.delimiter();
+            asm.eol();
+
+            // masked = shifted & 0b111   (0b111 = MASK: keep 3 bits = 8 distinct rows)
+            asm.emitSymbol(TAB);
+            asm.emit("and.b32 ");
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("7");
+            asm.delimiter();
+            asm.eol();
+
+            // xorTerm = masked << 4   (4 = T: place permutation at the 16-byte boundary)
+            asm.emitSymbol(TAB);
+            asm.emit("shl.b32 ");
+            asm.emitValue(xorTerm);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("4");
+            asm.delimiter();
+            asm.eol();
+
+            // swzByte = byteOff ^ xorTerm   (apply the swizzle)
+            asm.emitSymbol(TAB);
+            asm.emit("xor.b32 ");
+            asm.emitValue(swzByte);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(xorTerm);
+            asm.delimiter();
+            asm.eol();
+
+            // sharedMem[swzByte] = value   (st.shared.b16 = store one fp16)
+            asm.emitSymbol(TAB);
+            asm.emit("st.shared.b16 ");
+            asm.emitValue(localArray);
+            asm.emitSymbol("[");
+            asm.emitValue(swzByte);
+            asm.emitSymbol("]");
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(value);
+            asm.delimiter();
+            asm.eol();
+        }
+    }
+
+    @Opcode("SWIZZLED_STORE_FP16_STRIDE_16")
+    public static class SwizzledStoreFP16Stride16Stmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<SwizzledStoreFP16Stride16Stmt> TYPE
+                = LIRInstructionClass.create(SwizzledStoreFP16Stride16Stmt.class);
+
+        @Use protected Value localArray;
+        @Use protected Value row;
+        @Use protected Value column;
+        @Use protected Value stride;
+        @Use protected Value value;
+        @Def protected Value linIdx;
+        @Def protected Value byteOff;
+        @Def protected Value shifted;
+        @Def protected Value masked;
+        @Def protected Value xorTerm;
+        @Def protected Value swzByte;
+
+        public SwizzledStoreFP16Stride16Stmt(Value localArray, Value row, Value column, Value stride, Value value,
+                                             Value linIdx, Value byteOff, Value shifted, Value masked,
+                                             Value xorTerm, Value swzByte) {
+            super(TYPE);
+            this.localArray = localArray;
+            this.row = row;
+            this.column = column;
+            this.stride = stride;
+            this.value = value;
+            this.linIdx = linIdx;
+            this.byteOff = byteOff;
+            this.shifted = shifted;
+            this.masked = masked;
+            this.xorTerm = xorTerm;
+            this.swzByte = swzByte;
+        }
+
+        @Override
+        public void emitCode(PTXCompilationResultBuilder crb, PTXAssembler asm) {
+            // ----------------------------------------------------------------------------
+            // Swizzled FP16 store, stride-16 layout. Mirror of SwizzledLoadFP16Stride16.
+            //
+            // Computes:  swzByte = byteOff ^ (((byteOff >> 6) & 0b111) << 3)
+            //            sharedMem[swzByte] = value
+            //
+            // Constants: 2 bytes/elem (<<1), 6 = S, 0b111 = MASK, 3 = T (8-byte boundary).
+            // ----------------------------------------------------------------------------
+
+            // linIdx = row * stride + column   (logical element index within the tile)
+            asm.emitSymbol(TAB);
+            asm.emit("mad.lo.s32 ");
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(row);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(stride);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(column);
+            asm.delimiter();
+            asm.eol();
+
+            // byteOff = linIdx << 1   (element index -> byte offset; fp16 = 2 bytes)
+            asm.emitSymbol(TAB);
+            asm.emit("shl.b32 ");
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("1");
+            asm.delimiter();
+            asm.eol();
+
+            // shifted = byteOff >> 6   (6 = S: row-group bits for the 16-byte stride)
+            asm.emitSymbol(TAB);
+            asm.emit("shr.b32 ");
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("6");
+            asm.delimiter();
+            asm.eol();
+
+            // masked = shifted & 0b111   (0b111 = MASK: keep 3 bits = 8 distinct rows)
+            asm.emitSymbol(TAB);
+            asm.emit("and.b32 ");
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("7");
+            asm.delimiter();
+            asm.eol();
+
+            // xorTerm = masked << 3   (3 = T: place permutation at the 8-byte boundary)
+            asm.emitSymbol(TAB);
+            asm.emit("shl.b32 ");
+            asm.emitValue(xorTerm);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("3");
+            asm.delimiter();
+            asm.eol();
+
+            // swzByte = byteOff ^ xorTerm   (apply the swizzle)
+            asm.emitSymbol(TAB);
+            asm.emit("xor.b32 ");
+            asm.emitValue(swzByte);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(byteOff);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(xorTerm);
+            asm.delimiter();
+            asm.eol();
+
+            // sharedMem[swzByte] = value   (st.shared.b16 = store one fp16)
+            asm.emitSymbol(TAB);
+            asm.emit("st.shared.b16 ");
+            asm.emitValue(localArray);
+            asm.emitSymbol("[");
+            asm.emitValue(swzByte);
+            asm.emitSymbol("]");
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(value);
+            asm.delimiter();
+            asm.eol();
+        }
+    }
+
+    @Opcode("SWIZZLED_STORE_INT8")
+    public static class SwizzledStoreInt8Stmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<SwizzledStoreInt8Stmt> TYPE
+                = LIRInstructionClass.create(SwizzledStoreInt8Stmt.class);
+
+        @Use protected Value localArray;
+        @Use protected Value row;
+        @Use protected Value column;
+        @Use protected Value stride;
+        @Use protected Value value;
+        @Def protected Value linIdx;
+        @Def protected Value shifted;
+        @Def protected Value masked;
+        @Def protected Value xorTerm;
+        @Def protected Value swzByte;
+
+        public SwizzledStoreInt8Stmt(Value localArray, Value row, Value column, Value stride, Value value,
+                                     Value linIdx, Value shifted, Value masked, Value xorTerm, Value swzByte) {
+            super(TYPE);
+            this.localArray = localArray;
+            this.row = row;
+            this.column = column;
+            this.stride = stride;
+            this.value = value;
+            this.linIdx = linIdx;
+            this.shifted = shifted;
+            this.masked = masked;
+            this.xorTerm = xorTerm;
+            this.swzByte = swzByte;
+        }
+
+        @Override
+        public void emitCode(PTXCompilationResultBuilder crb, PTXAssembler asm) {
+            // ----------------------------------------------------------------------------
+            // Swizzled INT8 store. Mirror of SwizzledLoadInt8.
+            //
+            // Computes:  swzByte = linIdx ^ (((linIdx >> 7) & 0b111) << 4)
+            //            sharedMem[swzByte] = value
+            //
+            // Constants (same as FP16 stride-32; int8 ldmatrix still moves 16 bytes/lane):
+            //   1 byte/elem -> linIdx IS the byte offset (no <<1).
+            //   7 = S, 0b111 = MASK, 4 = T (16-byte boundary).
+            // Must stay identical to the load counterpart, or the round-trip breaks.
+            // ----------------------------------------------------------------------------
+
+            // linIdx = row * stride + column   (int8: this is the byte offset directly)
+            asm.emitSymbol(TAB);
+            asm.emit("mad.lo.s32 ");
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(row);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(stride);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(column);
+            asm.delimiter();
+            asm.eol();
+
+            // shifted = linIdx >> 7   (7 = S: isolate the row-group bits to permute)
+            asm.emitSymbol(TAB);
+            asm.emit("shr.b32 ");
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("7");
+            asm.delimiter();
+            asm.eol();
+
+            // masked = shifted & 0b111   (0b111 = MASK: keep 3 bits = 8 distinct rows)
+            asm.emitSymbol(TAB);
+            asm.emit("and.b32 ");
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(shifted);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("7");
+            asm.delimiter();
+            asm.eol();
+
+            // xorTerm = masked << 4   (4 = T: place permutation at the 16-byte boundary)
+            asm.emitSymbol(TAB);
+            asm.emit("shl.b32 ");
+            asm.emitValue(xorTerm);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(masked);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("4");
+            asm.delimiter();
+            asm.eol();
+
+            // swzByte = linIdx ^ xorTerm   (apply the swizzle)
+            asm.emitSymbol(TAB);
+            asm.emit("xor.b32 ");
+            asm.emitValue(swzByte);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(linIdx);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(xorTerm);
+            asm.delimiter();
+            asm.eol();
+
+            // sharedMem[swzByte] = value   (st.shared.s8 = store one int8)
+            asm.emitSymbol(TAB);
+            asm.emit("st.shared.s8 ");
+            asm.emitValue(localArray);
+            asm.emitSymbol("[");
+            asm.emitValue(swzByte);
+            asm.emitSymbol("]");
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(value);
+            asm.delimiter();
+            asm.eol();
+        }
+    }
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadFP16Stride16Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadFP16Stride16Node.java
@@ -21,16 +21,18 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
+import jdk.graal.compiler.core.common.type.StampFactory;
+import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
-import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.graph.NodeClass;
-import org.graalvm.compiler.lir.Variable;
-import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
-import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.FixedWithNextNode;
-import org.graalvm.compiler.nodes.ValueNode;
-import org.graalvm.compiler.nodes.spi.LIRLowerable;
-import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import jdk.graal.compiler.core.common.LIRKind;
+import jdk.graal.compiler.graph.NodeClass;
+import jdk.graal.compiler.lir.Variable;
+import jdk.graal.compiler.lir.gen.LIRGeneratorTool;
+import jdk.graal.compiler.nodeinfo.NodeInfo;
+import jdk.graal.compiler.nodes.FixedWithNextNode;
+import jdk.graal.compiler.nodes.ValueNode;
+import jdk.graal.compiler.nodes.spi.LIRLowerable;
+import jdk.graal.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 
@@ -52,7 +54,7 @@ public class SwizzledLoadFP16Stride16Node extends FixedWithNextNode implements L
     private ValueNode stride;
 
     public SwizzledLoadFP16Stride16Node(ValueNode fp16_local_array, ValueNode row, ValueNode column, ValueNode stride) {
-        super(TYPE, new uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp());
+        super(TYPE, StampFactory.forKind(JavaKind.Object));
         this.fp16_local_array = fp16_local_array;
         this.row = row;
         this.column = column;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadFP16Stride16Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadFP16Stride16Node.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
+
+@NodeInfo
+public class SwizzledLoadFP16Stride16Node extends FixedWithNextNode implements LIRLowerable {
+
+    public static final NodeClass<SwizzledLoadFP16Stride16Node> TYPE = NodeClass.create(SwizzledLoadFP16Stride16Node.class);
+
+    @Input
+    private ValueNode fp16_local_array;
+
+    @Input
+    private ValueNode row;
+
+    @Input
+    private ValueNode column;
+
+    @Input
+    private ValueNode stride;
+
+    public SwizzledLoadFP16Stride16Node(ValueNode fp16_local_array, ValueNode row, ValueNode column, ValueNode stride) {
+        super(TYPE, new uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp());
+        this.fp16_local_array = fp16_local_array;
+        this.row = row;
+        this.column = column;
+        this.stride = stride;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable result = tool.newVariable(LIRKind.value(PTXKind.F16));
+
+        Value localArray = generator.operand(fp16_local_array);
+        Value rowVal    = generator.operand(row);
+        Value colVal    = generator.operand(column);
+        Value strideVal = generator.operand(stride);
+
+        Variable linIdx  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable byteOff = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable shifted = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable masked  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable xorTerm = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable swzByte = tool.newVariable(LIRKind.value(PTXKind.S32));
+
+        tool.append(new PTXLIRStmt.SwizzledLoadFP16Stride16Stmt(
+                result, localArray, rowVal, colVal, strideVal,
+                linIdx, byteOff, shifted, masked, xorTerm, swzByte));
+        generator.setResult(this, result);
+    }
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadFP16Stride32Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadFP16Stride32Node.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
+
+@NodeInfo
+public class SwizzledLoadFP16Stride32Node extends FixedWithNextNode implements LIRLowerable {
+
+    public static final NodeClass<SwizzledLoadFP16Stride32Node> TYPE = NodeClass.create(SwizzledLoadFP16Stride32Node.class);
+
+    @Input
+    private ValueNode fp16_local_array;
+
+    @Input
+    private ValueNode row;
+
+    @Input
+    private ValueNode column;
+
+    @Input
+    private ValueNode stride;
+
+    public SwizzledLoadFP16Stride32Node(ValueNode fp16_local_array, ValueNode row, ValueNode column, ValueNode stride) {
+        super(TYPE, new HalfFloatStamp());
+        this.fp16_local_array = fp16_local_array;
+        this.row = row;
+        this.column = column;
+        this.stride = stride;
+    }
+
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable result = tool.newVariable(LIRKind.value(PTXKind.F16));
+
+        Value localArray = generator.operand(fp16_local_array);
+        Value rowVal    = generator.operand(row);
+        Value colVal    = generator.operand(column);
+        Value strideVal = generator.operand(stride);
+
+        // Scratch registers for the swizzle address computation
+        Variable linIdx  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable byteOff = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable shifted = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable masked  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable xorTerm = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable swzByte = tool.newVariable(LIRKind.value(PTXKind.S32));
+
+        tool.append(new PTXLIRStmt.SwizzledLoadFP16Stride32Stmt(
+                result, localArray, rowVal, colVal, strideVal,
+                linIdx, byteOff, shifted, masked, xorTerm, swzByte));
+        generator.setResult(this, result);
+    }
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadFP16Stride32Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadFP16Stride32Node.java
@@ -21,17 +21,18 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
+import jdk.graal.compiler.core.common.type.StampFactory;
+import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
-import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.graph.NodeClass;
-import org.graalvm.compiler.lir.Variable;
-import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
-import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.FixedWithNextNode;
-import org.graalvm.compiler.nodes.ValueNode;
-import org.graalvm.compiler.nodes.spi.LIRLowerable;
-import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
-import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
+import jdk.graal.compiler.core.common.LIRKind;
+import jdk.graal.compiler.graph.NodeClass;
+import jdk.graal.compiler.lir.Variable;
+import jdk.graal.compiler.lir.gen.LIRGeneratorTool;
+import jdk.graal.compiler.nodeinfo.NodeInfo;
+import jdk.graal.compiler.nodes.FixedWithNextNode;
+import jdk.graal.compiler.nodes.ValueNode;
+import jdk.graal.compiler.nodes.spi.LIRLowerable;
+import jdk.graal.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 
@@ -53,7 +54,7 @@ public class SwizzledLoadFP16Stride32Node extends FixedWithNextNode implements L
     private ValueNode stride;
 
     public SwizzledLoadFP16Stride32Node(ValueNode fp16_local_array, ValueNode row, ValueNode column, ValueNode stride) {
-        super(TYPE, new HalfFloatStamp());
+        super(TYPE, StampFactory.forKind(JavaKind.Object));
         this.fp16_local_array = fp16_local_array;
         this.row = row;
         this.column = column;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadInt8Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadInt8Node.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
+
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
+
+@NodeInfo
+public class SwizzledLoadInt8Node extends FixedWithNextNode implements LIRLowerable {
+    public static final NodeClass<SwizzledLoadInt8Node> TYPE = NodeClass.create(SwizzledLoadInt8Node.class);
+
+    @Input private ValueNode int8_local_array;
+    @Input private ValueNode row;
+    @Input private ValueNode column;
+    @Input private ValueNode stride;
+
+    public SwizzledLoadInt8Node(ValueNode int8_local_array, ValueNode row, ValueNode column, ValueNode stride) {
+        super(TYPE, StampFactory.forKind(JavaKind.Byte));
+        this.int8_local_array = int8_local_array;
+        this.row = row;
+        this.column = column;
+        this.stride = stride;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable result = tool.newVariable(LIRKind.value(PTXKind.S8));
+
+        Value localArray = generator.operand(int8_local_array);
+        Value rowVal    = generator.operand(row);
+        Value colVal    = generator.operand(column);
+        Value strideVal = generator.operand(stride);
+
+        Variable linIdx  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable shifted = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable masked  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable xorTerm = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable swzByte = tool.newVariable(LIRKind.value(PTXKind.S32));
+
+        tool.append(new PTXLIRStmt.SwizzledLoadInt8Stmt(
+                result, localArray, rowVal, colVal, strideVal,
+                linIdx, shifted, masked, xorTerm, swzByte));
+        generator.setResult(this, result);
+    }
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadInt8Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledLoadInt8Node.java
@@ -23,16 +23,16 @@ package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
-import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
-import org.graalvm.compiler.graph.NodeClass;
-import org.graalvm.compiler.lir.Variable;
-import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
-import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.FixedWithNextNode;
-import org.graalvm.compiler.nodes.ValueNode;
-import org.graalvm.compiler.nodes.spi.LIRLowerable;
-import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import jdk.graal.compiler.core.common.LIRKind;
+import jdk.graal.compiler.core.common.type.StampFactory;
+import jdk.graal.compiler.graph.NodeClass;
+import jdk.graal.compiler.lir.Variable;
+import jdk.graal.compiler.lir.gen.LIRGeneratorTool;
+import jdk.graal.compiler.nodeinfo.NodeInfo;
+import jdk.graal.compiler.nodes.FixedWithNextNode;
+import jdk.graal.compiler.nodes.ValueNode;
+import jdk.graal.compiler.nodes.spi.LIRLowerable;
+import jdk.graal.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride16Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride16Node.java
@@ -21,16 +21,18 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
+import jdk.graal.compiler.core.common.type.StampFactory;
+import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
-import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.graph.NodeClass;
-import org.graalvm.compiler.lir.Variable;
-import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
-import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.FixedWithNextNode;
-import org.graalvm.compiler.nodes.ValueNode;
-import org.graalvm.compiler.nodes.spi.LIRLowerable;
-import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import jdk.graal.compiler.core.common.LIRKind;
+import jdk.graal.compiler.graph.NodeClass;
+import jdk.graal.compiler.lir.Variable;
+import jdk.graal.compiler.lir.gen.LIRGeneratorTool;
+import jdk.graal.compiler.nodeinfo.NodeInfo;
+import jdk.graal.compiler.nodes.FixedWithNextNode;
+import jdk.graal.compiler.nodes.ValueNode;
+import jdk.graal.compiler.nodes.spi.LIRLowerable;
+import jdk.graal.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 
@@ -55,7 +57,7 @@ public class SwizzledStoreFP16Stride16Node extends FixedWithNextNode implements 
     private ValueNode fp16_value;
 
     public SwizzledStoreFP16Stride16Node(ValueNode fp16_local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode fp16_value) {
-        super(TYPE, new uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp());
+        super(TYPE, StampFactory.forKind(JavaKind.Object));
         this.fp16_local_array = fp16_local_array;
         this.row = row;
         this.column = column;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride16Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride16Node.java
@@ -57,7 +57,7 @@ public class SwizzledStoreFP16Stride16Node extends FixedWithNextNode implements 
     private ValueNode fp16_value;
 
     public SwizzledStoreFP16Stride16Node(ValueNode fp16_local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode fp16_value) {
-        super(TYPE, StampFactory.forKind(JavaKind.Object));
+        super(TYPE, StampFactory.forVoid());
         this.fp16_local_array = fp16_local_array;
         this.row = row;
         this.column = column;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride16Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride16Node.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
+
+@NodeInfo
+public class SwizzledStoreFP16Stride16Node extends FixedWithNextNode implements LIRLowerable {
+
+    public static final NodeClass<SwizzledStoreFP16Stride16Node> TYPE = NodeClass.create(SwizzledStoreFP16Stride16Node.class);
+
+    @Input
+    private ValueNode fp16_local_array;
+
+    @Input
+    private ValueNode row;
+
+    @Input
+    private ValueNode column;
+
+    @Input
+    private ValueNode stride;
+
+    @Input
+    private ValueNode fp16_value;
+
+    public SwizzledStoreFP16Stride16Node(ValueNode fp16_local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode fp16_value) {
+        super(TYPE, new uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp());
+        this.fp16_local_array = fp16_local_array;
+        this.row = row;
+        this.column = column;
+        this.stride = stride;
+        this.fp16_value = fp16_value;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+
+        Value localArray = generator.operand(fp16_local_array);
+        Value rowVal    = generator.operand(row);
+        Value colVal    = generator.operand(column);
+        Value strideVal = generator.operand(stride);
+        Value valueVal  = generator.operand(fp16_value);
+
+        Variable linIdx  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable byteOff = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable shifted = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable masked  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable xorTerm = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable swzByte = tool.newVariable(LIRKind.value(PTXKind.S32));
+
+        tool.append(new PTXLIRStmt.SwizzledStoreFP16Stride16Stmt(
+                localArray, rowVal, colVal, strideVal, valueVal,
+                linIdx, byteOff, shifted, masked, xorTerm, swzByte));
+    }
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride32Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride32Node.java
@@ -57,7 +57,7 @@ public class SwizzledStoreFP16Stride32Node extends FixedWithNextNode implements 
     private ValueNode fp16_value;
 
     public SwizzledStoreFP16Stride32Node(ValueNode fp16_local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode fp16_value) {
-        super(TYPE, StampFactory.forKind(JavaKind.Object));
+        super(TYPE, StampFactory.forVoid());
         this.fp16_local_array = fp16_local_array;
         this.row = row;
         this.column = column;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride32Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride32Node.java
@@ -21,16 +21,18 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
+import jdk.graal.compiler.core.common.type.StampFactory;
+import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
-import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.graph.NodeClass;
-import org.graalvm.compiler.lir.Variable;
-import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
-import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.FixedWithNextNode;
-import org.graalvm.compiler.nodes.ValueNode;
-import org.graalvm.compiler.nodes.spi.LIRLowerable;
-import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import jdk.graal.compiler.core.common.LIRKind;
+import jdk.graal.compiler.graph.NodeClass;
+import jdk.graal.compiler.lir.Variable;
+import jdk.graal.compiler.lir.gen.LIRGeneratorTool;
+import jdk.graal.compiler.nodeinfo.NodeInfo;
+import jdk.graal.compiler.nodes.FixedWithNextNode;
+import jdk.graal.compiler.nodes.ValueNode;
+import jdk.graal.compiler.nodes.spi.LIRLowerable;
+import jdk.graal.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 
@@ -55,7 +57,7 @@ public class SwizzledStoreFP16Stride32Node extends FixedWithNextNode implements 
     private ValueNode fp16_value;
 
     public SwizzledStoreFP16Stride32Node(ValueNode fp16_local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode fp16_value) {
-        super(TYPE, new uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp());
+        super(TYPE, StampFactory.forKind(JavaKind.Object));
         this.fp16_local_array = fp16_local_array;
         this.row = row;
         this.column = column;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride32Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreFP16Stride32Node.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
+
+@NodeInfo
+public class SwizzledStoreFP16Stride32Node extends FixedWithNextNode implements LIRLowerable {
+
+    public static final NodeClass<SwizzledStoreFP16Stride32Node> TYPE = NodeClass.create(SwizzledStoreFP16Stride32Node.class);
+
+    @Input
+    private ValueNode fp16_local_array;
+
+    @Input
+    private ValueNode row;
+
+    @Input
+    private ValueNode column;
+
+    @Input
+    private ValueNode stride;
+
+    @Input
+    private ValueNode fp16_value;
+
+    public SwizzledStoreFP16Stride32Node(ValueNode fp16_local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode fp16_value) {
+        super(TYPE, new uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp());
+        this.fp16_local_array = fp16_local_array;
+        this.row = row;
+        this.column = column;
+        this.stride = stride;
+        this.fp16_value = fp16_value;
+    }
+
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+
+        Value localArray = generator.operand(fp16_local_array);
+        Value rowVal    = generator.operand(row);
+        Value colVal    = generator.operand(column);
+        Value strideVal = generator.operand(stride);
+        Value valueVal  = generator.operand(fp16_value);
+
+        Variable linIdx  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable byteOff = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable shifted = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable masked  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable xorTerm = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable swzByte = tool.newVariable(LIRKind.value(PTXKind.S32));
+
+        tool.append(new PTXLIRStmt.SwizzledStoreFP16Stride32Stmt(
+                localArray, rowVal, colVal, strideVal, valueVal,
+                linIdx, byteOff, shifted, masked, xorTerm, swzByte));
+    }
+
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreInt8Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreInt8Node.java
@@ -21,17 +21,18 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
 
+import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
-import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.core.common.type.StampFactory;
-import org.graalvm.compiler.graph.NodeClass;
-import org.graalvm.compiler.lir.Variable;
-import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
-import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodes.FixedWithNextNode;
-import org.graalvm.compiler.nodes.ValueNode;
-import org.graalvm.compiler.nodes.spi.LIRLowerable;
-import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import jdk.graal.compiler.core.common.LIRKind;
+import jdk.graal.compiler.core.common.type.StampFactory;
+import jdk.graal.compiler.graph.NodeClass;
+import jdk.graal.compiler.lir.Variable;
+import jdk.graal.compiler.lir.gen.LIRGeneratorTool;
+import jdk.graal.compiler.nodeinfo.NodeInfo;
+import jdk.graal.compiler.nodes.FixedWithNextNode;
+import jdk.graal.compiler.nodes.ValueNode;
+import jdk.graal.compiler.nodes.spi.LIRLowerable;
+import jdk.graal.compiler.nodes.spi.NodeLIRBuilderTool;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 
@@ -46,7 +47,7 @@ public class SwizzledStoreInt8Node extends FixedWithNextNode implements LIRLower
     @Input private ValueNode int8_value;
 
     public SwizzledStoreInt8Node(ValueNode int8_local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode int8_value) {
-        super(TYPE, StampFactory.forVoid());
+        super(TYPE, StampFactory.forKind(JavaKind.Byte));
         this.int8_local_array = int8_local_array;
         this.row = row;
         this.column = column;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreInt8Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreInt8Node.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.ptx.graal.nodes;
+
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
+import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
+
+@NodeInfo
+public class SwizzledStoreInt8Node extends FixedWithNextNode implements LIRLowerable {
+    public static final NodeClass<SwizzledStoreInt8Node> TYPE = NodeClass.create(SwizzledStoreInt8Node.class);
+
+    @Input private ValueNode int8_local_array;
+    @Input private ValueNode row;
+    @Input private ValueNode column;
+    @Input private ValueNode stride;
+    @Input private ValueNode int8_value;
+
+    public SwizzledStoreInt8Node(ValueNode int8_local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode int8_value) {
+        super(TYPE, StampFactory.forVoid());
+        this.int8_local_array = int8_local_array;
+        this.row = row;
+        this.column = column;
+        this.stride = stride;
+        this.int8_value = int8_value;
+    }
+
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+
+        Value localArray = generator.operand(int8_local_array);
+        Value rowVal    = generator.operand(row);
+        Value colVal    = generator.operand(column);
+        Value strideVal = generator.operand(stride);
+        Value valueVal  = generator.operand(int8_value);
+
+        Variable linIdx  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable shifted = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable masked  = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable xorTerm = tool.newVariable(LIRKind.value(PTXKind.S32));
+        Variable swzByte = tool.newVariable(LIRKind.value(PTXKind.S32));
+
+        tool.append(new PTXLIRStmt.SwizzledStoreInt8Stmt(
+                localArray, rowVal, colVal, strideVal, valueVal,
+                linIdx, shifted, masked, xorTerm, swzByte));
+    }
+}

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreInt8Node.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/SwizzledStoreInt8Node.java
@@ -47,7 +47,7 @@ public class SwizzledStoreInt8Node extends FixedWithNextNode implements LIRLower
     @Input private ValueNode int8_value;
 
     public SwizzledStoreInt8Node(ValueNode int8_local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode int8_value) {
-        super(TYPE, StampFactory.forKind(JavaKind.Byte));
+        super(TYPE, StampFactory.forVoid());
         this.int8_local_array = int8_local_array;
         this.row = row;
         this.column = column;

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
@@ -59,6 +59,8 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXConvertHalfToFloat;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXHalfFloatDivisionNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.ReadHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SubHalfNode;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SwizzledLoadFP16Stride16Node;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.SwizzledLoadFP16Stride32Node;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.WriteHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector.LoadIndexedVectorNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.vector.VectorAddHalfNode;
@@ -242,7 +244,7 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
     }
     private static Node identifyFieldReplacement(Node input, ArrayList<Node> nodesToBeDeleted) {
         // the replacement is expected to be either the read node of a half value, or a phi node in case of accumulation
-        if (input instanceof ReadHalfFloatNode || input instanceof ValuePhiNode) {
+        if (input instanceof ReadHalfFloatNode || input instanceof ValuePhiNode || input instanceof SwizzledLoadFP16Stride32Node || input instanceof SwizzledLoadFP16Stride16Node) {
             return input;
         }
         if (input instanceof PiNode || input instanceof IsNullNode) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVGraphBuilderPlugins.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/compiler/plugins/SPIRVGraphBuilderPlugins.java
@@ -105,6 +105,7 @@ import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.Int8Array;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoMemorySegment;
 import uk.ac.manchester.tornado.api.utils.QuantizationUtils;
@@ -191,6 +192,61 @@ public class SPIRVGraphBuilderPlugins {
         registerLocalBarrier(r);
         registerGlobalBarrier(r);
         localArraysPlugins(r);
+        registerSwizzledLocalAccessesPlugins(r);
+    }
+
+    private static void registerSwizzledLocalAccessesPlugins(Registration r) {
+        r.register(new InvocationPlugin("swizzleLoadFp16Stride32", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreFp16Stride32", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class, HalfFloat.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleLoadFp16Stride16", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreFp16Stride16", InvocationPlugin.Receiver.class, HalfFloat[].class, int.class, int.class, int.class, HalfFloat.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleLoadInt8", InvocationPlugin.Receiver.class,
+                byte[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver,
+                                 ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
+
+        r.register(new InvocationPlugin("swizzleStoreInt8", InvocationPlugin.Receiver.class,
+                byte[].class, int.class, int.class, int.class, byte.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver,
+                                 ValueNode local_array, ValueNode row, ValueNode column, ValueNode stride, ValueNode value) {
+                unimplemented("Swizzled local memory accesses are currently only supported for the PTX backend.");
+                return false;
+            }
+        });
     }
 
     private static void registerLocalBarrier(Registration r) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/local/memory/TestSwizzledLocalArrays.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/local/memory/TestSwizzledLocalArrays.java
@@ -30,6 +30,7 @@ import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
@@ -103,6 +104,66 @@ public class TestSwizzledLocalArrays extends TornadoTestBase {
         context.localBarrier();
 
         int readElem = 511 - localIdx;          // reverse within the 512-element tile
+        int rRow = readElem / stride;
+        int rCol = readElem % stride;
+        byte v = context.swizzleLoadInt8(tile, rRow, rCol, stride);
+        out.set(globalIdx, v);
+    }
+
+    public static void swizzleLoadConvertToFloatKernel(KernelContext context, HalfFloatArray in, FloatArray out) {
+        final int stride = 16;
+
+        int globalIdx = context.globalIdx;
+        int localIdx = context.localIdx;
+
+        int row = localIdx / stride;
+        int col = localIdx % stride;
+
+        HalfFloat[] tile = context.allocateHalfFloatLocalArray(256);
+
+        context.swizzleStoreFp16Stride32(tile, row, col, stride, in.get(globalIdx));
+        context.localBarrier();
+
+        HalfFloat v = context.swizzleLoadFp16Stride32(tile, row, col, stride);
+        // Convert the swizzle-loaded HalfFloat to float in-kernel.
+        // Exercises the HalfFloat -> half-bits rewrite pipeline (TornadoHalfFloatReplacement)
+        // applied to a value produced by SwizzledLoadFP16Stride32Node.
+        float f = v.getFloat32();
+        out.set(globalIdx, f * 2.0f);
+    }
+
+    public static void swizzleLoadConvertToFloatStride16Kernel(KernelContext context, HalfFloatArray in, FloatArray out) {
+        final int stride = 8;
+        int globalIdx = context.globalIdx;
+        int localIdx = context.localIdx;
+        int row = localIdx / stride;
+        int col = localIdx % stride;
+
+        HalfFloat[] tile = context.allocateHalfFloatLocalArray(128);
+        context.swizzleStoreFp16Stride16(tile, row, col, stride, in.get(globalIdx));
+        context.localBarrier();
+        HalfFloat v = context.swizzleLoadFp16Stride16(tile, row, col, stride);
+        float f = v.getFloat32();
+        out.set(globalIdx, f * 2.0f);
+    }
+
+    public static void swizzleRoundTripKernelInt8Stride16(KernelContext context, ByteArray in, ByteArray out) {
+        final int stride = 16;   // narrow tile: 16 int8 cols per row
+        int globalIdx = context.globalIdx;
+        int localIdx = context.localIdx;
+
+        int row = localIdx / stride;
+        int col = localIdx % stride;
+
+        byte[] tile = context.allocateByteLocalArray(256);   // 16 rows × 16 cols
+
+        context.swizzleStoreInt8(tile, row, col, stride, in.get(globalIdx));
+        context.localBarrier();
+
+        // Cross-lane read within the tile (reverse order), same pattern as the
+        // stride-32 test: proves store/load agree on the swizzled layout
+        // across threads, with no byte arithmetic in the kernel.
+        int readElem = 255 - localIdx;
         int rRow = readElem / stride;
         int rCol = readElem % stride;
         byte v = context.swizzleLoadInt8(tile, rRow, rCol, stride);
@@ -226,6 +287,131 @@ public class TestSwizzledLocalArrays extends TornadoTestBase {
                 int globalIdx = t * tileElements + e;
                 int srcGlobalIdx = t * tileElements + (tileElements - 1 - e);
                 assertEquals(input.get(srcGlobalIdx), output.get(globalIdx));
+            }
+        }
+    }
+
+    @Test
+    public void testSwizzleLoadConvertToFloat() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
+
+        final int rowsPerTile = 16;
+        final int colsPerTile = 16;
+        final int tileElements = rowsPerTile * colsPerTile;  // 256
+        final int numTiles = 4;
+        final int size = tileElements * numTiles;            // 1024
+        final int localSize = tileElements;
+
+        HalfFloatArray input = new HalfFloatArray(size);
+        FloatArray output = new FloatArray(size);
+        IntStream.range(0, size).forEach(i -> input.set(i, new HalfFloat((float) i)));
+
+        WorkerGrid worker = new WorkerGrid1D(size);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0")
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input)
+                .task("t0", TestSwizzledLocalArrays::swizzleLoadConvertToFloatKernel, context, input, output)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        worker.setGlobalWork(size, 1, 1);
+        worker.setLocalWork(localSize, 1, 1);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        for (int i = 0; i < size; i++) {
+            // Allow modest fp16->fp32 conversion tolerance for larger values.
+            assertEquals(input.get(i).getFloat32() * 2.0f, output.get(i), 1e-2f);
+        }
+    }
+
+    @Test
+    public void testSwizzleLoadConvertToFloatStride16() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
+
+        final int rowsPerTile = 16;
+        final int colsPerTile = 8;                           // narrow tile: 8 fp16 cols
+        final int tileElements = rowsPerTile * colsPerTile;  // 128
+        final int numTiles = 8;
+        final int size = tileElements * numTiles;            // 1024
+        final int localSize = tileElements;
+
+        HalfFloatArray input = new HalfFloatArray(size);
+        FloatArray output = new FloatArray(size);
+        IntStream.range(0, size).forEach(i -> input.set(i, new HalfFloat((float) i)));
+
+        WorkerGrid worker = new WorkerGrid1D(size);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0")
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input)
+                .task("t0", TestSwizzledLocalArrays::swizzleLoadConvertToFloatStride16Kernel, context, input, output)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        worker.setGlobalWork(size, 1, 1);
+        worker.setLocalWork(localSize, 1, 1);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        for (int i = 0; i < size; i++) {
+            // Allow modest fp16->fp32 conversion tolerance.
+            assertEquals(input.get(i).getFloat32() * 2.0f, output.get(i), 1e-2f);
+        }
+    }
+
+    @Test
+    public void testSwizzleLoadStoreInt8Stride16() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
+
+        final int rowsPerTile = 16;
+        final int colsPerTile = 16;                          // narrow int8 tile
+        final int tileElements = rowsPerTile * colsPerTile;  // 256
+        final int numTiles = 4;
+        final int size = tileElements * numTiles;            // 1024
+        final int localSize = tileElements;
+
+        ByteArray input = new ByteArray(size);
+        ByteArray output = new ByteArray(size);
+        IntStream.range(0, size).forEach(i -> input.set(i, (byte) (i % 60)));
+
+        WorkerGrid worker = new WorkerGrid1D(size);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0")
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input)
+                .task("t0", TestSwizzledLocalArrays::swizzleRoundTripKernelInt8Stride16, context, input, output)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        worker.setGlobalWork(size, 1, 1);
+        worker.setLocalWork(localSize, 1, 1);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.withGridScheduler(gridScheduler).execute();
+        }
+
+        // Cross-lane: output[i] should equal input[srcGlobalIdx], where srcGlobalIdx
+        // is the reverse position within the same tile.
+        for (int t = 0; t < numTiles; t++) {
+            for (int e = 0; e < tileElements; e++) {
+                int globalIdx = t * tileElements + e;
+                int srcGlobalIdx = t * tileElements + (tileElements - 1 - e);
+                assertEquals("Mismatch at globalIdx=" + globalIdx,
+                        input.get(srcGlobalIdx), output.get(globalIdx));
             }
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/local/memory/TestSwizzledLocalArrays.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/local/memory/TestSwizzledLocalArrays.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.kernelcontext.local.memory;
+
+import org.junit.Test;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * How to run?
+ *
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.local.memory.TestSwizzledLocalArrays
+ * </code>
+ * </p>
+ */
+public class TestSwizzledLocalArrays extends TornadoTestBase {
+
+    public static void swizzleDoubleKernel(KernelContext context, HalfFloatArray in, HalfFloatArray out) {
+        final int stride = 16; // 16 fp16 cols per row → 32-byte row stride
+
+        int globalIdx = context.globalIdx;
+        int localIdx = context.localIdx;
+
+        int row = localIdx / stride;
+        int col = localIdx % stride;
+
+        HalfFloat[] tile = context.allocateHalfFloatLocalArray(256);
+
+        // Store input into local memory via the swizzled accessor.
+        context.swizzleStoreFp16Stride32(tile, row, col, stride, in.get(globalIdx));
+        context.localBarrier();
+
+        // Load back via the swizzled accessor, double, write to global output.
+        HalfFloat v = context.swizzleLoadFp16Stride32(tile, row, col, stride);
+        HalfFloat doubled = HalfFloat.add(v, v);
+        out.set(globalIdx, doubled);
+    }
+
+    public static void swizzleDoubleKernelStride16(KernelContext context,
+                                                   HalfFloatArray in, HalfFloatArray out) {
+        final int stride = 8;  // 8 fp16 cols per row → 16-byte row stride
+
+        int globalIdx = context.globalIdx;
+        int localIdx = context.localIdx;
+
+        int row = localIdx / stride;
+        int col = localIdx % stride;
+
+        HalfFloat[] tile = context.allocateHalfFloatLocalArray(128);
+
+        context.swizzleStoreFp16Stride16(tile, row, col, stride, in.get(globalIdx));
+        context.localBarrier();
+
+        HalfFloat v = context.swizzleLoadFp16Stride16(tile, row, col, stride);
+        HalfFloat doubled = HalfFloat.add(v, v);
+        out.set(globalIdx, doubled);
+    }
+
+    public static void swizzleReverseKernelInt8(KernelContext context, ByteArray in, ByteArray out) {
+        final int stride = 32;  // A-operand stride; B would use 16
+        int globalIdx = context.globalIdx;
+        int localIdx = context.localIdx;
+
+        int row = localIdx / stride;
+        int col = localIdx % stride;
+
+        byte[] tile = context.allocateByteLocalArray(512);
+
+        context.swizzleStoreInt8(tile, row, col, stride, in.get(globalIdx));
+        context.localBarrier();
+
+        int readElem = 511 - localIdx;          // reverse within the 512-element tile
+        int rRow = readElem / stride;
+        int rCol = readElem % stride;
+        byte v = context.swizzleLoadInt8(tile, rRow, rCol, stride);
+        out.set(globalIdx, v);
+    }
+
+    @Test
+    public void testSwizzleLoadStoreFp16Stride32() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
+        // Tile geometry: 16 rows × 16 fp16 cols = 256 elements per work-group.
+        // Stride 32 bytes = 16 fp16 cols, which matches FP16_STRIDE_32 policy.
+        final int rowsPerTile = 16;
+        final int colsPerTile = 16;
+        final int tileElements = rowsPerTile * colsPerTile; // 256
+        final int numTiles = 4;
+        final int size = tileElements * numTiles; // 1024
+        final int localSize = tileElements;       // one thread per element
+
+        HalfFloatArray input = new HalfFloatArray(size);
+        HalfFloatArray output = new HalfFloatArray(size);
+        IntStream.range(0, size).forEach(i -> input.set(i, new HalfFloat((float) i)));
+
+        WorkerGrid worker = new WorkerGrid1D(size);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0")
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input)
+                .task("t0", TestSwizzledLocalArrays::swizzleDoubleKernel, context, input, output)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        worker.setGlobalWork(size, 1, 1);
+        worker.setLocalWork(localSize, 1, 1);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(input.get(i).getFloat32() * 2.0f, output.get(i).getFloat32(), 0.0f);
+        }
+    }
+
+    @Test
+    public void testSwizzleLoadStoreFp16Stride16() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
+        // Tile geometry: 16 rows × 8 fp16 cols = 128 elements per work-group.
+        // Stride 16 bytes = 8 fp16 cols, which matches FP16_STRIDE_16 policy.
+        final int rowsPerTile = 16;
+        final int colsPerTile = 8;
+        final int tileElements = rowsPerTile * colsPerTile; // 128
+        final int numTiles = 8;
+        final int size = tileElements * numTiles; // 1024
+        final int localSize = tileElements;       // one thread per element
+
+        HalfFloatArray input = new HalfFloatArray(size);
+        HalfFloatArray output = new HalfFloatArray(size);
+        IntStream.range(0, size).forEach(i -> input.set(i, new HalfFloat((float) i)));
+
+        WorkerGrid worker = new WorkerGrid1D(size);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0")
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input)
+                .task("t0", TestSwizzledLocalArrays::swizzleDoubleKernelStride16, context, input, output)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        worker.setGlobalWork(size, 1, 1);
+        worker.setLocalWork(localSize, 1, 1);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(input.get(i).getFloat32() * 2.0f, output.get(i).getFloat32(), 0.0f);
+        }
+    }
+
+    @Test
+    public void testSwizzleLoadStoreInt8() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
+        final int rowsPerTile = 16;
+        final int colsPerTile = 32;          // A-operand layout: 32 int8 = 32 bytes/row
+        final int tileElements = rowsPerTile * colsPerTile; // 512
+        final int numTiles = 2;
+        final int size = tileElements * numTiles; // 1024
+        final int localSize = tileElements;
+
+        ByteArray input = new ByteArray(size);
+        ByteArray output = new ByteArray(size);
+        IntStream.range(0, size).forEach(i -> input.set(i, (byte) (i % 60)));
+
+        WorkerGrid worker = new WorkerGrid1D(size);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0")
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input)
+                .task("t0", TestSwizzledLocalArrays::swizzleReverseKernelInt8, context, input, output)
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        worker.setGlobalWork(size, 1, 1);
+        worker.setLocalWork(localSize, 1, 1);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.withGridScheduler(gridScheduler).execute();
+        }
+
+        for (int t = 0; t < numTiles; t++) {
+            for (int e = 0; e < tileElements; e++) {
+                int globalIdx = t * tileElements + e;
+                int srcGlobalIdx = t * tileElements + (tileElements - 1 - e);
+                assertEquals(input.get(srcGlobalIdx), output.get(globalIdx));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
#### Description
Companion to PR #842, with the compiler changes required for JDK25

This PR adds swizzled shared-memory accessors to the `KernelContext` for the PTX backend, providing bank-conflict-free layouts for FP16 and INT8 matrix tiles. The new accessors exposed through the `KernelContext` are:

- `swizzleLoadFp16Stride32` / `swizzleStoreFp16Stride32`
- `swizzleLoadFp16Stride16` / `swizzleStoreFp16Stride16`
- `swizzleLoadInt8` / `swizzleStoreInt8`

Each applies an involutive XOR permutation to the logical `(row, col)` coordinate before accessing shared memory, so that the resulting access pattern spreads across distinct memory banks instead of colliding. On NVIDIA GPUs shared
memory has 32 banks of 4 bytes each. A naive row-major tile layout causes many threads in a warp to hit the same bank, serializing the access. The XOR rotates each row's bank assignment to avoid this.

The constants follow the CUTLASS `Swizzle<>`, parameterized per layout:
- **FP16 stride-32**: permutation at the 16-byte boundary over groups of 8 rows (a 32-byte row holds 16 fp16 elements).
- **FP16 stride-16**: the same shape shifted down one bit, for a 16-byte row (8 fp16 elements), used for narrower, transposed tiles.
- **INT8**: identical math to FP16 stride-32. The permutation operates on a 16-byte granularity that is independent of element type, so int8 reuses the stride-32 constants directly. Because int8 elements are one byte, the caller expresses the row stride in bytes (32 for a wide tile, 16 for a narrow one) and the same swizzle serves both.

The layout is primarily intended for staging matrix tiles for future Tensor Core (MMA) work, but is a general bank conflict-avoidance mechanism usable by any kernel with a matching access pattern.

#### Problem description
Efficient Tensor Core (MMA) matrix multiplication requires shared-memory tiles to be laid out so that warp-level matrix loads do not incur bank conflicts. Currently shared arrays are addressed linearly, which produces heavy bank conflicts for the strided access patterns matrix loads use. This PR adds the swizzled-layout support needed to lay those tiles out in shared memory conflict-free, ahead of the MMA work that will consume it.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [x] PTX
- [ ] SPIRV
- [ ] Metal

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

The load/store functionality can be verified by running the unittest:
 `tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.local.memory.TestSwizzledLocalArrays` 

Each kernel in the test was also profiled with Nsight Compute and produces zero shared-memory bank conflicts (`l1tex__data_bank_conflicts_pipe_lsu_mem_shared_op_ld/st = 0`), with non-zero `smsp__inst_executed_op_shared_ld/st`, confirming the accesses execute.
