### PR TITLE
[cuda] Fix misleading NVRTC compilation errors: memoized FP16 header resolution + explanatory driver/toolkit diagnostics

### DIFF
--- a/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAProgram.cpp
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAProgram.cpp
@@ -38,6 +38,23 @@
 static std::mutex g_cubin_cache_mtx;
 static std::unordered_map<std::string, std::string> g_cubin_cache;
 
+// One-time NVRTC header-resolution mode. Whether NVRTC can resolve
+// #include <cuda_fp16.h> on its own, needs an explicit toolkit include path, or
+// cannot resolve it at all is a fixed property of the (NVRTC, toolkit) pair on
+// this machine — not of any individual kernel. It is therefore discovered once
+// (by the first FP16 kernel) and reused, so later FP16 kernels compile in a
+// single attempt instead of repeating the failed built-in probe. Kernels with
+// no #include never consult it. See compile_with_nvrtc.
+enum class Fp16IncludeMode { UNKNOWN, NEEDS_INCLUDE_PATHS, UNRESOLVABLE };
+static std::mutex g_fp16_mode_mtx;
+static Fp16IncludeMode g_fp16_mode = Fp16IncludeMode::UNKNOWN;
+static std::vector<std::string> g_fp16_include_opts; // "--include-path=..." dirs, once resolved
+
+// One-time latch for the working-but-suboptimal PTX-JIT fallback warning (GPU
+// arch newer than the toolkit). The fallback runs correctly, so this is a
+// warning, not an error; emit it once per process rather than once per kernel.
+static std::once_flag g_arch_fallback_warn_once;
+
 extern "C" {
 
 /* OpenCL cl_program_build_info / cl_program_info values used by the Java clone. */
@@ -81,6 +98,17 @@ static std::vector<std::string> find_cuda_header_include_dirs() {
     return found;
 }
 
+// Explanatory root cause + remediation for an unresolved <cuda_fp16.h>. The raw
+// NVRTC diagnostic is only "could not open source file", which says neither why
+// nor how to fix it; this spells out that the toolkit/host is missing the CUDA
+// headers the FP16 kernels need.
+static std::string fp16_unresolvable_message() {
+    return "NVRTC cannot resolve <cuda_fp16.h>: this NVRTC provides no built-in CUDA headers "
+           "and no CUDA toolkit include directory containing cuda_fp16.h was found (checked "
+           "$CUDA_PATH/$CUDA_HOME/$CUDA_ROOT/include, /usr/local/cuda/include, /usr/include). "
+           "Install a CUDA toolkit or set CUDA_PATH to one so the CUDA backend can compile FP16 kernels.";
+}
+
 // Copies the NVRTC build log (errors and warnings) of `prog` into the
 // program's log buffer, replacing any log from a previous compile attempt.
 static void capture_nvrtc_log(nvrtcProgram prog, cuda_program_t *program) {
@@ -99,6 +127,14 @@ static void capture_nvrtc_log(nvrtcProgram prog, cuda_program_t *program) {
  * compute capability of the program's device, then loads it as a CUmodule.
  */
 static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
+    // Hoisted to function scope so the module-load failure branch can explain an
+    // NVRTC/GPU-arch mismatch. Defaults suit the pre-built-binary path below,
+    // which loads a cubin directly (no PTX-JIT fallback).
+    int gpuArchNum = 0;        // device compute capability, e.g. cc 12.0 -> 120
+    int maxSupportedArch = 0;  // highest arch this NVRTC can emit
+    int fallbackArch = 0;      // highest supported arch <= GPU (0 if none)
+    bool useCubin = true;
+    bool archKnown = false;    // arch vars populated (false for pre-supplied images)
     if (!program->binary.empty()) {
         // Already have a module image (createProgramWithBinary path) - just load it below.
         program->build_status = CL_BUILD_SUCCESS;
@@ -121,9 +157,8 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
         //
         // This makes the backend robust across the full (toolkit, driver, GPU) matrix
         // instead of assuming toolkit >= GPU.
-        const int gpuArchNum = major * 10 + minor;   // e.g. cc 12.0 -> 120, 9.0 -> 90
+        gpuArchNum = major * 10 + minor;              // e.g. cc 12.0 -> 120, 9.0 -> 90
         bool gpuArchSupported = false;
-        int fallbackArch = 0;                         // highest supported arch <= GPU
         int numArchs = 0;
         if (nvrtcGetNumSupportedArchs(&numArchs) == NVRTC_SUCCESS && numArchs > 0) {
             std::vector<int> supported(numArchs);
@@ -135,11 +170,13 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
                     if (a <= gpuArchNum && a > fallbackArch) {
                         fallbackArch = a;
                     }
+                    if (a > maxSupportedArch) {
+                        maxSupportedArch = a;
+                    }
                 }
             }
         }
 
-        bool useCubin;
         std::string arch;
         if (gpuArchSupported) {
             arch = "--gpu-architecture=sm_" + std::to_string(gpuArchNum);
@@ -152,6 +189,7 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
             arch = "--gpu-architecture=compute_" + std::to_string(target);
             useCubin = false;
         }
+        archKnown = true; // gpuArchNum/maxSupportedArch/fallbackArch/useCubin now describe this compile
 
         // Cache lookup: identical kernel source for the same architecture yields an
         // identical cubin, so reuse a previously compiled image instead of invoking
@@ -185,19 +223,50 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
         //     supplied; their on-disk headers are RTC-safe.
         //
         // A version gate cannot capture this reliably across the toolkit matrix,
-        // so compile with NVRTC's own resolution first and, only if that fails
-        // on a missing header, retry once with the toolkit include dirs.
+        // and it is a fixed property of the (NVRTC, toolkit) pair rather than of
+        // any one kernel. So the first FP16 kernel probes it (built-in first,
+        // then the toolkit include dirs) and memoizes the outcome in g_fp16_mode;
+        // later FP16 kernels read the memo and compile in a single attempt. Only
+        // kernels that actually #include a header consult this at all.
+        const bool needsHeader = program->source.find("#include") != std::string::npos;
+
+        Fp16IncludeMode mode;
         std::vector<std::string> includeOpts; // storage must outlive `options`
+        {
+            std::lock_guard<std::mutex> lock(g_fp16_mode_mtx);
+            mode = g_fp16_mode;
+            if (needsHeader && mode == Fp16IncludeMode::NEEDS_INCLUDE_PATHS) {
+                includeOpts = g_fp16_include_opts;
+            }
+        }
+
+        // A previous probe already proved the header cannot be resolved on this
+        // host: skip the doomed compile and report the explanatory failure.
+        if (needsHeader && mode == Fp16IncludeMode::UNRESOLVABLE) {
+            program->build_status = CL_BUILD_ERROR;
+            program->log = fp16_unresolvable_message();
+            std::cout << "[TornadoVM-CUDA-JNI] " << program->log << std::endl;
+            nvrtcDestroyProgram(&prog);
+            return;
+        }
+
         std::vector<const char *> options;
         options.push_back(arch.c_str());
-        // A failure here may be recovered by the missing-header retry below,
+        for (const std::string &opt : includeOpts) {
+            options.push_back(opt.c_str());
+        }
+        // A failure here may be recovered by the missing-header probe below,
         // so don't print an ERROR for it; terminal failures are reported after
-        // the retry with the full NVRTC build log.
+        // the probe with the full NVRTC build log.
         nv = nvrtcCompileProgram(prog, (int) options.size(), options.data());
         LOG_NVRTC_CALL("nvrtcCompileProgram", nv);
         capture_nvrtc_log(prog, program);
 
-        if (nv != NVRTC_SUCCESS && program->log.find("could not open source file") != std::string::npos) {
+        // First FP16 kernel whose built-in header resolution failed: probe the
+        // toolkit include dirs once, retry, then memoize what worked so no other
+        // kernel in this process repeats the failed built-in attempt.
+        if (needsHeader && nv != NVRTC_SUCCESS && mode == Fp16IncludeMode::UNKNOWN &&
+                program->log.find("could not open source file") != std::string::npos) {
             for (const std::string &dir : find_cuda_header_include_dirs()) {
                 includeOpts.push_back("--include-path=" + dir);
             }
@@ -206,6 +275,8 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
                 nvrtcDestroyProgram(&prog);
                 nv = nvrtcCreateProgram(&prog, program->source.c_str(), "tornado_kernel.cu", 0, nullptr, nullptr);
                 LOG_NVRTC_AND_VALIDATE("nvrtcCreateProgram", nv);
+                options.clear();
+                options.push_back(arch.c_str());
                 for (const std::string &opt : includeOpts) {
                     options.push_back(opt.c_str());
                 }
@@ -213,10 +284,25 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
                 LOG_NVRTC_CALL("nvrtcCompileProgram", nv);
                 capture_nvrtc_log(prog, program);
             }
+            {
+                std::lock_guard<std::mutex> lock(g_fp16_mode_mtx);
+                if (nv == NVRTC_SUCCESS && !includeOpts.empty()) {
+                    g_fp16_mode = Fp16IncludeMode::NEEDS_INCLUDE_PATHS;
+                    g_fp16_include_opts = includeOpts;
+                } else if (program->log.find("could not open source file") != std::string::npos) {
+                    // Neither built-ins nor any toolkit include dir has the header.
+                    g_fp16_mode = Fp16IncludeMode::UNRESOLVABLE;
+                }
+            }
         }
 
         if (nv != NVRTC_SUCCESS) {
             program->build_status = CL_BUILD_ERROR;
+            // An unresolved cuda_fp16.h reports only "could not open source file";
+            // prepend the root cause + remediation so the failure is actionable.
+            if (program->log.find("could not open source file") != std::string::npos) {
+                program->log = fp16_unresolvable_message() + "\n\nNVRTC log:\n" + program->log;
+            }
             std::cout << "[TornadoVM-CUDA-JNI] NVRTC compilation failed:\n" << program->log << std::endl;
             nvrtcDestroyProgram(&prog);
             return;
@@ -265,10 +351,52 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
         if (jitErrorLog[0] != '\0') {
             program->log += std::string("\nJIT log:\n") + jitErrorLog;
         }
+        // A load failure on a freshly compiled image (archKnown) means the driver
+        // rejected our output; which component is stale depends on the image kind.
+        // The raw error is only INVALID_PTX/unsupported-version, so name the cause.
+        if (archKnown && !useCubin) {
+            // PTX fallback (toolkit older than GPU): the driver JIT'd compute_<fallback>
+            // PTX and failed, which means the driver's ptxas is too old for this
+            // toolkit's PTX ISA. Updating the driver is the direct fix; a newer
+            // toolkit that natively supports the GPU also helps by skipping PTX JIT.
+            program->log = std::string("Driver could not JIT compute_") +
+                           std::to_string(fallbackArch > 0 ? fallbackArch : gpuArchNum) +
+                           " PTX for this GPU (sm_" + std::to_string(gpuArchNum) +
+                           "): the GPU driver is too old for this toolkit's PTX ISA. Update the GPU "
+                           "driver, or use a CUDA toolkit whose NVRTC natively supports sm_" +
+                           std::to_string(gpuArchNum) + " (native cubin avoids PTX JIT entirely).\n\n" +
+                           program->log;
+        } else if (archKnown) {
+            // Native cubin (toolkit knew the GPU arch) rejected at load: the driver
+            // is older than the toolkit that produced the cubin. Update the driver,
+            // or build with a toolkit matching the driver.
+            program->log = std::string("Driver rejected the native sm_") + std::to_string(gpuArchNum) +
+                           " cubin: the GPU driver is older than the CUDA toolkit that produced it. "
+                           "Update the GPU driver, or use a CUDA toolkit matching the installed driver.\n\n" +
+                           program->log;
+        }
         std::cout << "[TornadoVM-CUDA-JNI] " << program->log << std::endl;
         program->module_loaded = false;
     } else {
         program->module_loaded = true;
+        // Working, but suboptimal: the toolkit did not know the GPU's arch, so we
+        // loaded compute_<fallback> PTX JIT'd by the (newer) driver. It runs, but
+        // every load pays a driver JIT and codegen is capped at the compute_<fallback>
+        // virtual ISA — no sm_<gpuArch>-native instructions (e.g. newer tensor-core
+        // MMA shapes). Warn once so the degraded path is visible; native codegen
+        // needs a newer toolkit, not a driver change (the driver is already ahead).
+        if (archKnown && !useCubin) {
+            std::call_once(g_arch_fallback_warn_once, [&]() {
+                std::cout << "[TornadoVM-CUDA-JNI] WARNING: CUDA toolkit (NVRTC max sm_"
+                          << maxSupportedArch << ") predates this GPU (sm_" << gpuArchNum
+                          << "). Using compute_" << (fallbackArch > 0 ? fallbackArch : gpuArchNum)
+                          << " PTX JIT'd by the driver - functional but not optimal (extra load-time "
+                             "JIT; codegen limited to the compute_"
+                          << (fallbackArch > 0 ? fallbackArch : gpuArchNum)
+                          << " ISA). Upgrade the CUDA toolkit to one supporting sm_" << gpuArchNum
+                          << " for native codegen." << std::endl;
+            });
+        }
     }
 }
 

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAProgram.cpp
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAProgram.cpp
@@ -190,8 +190,11 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
         std::vector<std::string> includeOpts; // storage must outlive `options`
         std::vector<const char *> options;
         options.push_back(arch.c_str());
+        // A failure here may be recovered by the missing-header retry below,
+        // so don't print an ERROR for it; terminal failures are reported after
+        // the retry with the full NVRTC build log.
         nv = nvrtcCompileProgram(prog, (int) options.size(), options.data());
-        LOG_NVRTC_AND_VALIDATE("nvrtcCompileProgram", nv);
+        LOG_NVRTC_CALL("nvrtcCompileProgram", nv);
         capture_nvrtc_log(prog, program);
 
         if (nv != NVRTC_SUCCESS && program->log.find("could not open source file") != std::string::npos) {
@@ -207,7 +210,7 @@ static void compile_with_nvrtc(cuda_program_t *program, CUdevice device) {
                     options.push_back(opt.c_str());
                 }
                 nv = nvrtcCompileProgram(prog, (int) options.size(), options.data());
-                LOG_NVRTC_AND_VALIDATE("nvrtcCompileProgram", nv);
+                LOG_NVRTC_CALL("nvrtcCompileProgram", nv);
                 capture_nvrtc_log(prog, program);
             }
         }

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/cuda_jni.h
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/cuda_jni.h
@@ -70,6 +70,16 @@
                   << std::endl;                                   \
     }
 
+// Variant without the unconditional ERROR print, for calls whose failure may
+// be handled by a retry; the caller is responsible for reporting terminal
+// failures (with the full NVRTC build log) itself.
+#define LOG_NVRTC_CALL(name, result)                              \
+    if (LOG_CUDA == 1) {                                          \
+        std::cout << "[TornadoVM-CUDA-NVRTC-JNI] Calling : "      \
+                  << name << " -> Status: " << result             \
+                  << std::endl;                                   \
+    }
+
 /*
  * One physical platform is modelled. The OpenCL clone enumerates one platform
  * (CUDA) and then asks it for its devices.

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACodeCache.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACodeCache.java
@@ -610,7 +610,7 @@ public class CUDACodeCache {
             final String log = program.getBuildLog(deviceContext.getDeviceId());
             System.err.println("\n[ERROR] TornadoVM JIT Compiler - CUDADriver Build Error Log:\n\n" + log + "\n");
             dumpKernelSource(id, entryPoint, log, source);
-            throw new TornadoBailoutRuntimeException("Error during code compilation with the CUDADriver driver");
+            throw new TornadoBailoutRuntimeException("Error during code compilation with the CUDADriver driver:\n" + log);
         }
 
         CUDAKernel kernel = null;


### PR DESCRIPTION
#### Description

This PR removes the misleading NVRTC_ERROR_COMPILATION noise emitted by the CUDA backend at kernel-compilation time and replaces opaque compile/load failures with actionable diagnostics that name the stale component (toolkit vs. driver) and the remediation.

The first NVRTC attempt for an FP16 kernel (`#include <cuda_fp16.h>`) can legitimately fail with a retryable "could not open source file" and then succeed once the toolkit include path is supplied — but that intermediate failure was printed unconditionally as an ERROR, alarming users on a healthy setup and obscuring real errors. Retryable attempts are now quiet; terminal failures are still reported with the full build log.

Whether NVRTC resolves `<cuda_fp16.h>` via built-ins, needs an explicit --include-path, or cannot resolve it at all is a fixed property of the (NVRTC, toolkit) pair, so it is now discovered once (by the first FP16 kernel) and memoized, collapsing the built-in-fail→include-path retry from once-per-kernel to once-per-process. The canonical `#include <cuda_fp16.h>` is retained (rather than a hand-rolled __half preamble) so the backend stays immune to the code generator emitting new fp16 intrinsics.

Genuine capability gaps now produce explanatory, categorized diagnostics embedded in the build log (which also propagates into the thrown `TornadoBailoutRuntimeException`, not just `System.err`):

- Unresolvable `<cuda_fp16.h>` → root cause + remediation (install a toolkit / set `CUDA_PATH`).
- PTX fallback rejected at load (toolkit older than GPU, driver too old for the PTX ISA) → update the GPU driver, or use a toolkit that natively supports the GPU arch to skip PTX JIT.
- Native cubin rejected at load (toolkit newer than driver) → update the driver / use a matching toolkit.
- Working-but-suboptimal PTX-JIT fallback (toolkit older than GPU, driver JITs successfully) → a one-time WARNING that the path is functional but not optimal (extra load-time JIT; codegen capped at the fallback virtual ISA), advising a toolkit upgrade for native codegen.

#### Problem description

 On a system whose CUDA toolkit predates the GPU (e.g. NVRTC 12.0, max sm_90, on a Blackwell sm_120 GPU), starting any FP16 workload printed a wall of:
```
  [TornadoVM-CUDA-NVRTC-JNI] ERROR : nvrtcCompileProgram -> NVRTC_ERROR_COMPILATION
```
These were benign — first-attempt header-resolution misses that the backend already retried successfully via --include-path — but they looked like hard failures and obscured any real compilation error. Genuine failures also surfaced only as opaque `NVRTC_ERROR_COMPILATION` / `CUDA_ERROR_INVALID_PTX` codes with no indication of cause or fix.

Reproduce (pre-fix): run any FP16 kernel / GPULlama3 model on a host where NVRTC has no built-in CUDA headers (e.g. Ubuntu's distro NVRTC 12.0) → benign ERROR spam at every kernel compile.

  #### Backend/s tested

  - [ ] OpenCL
  - [ ] PTX
  - [x] CUDA
  - [ ] SPIRV
  - [ ] Metal

  #### OS tested

  - [x] Linux
  - [ ] OSx
  - [ ] Windows

  #### Did you check on FPGAs?

  - [ ] Yes
  - [x] No (not applicable — CUDA backend only)

  #### How to test the new patch?

  ```bash
  make BACKEND=cuda
  make tests

  # FP16 unit suites (counts unchanged vs. pre-patch; zero NVRTC_ERROR lines):

  tornado-test -V uk.ac.manchester.tornado.unittests.foundation.TestHalfFloats                          # 4/4
  tornado-test -V uk.ac.manchester.tornado.unittests.vectortypes.TestHalfFloats                         # 25 ran, 0 failed, 23
  unsupported
  tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.reductions.TestLocalMemoryReductionsHalfFloats  # 4 ran, 0 failed, 2
  unsupported
  tornado-test -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestHalfFloatLocalArray          # 1/1
```

Verified additionally:
  - FP16 workloads compile and run correctly with zero NVRTC_ERROR output; --printKernel confirms #include <cuda_fp16.h> is present in
  emitted FP16 kernels.
  - The built-in-header miss + include-path retry happens exactly once per process (instrumented count = 1 across dozens of FP16
  kernels), not per kernel.
  - On a toolkit-older-than-GPU host, the one-time suboptimal-fallback WARNING fires exactly once and the workload produces correct
  output.
  - Exception enrichment: forcing a synthetic NVRTC compile error makes the thrown TornadoBailoutRuntimeException message carry the
  full NVRTC build log (previously only on System.err).