### PR TITLE
Fix repeated execution of batched plans

### DIFF
--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXCodeCache.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/PTXCodeCache.java
@@ -55,7 +55,13 @@ public class PTXCodeCache {
 
     public PTXInstalledCode installSource(TaskDataContext taskMeta, String name, byte[] targetCode, String resolvedMethodName, boolean debugKernel) {
 
-        if (!cache.containsKey(name)) {
+        // Recompile if the kernel is absent OR its cached module was invalidated (unloaded). The latter
+        // happens when the interpreter forces recompilation across executions (e.g. a batched plan whose
+        // chunk thread-count changes): it calls invalidate() -> module.unload() but leaves the entry here.
+        // Without the validity check we would return the stale, unloaded module and cuModuleGetFunction
+        // would fail with CUDA_ERROR_INVALID_HANDLE (400) on the next launch.
+        PTXInstalledCode cachedCode = cache.get(name);
+        if (cachedCode == null || !cachedCode.isValid()) {
             if (debugKernel) {
                 RuntimeUtilities.dumpKernel(targetCode);
             }
@@ -121,7 +127,13 @@ public class PTXCodeCache {
     }
 
     boolean isCached(String name) {
-        return cache.containsKey(name);
+        // Treat an invalidated entry as not cached: its module was unloaded (e.g. the interpreter forced
+        // recompilation across executions for a batched plan whose chunk thread-count changed). Reporting
+        // it as cached makes compileTask skip code generation and build an empty (null target code)
+        // result, which then crashes in cuModuleLoadDataEx. Requiring validity keeps the cache, the
+        // interpreter's invalidation, and installSource() consistent.
+        PTXInstalledCode code = cache.get(name);
+        return code != null && code.isValid();
     }
 
     void reset() {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/batches/TestBatches.java
@@ -237,6 +237,44 @@ public class TestBatches extends TornadoTestBase {
 
     }
 
+    /**
+     * Repeated execution of a batched plan.
+     * The batch's remainder chunk uses a different thread-count than the full chunks,
+     * so re-executing the plan forces the interpreter to invalidate and recompile the kernel.
+     * This test executes the batched plan several times AND changes the input each iteration, so it also
+     * verifies the <em>recompiled</em> kernel keeps producing correct results across executions.
+     */
+    @Test
+    public void testBatchRepeatedExecution() throws TornadoExecutionPlanException {
+        long maxAllocMemory = checkMaxHeapAllocationOnDevice(64, MemoryUnit.MB);
+        int size = 64 * 1024 * 1024; // 256 MB float array
+        if ((long) size * 4 > maxAllocMemory) {
+            size = (int) ((maxAllocMemory / 4 / 2) * 0.9);
+        }
+        FloatArray arrayA = new FloatArray(size);
+        FloatArray arrayB = new FloatArray(size);
+
+        TaskGraph taskGraph = new TaskGraph("batchRepeat") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, arrayA) //
+                .task("t0", TestBatches::compute, arrayA, arrayB) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, arrayB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withBatch("40MB"); // 6 full chunks + a smaller remainder
+            // Several executions: >=2 exercises the invalidate/recompile path, >=3 the persisted-object
+            // bookkeeping. A different input each iteration checks the recompiled kernel stays correct.
+            for (int iteration = 0; iteration < 4; iteration++) {
+                float value = 3.0f + iteration;
+                arrayA.init(value);
+                executionPlan.execute();
+                for (int i = 0; i < arrayB.getSize(); i++) {
+                    assertEquals(value + 100, arrayB.get(i), 0.1f);
+                }
+            }
+        }
+    }
+
     @Test
     public void test100MB() throws TornadoExecutionPlanException {
 


### PR DESCRIPTION
#### Description

Fixes a crash when re-executing a batched (withBatch) plan on the PTX backend.
A batched plan's remainder chunk has a different thread-count than its full
chunks, so re-execution forces the interpreter to invalidate and recompile the
kernel; PTXCodeCache treated the invalidated (module-unloaded) entry as still
cached (installSource returned the dead module, and isCached made compileTask
skip codegen and build a null-target-code result), crashing in
cuModuleLoadDataEx. isCached/installSource are now validity-aware.

#### Problem description

Reproduce: run a withBatch(...) plan whose size is not a multiple of the batch
size (so there is a remainder chunk) more than once. On the 2nd execution it
fails with cuModuleGetFunction -> CUDA_ERROR_INVALID_HANDLE (400) / SIGSEGV.
The batch loop was only ever executed once by the suite, so this was uncovered;
now guarded by TestBatches#testBatchRepeatedExecution.
  
  
#### Backend/s tested

Mark the backends affected by this PR.

- [x] OpenCL
- [x] PTX
- [x] CUDA
- [ ] SPIRV
- [ ] Metal

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
$ make BACKEND=<opencl | ptx | cuda >

# Repeated execution of a batched plan (new regression test)
$ tornado-test -V uk.ac.manchester.tornado.unittests.batches.TestBatches#testBatchRepeatedExecution

# Full affected suites
$ tornado-test -V uk.ac.manchester.tornado.unittests.batches.TestBatches
```

----------------------------------------------------------------------------
