### PR TITLE
Fix CUDA-backend build on develop (cuFFT broken merge + cudnn SDPA)

### DIFF
--- a/tornado-cufft/src/main/java/uk/ac/manchester/tornado/cufft/provider/CuFftLibraryProvider.java
+++ b/tornado-cufft/src/main/java/uk/ac/manchester/tornado/cufft/provider/CuFftLibraryProvider.java
@@ -125,12 +125,8 @@ public final class CuFftLibraryProvider implements TornadoLibraryProvider {
         CuFftNativeLib.checkResult(result, functionName);
     }
 
-    /** (input, output, n, batch). */
-    private static void execC2C(CuFftContext context, LibraryInvocation invocation, int direction) {
-        final int n = (int) invocation.getArg(2);
-        final int batch = (int) invocation.getArg(3);
-
-        String planKey = n + ":" + batch;
+    private static long getOrCreatePlan(CuFftContext context, PlanKind kind, int dim1, int dim2) {
+        String planKey = kind + ":" + dim1 + ":" + dim2;
         Long plan = context.planCache.get(planKey);
         if (plan == null) {
             plan = switch (kind) {

--- a/tornado-drivers/cudnn-jni/src/main/cpp/source/tornado-cudnn-sdpa.cpp
+++ b/tornado-drivers/cudnn-jni/src/main/cpp/source/tornado-cudnn-sdpa.cpp
@@ -30,10 +30,31 @@
  * provider prepare() hook, before CUDA graph capture) and replayed with
  * executeSdpaPlan. Layout: packed BHSD (batch, heads, sequence, head-dim),
  * FP16 I/O, FP32 intermediates/compute, inference only (no stats output).
+ *
+ * Toolkit guard: recent cudnn-frontend releases transitively include
+ * experimental sm90/sm100 prefill engine headers that reference CUDA 12.x
+ * driver types (CUlibrary, CUkernel, CUtensorMap, ...). Those types do not
+ * exist on older toolkits, so on CUDA < 12 we cannot even parse the frontend
+ * headers. To keep the JNI library building (and loading) everywhere, the
+ * fused-SDPA implementation is compiled only when CUDA_VERSION >= 12000;
+ * otherwise the four JNI entry points are provided as stubs that report the
+ * feature as unavailable. createSdpaPlan returning 0 is already handled by the
+ * Java provider (CuDnnLibraryProvider) as "SDPA plan creation failed".
  */
 
 #include <jni.h>
 #include <cstdio>
+
+#include <cuda.h> // CUDA_VERSION
+
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 12000
+#define TORNADO_CUDNN_SDPA_SUPPORTED 1
+#else
+#define TORNADO_CUDNN_SDPA_SUPPORTED 0
+#endif
+
+#if TORNADO_CUDNN_SDPA_SUPPORTED
+
 #include <memory>
 #include <unordered_map>
 
@@ -83,7 +104,7 @@ JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_cudnn_provider_CuDnnNative
 
     auto sdpa_options = fe::graph::SDPA_attributes()
             .set_name("sdpa")
-            .set_is_inference(true)
+            .set_generate_stats(false) // inference-only: don't emit softmax stats (replaces deprecated set_is_inference(true))
             .set_attn_scale(scale);
     if (causal) {
         sdpa_options.set_causal_mask(true);
@@ -157,3 +178,46 @@ JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_cudnn_provider_CuDnnNativeL
 }
 
 } // extern "C"
+
+#else // !TORNADO_CUDNN_SDPA_SUPPORTED
+
+/*
+ * Fallback stubs for CUDA toolkits older than 12.0, where cudnn-frontend's
+ * fused-SDPA headers do not compile. The symbols are kept so the JNI library
+ * links and loads; the feature simply reports itself as unavailable.
+ */
+
+extern "C" {
+
+JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_cudnn_provider_CuDnnNativeLib_createSdpaPlan
+        (JNIEnv *env, jclass clazz, jlong handle, jint b, jint h, jint s_q, jint s_kv, jint d,
+         jfloat scale, jboolean causal) {
+    (void) env; (void) clazz; (void) handle;
+    (void) b; (void) h; (void) s_q; (void) s_kv; (void) d; (void) scale; (void) causal;
+    fprintf(stderr, "[tornado-cudnn] fused SDPA unavailable: built against CUDA %d.%d "
+                    "(requires CUDA >= 12.0 for the cudnn-frontend flash-attention path)\n",
+            CUDA_VERSION / 1000, (CUDA_VERSION % 1000) / 10);
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_cudnn_provider_CuDnnNativeLib_sdpaPlanWorkspaceBytes
+        (JNIEnv *env, jclass clazz, jlong plan_ptr) {
+    (void) env; (void) clazz; (void) plan_ptr;
+    return 0;
+}
+
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_cudnn_provider_CuDnnNativeLib_executeSdpaPlan
+        (JNIEnv *env, jclass clazz, jlong handle, jlong plan_ptr, jlong d_q, jlong d_k, jlong d_v, jlong d_o, jlong workspace_ptr) {
+    (void) env; (void) clazz; (void) handle; (void) plan_ptr;
+    (void) d_q; (void) d_k; (void) d_v; (void) d_o; (void) workspace_ptr;
+    return 1;
+}
+
+JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_cudnn_provider_CuDnnNativeLib_destroySdpaPlan
+        (JNIEnv *env, jclass clazz, jlong plan_ptr) {
+    (void) env; (void) clazz; (void) plan_ptr;
+}
+
+} // extern "C"
+
+#endif // TORNADO_CUDNN_SDPA_SUPPORTED


### PR DESCRIPTION
## Problem

`develop` does not currently build with the CUDA backend (`-Pcuda-backend`):

1. **tornado-cufft fails to compile.** A merge text-combined two divergent versions of the plan method in `CuFftLibraryProvider`, leaving an `execC2C(...)` signature over a `getOrCreatePlan` body: `getOrCreatePlan(CuFftContext, PlanKind, int, int)` is *called* (lines 105, 115) but never defined, and the method ends with `return plan;` in a `void` method → 14 `cannot find symbol` errors + one `incompatible types`.

2. **tornado-drivers-cudnn-jni fails on the CUDA JNI runner.** `tornado-cudnn-sdpa.cpp` calls the `[[deprecated]]` `SDPA_attributes::set_is_inference` (promoted to an error by the CI toolchain), and cudnn-frontend's experimental SDPA headers reference CUDA 12.x driver types (`CUtensorMap`, `CUlibrary`, …) that don't exist on older toolkits (the runner builds against CUDA 11.5).

## Fix

1. Restore `getOrCreatePlan(CuFftContext, PlanKind, int, int)` so the calls resolve and the method returns `long`.
2. Replace the deprecated `set_is_inference(true)` with `set_generate_stats(false)`, and compile the fused-SDPA implementation only when `CUDA_VERSION >= 12000`; on older toolkits the four JNI entry points are stubs (`createSdpaPlan` → 0, already handled by `CuDnnLibraryProvider` as "SDPA unavailable"), so the JNI library still builds and loads everywhere.

Both changes are self-contained (two files). Verified locally: the cudnn JNI module builds against both CUDA 12.6 and (via the guard) toolkits < 12; the cuFFT fix restores compilation and `TestCuFft` runs.

