### PR TITLE
[OpenCL] [Metal] Fix unbalanced brackets in code generation for nested control flow

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -176,6 +176,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestVectorAdditionKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.KernelContextWorkGroupTests"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestHalfFloatLocalArray"),
+    TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestFlashAttentionKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.local.memory.TestSwizzledLocalArrays"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsIntegersKernelContext"),

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -160,7 +160,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.reductions.InstanceReduction"),
     TestEntry("uk.ac.manchester.tornado.unittests.reductions.MultipleReductions"),
     TestEntry("uk.ac.manchester.tornado.unittests.reductions.TestReductionsAutomatic"),
-    TestEntry("uk.ac.manchester.tornado.unittests.reductions.TestSIMDGroupReductions"),
+    TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestSIMDGroupReductions"),
     TestEntry("uk.ac.manchester.tornado.unittests.instances.TestInstances"),
     TestEntry("uk.ac.manchester.tornado.unittests.matrices.TestMatrixTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestAPI"),

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/MetalBlockVisitor.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/MetalBlockVisitor.java
@@ -66,6 +66,12 @@ public class MetalBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRB
     Set<Node> switchClosed;
     HashMap<HIRBlock, Integer> pending;
     Set<HIRBlock> rmvEndBracket;
+    /**
+     * Loop-end scopes whose close has been deferred to a merge block: when a loop-end block that begins with a
+     * {@link LoopExitNode} depends on a merge (see {@link #closeScope}), the loop bracket must be emitted when the merge block
+     * exits, in case no other rule emits it. Maps the merge block to {loop-end block, loop-header block}.
+     */
+    Map<HIRBlock, HIRBlock[]> pendingLoopEndClose;
     private int loopCount;
     private int loopEnds;
 
@@ -80,6 +86,7 @@ public class MetalBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRB
         closedBlocks = new HashMap<>();
         pending = new HashMap<>();
         rmvEndBracket = new HashSet<>();
+        pendingLoopEndClose = new HashMap<>();
     }
 
     private static boolean isMergeBlock(HIRBlock block) {
@@ -343,6 +350,12 @@ public class MetalBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRB
                         incrementClosedLoops(loopBeginBlock);
                     }
                 }
+                if (!wasBlockAlreadyClosed(block)) {
+                    // The close was deferred to the merge block the loop exit depends on. Register the
+                    // deferral so that the exit of the merge block emits the loop bracket in case no
+                    // other rule does (see exit()).
+                    pendingLoopEndClose.put(block.getDominator().getDominator(), new HIRBlock[] { block, loopBeginBlock });
+                }
             }
         } else {
             closeBlock(block);
@@ -382,8 +395,39 @@ public class MetalBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRB
         return false;
     }
 
+    /**
+     * Returns true if every block of the loop headed by {@code loopHeaderBlock} has already been emitted (entered by this
+     * visitor). Used to decide whether a deferred loop-end close can be emitted at a merge block: it can only be emitted once
+     * no loop-body content remains to be generated.
+     */
+    private boolean allLoopBlocksEmitted(HIRBlock loopHeaderBlock) {
+        Loop<HIRBlock> loop = loopHeaderBlock.getLoop();
+        if (loop == null) {
+            return false;
+        }
+        for (HIRBlock loopBlock : loop.getBlocks()) {
+            if (!openBlocks.getOrDefault(loopBlock, false)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     public void exit(HIRBlock block, HIRBlock value) {
+        if (pendingLoopEndClose.containsKey(block)) {
+            // A loop-end close was deferred to this merge block (see closeScope()). Emit the loop
+            // bracket here, but only when the whole loop body has already been emitted: if body
+            // blocks are still pending (e.g. an if-branch with a break that is traversed after
+            // this merge), closing here would leave them outside the loop scope. In that case the
+            // deferral is dropped and the pre-existing closing rules apply.
+            HIRBlock[] deferred = pendingLoopEndClose.remove(block);
+            if (!wasBlockAlreadyClosed(deferred[0]) && allLoopBlocksEmitted(deferred[1])) {
+                closeBlock(deferred[0]);
+                incrementClosedLoops(deferred[1]);
+            }
+        }
+
         if (block.isLoopEnd()) {
             LoopEndNode loopEndNode = (LoopEndNode) block.getEndNode();
             LoopBeginNode loopBeginNode = loopEndNode.loopBegin();
@@ -453,7 +497,14 @@ public class MetalBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRB
             boolean isTrueBranch = ifNode.trueSuccessor() == block.getBeginNode();
             if (!(isTrueBranch && isLoopEnd)) {
                 closeBlock(block);
-                if (block.getLoop() != null) {
+                // The bracket emitted above closes the if-branch scope. It only counts towards
+                // closing the enclosing loop when this branch terminates the loop body: either
+                // it contains the loop back-edge (ends with a LoopEndNode) or it leaves the
+                // loop (begins with a LoopExitNode). For a plain if/else branch that flows
+                // into a merge, the loop remains open; counting it would make
+                // wasLoopBlockAlreadyClosed() suppress the closing brackets of subsequent
+                // if-branches within the same loop body.
+                if (block.getLoop() != null && (isLoopEnd || block.getBeginNode() instanceof LoopExitNode)) {
                     incrementClosedLoops(block.getLoop().getHeader());
                 }
             }

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/MetalBlockVisitor.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/MetalBlockVisitor.java
@@ -358,9 +358,36 @@ public class MetalBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRB
                 }
             }
         } else {
+            if (isNestedInOpenIfBranchScope(block, loopBeginBlock)) {
+                // The loop-end block sits inside an if-branch whose scope is still open (e.g.
+                // for { if (c) { ... back-edge } else { break } }). Emitting the loop bracket here
+                // would lexically close the if-branch instead of the loop, leaving the else
+                // dangling. The bracket is emitted instead when the remaining loop-exit block of
+                // the if is closed by the regular rules in exit().
+                return;
+            }
             closeBlock(block);
             incrementClosedLoops(loopBeginBlock);
         }
+    }
+
+    /**
+     * Returns true if {@code block} is dominated by an if-branch block (a block that opened an if/else scope on enter) whose
+     * scope has not been closed yet, before reaching {@code loopBeginBlock} in the dominator chain. In that case a bracket
+     * emitted at {@code block} would close the if-branch scope rather than the intended loop scope.
+     */
+    private boolean isNestedInOpenIfBranchScope(HIRBlock block, HIRBlock loopBeginBlock) {
+        HIRBlock current = block.getDominator();
+        while (current != null && current != loopBeginBlock) {
+            HIRBlock dom = current.getDominator();
+            // Mirrors the condition under which enter() opens an if/else scope for a block.
+            boolean opensIfBranchScope = dom != null && !dom.isLoopHeader() && isIfBlock(dom) && !(current.getBeginNode() instanceof MergeNode);
+            if (opensIfBranchScope && openBlocks.getOrDefault(current, false) && !wasBlockAlreadyClosed(current)) {
+                return true;
+            }
+            current = dom;
+        }
+        return false;
     }
 
     private boolean isComplexLoopCondition(HIRBlock block) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
@@ -63,6 +63,12 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
     Set<Node> switchClosed;
     HashMap<HIRBlock, Integer> pending;
     Set<HIRBlock> rmvEndBracket;
+    /**
+     * Loop-end scopes whose close has been deferred to a merge block: when a loop-end block that begins with a
+     * {@link LoopExitNode} depends on a merge (see {@link #closeScope}), the loop bracket must be emitted when the merge block
+     * exits, in case no other rule emits it. Maps the merge block to {loop-end block, loop-header block}.
+     */
+    Map<HIRBlock, HIRBlock[]> pendingLoopEndClose;
     private int loopCount;
     private int loopEnds;
 
@@ -77,6 +83,7 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
         closedBlocks = new HashMap<>();
         pending = new HashMap<>();
         rmvEndBracket = new HashSet<>();
+        pendingLoopEndClose = new HashMap<>();
     }
 
     private static boolean isMergeBlock(HIRBlock block) {
@@ -340,6 +347,12 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
                         incrementClosedLoops(loopBeginBlock);
                     }
                 }
+                if (!wasBlockAlreadyClosed(block)) {
+                    // The close was deferred to the merge block the loop exit depends on. Register the
+                    // deferral so that the exit of the merge block emits the loop bracket in case no
+                    // other rule does (see exit()).
+                    pendingLoopEndClose.put(block.getDominator().getDominator(), new HIRBlock[] { block, loopBeginBlock });
+                }
             }
         } else {
             closeBlock(block);
@@ -379,8 +392,39 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
         return false;
     }
 
+    /**
+     * Returns true if every block of the loop headed by {@code loopHeaderBlock} has already been emitted (entered by this
+     * visitor). Used to decide whether a deferred loop-end close can be emitted at a merge block: it can only be emitted once
+     * no loop-body content remains to be generated.
+     */
+    private boolean allLoopBlocksEmitted(HIRBlock loopHeaderBlock) {
+        Loop<HIRBlock> loop = loopHeaderBlock.getLoop();
+        if (loop == null) {
+            return false;
+        }
+        for (HIRBlock loopBlock : loop.getBlocks()) {
+            if (!openBlocks.getOrDefault(loopBlock, false)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     public void exit(HIRBlock block, HIRBlock value) {
+        if (pendingLoopEndClose.containsKey(block)) {
+            // A loop-end close was deferred to this merge block (see closeScope()). Emit the loop
+            // bracket here, but only when the whole loop body has already been emitted: if body
+            // blocks are still pending (e.g. an if-branch with a break that is traversed after
+            // this merge), closing here would leave them outside the loop scope. In that case the
+            // deferral is dropped and the pre-existing closing rules apply.
+            HIRBlock[] deferred = pendingLoopEndClose.remove(block);
+            if (!wasBlockAlreadyClosed(deferred[0]) && allLoopBlocksEmitted(deferred[1])) {
+                closeBlock(deferred[0]);
+                incrementClosedLoops(deferred[1]);
+            }
+        }
+
         if (block.isLoopEnd()) {
             LoopEndNode loopEndNode = (LoopEndNode) block.getEndNode();
             LoopBeginNode loopBeginNode = loopEndNode.loopBegin();
@@ -450,7 +494,14 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
             boolean isTrueBranch = ifNode.trueSuccessor() == block.getBeginNode();
             if (!(isTrueBranch && isLoopEnd)) {
                 closeBlock(block);
-                if (block.getLoop() != null) {
+                // The bracket emitted above closes the if-branch scope. It only counts towards
+                // closing the enclosing loop when this branch terminates the loop body: either
+                // it contains the loop back-edge (ends with a LoopEndNode) or it leaves the
+                // loop (begins with a LoopExitNode). For a plain if/else branch that flows
+                // into a merge, the loop remains open; counting it would make
+                // wasLoopBlockAlreadyClosed() suppress the closing brackets of subsequent
+                // if-branches within the same loop body.
+                if (block.getLoop() != null && (isLoopEnd || block.getBeginNode() instanceof LoopExitNode)) {
                     incrementClosedLoops(block.getLoop().getHeader());
                 }
             }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLBlockVisitor.java
@@ -355,9 +355,36 @@ public class OCLBlockVisitor implements ControlFlowGraph.RecursiveVisitor<HIRBlo
                 }
             }
         } else {
+            if (isNestedInOpenIfBranchScope(block, loopBeginBlock)) {
+                // The loop-end block sits inside an if-branch whose scope is still open (e.g.
+                // for { if (c) { ... back-edge } else { break } }). Emitting the loop bracket here
+                // would lexically close the if-branch instead of the loop, leaving the else
+                // dangling. The bracket is emitted instead when the remaining loop-exit block of
+                // the if is closed by the regular rules in exit().
+                return;
+            }
             closeBlock(block);
             incrementClosedLoops(loopBeginBlock);
         }
+    }
+
+    /**
+     * Returns true if {@code block} is dominated by an if-branch block (a block that opened an if/else scope on enter) whose
+     * scope has not been closed yet, before reaching {@code loopBeginBlock} in the dominator chain. In that case a bracket
+     * emitted at {@code block} would close the if-branch scope rather than the intended loop scope.
+     */
+    private boolean isNestedInOpenIfBranchScope(HIRBlock block, HIRBlock loopBeginBlock) {
+        HIRBlock current = block.getDominator();
+        while (current != null && current != loopBeginBlock) {
+            HIRBlock dom = current.getDominator();
+            // Mirrors the condition under which enter() opens an if/else scope for a block.
+            boolean opensIfBranchScope = dom != null && !dom.isLoopHeader() && isIfBlock(dom) && !(current.getBeginNode() instanceof MergeNode);
+            if (opensIfBranchScope && openBlocks.getOrDefault(current, false) && !wasBlockAlreadyClosed(current)) {
+                return true;
+            }
+            current = dom;
+        }
+        return false;
     }
 
     private boolean isComplexLoopCondition(HIRBlock block) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/CodeGenTest.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/codegen/CodeGenTest.java
@@ -431,4 +431,125 @@ public class CodeGenTest extends TornadoTestBase {
 
     }
 
+    /**
+     * Kernel modelled on the soft-shadow path of the TornadoVM-Ray-Tracer (Shader#getShadow calling BodyOps#intersects): a
+     * sequential sample loop containing an inner loop with a compound exit condition {@code i < numBodies && !intersects}.
+     * The {@code !intersects} part is compiled into an if/else inside the inner loop whose else-branch is a break (loop
+     * exit), with the loop back-edge nested inside the if-branch. The OpenCL block visitor used to emit the inner loop's
+     * closing bracket right after the back-edge block, lexically closing the if-branch instead of the loop and leaving the
+     * else dangling (clBuildProgram error -11, "expected expression").
+     *
+     * <p>
+     * The loop bounds are read from {@code params} at runtime so that the inner loop is not unrolled at compile time, which
+     * would remove the back-edge and hide the control-flow shape under test.
+     * </p>
+     */
+    public static void shadowFeelerKernel(FloatArray bodyPositions, FloatArray rayOrigins, FloatArray output, IntArray params) {
+        for (@Parallel int p = 0; p < output.getSize(); p++) {
+            int numBodies = params.get(0);
+            int numSamples = params.get(1);
+
+            float ox = rayOrigins.get(p * 4);
+            float oy = rayOrigins.get(p * 4 + 1);
+            float oz = rayOrigins.get(p * 4 + 2);
+            float lightDistance = rayOrigins.get(p * 4 + 3);
+
+            float shadow = 0.0f;
+            for (int s = 0; s < numSamples; s++) {
+                float jx = ox + s * 0.05f;
+                float jy = oy - s * 0.03f;
+
+                boolean intersects = false;
+                for (int i = 0; i < numBodies && !intersects; i++) {
+                    float dx = bodyPositions.get(i * 4) - jx;
+                    float dy = bodyPositions.get(i * 4 + 1) - jy;
+                    float dz = bodyPositions.get(i * 4 + 2) - oz;
+                    float distance = TornadoMath.sqrt(dx * dx + dy * dy + dz * dz);
+                    float w = bodyPositions.get(i * 4 + 3);
+                    if (w == 0.0f && distance < lightDistance) {
+                        intersects = true;
+                    }
+                }
+
+                if (intersects) {
+                    shadow += 1.0f;
+                }
+            }
+
+            output.set(p, shadow / numSamples);
+        }
+    }
+
+    @Test
+    public void testLoopConditionWithBreakInsideIf() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        final int numBodies = 8;
+        final int numSamples = 4;
+        final int numRays = 256;
+
+        FloatArray bodyPositions = new FloatArray(numBodies * 4);
+        FloatArray rayOrigins = new FloatArray(numRays * 4);
+        FloatArray output = new FloatArray(numRays);
+        IntArray params = new IntArray(2);
+        params.set(0, numBodies);
+        params.set(1, numSamples);
+
+        for (int i = 0; i < numBodies; i++) {
+            bodyPositions.set(i * 4, (float) Math.sin(i * 0.7f) * 10.0f);
+            bodyPositions.set(i * 4 + 1, (float) Math.cos(i * 0.9f) * 10.0f);
+            bodyPositions.set(i * 4 + 2, (float) Math.sin(i * 1.3f) * 10.0f);
+            bodyPositions.set(i * 4 + 3, (i % 3 == 0) ? 0.0f : 1.0f);
+        }
+        for (int p = 0; p < numRays; p++) {
+            rayOrigins.set(p * 4, (float) Math.cos(p * 0.05f) * 8.0f);
+            rayOrigins.set(p * 4 + 1, (float) Math.sin(p * 0.03f) * 8.0f);
+            rayOrigins.set(p * 4 + 2, (float) Math.cos(p * 0.11f) * 8.0f);
+            rayOrigins.set(p * 4 + 3, 6.0f + (p % 16));
+        }
+        output.init(-1.0f);
+
+        // Sequential reference
+        float[] expected = new float[numRays];
+        for (int p = 0; p < numRays; p++) {
+            float ox = rayOrigins.get(p * 4);
+            float oy = rayOrigins.get(p * 4 + 1);
+            float oz = rayOrigins.get(p * 4 + 2);
+            float lightDistance = rayOrigins.get(p * 4 + 3);
+            float shadow = 0.0f;
+            for (int s = 0; s < numSamples; s++) {
+                float jx = ox + s * 0.05f;
+                float jy = oy - s * 0.03f;
+                boolean intersects = false;
+                for (int i = 0; i < numBodies && !intersects; i++) {
+                    float dx = bodyPositions.get(i * 4) - jx;
+                    float dy = bodyPositions.get(i * 4 + 1) - jy;
+                    float dz = bodyPositions.get(i * 4 + 2) - oz;
+                    float distance = (float) Math.sqrt(dx * dx + dy * dy + dz * dz);
+                    float w = bodyPositions.get(i * 4 + 3);
+                    if (w == 0.0f && distance < lightDistance) {
+                        intersects = true;
+                    }
+                }
+                if (intersects) {
+                    shadow += 1.0f;
+                }
+            }
+            expected[p] = shadow / numSamples;
+        }
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, bodyPositions, rayOrigins, params) //
+                .task("t0", CodeGenTest::shadowFeelerKernel, bodyPositions, rayOrigins, output, params) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int p = 0; p < numRays; p++) {
+            assertEquals(expected[p], output.get(p), 1e-6f);
+        }
+    }
+
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestFlashAttentionKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestFlashAttentionKernelContext.java
@@ -54,8 +54,8 @@ public class TestFlashAttentionKernelContext extends TornadoTestBase {
 
     public static void processHeadsFlashAttentionOptV2(KernelContext context, FloatArray q, FloatArray key_cache, FloatArray value_cache, FloatArray xb, int nHeads, int headSize, int kvDim, int kvMul, IntArray positionHolder, int layer, int contextLength) {
 
-        final int MAX_HEAD_SIZE = 128;
-        final int MAX_LOCAL_SIZE = 128;
+        final int MAX_HEAD_SIZE = 64;
+        final int MAX_LOCAL_SIZE = 64;
         final int MAX_BLOCK_SIZE_C = 32;
         final int MAX_TILE_ELEMENTS = MAX_BLOCK_SIZE_C * MAX_HEAD_SIZE;
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestFlashAttentionKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestFlashAttentionKernelContext.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.kernelcontext.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.math.TornadoMath;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Standalone reproducer for the GPULlama3 Flash-Attention kernel that fails to compile under the TornadoVM OpenCL backend.
+ *
+ * <p>
+ * The kernel uses one work-group per attention head ({@code groupIdx == head}) and {@code localSize} cooperative threads per
+ * head ({@code localIdx == tid}). The output of the GPU kernel is validated against a sequential softmax-attention reference.
+ * </p>
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestFlashAttentionKernelContext
+ * </code>
+ */
+public class TestFlashAttentionKernelContext extends TornadoTestBase {
+
+    public static void processHeadsFlashAttentionOptV2(KernelContext context, FloatArray q, FloatArray key_cache, FloatArray value_cache, FloatArray xb, int nHeads, int headSize, int kvDim, int kvMul, IntArray positionHolder, int layer, int contextLength) {
+
+        final int MAX_HEAD_SIZE = 128;
+        final int MAX_LOCAL_SIZE = 128;
+        final int MAX_BLOCK_SIZE_C = 32;
+        final int MAX_TILE_ELEMENTS = MAX_BLOCK_SIZE_C * MAX_HEAD_SIZE;
+
+        int tid = context.localIdx;
+        int h = context.groupIdx;
+        int localSize = context.localGroupSizeX;
+
+        if (h >= nHeads) {
+            return;
+        }
+
+        int pos = positionHolder.get(0);
+        int loff = layer * contextLength * kvDim;
+        int kvHeadIdx = h / kvMul;
+        int BLOCK_SIZE_C = 32;
+
+        float[] q_shared = context.allocateFloatLocalArray(MAX_HEAD_SIZE);
+        float[] k_tile = context.allocateFloatLocalArray(MAX_TILE_ELEMENTS);
+        float[] v_tile = context.allocateFloatLocalArray(MAX_TILE_ELEMENTS);
+
+        float[] s_tile = context.allocateFloatLocalArray(BLOCK_SIZE_C);
+        float[] exp_tile = context.allocateFloatLocalArray(BLOCK_SIZE_C);
+        float[] reduction_shared = context.allocateFloatLocalArray(MAX_LOCAL_SIZE);
+        float[] state_shared = context.allocateFloatLocalArray(4);
+
+        // === Dimension partitioning: each thread handles subset of output dims ===
+        int dimsPerThread = (headSize + localSize - 1) / localSize;
+        int myStartDim = tid * dimsPerThread;
+        int myEndDim = Math.min(myStartDim + dimsPerThread, headSize);
+        int myDimCount = myEndDim - myStartDim;
+
+        // FIX from previous iteration: ensuring output array is statically sized
+        final int MAX_OUTPUT_DIMS = MAX_HEAD_SIZE / 8; // e.g., 32 if MAX_HEAD_SIZE=256
+        float[] output = new float[MAX_OUTPUT_DIMS];
+
+        // Initialize thread-local output
+        for (int i = 0; i < myDimCount; i++) {
+            output[i] = 0.0f;
+        }
+
+        // Initialize shared state
+        if (tid == 0) {
+            state_shared[0] = Float.NEGATIVE_INFINITY;
+            state_shared[1] = 0.0f;
+        }
+
+        // Load query into shared memory (cooperative)
+        // NOTE: Loop bound must still use headSize to read correct data volume
+        for (int i = tid; i < headSize; i += localSize) {
+            q_shared[i] = q.get(h * headSize + i);
+        }
+        context.localBarrier();
+
+        // Process sequence in tiles
+        for (int tileC = 0; tileC <= pos; tileC += BLOCK_SIZE_C) {
+            int tileEnd = Math.min(tileC + BLOCK_SIZE_C - 1, pos);
+            int tileLen = tileEnd - tileC + 1;
+
+            // === Cooperative K/V tile loading ===
+            int totalElements = tileLen * headSize;
+            int elementsPerThread = (totalElements + localSize - 1) / localSize;
+            int startElem = tid * elementsPerThread;
+            int endElem = Math.min(startElem + elementsPerThread, totalElements);
+
+            for (int globalElemIdx = startElem; globalElemIdx < endElem; globalElemIdx++) {
+                int seqIdx = globalElemIdx / headSize;
+                int dimIdx = globalElemIdx % headSize;
+                int kvOffset = loff + (tileC + seqIdx) * kvDim + kvHeadIdx * headSize + dimIdx;
+                int tileMemOffset = seqIdx * headSize + dimIdx;
+
+                // Check bounds just to be safe, though kvDim/headSize should ensure this is valid.
+                if (tileMemOffset < MAX_TILE_ELEMENTS) {
+                    k_tile[tileMemOffset] = key_cache.get(kvOffset);
+                    v_tile[tileMemOffset] = value_cache.get(kvOffset);
+                }
+            }
+            context.localBarrier();
+
+            // === Compute attention scores (cooperative) ===
+            for (int t = tid; t < tileLen; t += localSize) {
+                float score = 0.0f;
+                for (int d = 0; d < headSize; d++) {
+                    score += q_shared[d] * k_tile[t * headSize + d];
+                }
+                s_tile[t] = score / TornadoMath.sqrt(headSize);
+            }
+            context.localBarrier();
+
+            // ... (Parallel reduction for tileMax - uses reduction_shared, which is now fixed)
+            float threadMax = Float.NEGATIVE_INFINITY;
+            for (int t = tid; t < tileLen; t += localSize) {
+                if (s_tile[t] > threadMax) {
+                    threadMax = s_tile[t];
+                }
+            }
+            reduction_shared[tid] = threadMax;
+            context.localBarrier();
+
+            for (int stride = localSize / 2; stride > 0; stride /= 2) {
+                if (tid < stride) {
+                    reduction_shared[tid] = Math.max(reduction_shared[tid], reduction_shared[tid + stride]);
+                }
+                context.localBarrier();
+            }
+            float tileMax = reduction_shared[0];
+
+            // === Update running max and rescale if needed ===
+            float prevMax = state_shared[0];
+            float newMax = Math.max(prevMax, tileMax);
+            float scale = 1.0f;
+
+            if (newMax != prevMax && prevMax != Float.NEGATIVE_INFINITY) {
+                scale = TornadoMath.exp(prevMax - newMax);
+                for (int i = 0; i < myDimCount; i++) {
+                    output[i] *= scale;
+                }
+            }
+
+            // === Compute exp(score - max) and tile sum (cooperative) ===
+            for (int t = tid; t < tileLen; t += localSize) {
+                exp_tile[t] = TornadoMath.exp(s_tile[t] - newMax);
+            }
+            context.localBarrier();
+
+            // Parallel reduction for tile sum
+            // ... (Uses reduction_shared, which is now fixed)
+            float threadSum = 0.0f;
+            for (int t = tid; t < tileLen; t += localSize) {
+                threadSum += exp_tile[t];
+            }
+            reduction_shared[tid] = threadSum;
+            context.localBarrier();
+
+            for (int stride = localSize / 2; stride > 0; stride /= 2) {
+                if (tid < stride) {
+                    reduction_shared[tid] += reduction_shared[tid + stride];
+                }
+                context.localBarrier();
+            }
+            float tileSum = reduction_shared[0];
+
+            // Update shared state (thread 0)
+            if (tid == 0) {
+                state_shared[0] = newMax;
+                state_shared[1] = state_shared[1] * scale + tileSum;
+            }
+            context.localBarrier();
+
+            // === Accumulate output (each thread handles its dimensions) ===
+            for (int t = 0; t < tileLen; t++) {
+                float expScore = exp_tile[t];
+                for (int i = 0; i < myDimCount; i++) {
+                    int d = myStartDim + i;
+                    output[i] += expScore * v_tile[t * headSize + d];
+                }
+            }
+            context.localBarrier();
+        }
+
+        // === Final normalization and write ===
+        float sumExp = state_shared[1];
+        float normFactor = (sumExp > 0.0f) ? (1.0f / sumExp) : 0.0f;
+
+        int baseOffset = h * headSize + myStartDim;
+        for (int i = 0; i < myDimCount; i++) {
+            xb.set(baseOffset + i, output[i] * normFactor);
+        }
+    }
+
+    /**
+     * Sequential softmax-attention reference. The numerically-stable streaming Flash-Attention kernel above should produce the
+     * same result, head-by-head, as this textbook implementation.
+     */
+    private static void flashAttentionSequential(FloatArray q, FloatArray key_cache, FloatArray value_cache, FloatArray xb, int nHeads, int headSize, int kvDim, int kvMul, int pos, int layer,
+            int contextLength) {
+        int loff = layer * contextLength * kvDim;
+        for (int h = 0; h < nHeads; h++) {
+            int kvHeadIdx = h / kvMul;
+
+            // scores
+            float[] scores = new float[pos + 1];
+            float max = Float.NEGATIVE_INFINITY;
+            for (int t = 0; t <= pos; t++) {
+                float score = 0.0f;
+                for (int d = 0; d < headSize; d++) {
+                    int kvOffset = loff + t * kvDim + kvHeadIdx * headSize + d;
+                    score += q.get(h * headSize + d) * key_cache.get(kvOffset);
+                }
+                score /= (float) Math.sqrt(headSize);
+                scores[t] = score;
+                if (score > max) {
+                    max = score;
+                }
+            }
+
+            // softmax
+            float sum = 0.0f;
+            for (int t = 0; t <= pos; t++) {
+                scores[t] = (float) Math.exp(scores[t] - max);
+                sum += scores[t];
+            }
+            float norm = (sum > 0.0f) ? (1.0f / sum) : 0.0f;
+
+            // weighted sum of values
+            for (int d = 0; d < headSize; d++) {
+                float acc = 0.0f;
+                for (int t = 0; t <= pos; t++) {
+                    int kvOffset = loff + t * kvDim + kvHeadIdx * headSize + d;
+                    acc += scores[t] * value_cache.get(kvOffset);
+                }
+                xb.set(h * headSize + d, acc * norm);
+            }
+        }
+    }
+
+    @Test
+    public void testFlashAttention() throws TornadoExecutionPlanException {
+        final int nHeads = 4;
+        final int headSize = 64;        // <= MAX_HEAD_SIZE (256)
+        final int kvMul = 1;            // no grouped-query attention => one KV head per query head
+        final int kvDim = nHeads * headSize / kvMul; // 256
+        final int layer = 0;
+        final int contextLength = 128;
+        final int pos = 40;             // current sequence position (spans 2 tiles of 32)
+        final int localSize = 32;       // threads per head (work-group size)
+
+        // --- Allocate and seed input/output data ---
+        FloatArray q = new FloatArray(nHeads * headSize);
+        FloatArray keyCache = new FloatArray(contextLength * kvDim);
+        FloatArray valueCache = new FloatArray(contextLength * kvDim);
+        FloatArray xb = new FloatArray(nHeads * headSize);
+        IntArray positionHolder = new IntArray(1);
+        positionHolder.set(0, pos);
+
+        // Deterministic pseudo-random-ish seeding so the result is reproducible.
+        for (int i = 0; i < q.getSize(); i++) {
+            q.set(i, (float) Math.sin(i * 0.01f) * 0.5f);
+        }
+        for (int i = 0; i < keyCache.getSize(); i++) {
+            keyCache.set(i, (float) Math.cos(i * 0.001f) * 0.5f);
+            valueCache.set(i, (float) Math.sin(i * 0.002f) * 0.5f);
+        }
+        xb.init(0.0f);
+
+        // --- Compute the sequential reference ---
+        FloatArray xbReference = new FloatArray(nHeads * headSize);
+        xbReference.init(0.0f);
+        flashAttentionSequential(q, keyCache, valueCache, xbReference, nHeads, headSize, kvDim, kvMul, pos, layer, contextLength);
+
+        // --- Configure the grid: one work-group per head, localSize threads per group ---
+        WorkerGrid worker = new WorkerGrid1D(nHeads * localSize);
+        worker.setLocalWork(localSize, 1, 1);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, q, keyCache, valueCache, positionHolder) //
+                .task("t0", TestFlashAttentionKernelContext::processHeadsFlashAttentionOptV2, context, q, keyCache, valueCache, xb, nHeads, headSize, kvDim, kvMul, positionHolder, layer,
+                        contextLength) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, xb);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        // --- Validate against the sequential reference ---
+        for (int i = 0; i < xb.getSize(); i++) {
+            assertEquals(xbReference.get(i), xb.get(i), 1e-3f);
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestFlashAttentionKernelContext.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestFlashAttentionKernelContext.java
@@ -29,6 +29,7 @@ import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
@@ -273,14 +274,16 @@ public class TestFlashAttentionKernelContext extends TornadoTestBase {
 
     @Test
     public void testFlashAttention() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+
         final int nHeads = 4;
-        final int headSize = 64;        // <= MAX_HEAD_SIZE (256)
-        final int kvMul = 1;            // no grouped-query attention => one KV head per query head
-        final int kvDim = nHeads * headSize / kvMul; // 256
+        final int headSize = 64;
+        final int kvMul = 1;
+        final int kvDim = nHeads * headSize / kvMul;
         final int layer = 0;
         final int contextLength = 128;
-        final int pos = 40;             // current sequence position (spans 2 tiles of 32)
-        final int localSize = 32;       // threads per head (work-group size)
+        final int pos = 40;
+        final int localSize = 32;
 
         // --- Allocate and seed input/output data ---
         FloatArray q = new FloatArray(nHeads * headSize);


### PR DESCRIPTION
**Description**
  
 This PR fixes three independent code-generation defects in the OpenCL block structurizer (`OCLBlockVisitor`) that produced syntactically invalid OpenCL C (unbalanced brackets / dangling else) for kernels with non-trivial control flow, and ports the fixes to the Metal backend (`MetalBlockVisitor`, a fork  of the same visitor). It also adds two reproducer unit tests and documents a separate SPIR-V correctness issue.

  **Fix 1** — if-branch closes mis-counted as loop closes (closeIfBlock). Closing any if/else branch bracket incremented closedLoops for the branch's
  enclosing loop, even though no loop scope was closed. Once the counter reached the loop's exit count, wasLoopBlockAlreadyClosed() suppressed the
  closing brackets of all subsequent if-branches in the same loop body. The increment is now restricted to branches that actually terminate the loop
  body (end with a LoopEndNode or begin with a LoopExitNode).

  **Fix 2** — deferred loop-end close that no rule emitted (closeScope / exit). When a loop-end block beginning with a LoopExitNode depends on a merge
  block, closeScope() defers the close, assuming "the merge will generate the correct close scope" — but for some CFG shapes no rule emitted it, losing
  the loop bracket. The deferral is now tracked explicitly (pendingLoopEndClose) and emitted at the merge block's exit, guarded by
  allLoopBlocksEmitted() so that loops whose body blocks are traversed after the merge (e.g. CodeGenTest#test02) keep the previous behaviour.

  **Fix 3** — loop close emitted inside an open if-branch (closeScope). For loops of the shape for { if (c) { ... back-edge } else { break } } (produced by
  compound exit conditions such as i < n && !found), the loop bracket was emitted right after the back-edge block, which lexically sits inside the
  if-branch scope. The bracket closed the if-branch instead of the loop and left the else dangling. The close is now suppressed when the back-edge is
  dominated by a still-open if-branch scope (isNestedInOpenIfBranchScope); the bracket is then emitted by the existing rules at the loop's remaining
  exit block, the lexical end of the loop.

  **_New tests:_**
  - `TestFlashAttentionKernelContext`: standalone reproducer for the GPULlama3 flash-attention kernel (triggers fixes 1 and 2), validated against a
  sequential softmax-attention reference. Excluded on SPIR-V (see below).
  - `CodeGenTest#testLoopConditionWithBreakInsideIf`: kernel modelled on the TornadoVM-Ray-Tracer soft-shadow path (Shader#getShadow→BodyOps#intersects), which triggers fix 3. Loop bounds are read from an IntArray at runtime so the inner loop is not constant-unrolled, which would hide the shape under test.

  **SPIR-V note**: the flash-attention kernel compiles on SPIR-V but produces wrong results — local-memory reads in the tile loop observe values one loop iteration stale, so the softmax denominator misses the last tile. Verified on Intel Iris Xe via both the OpenCL and Level Zero dispatchers, while the OpenCL C backend on the same device is correct. This is a pre-existing, separate issue (the same exclusion already exists in `CodeGenTest#testFlashAttention`, so the new test carries `assertNotBackend(SPIRV);` a dedicated issue can follow.

  **Problem description**

  1. The GPULlama3 `processHeadsFlashAttentionOptV2` kernel failed with `clBuildProgram -> -11`, error: expected expression at a dangling else: a divergent if (tid == 0) between nested loops and the enclosing loop back-edge lost its closing bracket (fixes 1+2). #837 
  2. The [TornadoVM-Ray-Tracer](https://github.com/beehive-lab/TornadoVM-Ray-Tracer) render kernel failed with the same error class at two sites and bailed out to sequential execution (0.18x vs Java streams): inner intersection loops with i < n && !intersects placed the back-edge inside an if-branch with a break in the else (fix 3). After the fix the ray tracer runs on GPU at 15–20x over Java streams.

  Both reproduce via the new unit tests: without the fixes, `TestFlashAttentionKernelContext#testFlashAttention` and
  `CodeGenTest#testLoopConditionWithBreakInsideIf` fail with `clBuildProgram -11;` with the fixes they pass with validated numerics (verified in both directions by stashing the visitor changes).

  **Backend/s tested**

  - [x] OpenCL
  - [ ] PTX 
  - [x] SPIRV 
  - [x] Metal

  **OS tested**

  - [x] Linux
  - [ ] OSx
  - [ ] Windows

  Did you check on FPGAs?

  - [ ] Yes
  - [x] No

  **How to test the new patch?**

```bash
  make BACKEND=opencl

  # Reproducers (fail with clBuildProgram -11 without the OCLBlockVisitor changes):
  tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestFlashAttentionKernelContext
  tornado-test -V uk.ac.manchester.tornado.unittests.codegen.CodeGenTest

  # Regression suites exercised during development:
  tornado-test -V uk.ac.manchester.tornado.unittests.branching.TestConditionals
  tornado-test -V uk.ac.manchester.tornado.unittests.branching.TestLoopConditions
  tornado-test -V uk.ac.manchester.tornado.unittests.loops.TestLoops
  tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsFloatsKernelContext
```

```bash
  make BACKEND=metal

  # Reproducers (fail with clBuildProgram -11 without the OCLBlockVisitor changes):
  tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestFlashAttentionKernelContext
  tornado-test -V uk.ac.manchester.tornado.unittests.codegen.CodeGenTest

  # Regression suites exercised during development:
  tornado-test -V uk.ac.manchester.tornado.unittests.branching.TestConditionals
  tornado-test -V uk.ac.manchester.tornado.unittests.branching.TestLoopConditions
  tornado-test -V uk.ac.manchester.tornado.unittests.loops.TestLoops
  tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestReductionsFloatsKernelContext
```