### PR TITLE
[OpenCL] Fix pointer-to-ulong conversions rejected by strict OpenCL compilers (Intel iGPUs)

### DIFF
--- a/tornado-assembly/src/examples/generated/add.cl
+++ b/tornado-assembly/src/examples/generated/add.cl
@@ -6,9 +6,9 @@ __kernel void add(__global long *_kernel_context, __constant uchar *_constant_re
   int i_11, i_9, i_15, i_14, i_13, i_3, i_4;
 
   // BLOCK 0
-  ul_0  =  a;
-  ul_1  =  b;
-  ul_2  =  c;
+  ul_0  =  (ulong) a;
+  ul_1  =  (ulong) b;
+  ul_2  =  (ulong) c;
   i_3  =  get_global_id(0);
   // BLOCK 1 MERGES [0 2 ]
   i_4  =  i_3;

--- a/tornado-assembly/src/examples/generated/add_uncompressed.cl
+++ b/tornado-assembly/src/examples/generated/add_uncompressed.cl
@@ -6,9 +6,9 @@ __kernel void add(__global long *_kernel_context, __constant uchar *_constant_re
   int i_11, i_9, i_15, i_14, i_13, i_3, i_4;
 
   // BLOCK 0
-  ul_0  =  a;
-  ul_1  =  b;
-  ul_2  =  c;
+  ul_0  =  (ulong) a;
+  ul_1  =  (ulong) b;
+  ul_2  =  (ulong) c;
   i_3  =  get_global_id(0);
   // BLOCK 1 MERGES [0 2 ]
   i_4  =  i_3;

--- a/tornado-assembly/src/examples/generated/atomics.cl
+++ b/tornado-assembly/src/examples/generated/atomics.cl
@@ -12,8 +12,8 @@ __kernel void add(__global long *_kernel_context,
   int i_11, i_9, i_15, i_14, i_13, i_3, i_4;
 
   int ul_atomic = _kernel_context[0];
-  ul_0  =  a;
-  ul_1  =  b;
+  ul_0  =  (ulong) a;
+  ul_1  =  (ulong) b;
   i_3  =  get_global_id(0);
   i_4  =  i_3;
 

--- a/tornado-assembly/src/examples/generated/atomics_16L.cl
+++ b/tornado-assembly/src/examples/generated/atomics_16L.cl
@@ -12,8 +12,8 @@ __kernel void add(__global long *_kernel_context,
   int i_11, i_9, i_15, i_14, i_13, i_3, i_4;
 
   int ul_atomic = _kernel_context[0];
-  ul_0  =  a;
-  ul_1  =  b;
+  ul_0  =  (ulong) a;
+  ul_1  =  (ulong) b;
   i_3  =  get_global_id(0);
   i_4  =  i_3;
 

--- a/tornado-assembly/src/examples/generated/atomics_uncompressed.cl
+++ b/tornado-assembly/src/examples/generated/atomics_uncompressed.cl
@@ -12,8 +12,8 @@ __kernel void add(__global long *_kernel_context,
   int i_11, i_9, i_15, i_14, i_13, i_3, i_4;
 
   int ul_atomic = _kernel_context[0];
-  ul_0  =  a;
-  ul_1  =  b;
+  ul_0  =  (ulong) a;
+  ul_1  =  (ulong) b;
   i_3  =  get_global_id(0);
   i_4  =  i_3;
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLNodeLIRBuilder.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLNodeLIRBuilder.java
@@ -120,6 +120,8 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLNullary;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLReturnSlot;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLUnary;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.FPGAWorkGroupSizeNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.FixedArrayCopyNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.FixedArrayNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.IntelUnrollPragmaNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.XilinxPipeliningPragmaNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.logic.LogicalAndNode;
@@ -494,7 +496,7 @@ public class OCLNodeLIRBuilder extends NodeLIRBuilder {
                 setResult(phi, value);
             } else {
                 final AllocatableValue result = gen.asAllocatable(operandForPhi(phi));
-                append(new OCLLIRStmt.AssignStmt(result, value));
+                append(new OCLLIRStmt.AssignStmt(result, operandForPhiMove(phi.firstValue())));
             }
         }
         emitOCLFPGAPragmas(currentBlockDominator);
@@ -515,7 +517,7 @@ public class OCLNodeLIRBuilder extends NodeLIRBuilder {
             Value src = operand(phi.valueAt(loopEnd));
 
             if (!dest.equals(src)) {
-                append(new OCLLIRStmt.AssignStmt(dest, src));
+                append(new OCLLIRStmt.AssignStmt(dest, operandForPhiMove(phi.valueAt(loopEnd))));
             }
         }
     }
@@ -536,13 +538,12 @@ public class OCLNodeLIRBuilder extends NodeLIRBuilder {
                 Value src = operand(value);
 
                 if (!dest.equals(src)) {
-                    append(new OCLLIRStmt.AssignStmt(dest, src));
+                    append(new OCLLIRStmt.AssignStmt(dest, operandForPhiMove(value)));
                 }
             } else if (loopExitMerge) {
                 AllocatableValue dest = gen.asAllocatable(operandForPhi(phi));
-                Value src = operand(phi.valueAt(1));
 
-                append(new OCLLIRStmt.AssignStmt(dest, src));
+                append(new OCLLIRStmt.AssignStmt(dest, operandForPhiMove(phi.valueAt(1))));
             }
         }
     }
@@ -776,10 +777,25 @@ public class OCLNodeLIRBuilder extends NodeLIRBuilder {
                 if (((!phi.isLoopPhi()) && (phi.singleValueOrThis() == phi)) || (value instanceof PhiNode && !((PhiNode) value).isLoopPhi())) {
 
                     final AllocatableValue result = gen.asAllocatable(operandForPhi(phi));
-                    append(new OCLLIRStmt.AssignStmt(result, operand(value)));
+                    append(new OCLLIRStmt.AssignStmt(result, operandForPhiMove(value)));
                 }
             }
         }
+    }
+
+    /**
+     * Phi variables are integer-typed (ulong), but the operand of a
+     * {@link FixedArrayNode} or {@link FixedArrayCopyNode} is a private-memory
+     * pointer. OpenCL C does not allow implicit pointer-to-integer conversion
+     * (strict compilers such as Intel's reject it), so an explicit cast is
+     * required for these phi moves.
+     */
+    private Value operandForPhiMove(final ValueNode value) {
+        final Value operand = operand(value);
+        if (value instanceof FixedArrayNode || value instanceof FixedArrayCopyNode) {
+            return new OCLUnary.Expr(OCLUnaryOp.CAST_TO_ULONG, LIRKind.value(gen.target().arch.getWordKind()), operand);
+        }
+        return operand;
     }
 
     private boolean blockContainsIfNode(HIRBlock block) {


### PR DESCRIPTION
#### Description

This patch fixes OpenCL kernel build failures (clBuildProgram error -11) on devices with strict OpenCL C compilers, such as Intel integrated GPUs. It contains two fixes:

  1. JIT code generator (OCLNodeLIRBuilder): when a kernel conditionally selects between two arrays in private memory, the phi merge variable is integer-typed (ulong) while the incoming values from FixedArrayNode/FixedArrayCopyNode are private pointers (e.g. __private int*). The phi move was emitted as a plain assignment (ul_17 = ul_3;), relying on implicit pointer-to-integer conversion, which OpenCL C forbids. The generator now emits an explicit cast: ul_17 = (ulong) ul_3;.
  2. Pre-generated kernels (tornado-assembly/src/examples/generated/): add.cl, add_uncompressed.cl, atomics.cl, atomics_16L.cl and atomics_uncompressed.cl were produced by an older code generator that assigned kernel pointer parameters to ulong variables without a cast (ul_0 = a;). The explicit (ulong) casts that the current code generator emits have been added.

#### Problem description

Issues observed when running on Integrated GPUs in the TornadoVM CI pipeline, [here](https://github.com/beehive-lab/TornadoVM/actions/runs/28577829057/job/84730514315).

NVIDIA's OpenCL compiler accepts implicit pointer-to-integer conversion with a warning, but Intel's clang-based compiler rejects it as an error, e.g.:
 
 ```bash
  error: incompatible pointer to integer conversion assigning to '__private ulong' from '__private int *__private'
        ul_17  =  ul_3;
```

As a result, the following tests failed on an Intel integrated GPU (e.g. UHD Graphics 770) while passing on NVIDIA GPUs:

  - `TestArrayCopies#testPrivateArrayCopyInt / Float / Long` (JIT codegen, fix 1)
  - `PrebuiltTests#testPrebuilt01`, `#testPrebuilt01MultiIterations` and `TestAtomics#testAtomic05_precompiled` (stale pre-generated kernels, fix 2)

To reproduce, build with `make BACKEND=opencl` on a machine where the Intel iGPU is device 0:1 and run:

```bash 
  tornado-test --jvm "-Dtornado.unittests.device=0:1" -V uk.ac.manchester.tornado.unittests.arrays.TestArrayCopies
  tornado-test --jvm "-Dtornado.unittests.device=0:1" -V uk.ac.manchester.tornado.unittests.prebuilt.PrebuiltTests
  tornado-test --jvm "-Dtornado.unittests.device=0:1" -V uk.ac.manchester.tornado.unittests.atomics.TestAtomics#testAtomic05_precompiled
```

#### Backend/s tested
 
  - [x] OpenCL
  - [ ] PTX
  - [ ] CUDA
  - [ ] SPIRV
  - [ ] Metal

#### OS tested

  - [x] Linux
  - [ ] OSx
  - [ ] Windows

#### Did you check on FPGAs?

  - [ ] Yes
  - [x] No

#### How to test the new patch?
 
On a system with an Intel integrated GPU (tested on Intel UHD Graphics 770, with an NVIDIA RTX 5070 Ti as device 0:0):

```bash
  make BACKEND=opencl
  tornado-test --jvm "-Dtornado.unittests.device=0:1" -V uk.ac.manchester.tornado.unittests.arrays.TestArrayCopies
  tornado-test --jvm "-Dtornado.unittests.device=0:1" -V uk.ac.manchester.tornado.unittests.prebuilt.PrebuiltTests
  tornado-test --jvm "-Dtornado.unittests.device=0:1" -V uk.ac.manchester.tornado.unittests.atomics.TestAtomics
```

All previously failing tests pass. Regression runs of TestArrayCopies, PrebuiltTests, TestAtomics and TestLoops on the NVIDIA device (0:0) show no failures.