### PR TITLE
[fix] Handle ObjectStamp compatibility for vector types in OpenCL, Metal and SPIRV backends

### DIFF
--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/MetalStamp.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/MetalStamp.java
@@ -24,7 +24,6 @@
 package uk.ac.manchester.tornado.drivers.metal.graal;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 
 import jdk.graal.compiler.core.common.LIRKind;
 import jdk.graal.compiler.core.common.spi.LIRKindTool;
@@ -129,7 +128,14 @@ public class MetalStamp extends ObjectStamp {
             return true;
         }
 
-        unimplemented("stamp iscompat: %s + %s", this, stamp);
+        // In Graal 25, FixReadsPhase checks compatibility between MetalStamp
+        // and ObjectStamp for vector types (e.g., FLOAT4 vs Float4 object).
+        // MetalStamp extends ObjectStamp, so these are compatible when the
+        // MetalStamp represents the vector version of the Java object type.
+        if (stamp instanceof ObjectStamp && metalKind.isVector()) {
+            return true;
+        }
+
         return false;
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLStamp.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLStamp.java
@@ -22,7 +22,6 @@
 package uk.ac.manchester.tornado.drivers.opencl.graal;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 
 import jdk.graal.compiler.core.common.LIRKind;
 import jdk.graal.compiler.core.common.spi.LIRKindTool;
@@ -127,7 +126,14 @@ public class OCLStamp extends ObjectStamp {
             return true;
         }
 
-        unimplemented("stamp iscompat: %s + %s", this, stamp);
+        // In Graal 25, FixReadsPhase checks compatibility between OCLStamp
+        // and ObjectStamp for vector types (e.g., FLOAT4 vs Float4 object).
+        // OCLStamp extends ObjectStamp, so these are compatible when the
+        // OCLStamp represents the vector version of the Java object type.
+        if (stamp instanceof ObjectStamp && oclKind.isVector()) {
+            return true;
+        }
+
         return false;
     }
 

--- a/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVStamp.java
+++ b/tornado-drivers/spirv/src/main/java/uk/ac/manchester/tornado/drivers/spirv/graal/SPIRVStamp.java
@@ -25,7 +25,6 @@
 package uk.ac.manchester.tornado.drivers.spirv.graal;
 
 import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.shouldNotReachHere;
-import static uk.ac.manchester.tornado.api.exceptions.TornadoInternalError.unimplemented;
 
 import jdk.graal.compiler.core.common.LIRKind;
 import jdk.graal.compiler.core.common.spi.LIRKindTool;
@@ -68,7 +67,7 @@ public class SPIRVStamp extends ObjectStamp {
     /**
      * Gets a platform dependent {@link LIRKind} that can be used to store a value
      * of this stamp.
-     * 
+     *
      * @param lirKindTool
      *            Platform VM specific kinds.
      * @return {@link LIRKind}
@@ -135,7 +134,15 @@ public class SPIRVStamp extends ObjectStamp {
         if (stamp instanceof SPIRVStamp && ((SPIRVStamp) stamp).spirvKind == spirvKind) {
             return true;
         }
-        unimplemented("stamp is compat: %s + %s", this, stamp);
+
+        // In Graal 25, FixReadsPhase checks compatibility between SPIRVStamp
+        // and ObjectStamp for vector types (e.g., FLOAT4 vs Float4 object).
+        // SPIRVStamp extends ObjectStamp, so these are compatible when the
+        // SPIRVStamp represents the vector version of the Java object type.
+        if (stamp instanceof ObjectStamp && spirvKind.isVector()) {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
# Description

  On the `jdk25` branch, running vector-typed kernels (e.g. the TornadoVM Ray Tracer)  crashes on the OpenCL, Metal and SPIRV backends during compilation:

  ```
  uk.ac.manchester.tornado.api.exceptions.TornadoInternalError: unimplemented: stamp iscompat: ocl: FLOAT4 + a!# uk.ac.manchester.tornado.api.types.vectors.Float4
      at ...OCLStamp.isCompatible(OCLStamp.java:130)
      at jdk.graal.compiler.phases.common.FixReadsPhase$FixReadsClosure.processNode(FixReadsPhase.java:170)
  ```

  ## Root cause

  Graal 25's `FixReadsPhase` is stricter than Graal 21: it now compares a memory read's backend stamp (e.g. `FLOAT4`) against the access `ObjectStamp` of the corresponding Java vector type (e.g. `Float4`). This code path was never exercised under Graal 21, so the backend `Stamp.isCompatible(Stamp)` implementations fell through to `unimplemented(...)`, which throws.

  The PTX backend was already patched for this; OpenCL, Metal and SPIRV were not - which is why PTX worked for the Ray Tracer but the others did not.

  ## Fix

  Mirror the existing `PTXStamp` fix in `OCLStamp`, `MetalStamp` and `SPIRVStamp`:
  - Treat a backend stamp as compatible with an `ObjectStamp` when the backend
    kind is a vector type.
  - Return `false` instead of throwing for any other mismatch.
  - Remove the now-unused `unimplemented` import.

  This only affects the `jdk25` branch (Graal 25). The JDK21 `develop` branch is unaffected, since `FixReadsPhase` there never reaches the throwing branch.

  ## Testing

  - [x] OpenCL, Metal and SPIRV drivers build
  - [x] TornadoVM Ray Tracer regression passes on OpenCL, Metal