### PR TITLE
Fix for a bug that occurs when reusing a TaskGraph

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -568,7 +568,9 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
         if (objectsToSync == null) {
             objectsToSync = executionContext.getPersistedObjects();
-            executionContext.addPersistedObject(this.taskGraphName, objectsToSync);
+            for (Object obj: objectsToSync) {
+	            executionContext.addPersistedObject(this.taskGraphName, obj);
+	    }
         }
 
         for (Object objectToSync : objectsToSync) {


### PR DESCRIPTION

#### Description

The patch fixes the way that persistent variables are handled when reusing a kernel. In some situations, the list of persisted objects was added as a list to the new list of persisted objects, while it is its elements that should have been added individually. 

#### Problem description
In some cases, the previous list of persisted objects is added as a list to itself, while it is its elements that should be added individually.

If the list is added to the new list of persisted objects, this list ends up with an element of type ArrayList (the previous list), which raises an exception in that method:

```bash
TornadoExecutionContext.doesExceedExecutionPlanLimit(TornadoExecutionContext.java:201)
at TornadoVMInterpreter.execute(TornadoVMInterpreter.java:273) 
```

The exception is raised when checking the different persisted variables and stumbling upon the ArrayList which is not among the expected types (native arrays, KernelContext, ...)

#### Backend/s tested

Mark the backends affected by this PR.

- [X] OpenCL
- [X] PTX
- [X] SPIRV
- [X] Metal

#### OS tested

Mark the OS where this PR is tested.

- [X] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [X] No

#### How to test the new patch?

Working on a unit test to reproduce the problem. 

----------------------------------------------------------------------------
