### PR TITLE
Update level-zero library version to v1.18.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -267,7 +267,7 @@ def build_spirv_toolkit_and_level_zero(rebuild=False):
         level_zero_lib = "level-zero"
 
         if not os.path.exists(level_zero_lib):
-            subprocess.run(["git", "clone", "--branch", "v1.17.45", "https://github.com/oneapi-src/level-zero"])
+            subprocess.run(["git", "clone", "--branch", "v1.18.1", "https://github.com/oneapi-src/level-zero"])
             os.chdir(level_zero_lib)
             os.mkdir("build")
             os.chdir("build")


### PR DESCRIPTION
#### Description

Backporting PR 864 [https://github.com/beehive-lab/TornadoVM/pull/864](url) to JDK25.

#### Problem description

See [https://github.com/beehive-lab/TornadoVM/pull/864](url)

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [x] SPIRV
- [ ] Metal

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

N/A. This PR does not touch any TornadoVM code.

----------------------------------------------------------------------------
