### PR TITLE
Backport Persist obj to jdk25

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -566,8 +566,22 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         List<Object> objectsToSync = executionContext.getPersistedTaskToObjectsMap().get(graphSrc.taskGraphName);
 
         if (objectsToSync == null) {
-            objectsToSync = executionContext.getPersistedObjects();
-            executionContext.addPersistedObject(this.taskGraphName, objectsToSync);
+            // Empty consumeFromDevice (no explicit source task-graph name): the objects to
+            // synchronise from the previously executed task-graph are exactly the ones marked
+            // as consumed/on-device. The graph's own persisted *outputs* must NOT be included:
+            // they are produced by this graph, so flagging them as persisted (see
+            // TornadoVMInterpreter#isPersistentObject) would make the interpreter skip their
+            // allocation and dereference a null device buffer. Each consumed object is also
+            // registered individually (not as a nested list) so that a reused task-graph does
+            // not end up with an ArrayList among its device objects.
+            objectsToSync = new ArrayList<>();
+            for (LocalObjectState localState : executionContext.getObjectStates()) {
+                if (localState.isOnDevice()) {
+                    Object consumedObject = localState.getObject();
+                    objectsToSync.add(consumedObject);
+                    executionContext.addPersistedObject(this.taskGraphName, consumedObject);
+                }
+            }
         }
 
         for (Object objectToSync : objectsToSync) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -579,7 +579,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                 if (localState.isOnDevice()) {
                     Object consumedObject = localState.getObject();
                     objectsToSync.add(consumedObject);
-                    executionContext.addPersistedObject(this.taskGraphName, consumedObject);
+                    executionContext.addPersistedObject(graphSrc.taskGraphName, consumedObject);
                 }
             }
         }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
@@ -430,6 +430,37 @@ public class TestSharedBuffers extends TornadoTestBase {
     }
 
     @Test
+    public void testReusePersistingTaskGraph() throws TornadoExecutionPlanException {
+        IntArray a = new IntArray(numElements);
+        IntArray b = new IntArray(numElements);
+        IntArray c = new IntArray(numElements);
+
+        a.init(10);
+        b.init(20);
+
+        // A single task graph that persists its own output on the device and is reused
+        // several times. On reuse, the previously-executed task graph is the graph itself,
+        // so updatePersistedObjectState() reads back what it stored on the prior run. If the
+        // persisted objects were stored as a nested list, the reused run would surface an
+        // ArrayList as a device object ("Unsupported type: ArrayList").
+        TaskGraph tg = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestHello::add, a, b, c) //
+                .persistOnDevice(c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(tg.snapshot())) {
+            executionPlan.withMemoryLimit("1GB");
+            for (int iteration = 0; iteration < 4; iteration++) {
+                executionPlan.execute();
+                for (int i = 0; i < numElements; i++) {
+                    assertEquals(30, c.get(i)); // 10 + 20 = 30
+                }
+            }
+        }
+    }
+
+    @Test
     public void testFourTaskGraphsWithPersistentBuffers() throws TornadoExecutionPlanException {
         int numElements = 10;
 


### PR DESCRIPTION
#### Description

Backport PR #870 to JDK25

#### Problem description

See [https://github.com/beehive-lab/TornadoVM/pull/870](url)

#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] CUDA
- [x] SPIRV
- [x] Metal

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

See [https://github.com/beehive-lab/TornadoVM/pull/870](url)

----------------------------------------------------------------------------
