### PR TITLE
Fix vmDeps path to dispatch KernelContext/WorkerGrid kernels

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/CUDAInstalledCode.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/CUDAInstalledCode.java
@@ -235,7 +235,7 @@ public class CUDAInstalledCode extends InstalledCode implements TornadoInstalled
         if (meta == null) {
             task = deviceContext.enqueueNDRangeKernel(executionPlanId, kernel, 1, null, singleThreadGlobalWorkSize, singleThreadLocalWorkSize, waitEvents);
         } else {
-            if (meta.isParallel()) {
+            if (meta.isParallel() || meta.isWorkerGridAvailable()) {
                 task = scheduler.submit(executionPlanId, kernel, meta, waitEvents, batchThreads);
             } else {
                 if (meta.isDebug()) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -229,7 +229,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
         if (meta == null) {
             task = deviceContext.enqueueNDRangeKernel(executionPlanId, kernel, 1, null, singleThreadGlobalWorkSize, singleThreadLocalWorkSize, waitEvents);
         } else {
-            if (meta.isParallel()) {
+            if (meta.isParallel() || meta.isWorkerGridAvailable()) {
                 task = scheduler.submit(executionPlanId, kernel, meta, waitEvents, batchThreads);
             } else {
                 if (meta.isDebug()) {


### PR DESCRIPTION
#### Description

Fixes kernel dispatch under `-Dtornado.vm.deps=true` (and therefore under `withIntraPlanConcurrency()`, which forces the same dependency-tracking path) for grid-scheduled tasks: `KernelContext`/`WorkerGrid` kernels.

`CUDAInstalledCode.submitWithEvents` and `OCLInstalledCode.submitWithEvents` (the dependency-aware launch path, used when `useDependencies` is true) dispatched a kernel to the full-grid scheduler only when `meta.isParallel()`. The no-dependency launch path (`launchKernel`/`submitWithoutEvents`) already also checks `meta.isWorkerGridAvailable()`, but the dependency-aware path did not. `KernelContext`-based kernels driven by an explicit `WorkerGrid` are not `isParallel()`, so under `useDependencies` they fell through to the single-thread branch and launched with `singleThreadGlobalWorkSize` (1 thread) instead of their real grid.

Fix: add `|| meta.isWorkerGridAvailable()` to the dispatch condition in both `CUDAInstalledCode.submitWithEvents` and `OCLInstalledCode.submitWithEvents`, matching the no-dependency path. The PTX backend already handles `WorkerGrid` correctly on both its dependency and no-dependency launch paths and needed no change.

#### Problem description

Any TornadoVM application using `KernelContext`/`WorkerGrid` kernels together with `-Dtornado.vm.deps=true`, or any execution plan calling `withIntraPlanConcurrency()` (which internally forces dependency tracking), silently launched those kernels with 1 thread, producing incorrect output with no error or warning.

Reproduced with `TestMatrixMultiplicationKernelContext#mxm1DKernelContext` under `-Dtornado.vm.deps=true`: the test returns all-zero output. End-to-end, this was found via GPULlama3.java (github.com/beehive-lab/GPULlama3.java): running any execution mode with `withIntraPlanConcurrency()` enabled produced garbage tokens instead of coherent text, in every configuration tested (1B/3B/8B models × standard/prefill-decode/batched-prefill-decode × cuda-graphs on/off).

To reproduce:
```bash
tornado-test --ea --jvm="-Dtornado.vm.deps=true" \
  "uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext#mxm1DKernelContext"
```
Before the fix: `FAILED — expected:<4.4367294> but was:<0.0>`. After: passes.

#### Backend/s tested

- [ ] OpenCL
- [x] PTX
- [x] CUDA
- [ ] SPIRV
- [ ] Metal

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
make BACKEND=cuda
source setvars.sh
tornado-test --ea --jvm="-Dtornado.vm.deps=true" uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext
tornado-test --ea --jvm="-Dtornado.vm.deps=true" uk.ac.manchester.tornado.unittests.kernelcontext.api.TestCombinedTaskGraph
```
Both suites pass clean after the fix (previously 3/3 and 4/5 failing respectively). `make fast-tests` shows no regressions beyond the pre-existing, hardware-specific failures already tracked for this environment (`ComputeTests#testMandelbrot`/`testJuliaSets`, `TestDevices#test04`).