### PR TITLE
[fix] NPE when calling HalfFloat.getFloat32() on a value read from a local HalfFloat[]

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -175,6 +175,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestCombinedTaskGraph"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestVectorAdditionKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.KernelContextWorkGroupTests"),
+    TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestHalfFloatLocalArray"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsIntegersKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsFloatsKernelContext"),

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/MetalLoweringProvider.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/MetalLoweringProvider.java
@@ -101,6 +101,7 @@ import uk.ac.manchester.tornado.drivers.metal.graal.nodes.GlobalThreadIdNode;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.GlobalThreadSizeNode;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.GroupIdNode;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.LocalArrayNode;
+import uk.ac.manchester.tornado.drivers.metal.graal.nodes.ReadHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.LocalThreadIdNode;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.LocalThreadSizeNode;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.MetalDecompressedReadFieldNode;
@@ -377,6 +378,14 @@ public class MetalLoweringProvider extends DefaultJavaLoweringProvider {
             loadStamp = loadStamp(loadIndexed.stamp(NodeView.DEFAULT), elementKind, false);
         }
         address = createArrayAccess(graph, loadIndexed, elementKind);
+        // Local-memory HalfFloat[] reads need a HALF-typed temporary; a generic ReadNode would
+        // assign half_arr[idx] into a ulong slot and silently truncate (1.5h -> 1ul -> 1.0f).
+        if (loadIndexed.array() instanceof LocalArrayNode localArrayNode && localArrayNode.getMetalKind() == MetalKind.HALF) {
+            ReadHalfFloatNode localHalfFloatRead = graph.add(new ReadHalfFloatNode(address, loadIndexed.index()));
+            loadIndexed.replaceAtUsages(localHalfFloatRead);
+            graph.replaceFixed(loadIndexed, localHalfFloatRead);
+            return;
+        }
         ReadNode memoryRead;
         if (loadIndexed instanceof LoadIndexedVectorNode) {
             memoryRead = graph.add(new ReadNode(address, LocationIdentity.any(), loadStamp, BarrierType.NONE, GPU_MEMORY_MODE));

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/nodes/LocalArrayNode.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/nodes/LocalArrayNode.java
@@ -88,6 +88,10 @@ public class LocalArrayNode extends FixedNode implements LIRLowerable, MarkLocal
         return length;
     }
 
+    public MetalKind getMetalKind() {
+        return kind;
+    }
+
     @Override
     public void generate(NodeLIRBuilderTool gen) {
         final Value lengthValue = gen.operand(length);

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/nodes/MetalConvertHalfToFloat.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/nodes/MetalConvertHalfToFloat.java
@@ -34,6 +34,7 @@ import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.metal.graal.lir.MetalKind;
 import uk.ac.manchester.tornado.drivers.metal.graal.lir.MetalLIRStmt;
 
@@ -51,6 +52,13 @@ public class MetalConvertHalfToFloat extends ValueNode implements LIRLowerable {
     }
 
     public void generate(NodeLIRBuilderTool generator) {
+        if (halfValueNode == null) {
+            // A preceding high-tier rewrite (typically TornadoHalfFloatReplacement) cleared this
+            // node's input without supplying a replacement. Fail at the phase boundary with a
+            // useful message instead of an opaque NPE in NodeLIRBuilder.getOperand.
+            throw new TornadoInternalError("MetalConvertHalfToFloat: input was cleared by a preceding graph rewrite; "
+                    + "an unrecognised half-source pattern reached LIR. Check TornadoHalfFloatReplacement#identifyFieldReplacement.");
+        }
         LIRGeneratorTool tool = generator.getLIRGeneratorTool();
         Variable floatValue = tool.newVariable(LIRKind.value(MetalKind.FLOAT));
         Value halfValue = generator.operand(halfValueNode);

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/nodes/ReadHalfFloatNode.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/nodes/ReadHalfFloatNode.java
@@ -30,6 +30,7 @@ import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
@@ -49,10 +50,18 @@ public class ReadHalfFloatNode extends FixedWithNextNode implements LIRLowerable
 
     @Input
     private AddressNode addressNode;
+    @Input
+    private ValueNode indexNode;
 
     public ReadHalfFloatNode(AddressNode addressNode) {
         super(TYPE, new HalfFloatStamp());
         this.addressNode = addressNode;
+    }
+
+    public ReadHalfFloatNode(AddressNode addressNode, ValueNode indexNode) {
+        super(TYPE, new HalfFloatStamp());
+        this.addressNode = addressNode;
+        this.indexNode = indexNode;
     }
 
     public void generate(NodeLIRBuilderTool generator) {
@@ -61,7 +70,14 @@ public class ReadHalfFloatNode extends FixedWithNextNode implements LIRLowerable
         Value addressValue = generator.operand(addressNode);
         MetalArchitecture.MetalMemoryBase base = ((MetalUnary.MemoryAccess) addressValue).getBase();
         MetalUnary.MetalAddressCast cast = new MetalUnary.MetalAddressCast(base, LIRKind.value(MetalKind.HALF));
-        tool.append(new MetalLIRStmt.LoadStmt(result, cast, (MetalUnary.MemoryAccess) addressValue));
+        if (indexNode == null) {
+            // global / heap half read
+            tool.append(new MetalLIRStmt.LoadStmt(result, cast, (MetalUnary.MemoryAccess) addressValue));
+        } else {
+            // local- or private-memory indexed half read; LoadStmt emits `result = base[index];`
+            Value index = generator.operand(indexNode);
+            tool.append(new MetalLIRStmt.LoadStmt(result, cast, (MetalUnary.MemoryAccess) addressValue, index));
+        }
         generator.setResult(this, result);
     }
 }

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/phases/TornadoHalfFloatReplacement.java
@@ -46,6 +46,7 @@ import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.extended.JavaWriteNode;
 import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
 import org.graalvm.compiler.nodes.java.LoadFieldNode;
+import org.graalvm.compiler.nodes.java.LoadIndexedNode;
 import org.graalvm.compiler.nodes.java.NewInstanceNode;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.phases.BasePhase;
@@ -55,6 +56,7 @@ import uk.ac.manchester.tornado.drivers.metal.graal.lir.MetalKind;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.AddHalfNode;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.DivHalfNode;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.HalfFloatConstantNode;
+import uk.ac.manchester.tornado.drivers.metal.graal.nodes.LocalArrayNode;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.MultHalfNode;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.MetalConvertHalfToFloat;
 import uk.ac.manchester.tornado.drivers.metal.graal.nodes.ReadHalfFloatNode;
@@ -268,6 +270,14 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
     private static Node identifyFieldReplacement(Node input, ArrayList<Node> nodesToBeDeleted) {
         // the replacement is expected to be either the read node of a half value, or a phi node in case of accumulation
         if (input instanceof ReadHalfFloatNode || input instanceof ValuePhiNode) {
+            return input;
+        }
+        // A LoadIndexed on a local-memory HalfFloat[] (LocalArrayNode with MetalKind.HALF) is a
+        // valid half-source for MetalConvertHalfToFloat. Without this case, reading a HalfFloat
+        // out of a local array and calling getFloat32() on it nulls out the convert node's input.
+        if (input instanceof LoadIndexedNode loadIndexed //
+                && loadIndexed.array() instanceof LocalArrayNode localArray //
+                && localArray.getMetalKind() == MetalKind.HALF) {
             return input;
         }
         if (input instanceof PiNode || input instanceof IsNullNode) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLConvertHalfToFloat.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/OCLConvertHalfToFloat.java
@@ -32,6 +32,7 @@ import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLLIRStmt;
 
@@ -49,6 +50,13 @@ public class OCLConvertHalfToFloat extends ValueNode implements LIRLowerable {
     }
 
     public void generate(NodeLIRBuilderTool generator) {
+        if (halfValueNode == null) {
+            // A preceding high-tier rewrite (typically TornadoHalfFloatReplacement) cleared this
+            // node's input without supplying a replacement. Fail at the phase boundary with a
+            // useful message instead of an opaque NPE in NodeLIRBuilder.getOperand.
+            throw new TornadoInternalError("OCLConvertHalfToFloat: input was cleared by a preceding graph rewrite; "
+                    + "an unrecognised half-source pattern reached LIR. Check TornadoHalfFloatReplacement#identifyFieldReplacement.");
+        }
         LIRGeneratorTool tool = generator.getLIRGeneratorTool();
         Variable floatValue = tool.newVariable(LIRKind.value(OCLKind.FLOAT));
         Value halfValue = generator.operand(halfValueNode);

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoHalfFloatReplacement.java
@@ -41,6 +41,7 @@ import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.extended.JavaWriteNode;
 import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
 import org.graalvm.compiler.nodes.java.LoadFieldNode;
+import org.graalvm.compiler.nodes.java.LoadIndexedNode;
 import org.graalvm.compiler.nodes.java.NewInstanceNode;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.phases.BasePhase;
@@ -50,6 +51,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLKind;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.AddHalfNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.DivHalfNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.HalfFloatConstantNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.LocalArrayNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.MultHalfNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLConvertFloatToHalf;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLConvertHalfToFloat;
@@ -101,6 +103,15 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
     private static Node identifyFieldReplacement(Node input, ArrayList<Node> nodesToBeDeleted) {
         // the replacement is expected to be either the read node of a half value, or a phi node in case of accumulation
         if (input instanceof ReadHalfFloatNode || input instanceof ValuePhiNode) {
+            return input;
+        }
+        // A LoadIndexed on a local-memory HalfFloat[] (LocalArrayNode with OCLKind.HALF) is
+        // lowered to a ReadHalfFloatNode in OCLLoweringProvider#lowerLoadIndexedNode, so it is
+        // a valid half-source for OCLConvertHalfToFloat. Without this case, reading a HalfFloat
+        // out of a local array and calling getFloat32() on it nulls out the convert node's input.
+        if (input instanceof LoadIndexedNode loadIndexed //
+                && loadIndexed.array() instanceof LocalArrayNode localArray //
+                && localArray.getOCLKind() == OCLKind.HALF) {
             return input;
         }
         if (input instanceof PiNode || input instanceof IsNullNode) {

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXConvertHalfToFloat.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXConvertHalfToFloat.java
@@ -32,6 +32,7 @@ import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXLIRStmt;
 
@@ -49,6 +50,13 @@ public class PTXConvertHalfToFloat extends ValueNode implements LIRLowerable {
     }
 
     public void generate(NodeLIRBuilderTool generator) {
+        if (halfValueNode == null) {
+            // A preceding high-tier rewrite (typically TornadoHalfFloatReplacement) cleared this
+            // node's input without supplying a replacement. Fail at the phase boundary with a
+            // useful message instead of an opaque NPE in NodeLIRBuilder.getOperand.
+            throw new TornadoInternalError("PTXConvertHalfToFloat: input was cleared by a preceding graph rewrite; "
+                    + "an unrecognised half-source pattern reached LIR. Check TornadoHalfFloatReplacement#identifyFieldReplacement.");
+        }
         LIRGeneratorTool tool = generator.getLIRGeneratorTool();
         Variable floatValue = tool.newVariable(LIRKind.value(PTXKind.F32));
         Value halfValue = generator.operand(halfValueNode);

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/phases/TornadoHalfFloatReplacement.java
@@ -44,6 +44,7 @@ import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.extended.JavaWriteNode;
 import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
 import org.graalvm.compiler.nodes.java.LoadFieldNode;
+import org.graalvm.compiler.nodes.java.LoadIndexedNode;
 import org.graalvm.compiler.nodes.java.NewInstanceNode;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.phases.BasePhase;
@@ -53,6 +54,7 @@ import uk.ac.manchester.tornado.drivers.ptx.graal.HalfFloatStamp;
 import uk.ac.manchester.tornado.drivers.ptx.graal.lir.PTXKind;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.AddHalfNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.HalfFloatConstantNode;
+import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.LocalArrayNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.MultHalfNode;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXConvertFloatToHalf;
 import uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXConvertHalfToFloat;
@@ -243,6 +245,15 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
     private static Node identifyFieldReplacement(Node input, ArrayList<Node> nodesToBeDeleted) {
         // the replacement is expected to be either the read node of a half value, or a phi node in case of accumulation
         if (input instanceof ReadHalfFloatNode || input instanceof ValuePhiNode) {
+            return input;
+        }
+        // A LoadIndexed on a local-memory HalfFloat[] (LocalArrayNode with PTXKind.F16) is
+        // lowered to a ReadHalfFloatNode in PTXLoweringProvider#lowerLoadIndexedNode, so it is
+        // a valid half-source for PTXConvertHalfToFloat. Without this case, reading a HalfFloat
+        // out of a local array and calling getFloat32() on it nulls out the convert node's input.
+        if (input instanceof LoadIndexedNode loadIndexed //
+                && loadIndexed.array() instanceof LocalArrayNode localArray //
+                && localArray.getPTXKind() == PTXKind.F16) {
             return input;
         }
         if (input instanceof PiNode || input instanceof IsNullNode) {

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SPIRVConvertHalfToFloat.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/nodes/SPIRVConvertHalfToFloat.java
@@ -35,6 +35,7 @@ import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpConvertSToF;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpConvertUToPtr;
 import uk.ac.manchester.beehivespirvtoolkit.lib.instructions.SPIRVOpFConvert;
@@ -57,6 +58,13 @@ public class SPIRVConvertHalfToFloat extends ValueNode implements LIRLowerable {
     }
 
     public void generate(NodeLIRBuilderTool generator) {
+        if (halfValueNode == null) {
+            // A preceding high-tier rewrite (typically TornadoHalfFloatReplacement) cleared this
+            // node's input without supplying a replacement. Fail at the phase boundary with a
+            // useful message instead of an opaque NPE in NodeLIRBuilder.getOperand.
+            throw new TornadoInternalError("SPIRVConvertHalfToFloat: input was cleared by a preceding graph rewrite; "
+                    + "an unrecognised half-source pattern reached LIR. Check TornadoHalfFloatReplacement#identifyFieldReplacement.");
+        }
         LIRGeneratorTool tool = generator.getLIRGeneratorTool();
         Variable floatValue = tool.newVariable(LIRKind.value(SPIRVKind.OP_TYPE_FLOAT_32));
         Value halfValue = generator.operand(halfValueNode);

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/phases/TornadoHalfFloatReplacement.java
@@ -47,6 +47,7 @@ import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.extended.JavaWriteNode;
 import org.graalvm.compiler.nodes.extended.ValueAnchorNode;
 import org.graalvm.compiler.nodes.java.LoadFieldNode;
+import org.graalvm.compiler.nodes.java.LoadIndexedNode;
 import org.graalvm.compiler.nodes.java.NewInstanceNode;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.phases.BasePhase;
@@ -57,6 +58,7 @@ import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.DivHalfNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.HalfFloatConstantNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.lir.SPIRVKind;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.AddHalfNode;
+import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.LocalArrayNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.MultHalfNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.ReadHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.spirv.graal.nodes.SPIRVConvertFloatToHalf;
@@ -246,6 +248,15 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
     private static Node identifyFieldReplacement(Node input, ArrayList<Node> nodesToBeDeleted) {
         // the replacement is expected to be either the read node of a half value, or a phi node in case of accumulation
         if (input instanceof ReadHalfFloatNode || input instanceof ValuePhiNode) {
+            return input;
+        }
+        // A LoadIndexed on a local-memory HalfFloat[] (LocalArrayNode with SPIRVKind.OP_TYPE_FLOAT_16)
+        // is lowered to a ReadHalfFloatNode in SPIRVLoweringProvider#lowerLoadIndexedNode, so it is
+        // a valid half-source for SPIRVConvertHalfToFloat. Without this case, reading a HalfFloat
+        // out of a local array and calling getFloat32() on it nulls out the convert node's input.
+        if (input instanceof LoadIndexedNode loadIndexed //
+                && loadIndexed.array() instanceof LocalArrayNode localArray //
+                && localArray.getSPIRVKind() == SPIRVKind.OP_TYPE_FLOAT_16) {
             return input;
         }
         if (input instanceof PiNode || input instanceof IsNullNode) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestHalfFloatLocalArray.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestHalfFloatLocalArray.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.kernelcontext.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Regression test for an LIR-generation crash when a {@link HalfFloat} value
+ * is read back from a kernel-local {@code HalfFloat[]} (allocated via
+ * {@link KernelContext#allocateHalfFloatLocalArray(int)}) and converted to
+ * {@code float} via {@link HalfFloat#getFloat32()}.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestHalfFloatLocalArray
+ * </code>
+ */
+public class TestHalfFloatLocalArray extends TornadoTestBase {
+
+    public static void halfLocalArrayToFloat(KernelContext context, FloatArray out, int size) {
+        HalfFloat[] local = context.allocateHalfFloatLocalArray(size);
+        if (context.localIdx == 0) {
+            local[0] = new HalfFloat(1.5f);
+        }
+        context.localBarrier();
+        if (context.localIdx == 0) {
+            out.set(0, local[0].getFloat32());
+        }
+    }
+
+    @Test
+    public void testHalfFloatLocalArrayToFloat() throws TornadoExecutionPlanException {
+        KernelContext context = new KernelContext();
+        int size = 16;
+        FloatArray out = new FloatArray(size);
+
+        WorkerGrid worker = new WorkerGrid1D(size);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        worker.setLocalWork(size, 1, 1);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, context, out) //
+                .task("t0", TestHalfFloatLocalArray::halfLocalArrayToFloat, context, out, size) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler) //
+                    .withPreCompilation() //
+                    .execute();
+        }
+
+        assertEquals(1.5f, out.get(0), 0.0f);
+    }
+}


### PR DESCRIPTION
#### Description

Fixes #840 that causes an NPE in LIR generation when a `HalfFloat` value is read back from a kernel-local `HalfFloat[]` (allocated via `KernelContext.allocateHalfFloatLocalArray(int)`) and converted to `float` via `HalfFloat.getFloat32()`. The fix is applied across all four backends so the behaviour is consistent regardless of the target device.

Each `*ConvertHalfToFloat` node now also surfaces a clear `TornadoInternalError` if a preceding high-tier rewrite ever clears its input again, instead of letting the failure propagate as an opaque NPE inside `NodeLIRBuilder.getOperand`.

A regression unit test `TestHalfFloatLocalArray` is included.

#### Problem description

`TornadoHalfFloatReplacement#identifyFieldReplacement` walks the inputs of a `HalfFloat.halfFloatValue` field access looking for a node that can serve as the half-typed source for `*ConvertHalfToFloat`. The recognised sources were only `ReadHalfFloatNode` and `ValuePhiNode`.

When the half value originates from a local-memory `HalfFloat[]`, the front-end graph still contains a plain `LoadIndexedNode` at the point this phase runs (the lowering to `ReadHalfFloatNode` happens later in `*LoweringProvider#lowerLoadIndexedNode`). Because `LoadIndexedNode` was not recognised, the recursion fell through, the convert node's input was cleared, and code generation then NPE'd in `NodeLIRBuilder.getOperand`.

For Metal additionally, the lowering path itself did not exist: a generic `ReadNode` would assign `half_arr[idx]` into a `ulong` slot and silently truncate the value (e.g. `1.5h` → `1ul` → `1.0f`). Metal therefore also gets the indexed `ReadHalfFloatNode` lowering and an extra `MetalKind` accessor on `LocalArrayNode`.

**How to reproduce** (any backend):

```java
public static void halfLocalArrayToFloat(KernelContext context, FloatArray out, int size) {
    HalfFloat[] local = context.allocateHalfFloatLocalArray(size);
    if (context.localIdx == 0) {
        local[0] = new HalfFloat(1.5f);
    }
    context.localBarrier();
    if (context.localIdx == 0) {
        out.set(0, local[0].getFloat32()); // <- NPE in NodeLIRBuilder before the fix
    }
}
```

Backend/s tested

- [x] OpenCL
- [x] PTX
- [x] SPIRV
- [x] Metal

OS tested

- [x] Linux
- [x] OSx
- [ ] Windows

Did you check on FPGAs?

- [ ] Yes
- [x] No

How to test the new patch?

Run the new regression test on every backend:

```bash
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestHalfFloatLocalArray
```

Expected: `out[0] == 1.5f` on every backend, with no NPE and no value truncation. Prior to this patch the test crashed on OpenCL/PTX/SPIR-V with an NPE inside `NodeLIRBuilder.getOperand`, and silently returned `1.0f` on Metal.