### PR TITLE
Fix for stride-16 swizzled FP16 shared-memory load and store that caused segfault in tests

### DIFF
--- a/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
+++ b/tornado-drivers/ptx/src/main/java/uk/ac/manchester/tornado/drivers/ptx/graal/lir/PTXLIRStmt.java
@@ -2099,6 +2099,18 @@ public class PTXLIRStmt {
             asm.delimiter();
             asm.eol();
 
+            // convert byte offset back to fp16 element index for ld.shared.b16 arr[idx]
+            // swzByte is a byte offset. Shift right by 1 to get the element index.
+            asm.emitSymbol(TAB);
+            asm.emit("shr.b32 ");
+            asm.emitValue(swzByte);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(swzByte);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("1");
+            asm.delimiter();
+            asm.eol();
+
             // result = ld.shared.b16 sharedMem[swzByte]   (16-bit load = one fp16)
             asm.emitSymbol(TAB);
             asm.emit("ld.shared.b16 ");
@@ -2511,6 +2523,18 @@ public class PTXLIRStmt {
             asm.emitValue(byteOff);
             asm.emitSymbol(COMMA + SPACE);
             asm.emitValue(xorTerm);
+            asm.delimiter();
+            asm.eol();
+
+            // convert byte offset back to fp16 element index for st.shared.b16 arr[idx]
+            // swzByte is a byte offset. Shift right by 1 to get the element index.
+            asm.emitSymbol(TAB);
+            asm.emit("shr.b32 ");
+            asm.emitValue(swzByte);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emitValue(swzByte);
+            asm.emitSymbol(COMMA + SPACE);
+            asm.emit("1");
             asm.delimiter();
             asm.eol();
 


### PR DESCRIPTION
#### Description

This PR fixes a PTX code generation bug in the stride-16 swizzled FP16 shared-memory load and store, which caused a device-side illegal memory access and crashed the JVM when running `TestSwizzledLocalArrays` on the PTX backend.

The stride-16 swizzled FP16 load (`SwizzledLoadFP16Stride16Stmt`) and store (`SwizzledStoreFP16Stride16Stmt`) compute the swizzle on a **byte** offset (`linIdx << 1`, since fp16 = 2 bytes), but then index the `.f16` shared array directly with that byte offset. Because `st.shared.b16 arr[idx]` / `ld.shared.b16 arr[idx]` treat the subscript as an **element** index (scaled internally by the 2-byte element size), the effective address was doubled, reaching up to ~508 bytes into a 256-byte tile → out-of-bounds shared-memory access.

The stride-32 variant already emits a final `shr.b32 swzByte, swzByte, 1` to convert the byte offset back to an element index before the `.b16` access. The stride-16 load and store were missing this conversion. This PR adds the same `shr.b32 ..., 1` step to both, so the swizzled byte offset is converted to a valid fp16 element index. The Int8 swizzle paths are unaffected because their element size is 1 byte (byte offset == element index).

#### Problem description

Running the swizzled-local-array unit tests on the PTX backend crashes with a device-side `CUDA_ERROR_ILLEGAL_ADDRESS` (700). Once the illegal access occurs, the error sticks to the CUDA context, so every subsequent kernel's `cuModuleLoadDataEx` also fails with 700 and the JVM process aborts — reported as a SIGSEGV/segfault for the whole test class.

The out-of-bounds access is produced by the two stride-16 FP16 kernels:

- `TestSwizzledLocalArrays#testSwizzleLoadStoreFp16Stride16`
- `TestSwizzledLocalArrays#testSwizzleLoadConvertToFloatStride16`

To reproduce (PTX backend):

```bash
make BACKEND=ptx
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.local.memory.TestSwizzledLocalArrays
```

Before the fix, the two stride-16 tests trigger the illegal address and the remaining tests in the class then fail with `cuModuleLoadDataEx -> Returned: 700`. After the fix, all 6 tests pass.

The generated PTX for the store makes the fix visible — the stride-16 kernel was missing the `shr.b32` that the stride-32 kernel emits:

```
xor.b32 rsi13, rsi9, rsi12;
shr.b32 rsi13, rsi13, 1;      // byte offset -> fp16 element index (added by this PR)
st.shared.b16 rfhArr0[rsi13], rfh0;
```

#### Backend/s tested

- [ ] OpenCL
- [x] PTX
- [ ] CUDA
- [ ] SPIRV
- [ ] Metal

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
make BACKEND=ptx
tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.local.memory.TestSwizzledLocalArrays
```

All 6 tests should pass:

- `testSwizzleLoadStoreFp16Stride32`
- `testSwizzleLoadStoreFp16Stride16`
- `testSwizzleLoadStoreInt8`
- `testSwizzleLoadConvertToFloat`
- `testSwizzleLoadConvertToFloatStride16`
- `testSwizzleLoadStoreInt8Stride16`

The full PTX fast-test suite (`make fast-tests`) no longer reports a SEGFAULT for this class; only the pre-existing whitelisted failures remain.