### PR TITLE
[PTX] Add atan2 and asin math intrinsics and software atan implementation

### DIFF
--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXGraphBuilderPlugins.java
@@ -93,9 +93,11 @@ import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 import java.util.function.Supplier;
 
+import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrinsicNode.Operation.ATAN2;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrinsicNode.Operation.FMAX;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrinsicNode.Operation.FMIN;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrinsicNode.Operation.POW;
+import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.ASIN;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.ATAN;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.COS;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.EXP;
@@ -584,6 +586,22 @@ public class PTXGraphBuilderPlugins {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
                 b.push(JavaKind.Double, b.append(PTXFPUnaryIntrinsicNode.create(value, ATAN, JavaKind.Double)));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("atan2", Double.TYPE, Double.TYPE) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode x, ValueNode y) {
+                b.push(JavaKind.Double, b.append(PTXFPBinaryIntrinsicNode.create(x, y, ATAN2, JavaKind.Double)));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("asin", Double.TYPE) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(JavaKind.Double, b.append(PTXFPUnaryIntrinsicNode.create(value, ASIN, JavaKind.Double)));
                 return true;
             }
         });

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXMathPlugins.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/compiler/plugins/PTXMathPlugins.java
@@ -23,9 +23,11 @@
  */
 package uk.ac.manchester.tornado.drivers.ptx.graal.compiler.plugins;
 
+import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrinsicNode.Operation.ATAN2;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrinsicNode.Operation.FMAX;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrinsicNode.Operation.FMIN;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPBinaryIntrinsicNode.Operation.POW;
+import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.ASIN;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.ATAN;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.CEIL;
 import static uk.ac.manchester.tornado.drivers.ptx.graal.nodes.PTXFPUnaryIntrinsicNode.Operation.COS;
@@ -116,6 +118,14 @@ public class PTXMathPlugins {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
                 b.push(kind, b.append(PTXFPUnaryIntrinsicNode.create(value, ATAN, kind)));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("asin", type) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(kind, b.append(PTXFPUnaryIntrinsicNode.create(value, ASIN, kind)));
                 return true;
             }
         });
@@ -232,6 +242,14 @@ public class PTXMathPlugins {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode x, ValueNode y) {
                 b.push(kind, b.append(PTXFPBinaryIntrinsicNode.create(x, y, POW, kind)));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("atan2", type, type) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode x, ValueNode y) {
+                b.push(kind, b.append(PTXFPBinaryIntrinsicNode.create(x, y, ATAN2, kind)));
                 return true;
             }
         });

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXBuiltinTool.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXBuiltinTool.java
@@ -39,9 +39,12 @@ import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXUna
 import static uk.ac.manchester.tornado.drivers.ptx.graal.asm.PTXAssembler.PTXUnaryIntrinsic.TANH;
 
 import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.lir.ConstantValue;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
+import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.Value;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.common.logging.Logger;
@@ -465,6 +468,139 @@ public class PTXBuiltinTool {
     public Value genGeometricCross(Value x, Value y) {
         unimplemented();
         return null;
+    }
+
+    /**
+     * Coefficients of a 5-term Hastings minimax polynomial approximating atan(z) for z in [0, 1] (max absolute error
+     * ~3e-5 radians): atan(z) ~= z * (c0 + s*(c1 + s*(c2 + s*(c3 + s*c4)))), where s = z*z.
+     */
+    private static final double[] ATAN_POLYNOMIAL = { 0.9998660, -0.3302995, 0.1801410, -0.0851330, 0.0208351 };
+
+    /**
+     * Creates a floating-point constant matching the precision (F32 or F64) of the surrounding computation.
+     */
+    public ConstantValue genFloatConstant(PTXKind kind, double value) {
+        if (kind.isF32()) {
+            return new ConstantValue(LIRKind.value(PTXKind.F32), JavaConstant.forFloat((float) value));
+        }
+        return new ConstantValue(LIRKind.value(PTXKind.F64), JavaConstant.forDouble(value));
+    }
+
+    /**
+     * Materializes an expression into a fresh variable so it can be used as an operand in subsequent instructions.
+     */
+    public Value genMaterialize(NodeLIRBuilderTool builder, Value expression, LIRKind kind) {
+        Variable variable = builder.getLIRGeneratorTool().newVariable(kind);
+        return builder.getLIRGeneratorTool().append(new PTXLIRStmt.AssignStmt(variable, expression)).getResult();
+    }
+
+    /**
+     * Emits a floating-point comparison ({@code setp.<cmp>}) producing a predicate register.
+     */
+    public Variable genFloatCompare(NodeLIRBuilderTool builder, PTXAssembler.PTXBinaryOp comparison, Value a, Value b) {
+        LIRKind compareKind = LIRKind.value(a.getPlatformKind());
+        Variable predicate = builder.getLIRGeneratorTool().newVariable(LIRKind.value(PTXKind.PRED));
+        builder.getLIRGeneratorTool().append(new PTXLIRStmt.AssignStmt(predicate, new PTXBinary.Expr(comparison, compareKind, a, b)));
+        return predicate;
+    }
+
+    /**
+     * Emits a branchless select ({@code selp}): {@code predicate ? valueIfTrue : valueIfFalse}.
+     */
+    public Value genFloatSelect(NodeLIRBuilderTool builder, Value predicate, Value valueIfTrue, Value valueIfFalse) {
+        LIRKind kind = LIRKind.value(valueIfTrue.getPlatformKind());
+        Variable result = builder.getLIRGeneratorTool().newVariable(kind);
+        builder.getLIRGeneratorTool().append(new PTXLIRStmt.AssignStmt(result, new PTXTernary.Expr(PTXAssembler.PTXTernaryOp.SELP, kind, valueIfTrue, valueIfFalse, predicate)));
+        return result;
+    }
+
+    /**
+     * Approximates atan(z) for a reduced, non-negative argument z in [0, 1] using Horner evaluation of
+     * {@link #ATAN_POLYNOMIAL}.
+     */
+    public Value genAtanReduced(PTXArithmeticTool lirGen, Value z) {
+        PTXKind kind = (PTXKind) z.getPlatformKind();
+        Value s = lirGen.emitMul(z, z, false);
+        Value polynomial = genFloatConstant(kind, ATAN_POLYNOMIAL[ATAN_POLYNOMIAL.length - 1]);
+        for (int i = ATAN_POLYNOMIAL.length - 2; i >= 0; i--) {
+            polynomial = lirGen.emitAdd(lirGen.emitMul(s, polynomial, false), genFloatConstant(kind, ATAN_POLYNOMIAL[i]), false);
+        }
+        return lirGen.emitMul(z, polynomial, false);
+    }
+
+    /**
+     * Computes atan(x) over the full domain, returning a materialized value.
+     *
+     * The argument is range-reduced to [0, 1] via the identity atan(t) = pi/2 - atan(1/t) for t &gt; 1, the reduced
+     * argument is approximated with {@link #genAtanReduced}, and the sign of the input is restored (atan is odd).
+     */
+    public Value genAtan(NodeLIRBuilderTool builder, PTXArithmeticTool lirGen, Value x) {
+        PTXKind kind = (PTXKind) x.getPlatformKind();
+        LIRKind lirKind = LIRKind.value(kind);
+        Value one = genFloatConstant(kind, 1.0);
+        Value halfPi = genFloatConstant(kind, Math.PI / 2.0);
+
+        Value absX = genMaterialize(builder, genFloatAbs(x), lirKind);
+        Value isLarge = genFloatCompare(builder, PTXAssembler.PTXBinaryOp.SETP_GT, absX, one);
+        Value reciprocal = lirGen.emitDiv(one, absX, null);
+        Value z = genFloatSelect(builder, isLarge, reciprocal, absX);
+
+        Value atanZ = genMaterialize(builder, genAtanReduced(lirGen, z), lirKind);
+        Value complement = lirGen.emitSub(halfPi, atanZ, false);
+        Value magnitude = genFloatSelect(builder, isLarge, complement, atanZ);
+
+        return genMaterialize(builder, lirGen.emitMathCopySign(magnitude, x), lirKind);
+    }
+
+    /**
+     * Computes atan2(numerator, denominator) over the full domain, returning a materialized value.
+     *
+     * The angle is derived branchlessly from the reduced ratio min(|x|,|y|)/max(|x|,|y|) in [0, 1] and corrected for
+     * the quadrant given by the signs of the inputs (|x| = |denominator|, |y| = |numerator|):
+     *
+     * <code>
+     * r = atan(min(|x|,|y|) / max(|x|,|y|));
+     * if (|y| > |x|) r = pi/2 - r;
+     * if (denominator < 0) r = pi - r;
+     * r = copysign(r, numerator);
+     * </code>
+     */
+    public Value genAtan2(NodeLIRBuilderTool builder, PTXArithmeticTool lirGen, Value numerator, Value denominator) {
+        PTXKind kind = (PTXKind) LIRKind.combine(numerator, denominator).getPlatformKind();
+        LIRKind lirKind = LIRKind.value(kind);
+        Value zero = genFloatConstant(kind, 0.0);
+        Value halfPi = genFloatConstant(kind, Math.PI / 2.0);
+        Value pi = genFloatConstant(kind, Math.PI);
+
+        Value absX = genMaterialize(builder, genFloatAbs(denominator), lirKind);
+        Value absY = genMaterialize(builder, genFloatAbs(numerator), lirKind);
+
+        Value swap = genFloatCompare(builder, PTXAssembler.PTXBinaryOp.SETP_GT, absY, absX);
+        Value minAbs = genFloatSelect(builder, swap, absX, absY);
+        Value maxAbs = genFloatSelect(builder, swap, absY, absX);
+        Value ratio = lirGen.emitDiv(minAbs, maxAbs, null);
+        Value maxIsZero = genFloatCompare(builder, PTXAssembler.PTXBinaryOp.SETP_EQ, maxAbs, zero);
+        ratio = genFloatSelect(builder, maxIsZero, zero, ratio);
+
+        Value angle = genMaterialize(builder, genAtanReduced(lirGen, ratio), lirKind);
+        angle = genFloatSelect(builder, swap, lirGen.emitSub(halfPi, angle, false), angle);
+        Value denominatorNegative = genFloatCompare(builder, PTXAssembler.PTXBinaryOp.SETP_LT, denominator, zero);
+        angle = genFloatSelect(builder, denominatorNegative, lirGen.emitSub(pi, angle, false), angle);
+
+        return genMaterialize(builder, lirGen.emitMathCopySign(angle, numerator), lirKind);
+    }
+
+    /**
+     * Computes asin(x) for x in [-1, 1] using the identity asin(x) = atan2(x, sqrt(1 - x*x)), returning a materialized
+     * value. The denominator is non-negative, so atan2 yields a result in [-pi/2, pi/2] as required.
+     */
+    public Value genAsin(NodeLIRBuilderTool builder, PTXArithmeticTool lirGen, Value x) {
+        PTXKind kind = (PTXKind) x.getPlatformKind();
+        LIRKind lirKind = LIRKind.value(kind);
+        Value one = genFloatConstant(kind, 1.0);
+        Value oneMinusXSquared = lirGen.emitSub(one, lirGen.emitMul(x, x, false), false);
+        Value denominator = genMaterialize(builder, genFloatSqrt(oneMinusXSquared), lirKind);
+        return genAtan2(builder, lirGen, x, denominator);
     }
 
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXFPBinaryIntrinsicNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXFPBinaryIntrinsicNode.java
@@ -94,6 +94,7 @@ public class PTXFPBinaryIntrinsicNode extends BinaryNode implements ArithmeticLI
             case FMIN -> Math.min(x, y);
             case FMAX -> Math.max(x, y);
             case POW -> Math.pow(x, y);
+            case ATAN2 -> Math.atan2(x, y);
             default -> throw new TornadoInternalError("unknown op %s", op);
         };
     }
@@ -103,6 +104,7 @@ public class PTXFPBinaryIntrinsicNode extends BinaryNode implements ArithmeticLI
             case FMIN -> Math.min(x, y);
             case FMAX -> Math.max(x, y);
             case POW -> (float) Math.pow(x, y);
+            case ATAN2 -> (float) Math.atan2(x, y);
             default -> throw new TornadoInternalError("unknown op %s", op);
         };
     }
@@ -150,6 +152,9 @@ public class PTXFPBinaryIntrinsicNode extends BinaryNode implements ArithmeticLI
                 break;
             case POW:
                 generatePow(builder, (PTXArithmeticTool) lirGen, gen, x, y);
+                return;
+            case ATAN2:
+                builder.setResult(this, gen.genAtan2(builder, (PTXArithmeticTool) lirGen, x, y));
                 return;
             default:
                 throw shouldNotReachHere();
@@ -247,7 +252,8 @@ public class PTXFPBinaryIntrinsicNode extends BinaryNode implements ArithmeticLI
     public enum Operation {
         FMAX, //
         FMIN, //
-        POW //
+        POW, //
+        ATAN2 //
     }
 
 }

--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXFPUnaryIntrinsicNode.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/nodes/PTXFPUnaryIntrinsicNode.java
@@ -103,6 +103,8 @@ public class PTXFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
             case SQRT -> Math.sqrt(value);
             case FLOOR -> Math.floor(value);
             case LOG -> Math.log(value);
+            case ATAN -> Math.atan(value);
+            case ASIN -> Math.asin(value);
             default -> throw new TornadoInternalError("unable to compute op %s", op);
         };
     }
@@ -114,6 +116,8 @@ public class PTXFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
             case SQRT -> (float) Math.sqrt(value);
             case FLOOR -> (float) Math.floor(value);
             case LOG -> (float) Math.log(value);
+            case ATAN -> (float) Math.atan(value);
+            case ASIN -> (float) Math.asin(value);
             default -> throw new TornadoInternalError("unable to compute op %s", op);
         };
     }
@@ -155,8 +159,11 @@ public class PTXFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
 
         switch (operation()) {
             case ATAN:
-                result = gen.genFloatATan(auxValue);
-                break;
+                builder.setResult(this, gen.genAtan(builder, lirGenPTX, auxValue));
+                return;
+            case ASIN:
+                builder.setResult(this, gen.genAsin(builder, lirGenPTX, auxValue));
+                return;
             case CEIL:
                 result = gen.genFloatCeil(auxValue);
                 break;
@@ -375,6 +382,7 @@ public class PTXFPUnaryIntrinsicNode extends UnaryNode implements ArithmeticLIRL
     // @formatter:off
     public enum Operation {
         ATAN,
+        ASIN,
         CEIL,
         COS,
         EXP,


### PR DESCRIPTION
 ### Summary

  The PTX backend had no lowering for `Math.atan2`, `Math.asin`, or their `TornadoMath` equivalents, and `atan` relied on a hardware path. This PR adds full-domain software implementations of all three, emitted as branchless PTX LIR. Since PTX has no native instructions for these functions, they are computed from a polynomial approximation plus predicate-based (`setp`/`selp`) range reduction and quadrant correction.

This PR is to be merged prior to #835, in order to ensure that CI will not fail always on PTX.

 ### What changed

  Plugin registration
  - `PTXGraphBuilderPlugins` — register `atan2(double, double)` and `asin(double)` invocation plugins (Math.* call sites).
  - `PTXMathPlugins` — register `atan2` and `asin` invocation plugins (TornadoMath.* call sites).
  
 #### Intrinsic nodes
  - `PTXFPBinaryIntrinsicNode` — add ATAN2 operation, `Math.atan2` constant folding (float/double), and LIR dispatch to `genAtan2`.
  - `PTXFPUnaryIntrinsicNode` — add ASIN operation, `Math.atan/Math.asin` constant folding, and switch ATAN/ASIN dispatch to the new generators.
  
#### Code generation (`PTXBuiltinTool`)
  - `genAtan` — range-reduces the argument to [0, 1] via atan(t) = π/2 − atan(1/t), evaluates a 5-term Hastings minimax
  polynomial (max abs error ~3e-5 rad), and restores sign (atan is odd).
  - `genAtan2` — derives the angle branchlessly from min(|x|,|y|)/max(|x|,|y|) and corrects for quadrant using the input
  signs; guards the divide-by-zero case.
  - `genAsin` — reduces to atan2(x, sqrt(1 − x²)), which stays in [−π/2, π/2].
  - Helpers: `genFloatConstant`, `genMaterialize`, `genFloatCompare`, `genFloatSelect`, `genAtanReduced`.

 #### Implementation notes

  - All sequences are branchless, using `setp` to produce predicates and selp to select between branches — avoiding control flow in the generated PTX.
  - Constants are emitted at the precision (F32/F64) of the surrounding computation.
  - genAtan replaces the previous hardware genFloatATan lowering to get consistent full-domain behavior.

 ### Testing using RayTracer

The TornadoVM-Ray-Tracer is being added in the CI pipeline. Here are manual instructions that show that this PR adds support for PTX:

```bash
# Build this branch with PTX
make BACKEND=ptx
source setvars.sh
make fast-tests

git clone https://github.com/beehive-lab/TornadoVM-Ray-Tracer.git
cd TornadoVM-Ray-Tracer
mvn clean install && source sources.env && tornadovm-ray-tracer regression
```

The result is:
```bash
Running TornadoVM Ray Tracer benchmark mode...
WARNING: Using incubator modules: jdk.incubator.vector
-----------------------------------------
Building world...
-> Loading Skybox Image 'Sky.jpg'...
-> Adding object to the scene...
-> Allocating object representation buffers...
-----------------------------------------
Getting Tornado Devices...
0: (PTX) NVIDIA RTX A2000 8GB Laptop GPU
-----------------------------------------
Running [JAVA PARALLEL STREAMS]
Duration: 33.232405 ms
-----------------------------------------
-----------------------------------------
Running with TornadoVM for device: PTX -- NVIDIA RTX A2000 8GB Laptop GPU
Duration: 1.621872 ms
-----------------------------------------
Performance increase vs Java Streams: 20.49015273708406x
-----------------------------------------
```


