### PR TITLE
[hotfix][PTX] Align compileTask exception handling with other backends to preserve original exception on bailout-disabled path

### DIFF
--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/runtime/PTXTornadoDevice.java
@@ -194,12 +194,13 @@ public class PTXTornadoDevice implements TornadoXPUDevice {
             profiler.sum(ProfilerType.TOTAL_DRIVER_COMPILE_TIME, profiler.getTaskTimer(ProfilerType.TASK_COMPILE_DRIVER_TIME, taskMeta.getId()));
             return installedCode;
         } catch (Exception e) {
-            if (TornadoOptions.DEBUG) {
-                System.err.println(e.getMessage());
+            logger.fatal("Unable to compile %s for device %s\n", task.getId(), getDeviceName());
+            logger.fatal("Exception occurred when compiling %s\n", ((CompilableTask) task).getMethod().getName());
+            if (TornadoOptions.RECOVER_BAILOUT) {
+                throw new TornadoBailoutRuntimeException("[Error during the Task Compilation]: " + e.getMessage());
+            } else {
+                throw e;
             }
-            logger.fatal("unable to compile %s for device %s\n", task.getId(), getDeviceName());
-            logger.fatal("exception occurred when compiling %s\n", ((CompilableTask) task).getMethod().getName());
-            throw new TornadoBailoutRuntimeException("[Error During the Task Compilation] ", e);
         }
     }
 


### PR DESCRIPTION
#### Description

This PR aligns `PTXTornadoDevice.compileTask` exception handling with the pattern used by every other backend (CUDA, OpenCL, SPIR-V, Metal). With this PR, when `TornadoOptions.RECOVER_BAILOUT` is disabled the driver throws the original exception instead of wrapping it. This preserves the exception type so downstream code (test runners, users of the API) can pattern-match on specific compilation errors.

#### Problem description

`PTXTornadoDevice.compileTask` currently wraps every caught exception in a `TornadoBailoutRuntimeException` unconditionally:

```
} catch (Exception e) {
    throw new TornadoBailoutRuntimeException("[Error During the Task Compilation] ", e);
}
```

Other backends (see e.g. `CUDATornadoDevice.compileTask`) instead check `TornadoOptions.RECOVER_BAILOUT` and only wrap when bailout is enabled, otherwise the original exception is rethrown as-is. Because unit tests run with bailout disabled, PTX obscures the underlying exception type, which breaks any downstream check that relies on the specific class of the original exception.

Concrete case where this surfaces: `PTXTensorCoreSupportPhase` throws `TornadoDeviceMMANotSupported` on pre-Ampere devices, and `TornadoHelper.runTestVerbose` uses that exception type as the signal to report `[MMA UNSUPPORTED FOR CURRENT DEVICE]` instead of a hard failure:

```
if (result.getFailures().stream().anyMatch(e -> (e.getException() instanceof TornadoDeviceMMANotSupported))) {
                    message = String.format("%20s", " ................ " + ColorsTerminal.YELLOW + " [MMA UNSUPPORTED FOR CURRENT DEVICE] " + ColorsTerminal.RESET + "\n");
                    bufferConsole.append(message);
                    bufferFile.append(message);
                    notSupported++;
                    continue;
                }
```

On PTX with a device that does not support MMA instructions, the tests are reported as hard failures because `getException()` returns the `TornadoBailoutRuntimeException` wrapper, so the `instanceof TornadoDeviceMMANotSupported`  check in the `TornadoHelper` never matches.

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [x] PTX
- [ ] CUDA
- [ ] SPIRV
- [ ] Metal

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

Run any of the MMA unittests (e.g. `tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationMMA` ) on a device with compute capability below the MMA minimum (any pre-Ampere NVIDIA GPU, e.g. Pascal or Volta). 

- Expected behaviour after this PR: every MMA test reported as `[MMA UNSUPPORTED FOR CURRENT DEVICE]`. 
- Behaviour pre-patch: hard failures with `[Error During the Task Compilation]`.
