### PR TITLE
Backport Cuda fixes to jdk25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: build
 
-# Variable passed for the build process. List of backend/s to use { opencl, ptx, spirv }. The default one is `opencl`.
+# Variable passed for the build process. List of backend/s to use { opencl, ptx, spirv, cuda, metal }. The default one is `opencl`.
 # make BACKEND=<comma_separated_backend_list>
 BACKEND ?= opencl
 
@@ -52,7 +52,7 @@ checkstyle:
 	./mvnw checkstyle:check
 
 clean:
-	./mvnw -Popencl-backend,ptx-backend,spirv-backend,metal-backend,cuda-backend clean
+	./mvnw -Popencl-backend,ptx-backend,spirv-backend,cuda-backend,metal-backend clean
 
 example:
 	tornado --printKernel --debug -m tornado.examples/uk.ac.manchester.tornado.examples.VectorAddInt --params="8192"
@@ -83,7 +83,7 @@ fast-tests-uncompressed:
 	tornado --devices
 	tornado-test --verbose --quickPass --uncompressed
 	tornado-test -V --uncompressed -J"-Dtornado.device.memory=1MB" uk.ac.manchester.tornado.unittests.fails.HeapFail#test03
-	test-native.sh	
+	test-native.sh
 
 tests-spirv-levelzero:
 	rm -f tornado_unittests.log

--- a/bin/update_paths.py
+++ b/bin/update_paths.py
@@ -146,6 +146,10 @@ def update_tornado_paths():
         backend_info = "PTX"
     elif '-spirv' in selected_sdk.lower():
         backend_info = "SPIR-V"
+    elif '-cuda' in selected_sdk.lower():
+        backend_info = "CUDA"
+    elif '-metal' in selected_sdk.lower():
+        backend_info = "Metal"
 
     log_messages.append(
         "###########################################################################"

--- a/tornado-assembly/src/bin/test-native.sh
+++ b/tornado-assembly/src/bin/test-native.sh
@@ -30,6 +30,12 @@ if [[ $selected_backends == *"opencl"* ]]; then
   tornado uk.ac.manchester.tornado.drivers.opencl.tests.TestOpenCLTornadoCompiler
 fi
 
+if [[ $selected_backends == *"cuda"* ]]; then
+  echo -e "\nTesting the Native CUDA API\n"
+  tornado uk.ac.manchester.tornado.drivers.cuda.tests.TestCUDAJITCompiler
+  tornado uk.ac.manchester.tornado.drivers.cuda.tests.TestCUDATornadoCompiler
+fi
+
 if [[ $selected_backends == *"spirv"* ]]; then
 
   ## The SPIR-V Backend import Level Zero and OpenCL

--- a/tornado-assembly/src/bin/tornado
+++ b/tornado-assembly/src/bin/tornado
@@ -387,6 +387,11 @@ check_backend_dependencies() {
                     has_warnings=true
                 fi
                 ;;
+            *cuda*)
+                if ! check_ptx_backend; then
+                    has_warnings=true
+                fi
+                ;;
         esac
     done
 

--- a/tornado-assembly/src/bin/tornado.py
+++ b/tornado-assembly/src/bin/tornado.py
@@ -295,6 +295,61 @@ def validate_ptx_backend(sdk_path):
 
     return True
 
+def validate_cuda_backend(sdk_path):
+    """Validate CUDA backend dependencies on Windows."""
+    if os.name != 'nt':
+        return True
+
+    cuda_dll = os.path.join(sdk_path, 'lib', 'tornado-cuda.dll')
+
+    if not os.path.exists(cuda_dll):
+        print(f"[WARNING] CUDA backend configured but tornado-cuda.dll not found")
+        print(f"[INFO] Expected location: {cuda_dll}")
+        print()
+        return False
+
+    if not check_dll_loadable(cuda_dll):
+        print("[ERROR] Cannot load CUDA JNI library")
+        print()
+        print(f"[INFO] Library location: {cuda_dll}")
+        print()
+
+        gpus = get_gpu_info()
+        if gpus:
+            print("[INFO] Detected GPU(s):")
+            for gpu in gpus:
+                print(f"       - {gpu}")
+                if "NVIDIA" not in gpu.upper():
+                    print("         (This is not an NVIDIA GPU - CUDA requires NVIDIA)")
+            print()
+
+        has_nvidia_driver = check_nvidia_driver()
+
+        print("[CAUSE] Missing NVIDIA CUDA Toolkit or drivers")
+        print("        The CUDA backend requires:")
+        print("        - NVIDIA GPU")
+        print("        - NVIDIA drivers (usually pre-installed on Windows)")
+        print("        - CUDA Toolkit 12.0+")
+        print()
+
+        if not has_nvidia_driver:
+            print("[FIX] Install NVIDIA CUDA Toolkit and drivers")
+            print("      Download from: https://developer.nvidia.com/cuda-downloads")
+            print()
+        else:
+            print("[INFO] NVIDIA drivers detected (nvidia-smi available)")
+            print()
+            print("[FIX] Reinstall or update NVIDIA CUDA Toolkit 12.0+")
+            print("      Download from: https://developer.nvidia.com/cuda-downloads")
+            print()
+
+        print("[NOTE] CUDA backend is NVIDIA-specific")
+        print("       For non-NVIDIA GPUs, use OpenCL or SPIR-V backends instead")
+        print()
+        sys.exit(1)
+
+    return True
+
 def validate_spirv_backend(sdk_path):
     """Validate SPIR-V backend dependencies on Windows."""
     if os.name != 'nt':
@@ -414,6 +469,9 @@ def validate_windows_dependencies(sdk_path):
 
                 if 'ptx-backend' in content:
                     validate_ptx_backend(sdk_path)
+
+                if 'cuda-backend' in content:
+                    validate_cuda_backend(sdk_path)
 
                 if 'spirv-backend' in content:
                     validate_spirv_backend(sdk_path)

--- a/tornado-assembly/src/examples/generated/add_uncompressed.cu
+++ b/tornado-assembly/src/examples/generated/add_uncompressed.cu
@@ -15,7 +15,7 @@ extern "C" __global__ void add(long *_kernel_context, unsigned char *_constant_r
     // BLOCK 2
     l_5  =  (long) i_4;
     l_6  =  l_5 << 2;
-    l_7  =  l_6 + 16L;
+    l_7  =  l_6 + 24L;
     ul_8  =  ul_0 + l_7;
     i_9  =  *(( int *) ul_8);
     ul_10  =  ul_1 + l_7;

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/CUDACommandQueue.cpp
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/CUDACommandQueue.cpp
@@ -46,13 +46,45 @@ static bool stream_is_capturing(cuda_queue_t *queue) {
 /*
  * Creates and records a CUevent on the queue's stream, returning its boxed
  * handle. Used as the "event" result the OpenCL clone expects from enqueue ops.
+ * No start event is recorded, so the reported elapsed time is 0 (used by
+ * markers/barriers that do not bracket a timed operation).
  */
 static jlong record_event(cuda_queue_t *queue) {
     cuda_event_t *ev = new cuda_event_t();
+    ev->start = nullptr;
     CUresult result = cuEventCreate(&ev->event, CU_EVENT_DEFAULT);
     LOG_CUDA_AND_VALIDATE("cuEventCreate", result);
     result = cuEventRecord(ev->event, queue->stream);
     LOG_CUDA_AND_VALIDATE("cuEventRecord", result);
+    return (jlong) ev;
+}
+
+/*
+ * Allocates an event handle and records a START timestamp on the stream, to be
+ * paired with end_event() after the operation. CU_EVENT_DEFAULT keeps timing
+ * enabled (CU_EVENT_DISABLE_TIMING would not), so cuEventElapsedTime works.
+ */
+static cuda_event_t *begin_event(cuda_queue_t *queue) {
+    cuda_event_t *ev = new cuda_event_t();
+    ev->event = nullptr;
+    ev->start = nullptr;
+    CUresult result = cuEventCreate(&ev->start, CU_EVENT_DEFAULT);
+    LOG_CUDA_AND_VALIDATE("cuEventCreate(start)", result);
+    result = cuEventRecord(ev->start, queue->stream);
+    LOG_CUDA_AND_VALIDATE("cuEventRecord(start)", result);
+    return ev;
+}
+
+/*
+ * Records the END/completion timestamp for an event started with begin_event(),
+ * and returns the boxed handle. cuEventElapsedTime(start, event) then yields the
+ * device time of the operation enqueued between the two records.
+ */
+static jlong end_event(cuda_event_t *ev, cuda_queue_t *queue) {
+    CUresult result = cuEventCreate(&ev->event, CU_EVENT_DEFAULT);
+    LOG_CUDA_AND_VALIDATE("cuEventCreate(end)", result);
+    result = cuEventRecord(ev->event, queue->stream);
+    LOG_CUDA_AND_VALIDATE("cuEventRecord(end)", result);
     return (jlong) ev;
 }
 
@@ -188,6 +220,7 @@ JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_cuda_CUDACommandQu
     }
 
     cuCtxSetCurrent(queue->context);
+    cuda_event_t *ev = begin_event(queue);
     CUresult result = cuLaunchKernel(
             kernel->function,
             grid[0], grid[1], grid[2],
@@ -198,7 +231,7 @@ JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_cuda_CUDACommandQu
             nullptr);
     LOG_CUDA_AND_VALIDATE("cuLaunchKernel", result);
 
-    return record_event(queue);
+    return end_event(ev, queue);
 }
 
 /*
@@ -211,6 +244,7 @@ static jlong transfer_to_device(JNIEnv *env, cuda_queue_t *queue, void *host_bas
         return 0;
     }
     cuCtxSetCurrent(queue->context);
+    cuda_event_t *ev = begin_event(queue);
     CUresult result = cuMemcpyHtoDAsync(
             (CUdeviceptr) (device_ptr + device_offset),
             (const void *) ((char *) host_base + host_offset),
@@ -225,7 +259,7 @@ static jlong transfer_to_device(JNIEnv *env, cuda_queue_t *queue, void *host_bas
     if (!stream_is_capturing(queue)) {
         cuStreamSynchronize(queue->stream);
     }
-    return record_event(queue);
+    return end_event(ev, queue);
 }
 
 static jlong transfer_to_host(JNIEnv *env, cuda_queue_t *queue, void *host_base,
@@ -234,6 +268,7 @@ static jlong transfer_to_host(JNIEnv *env, cuda_queue_t *queue, void *host_base,
         return 0;
     }
     cuCtxSetCurrent(queue->context);
+    cuda_event_t *ev = begin_event(queue);
     CUresult result = cuMemcpyDtoHAsync(
             (void *) ((char *) host_base + host_offset),
             (CUdeviceptr) (device_ptr + device_offset),
@@ -244,7 +279,7 @@ static jlong transfer_to_host(JNIEnv *env, cuda_queue_t *queue, void *host_base,
     if (!stream_is_capturing(queue)) {
         cuStreamSynchronize(queue->stream);
     }
-    return record_event(queue);
+    return end_event(ev, queue);
 }
 
 /* ---- writeArrayToDevice overloads (byte/char/short/int/long/float/double) ---- */

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAEvent.cpp
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAEvent.cpp
@@ -62,7 +62,10 @@ JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_cuda_CUDAEvent_clGe
  * Method:    clGetEventProfilingInfo
  * Signature: (JJ[B)V
  *
- * STUB: profiling timestamps are not wired for MVP; report zero (cl_ulong).
+ * CUDA exposes no absolute event timestamps (unlike OpenCL's COMMAND_START/END),
+ * only cuEventElapsedTime between two events. The absolute-timestamp queries are
+ * therefore reported as zero; elapsed time is obtained via cuEventElapsedTime
+ * below.
  */
 JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_cuda_CUDAEvent_clGetEventProfilingInfo
         (JNIEnv *env, jclass clazz, jlong event_id, jlong param_name, jbyteArray array) {
@@ -70,6 +73,35 @@ JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_cuda_CUDAEvent_clGe
     jsize len = env->GetArrayLength(array);
     std::memset(buf, 0, len);
     env->ReleasePrimitiveArrayCritical(array, buf, 0);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_cuda_CUDAEvent
+ * Method:    cuEventElapsedTime
+ * Signature: (J)J
+ *
+ * Returns the device time, in NANOSECONDS, of the operation bracketed by the
+ * event's start/end CUevents (cuEventElapsedTime reports milliseconds as a
+ * float). Returns 0 when the event has no start timestamp (e.g. a marker), or if
+ * the events are not both complete / the query fails.
+ */
+JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_cuda_CUDAEvent_cuEventElapsedTime
+        (JNIEnv *env, jclass clazz, jlong event_id) {
+    cuda_event_t *ev = (cuda_event_t *) event_id;
+    if (ev == nullptr || ev->start == nullptr || ev->event == nullptr) {
+        return 0;
+    }
+    // Ensure both events have completed before querying (otherwise
+    // cuEventElapsedTime returns CUDA_ERROR_NOT_READY).
+    if (cuEventSynchronize(ev->event) != CUDA_SUCCESS) {
+        return 0;
+    }
+    float milliseconds = 0.0f;
+    CUresult result = cuEventElapsedTime(&milliseconds, ev->start, ev->event);
+    if (result != CUDA_SUCCESS) {
+        return 0;
+    }
+    return (jlong) (milliseconds * 1.0e6); // ms -> ns
 }
 
 /*
@@ -139,8 +171,14 @@ JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_cuda_CUDAEvent_clRe
     if (ev == nullptr) {
         return;
     }
-    CUresult result = cuEventDestroy(ev->event);
-    LOG_CUDA_AND_VALIDATE("cuEventDestroy", result);
+    if (ev->start != nullptr) {
+        CUresult startResult = cuEventDestroy(ev->start);
+        LOG_CUDA_AND_VALIDATE("cuEventDestroy(start)", startResult);
+    }
+    if (ev->event != nullptr) {
+        CUresult result = cuEventDestroy(ev->event);
+        LOG_CUDA_AND_VALIDATE("cuEventDestroy", result);
+    }
     delete ev;
 }
 

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAProgram.cpp
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAProgram.cpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 #include <cstdlib>
+#include <fstream>
 #include <unordered_map>
 #include <mutex>
 #include "cuda_jni.h"
@@ -48,6 +49,36 @@ extern "C" {
 /* CL_BUILD_* status codes (see cloned CUDABuildStatus enum). */
 #define CL_BUILD_SUCCESS 0
 #define CL_BUILD_ERROR (-2)
+
+// Locates directories that contain the toolkit's cuda_fp16.h, so an explicit
+// NVRTC include path can be supplied on CUDA 11.x toolkits (see comment at the
+// call site). Candidate roots are probed in priority order and only those that
+// actually hold the header are returned. Returns an empty vector if none exist.
+static std::vector<std::string> find_cuda_header_include_dirs() {
+    std::vector<std::string> candidates;
+    for (const char *var : {"CUDA_PATH", "CUDA_HOME", "CUDA_ROOT"}) {
+        const char *root = std::getenv(var);
+        if (root && *root) {
+            candidates.push_back(std::string(root) + "/include");
+        }
+    }
+    candidates.push_back("/usr/local/cuda/include");
+    candidates.push_back("/usr/include"); // distro-packaged toolkit (nvcc in /usr/bin)
+
+    std::vector<std::string> found;
+    for (const std::string &dir : candidates) {
+        if (std::ifstream(dir + "/cuda_fp16.h").good()) {
+            bool dup = false;
+            for (const std::string &f : found) {
+                if (f == dir) { dup = true; break; }
+            }
+            if (!dup) {
+                found.push_back(dir);
+            }
+        }
+    }
+    return found;
+}
 
 /*
  * Compiles the stored CUDA C source to a cubin using NVRTC, targeting the
@@ -126,15 +157,34 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
         nvrtcResult nv = nvrtcCreateProgram(&prog, program->source.c_str(), "tornado_kernel.cu", 0, nullptr, nullptr);
         LOG_NVRTC_AND_VALIDATE("nvrtcCreateProgram", nv);
 
-        // Do NOT add system CUDA include paths (e.g. /usr/local/cuda/include).
-        // NVRTC provides device-side built-in versions of all standard CUDA headers
-        // (cuda_fp16.h, cuda_runtime.h, etc.) that are designed for RTC mode.
-        // The system headers guard <nv/target> with !defined(__CUDACC_RTC__), so
-        // NV_IF_ELSE_TARGET / NV_IS_DEVICE are undefined when the system
-        // cuda_fp16.hpp is compiled under NVRTC, causing 100+ errors.
-        // Using NVRTC's own built-ins avoids this mismatch.
+        // Header resolution for #include <cuda_fp16.h> et al. is version-dependent:
+        //
+        //   * CUDA >= 12.0: NVRTC ships device-side built-in versions of the standard
+        //     CUDA headers (cuda_fp16.h, cuda_runtime.h, ...) designed for RTC mode.
+        //     Do NOT add a system include path here: the on-disk cuda_fp16.hpp guards
+        //     <nv/target> with !defined(__CUDACC_RTC__), so NV_IF_ELSE_TARGET /
+        //     NV_IS_DEVICE are undefined under NVRTC and produce 100+ errors. The
+        //     built-ins avoid that mismatch.
+        //
+        //   * CUDA < 12.0: NVRTC has NO built-in cuda_fp16.h, so a kernel that emits
+        //     #include <cuda_fp16.h> fails with "could not open source file". These
+        //     older toolkit headers are RTC-safe (no <nv/target> guard), so we point
+        //     NVRTC at the toolkit include dir to resolve them.
+        int nvrtcMajor = 0, nvrtcMinor = 0;
+        nvrtcVersion(&nvrtcMajor, &nvrtcMinor);
+
+        std::vector<std::string> includeOpts; // storage must outlive `options`
+        if (nvrtcMajor > 0 && nvrtcMajor < 12) {
+            for (const std::string &dir : find_cuda_header_include_dirs()) {
+                includeOpts.push_back("--include-path=" + dir);
+            }
+        }
+
         std::vector<const char *> options;
         options.push_back(arch.c_str());
+        for (const std::string &opt : includeOpts) {
+            options.push_back(opt.c_str());
+        }
         nv = nvrtcCompileProgram(prog, (int) options.size(), options.data());
         LOG_NVRTC_AND_VALIDATE("nvrtcCompileProgram", nv);
 

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAProgram.cpp
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAProgram.cpp
@@ -51,9 +51,10 @@ extern "C" {
 #define CL_BUILD_ERROR (-2)
 
 // Locates directories that contain the toolkit's cuda_fp16.h, so an explicit
-// NVRTC include path can be supplied on CUDA 11.x toolkits (see comment at the
-// call site). Candidate roots are probed in priority order and only those that
-// actually hold the header are returned. Returns an empty vector if none exist.
+// NVRTC include path can be supplied on toolkits whose NVRTC cannot resolve
+// the standard CUDA headers on its own (see comment at the call site).
+// Candidate roots are probed in priority order and only those that actually
+// hold the header are returned. Returns an empty vector if none exist.
 static std::vector<std::string> find_cuda_header_include_dirs() {
     std::vector<std::string> candidates;
     for (const char *var : {"CUDA_PATH", "CUDA_HOME", "CUDA_ROOT"}) {
@@ -78,6 +79,19 @@ static std::vector<std::string> find_cuda_header_include_dirs() {
         }
     }
     return found;
+}
+
+// Copies the NVRTC build log (errors and warnings) of `prog` into the
+// program's log buffer, replacing any log from a previous compile attempt.
+static void capture_nvrtc_log(nvrtcProgram prog, cuda_program_t *program) {
+    program->log.clear();
+    size_t log_size = 0;
+    nvrtcGetProgramLogSize(prog, &log_size);
+    if (log_size > 1) {
+        std::vector<char> log(log_size);
+        nvrtcGetProgramLog(prog, log.data());
+        program->log.assign(log.data(), log_size);
+    }
 }
 
 /*
@@ -157,44 +171,45 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
         nvrtcResult nv = nvrtcCreateProgram(&prog, program->source.c_str(), "tornado_kernel.cu", 0, nullptr, nullptr);
         LOG_NVRTC_AND_VALIDATE("nvrtcCreateProgram", nv);
 
-        // Header resolution for #include <cuda_fp16.h> et al. is version-dependent:
+        // Header resolution for #include <cuda_fp16.h> et al. varies by toolkit:
         //
-        //   * CUDA >= 12.0: NVRTC ships device-side built-in versions of the standard
-        //     CUDA headers (cuda_fp16.h, cuda_runtime.h, ...) designed for RTC mode.
-        //     Do NOT add a system include path here: the on-disk cuda_fp16.hpp guards
-        //     <nv/target> with !defined(__CUDACC_RTC__), so NV_IF_ELSE_TARGET /
-        //     NV_IS_DEVICE are undefined under NVRTC and produce 100+ errors. The
-        //     built-ins avoid that mismatch.
+        //   * Some NVRTC builds (observed on 12.x) resolve the standard CUDA
+        //     headers via RTC built-ins with an empty include list. For those,
+        //     adding the on-disk include dir is actively harmful: their on-disk
+        //     cuda_fp16.hpp guards <nv/target> with !defined(__CUDACC_RTC__),
+        //     so NV_IF_ELSE_TARGET / NV_IS_DEVICE are undefined under NVRTC and
+        //     produce 100+ errors.
         //
-        //   * CUDA < 12.0: NVRTC has NO built-in cuda_fp16.h, so a kernel that emits
-        //     #include <cuda_fp16.h> fails with "could not open source file". These
-        //     older toolkit headers are RTC-safe (no <nv/target> guard), so we point
-        //     NVRTC at the toolkit include dir to resolve them.
-        int nvrtcMajor = 0, nvrtcMinor = 0;
-        nvrtcVersion(&nvrtcMajor, &nvrtcMinor);
-
+        //   * Others (11.x, 13.x) have no built-in cuda_fp16.h and fail with
+        //     "could not open source file" unless the toolkit include dir is
+        //     supplied; their on-disk headers are RTC-safe.
+        //
+        // A version gate cannot capture this reliably across the toolkit matrix,
+        // so compile with NVRTC's own resolution first and, only if that fails
+        // on a missing header, retry once with the toolkit include dirs.
         std::vector<std::string> includeOpts; // storage must outlive `options`
-        if (nvrtcMajor > 0 && nvrtcMajor < 12) {
+        std::vector<const char *> options;
+        options.push_back(arch.c_str());
+        nv = nvrtcCompileProgram(prog, (int) options.size(), options.data());
+        LOG_NVRTC_AND_VALIDATE("nvrtcCompileProgram", nv);
+        capture_nvrtc_log(prog, program);
+
+        if (nv != NVRTC_SUCCESS && program->log.find("could not open source file") != std::string::npos) {
             for (const std::string &dir : find_cuda_header_include_dirs()) {
                 includeOpts.push_back("--include-path=" + dir);
             }
-        }
-
-        std::vector<const char *> options;
-        options.push_back(arch.c_str());
-        for (const std::string &opt : includeOpts) {
-            options.push_back(opt.c_str());
-        }
-        nv = nvrtcCompileProgram(prog, (int) options.size(), options.data());
-        LOG_NVRTC_AND_VALIDATE("nvrtcCompileProgram", nv);
-
-        // Always capture the build log (errors and warnings).
-        size_t log_size = 0;
-        nvrtcGetProgramLogSize(prog, &log_size);
-        if (log_size > 1) {
-            std::vector<char> log(log_size);
-            nvrtcGetProgramLog(prog, log.data());
-            program->log.assign(log.data(), log_size);
+            if (!includeOpts.empty()) {
+                // A failed nvrtcProgram cannot be recompiled; rebuild it for the retry.
+                nvrtcDestroyProgram(&prog);
+                nv = nvrtcCreateProgram(&prog, program->source.c_str(), "tornado_kernel.cu", 0, nullptr, nullptr);
+                LOG_NVRTC_AND_VALIDATE("nvrtcCreateProgram", nv);
+                for (const std::string &opt : includeOpts) {
+                    options.push_back(opt.c_str());
+                }
+                nv = nvrtcCompileProgram(prog, (int) options.size(), options.data());
+                LOG_NVRTC_AND_VALIDATE("nvrtcCompileProgram", nv);
+                capture_nvrtc_log(prog, program);
+            }
         }
 
         if (nv != NVRTC_SUCCESS) {

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAProgram.cpp
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAProgram.cpp
@@ -126,28 +126,15 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
         nvrtcResult nv = nvrtcCreateProgram(&prog, program->source.c_str(), "tornado_kernel.cu", 0, nullptr, nullptr);
         LOG_NVRTC_AND_VALIDATE("nvrtcCreateProgram", nv);
 
-        // Give NVRTC a search path so kernels can #include CUDA headers
-        // (e.g. cuda_fp16.h for half support). NVRTC starts with an empty
-        // include list, so without this even a bundled header is unreachable.
-        // Common locations are added; a non-existent path is simply ignored.
-        std::vector<std::string> incDirs = {
-            "/usr/local/cuda/include",
-            "/usr/include",
-            "/usr/lib/cuda/include"
-        };
-        const char *cudaPathEnv = getenv("CUDA_PATH");
-        if (cudaPathEnv != nullptr) {
-            incDirs.push_back(std::string(cudaPathEnv) + "/include");
-        }
-        std::vector<std::string> optStrings;
-        optStrings.push_back(arch);
-        for (const std::string &d : incDirs) {
-            optStrings.push_back("--include-path=" + d);
-        }
+        // Do NOT add system CUDA include paths (e.g. /usr/local/cuda/include).
+        // NVRTC provides device-side built-in versions of all standard CUDA headers
+        // (cuda_fp16.h, cuda_runtime.h, etc.) that are designed for RTC mode.
+        // The system headers guard <nv/target> with !defined(__CUDACC_RTC__), so
+        // NV_IF_ELSE_TARGET / NV_IS_DEVICE are undefined when the system
+        // cuda_fp16.hpp is compiled under NVRTC, causing 100+ errors.
+        // Using NVRTC's own built-ins avoids this mismatch.
         std::vector<const char *> options;
-        for (const std::string &o : optStrings) {
-            options.push_back(o.c_str());
-        }
+        options.push_back(arch.c_str());
         nv = nvrtcCompileProgram(prog, (int) options.size(), options.data());
         LOG_NVRTC_AND_VALIDATE("nvrtcCompileProgram", nv);
 

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/cuda_jni.h
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/cuda_jni.h
@@ -119,9 +119,15 @@ typedef struct cuda_kernel_s {
     std::vector<std::vector<char>> arg_data;
 } cuda_kernel_t;
 
-/* Opaque handle: maps the OpenCL cl_event long to a CUevent. */
+/* Opaque handle: maps the OpenCL cl_event long to a pair of CUevents.
+ * `event` is the completion event (used for wait/sync/query/dependency).
+ * `start` is an optional timestamp recorded BEFORE the operation so that
+ * cuEventElapsedTime(start, event) yields the operation's device time.
+ * `start` is nullptr for events that do not bracket a timed operation
+ * (e.g. markers/barriers), in which case the elapsed time is reported as 0. */
 typedef struct cuda_event_s {
     CUevent event;
+    CUevent start;
 } cuda_event_t;
 
 #endif // TORNADO_CUDA_JNI_H

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDAContext.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDAContext.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import uk.ac.manchester.tornado.api.exceptions.TornadoNoOpenCLPlatformException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoOutOfMemoryException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.cuda.enums.CUDACommandQueueProperties;
 import uk.ac.manchester.tornado.drivers.cuda.exceptions.CUDAException;
@@ -213,6 +214,16 @@ public class CUDAContext implements CUDAContextInterface {
     private CUDABufferResult createBuffer(long flags, long bytes, long hostPointer) {
         try {
             final CUDABufferResult result = createBuffer(contextID, flags, bytes, hostPointer);
+            // cuMemAlloc reports failures (notably CUDA_ERROR_OUT_OF_MEMORY) via the
+            // result status and a null device pointer rather than throwing. Surface it
+            // as a clean exception here: otherwise the zero buffer is used by a later
+            // copy/kernel launch and triggers an unrecoverable CUDA_ERROR_ILLEGAL_ADDRESS
+            // that poisons the whole context.
+            if (result == null || result.getResult() != CUDADriver.CUDA_SUCCESS || result.getBuffer() == 0L) {
+                int status = (result == null) ? -1 : result.getResult();
+                throw new TornadoOutOfMemoryException("[ERROR] Unable to allocate " + RuntimeUtilities.humanReadableByteCount(bytes, false) + " on the CUDA device (cuMemAlloc status=" + status
+                        + ").\n\tThe allocation exceeds available device memory. Reduce the working set, or enable CUDA Unified Memory to over-subscribe VRAM.");
+            }
             logger.info("buffer allocated %s @ 0x%x", RuntimeUtilities.humanReadableByteCount(bytes, false), result.getBuffer());
             return result;
         } catch (CUDAException e) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADriver.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADriver.java
@@ -56,6 +56,8 @@ public class CUDADriver {
 
     public static final int CL_TRUE = 1;
     public static final int CL_FALSE = 0;
+    // CUDA driver API CUresult success code (CUDA_SUCCESS == 0).
+    public static final int CUDA_SUCCESS = 0;
 
     static {
         if (VIRTUAL_DEVICE_ENABLED) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDAEvent.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDAEvent.java
@@ -81,6 +81,9 @@ public class CUDAEvent implements Event {
 
     native static void clReleaseEvent(long eventId) throws CUDAException;
 
+    // Returns the device elapsed time (ns) between the event's start and end CUevents.
+    native static long cuEventElapsedTime(long eventId);
+
     private long readEventTime(CUDAProfilingInfo eventType) {
         if (!ENABLE_OPENCL_PROFILING) {
             return -1;
@@ -186,7 +189,12 @@ public class CUDAEvent implements Event {
 
     @Override
     public long getElapsedTime() {
-        return (getCLEndTime() - getCLStartTime());
+        if (!ENABLE_OPENCL_PROFILING) {
+            return 0;
+        }
+        // CUDA has no absolute event timestamps; use cuEventElapsedTime between the
+        // operation's start and end events (returns nanoseconds).
+        return cuEventElapsedTime(oclEventID);
     }
 
     @Override

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDABackend.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDABackend.java
@@ -362,40 +362,16 @@ public class CUDABackend extends XPUBackend<CUDAProviders> implements FrameMap.R
         asm.emitLine("}");
     }
 
-    private boolean kernelUsesHalfTypes(LIR lir) {
-        for (int b : lir.linearScanOrder()) {
-            for (LIRInstruction instr : lir.getLIRforBlock(lir.getBlockById(b))) {
-                boolean[] found = { false };
-                instr.forEachOutput((instruction, value, mode, flags) -> {
-                    if (!found[0] && value instanceof Variable variable) {
-                        CUDAKind kind = (CUDAKind) variable.getPlatformKind();
-                        if (kind == CUDAKind.HALF || kind.getElementKind() == CUDAKind.HALF) {
-                            found[0] = true;
-                        }
-                    }
-                    return value;
-                });
-                if (found[0]) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     private void emitPrologue(CUDACompilationResultBuilder crb, CUDAAssembler asm, ResolvedJavaMethod method, LIR lir) {
 
         String methodName = crb.compilationResult.getName();
         final CallingConvention incomingArguments = CodeUtil.getCallingConvention(codeCache, HotSpotCallingConventionType.JavaCallee, method);
 
         if (crb.isKernel()) {
-            // Only include cuda_fp16.h when the kernel actually uses __half types.
-            // Including it unconditionally triggers NVRTC failures on CUDA 11.x
-            // toolkits where cuda_fp16.hpp uses NV_IF_ELSE_TARGET from <nv/target>,
-            // which is excluded under __CUDACC_RTC__.
-            if (kernelUsesHalfTypes(lir)) {
-                asm.emit(CUDAPreamble.PREAMBLE);
-            }
+            // cuda_fp16.h is injected once, after code emission, when the generated
+            // kernel actually references __half / half2 / __float2half constructs
+            // (see CUDACompilationResultBuilder#finish). It is not emitted here because
+            // half usage is not always visible from the LIR operands at this point.
 
             /*
              * BUG There is a bug on some CUDADriver devices which requires us to insert an

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDABackend.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDABackend.java
@@ -362,15 +362,40 @@ public class CUDABackend extends XPUBackend<CUDAProviders> implements FrameMap.R
         asm.emitLine("}");
     }
 
+    private boolean kernelUsesHalfTypes(LIR lir) {
+        for (int b : lir.linearScanOrder()) {
+            for (LIRInstruction instr : lir.getLIRforBlock(lir.getBlockById(b))) {
+                boolean[] found = { false };
+                instr.forEachOutput((instruction, value, mode, flags) -> {
+                    if (!found[0] && value instanceof Variable variable) {
+                        CUDAKind kind = (CUDAKind) variable.getPlatformKind();
+                        if (kind == CUDAKind.HALF || kind.getElementKind() == CUDAKind.HALF) {
+                            found[0] = true;
+                        }
+                    }
+                    return value;
+                });
+                if (found[0]) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private void emitPrologue(CUDACompilationResultBuilder crb, CUDAAssembler asm, ResolvedJavaMethod method, LIR lir) {
 
         String methodName = crb.compilationResult.getName();
         final CallingConvention incomingArguments = CodeUtil.getCallingConvention(codeCache, HotSpotCallingConventionType.JavaCallee, method);
 
         if (crb.isKernel()) {
-            // Emit the CUDA C preamble (cuda_fp16.h include) once at the top of the
-            // kernel, before the kernel signature.
-            asm.emit(CUDAPreamble.PREAMBLE);
+            // Only include cuda_fp16.h when the kernel actually uses __half types.
+            // Including it unconditionally triggers NVRTC failures on CUDA 11.x
+            // toolkits where cuda_fp16.hpp uses NV_IF_ELSE_TARGET from <nv/target>,
+            // which is excluded under __CUDACC_RTC__.
+            if (kernelUsesHalfTypes(lir)) {
+                asm.emit(CUDAPreamble.PREAMBLE);
+            }
 
             /*
              * BUG There is a bug on some CUDADriver devices which requires us to insert an

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDAPreamble.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDAPreamble.java
@@ -24,17 +24,22 @@
 package uk.ac.manchester.tornado.drivers.cuda.graal.backend;
 
 /**
- * CUDA C preamble emitted once before every compiled kernel.
+ * CUDA C preamble prepended to compiled kernels that need it.
  *
  * <p>The code generator emits native CUDA C / NVRTC types and intrinsics
  * directly (native unsigned types, inline relational operators, {@code fmin}/
  * {@code fmax}-based clamp, inline radians/sign, real {@code atomic*}
  * intrinsics, and componentwise vector expressions). The half-precision header
- * is only injected when the kernel actually uses {@code CUDAKind.HALF*} types
- * (see {@code CUDABackend#kernelUsesHalfTypes}). This avoids an NVRTC
- * compilation failure on CUDA 11.x toolkits where {@code cuda_fp16.hpp}
- * references {@code NV_IF_ELSE_TARGET} from {@code <nv/target>}, which is
- * excluded when {@code __CUDACC_RTC__} is defined.
+ * is only injected when the emitted kernel actually references fp16 constructs
+ * ({@code __half}, {@code half2}, {@code __float2half}); the generated source
+ * is scanned in {@code CUDACompilationResultBuilder#finish}. Keeping the
+ * include conditional limits the blast radius on toolkits whose on-disk
+ * {@code cuda_fp16.hpp} does not compile under NVRTC (it references
+ * {@code NV_IF_ELSE_TARGET} from {@code <nv/target>}, which is excluded when
+ * {@code __CUDACC_RTC__} is defined): only kernels that genuinely need fp16
+ * depend on the header resolving. How the include is resolved at compile time
+ * (NVRTC built-ins first, toolkit include paths as a fallback) is handled in
+ * the JNI layer ({@code CUDAProgram.cpp#compile_with_nvrtc}).
  *
  * <p>Note: DP4A is emitted as inline PTX ({@code dp4a.s32.s32}) directly at the
  * call site (see {@code CUDALIRStmt.Dp4aStmt}), so it needs no preamble helper.

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDAPreamble.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDAPreamble.java
@@ -29,9 +29,12 @@ package uk.ac.manchester.tornado.drivers.cuda.graal.backend;
  * <p>The code generator emits native CUDA C / NVRTC types and intrinsics
  * directly (native unsigned types, inline relational operators, {@code fmin}/
  * {@code fmax}-based clamp, inline radians/sign, real {@code atomic*}
- * intrinsics, and componentwise vector expressions). The only thing that must
- * be injected ahead of every kernel is the half-precision header, so the
- * preamble is reduced to a single {@code #include <cuda_fp16.h>}.
+ * intrinsics, and componentwise vector expressions). The half-precision header
+ * is only injected when the kernel actually uses {@code CUDAKind.HALF*} types
+ * (see {@code CUDABackend#kernelUsesHalfTypes}). This avoids an NVRTC
+ * compilation failure on CUDA 11.x toolkits where {@code cuda_fp16.hpp}
+ * references {@code NV_IF_ELSE_TARGET} from {@code <nv/target>}, which is
+ * excluded when {@code __CUDACC_RTC__} is defined.
  *
  * <p>Note: DP4A is emitted as inline PTX ({@code dp4a.s32.s32}) directly at the
  * call site (see {@code CUDALIRStmt.Dp4aStmt}), so it needs no preamble helper.

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/CUDACompilationResultBuilder.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/CUDACompilationResultBuilder.java
@@ -60,6 +60,7 @@ import jdk.vm.ci.meta.Value;
 import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 import uk.ac.manchester.tornado.drivers.cuda.CUDADeviceContextInterface;
 import uk.ac.manchester.tornado.drivers.cuda.graal.asm.CUDAAssembler;
+import uk.ac.manchester.tornado.drivers.cuda.graal.backend.CUDAPreamble;
 import uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDAControlFlow;
 import uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDAControlFlow.LoopConditionOp;
 import uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDAControlFlow.LoopInitOp;
@@ -246,8 +247,23 @@ public class CUDACompilationResultBuilder extends CompilationResultBuilder {
 
     @Override
     public void finish() {
-        int position = asm.position();
-        compilationResult.setTargetCode(asm.close(true), position);
+        byte[] code = asm.close(true);
+
+        // Inject the half-precision header when the emitted kernel actually references
+        // CUDA fp16 constructs. Deciding this from the generated source is deliberate:
+        // a half value can appear only as a pointer cast (*(__half *) ...) or a constant
+        // conversion (__float2half(...)) that carries no HALF-typed LIR operand, so
+        // scanning the LIR operands misses those kernels and the missing #include causes
+        // NVRTC to fail with "__half is undefined". Keying off the source text catches
+        // every spelling (__half, half2 vectors, __float2half / __half2float). See
+        // CUDAPreamble for why the header is not emitted unconditionally.
+        String source = new String(code);
+        if ((source.contains("__half") || source.contains("half2") || source.contains("2half")) && !source.contains("cuda_fp16.h")) {
+            source = CUDAPreamble.PREAMBLE + source;
+            code = source.getBytes();
+        }
+
+        compilationResult.setTargetCode(code, code.length);
     }
 
     void emitLoopBlock(HIRBlock block) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/tests/TestCUDATornadoCompiler.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/tests/TestCUDATornadoCompiler.java
@@ -39,11 +39,15 @@ import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class TestCUDATornadoCompiler {
 
+    // NVRTC compiles CUDA C, not OpenCL C, so the kernel must use CUDA spellings
+    // (extern "C" __global__, blockIdx/blockDim/threadIdx) rather than __kernel /
+    // __global / get_global_id, otherwise NVRTC rejects line 1 with
+    // "this declaration has no storage class or type specifier".
     // @formatter:off
-    private static final String OPENCL_KERNEL = "__kernel void saxpy(__global float *a," + 
-            "    __global float *b, __global float *c) { " +
-            "      int idx = get_global_id(0); " + 
-            "      c[idx]  =  a[idx] + b[idx]; " + 
+    private static final String CUDA_KERNEL = "extern \"C\" __global__ void saxpy(float *a," +
+            "    float *b, float *c) { " +
+            "      int idx = blockIdx.x * blockDim.x + threadIdx.x; " +
+            "      c[idx]  =  a[idx] + b[idx]; " +
             "}";
     // @formatter:on
 
@@ -66,7 +70,7 @@ public class TestCUDATornadoCompiler {
         TaskDataContext meta = new TaskDataContext(scheduleMeta, "saxpy");
         new CUDACompilationResult("internal", "saxpy", meta, backend);
 
-        byte[] source = OPENCL_KERNEL.getBytes();
+        byte[] source = CUDA_KERNEL.getBytes();
         CUDAInstalledCode code = codeCache.installSource(meta, "saxpy", "saxpy", source);
 
         String generatedSourceCode = code.getGeneratedSourceCode();

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestSimdgroupMatrix.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestSimdgroupMatrix.java
@@ -79,7 +79,7 @@ public class TestSimdgroupMatrix extends TornadoTestBase {
     }
 
     private void runAndCheck(int m, int n, int k) throws TornadoExecutionPlanException {
-        // simdgroup_matrix is Metal-only.
+        // simdgroup_matrix is Metal-only: no equivalent in OpenCL, PTX, SPIR-V or CUDA.
         assertNotBackend(TornadoVMBackendType.OPENCL);
         assertNotBackend(TornadoVMBackendType.PTX);
         assertNotBackend(TornadoVMBackendType.SPIRV);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestSimdgroupTiledMatrix.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/matrices/TestSimdgroupTiledMatrix.java
@@ -113,7 +113,7 @@ public class TestSimdgroupTiledMatrix extends TornadoTestBase {
     }
 
     private void runAndCheck(int m, int n, int k) throws TornadoExecutionPlanException {
-        // simdgroup_matrix is Metal-only.
+        // simdgroup_matrix is Metal-only: no equivalent in OpenCL, PTX, SPIR-V or CUDA.
         assertNotBackend(TornadoVMBackendType.OPENCL);
         assertNotBackend(TornadoVMBackendType.PTX);
         assertNotBackend(TornadoVMBackendType.SPIRV);


### PR DESCRIPTION
#### Description

Backport #874 to JDK 25.

#### Problem description

See #874 

#### Backend/s tested

Mark the backends affected by this PR.

- [ ] OpenCL
- [ ] PTX
- [x] CUDA
- [ ] SPIRV
- [ ] Metal

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

If it is applicable, check your changes on FPGAs.

- [ ] Yes
- [x] No

#### How to test the new patch?

See #874 

----------------------------------------------------------------------------
