### PR TITLE
Update level-zero library version to v1.18.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -267,7 +267,7 @@ def build_spirv_toolkit_and_level_zero(rebuild=False):
         level_zero_lib = "level-zero"
 
         if not os.path.exists(level_zero_lib):
-            subprocess.run(["git", "clone", "--branch", "v1.17.45", "https://github.com/oneapi-src/level-zero"])
+            subprocess.run(["git", "clone", "--branch", "v1.18.1", "https://github.com/oneapi-src/level-zero"])
             os.chdir(level_zero_lib)
             os.mkdir("build")
             os.chdir("build")


### PR DESCRIPTION
I noted that in the CI we have a consistent fail on a machine with an `Integrated Graphics 770`. 

I open this PR to test if it will resolve the issue by updating `level-zero` from `1.17.45` to `1.18.1`.

This PR does not touch any TornadoVM code.

The pipeline passed ([here](https://github.com/beehive-lab/TornadoVM/actions/runs/27908521996)).