### PR TITLE
Auto-disable intra-plan concurrency on serial task graphs

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACommandQueue.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACommandQueue.java
@@ -54,6 +54,13 @@ public class CUDACommandQueue extends CommandQueue {
     private final long properties;
     private final int openclVersion;
 
+    /**
+     * Set when work is issued to this (secondary) queue under intra-plan concurrency; drained
+     * by the per-plan join (see {@code CUDADeviceContext#joinRoleQueues}), which only needs to
+     * synchronise queues that were actually touched since the last join.
+     */
+    private volatile boolean dirty;
+
     public CUDACommandQueue(long commandQueuePtr, long properties, int version) {
         this.commandQueuePtr = commandQueuePtr;
         this.properties = properties;
@@ -64,6 +71,22 @@ public class CUDACommandQueue extends CommandQueue {
 
     public long getCommandQueuePtr() {
         return commandQueuePtr;
+    }
+
+    /** Marks this queue as having received work since the last join. */
+    public void markDirty() {
+        if (!dirty) {
+            dirty = true;
+        }
+    }
+
+    /** Returns whether this queue was touched since the last join, clearing the flag. */
+    public boolean pollDirty() {
+        if (dirty) {
+            dirty = false;
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContext.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContext.java
@@ -371,7 +371,9 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
         if (streamType == CUDAStreamType.DEFAULT || !isMultiStreamEnabled(executionPlanId)) {
             return getCommandQueue(executionPlanId);
         }
-        return roleQueueTable.computeIfAbsent(executionPlanId, id -> new EnumMap<>(CUDAStreamType.class)).computeIfAbsent(streamType, type -> createQueue(type.name()));
+        CUDACommandQueue queue = roleQueueTable.computeIfAbsent(executionPlanId, id -> new EnumMap<>(CUDAStreamType.class)).computeIfAbsent(streamType, type -> createQueue(type.name()));
+        queue.markDirty();
+        return queue;
     }
 
     /**
@@ -390,7 +392,9 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
             while (pool.size() <= index) {
                 pool.add(createQueue(pool.isEmpty() ? "COMPUTE" : "COMPUTE_" + pool.size()));
             }
-            return pool.get(index);
+            CUDACommandQueue queue = pool.get(index);
+            queue.markDirty();
+            return queue;
         }
     }
 
@@ -401,22 +405,31 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
     }
 
     /**
-     * All secondary queues for a plan under intra-plan concurrency: the single-instance role queues
-     * (H2D / D2H) plus the whole COMPUTE pool. Excludes the plan's default queue, which is the join target.
+     * The plan's secondary queues (role + COMPUTE pool) that received work since the last join,
+     * clearing their dirty flags. Untouched queues are excluded: their last marker is already
+     * ordered into the default queue by the previous join, so re-joining them is pure overhead.
      */
-    private List<CUDACommandQueue> secondaryQueues(long executionPlanId) {
-        List<CUDACommandQueue> all = new ArrayList<>();
+    private List<CUDACommandQueue> drainDirtySecondaryQueues(long executionPlanId) {
+        List<CUDACommandQueue> dirty = new ArrayList<>();
         EnumMap<CUDAStreamType, CUDACommandQueue> roles = roleQueueTable.get(executionPlanId);
         if (roles != null) {
-            all.addAll(roles.values());
+            for (CUDACommandQueue queue : roles.values()) {
+                if (queue.pollDirty()) {
+                    dirty.add(queue);
+                }
+            }
         }
         List<CUDACommandQueue> pool = computePool.get(executionPlanId);
         if (pool != null) {
             synchronized (pool) {
-                all.addAll(pool);
+                for (CUDACommandQueue queue : pool) {
+                    if (queue.pollDirty()) {
+                        dirty.add(queue);
+                    }
+                }
             }
         }
-        return all;
+        return dirty;
     }
 
     private CUDACommandQueue createQueue(String nvtxName) {
@@ -432,12 +445,12 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
     }
 
     /**
-     * Joins the plan's role queues into its default queue: records a marker event on each role
-     * queue and makes the default queue wait on all of them, so a subsequent marker/barrier on the
-     * default queue covers the whole plan.
+     * Joins the plan's dirty (touched since the last join) secondary queues into its default
+     * queue: records a marker event on each and makes the default queue wait on all of them,
+     * so a subsequent marker/barrier on the default queue covers the whole plan.
      */
     private void joinRoleQueues(long executionPlanId, CUDACommandQueue defaultQueue) {
-        List<CUDACommandQueue> queues = secondaryQueues(executionPlanId);
+        List<CUDACommandQueue> queues = drainDirtySecondaryQueues(executionPlanId);
         if (queues.isEmpty()) {
             return;
         }

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDAEventPool.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDAEventPool.java
@@ -131,8 +131,6 @@ public class CUDAEventPool {
             return false;
         }
 
-        Arrays.fill(waitEventsBuffer, 0);
-
         int index = 0;
         for (final int value : dependencies) {
             if (value == -1) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/CUDAInstalledCode.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/CUDAInstalledCode.java
@@ -235,7 +235,7 @@ public class CUDAInstalledCode extends InstalledCode implements TornadoInstalled
         if (meta == null) {
             task = deviceContext.enqueueNDRangeKernel(executionPlanId, kernel, 1, null, singleThreadGlobalWorkSize, singleThreadLocalWorkSize, waitEvents);
         } else {
-            if (meta.isParallel()) {
+            if (meta.isParallel() || meta.isWorkerGridAvailable()) {
                 task = scheduler.submit(executionPlanId, kernel, meta, waitEvents, batchThreads);
             } else {
                 if (meta.isDebug()) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventPool.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLEventPool.java
@@ -121,8 +121,6 @@ public class OCLEventPool {
             return false;
         }
 
-        Arrays.fill(waitEventsBuffer, 0);
-
         int index = 0;
         for (final int value : dependencies) {
             if (value != -1) {

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/OCLInstalledCode.java
@@ -229,7 +229,7 @@ public class OCLInstalledCode extends InstalledCode implements TornadoInstalledC
         if (meta == null) {
             task = deviceContext.enqueueNDRangeKernel(executionPlanId, kernel, 1, null, singleThreadGlobalWorkSize, singleThreadLocalWorkSize, waitEvents);
         } else {
-            if (meta.isParallel()) {
+            if (meta.isParallel() || meta.isWorkerGridAvailable()) {
                 task = scheduler.submit(executionPlanId, kernel, meta, waitEvents, batchThreads);
             } else {
                 if (meta.isDebug()) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/IntermediateTornadoGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/IntermediateTornadoGraph.java
@@ -110,6 +110,41 @@ public class IntermediateTornadoGraph {
         return dependencies;
     }
 
+    /**
+     * Whether the task nodes of this graph form a dependency CHAIN (max antichain width == 1),
+     * i.e. no two tasks are mutually independent, so no two kernels could ever execute
+     * concurrently. Used to auto-disable intra-plan concurrency for such graphs: multi-queue
+     * issue cannot overlap anything on a chain and only adds cross-stream event overhead.
+     *
+     * <p>Must be called after {@link #analyzeDependencies()}.</p>
+     */
+    public boolean isTaskChain() {
+        // Transitive closure of the dependency relation, indexed by node id. Node ids are
+        // assigned in construction order and dependency edges point at earlier nodes, so one
+        // ascending pass folds each dependency's already-computed closure.
+        final BitSet[] reachable = new BitSet[graph.getValid().length()];
+        for (int i = 0; i < index; i++) {
+            final BitSet reach = new BitSet(reachable.length);
+            reach.or(dependencies[i]);
+            for (int dep = dependencies[i].nextSetBit(0); dep != -1; dep = dependencies[i].nextSetBit(dep + 1)) {
+                if (dep < reachable.length && reachable[dep] != null) {
+                    reach.or(reachable[dep]);
+                }
+            }
+            reachable[nodeIds[i]] = reach;
+        }
+
+        // Two tasks are concurrent if neither (transitively) depends on the other.
+        for (int t1 = tasks.nextSetBit(0); t1 != -1; t1 = tasks.nextSetBit(t1 + 1)) {
+            for (int t2 = tasks.nextSetBit(t1 + 1); t2 != -1; t2 = tasks.nextSetBit(t2 + 1)) {
+                if (!reachable[nodeIds[t2]].get(nodeIds[t1]) && !reachable[nodeIds[t1]].get(nodeIds[t2])) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     public void printDependencyMatrix() {
         StringBuilder output = new StringBuilder();
         output.append("TornadoGraph dependency matrix...\n");

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeResult.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeResult.java
@@ -40,6 +40,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoInternalError;
 public class TornadoVMBytecodeResult {
     private final byte[] bytecode;
     private final ByteBuffer buffer;
+    private final boolean serialTaskGraph;
 
     /**
      * Constructs a new TornadoVMBytecodeResult object with the given bytecode and
@@ -49,11 +50,26 @@ public class TornadoVMBytecodeResult {
      *            the bytecode as a byte array
      * @param size
      *            the size of the bytecode
+     * @param serialTaskGraph
+     *            whether this (non-batched) graph's tasks form a dependency chain (max width 1),
+     *            in which case intra-plan concurrency cannot overlap anything for this graph;
+     *            always {@code false} for batched graphs
      */
-    TornadoVMBytecodeResult(byte[] bytecode, int size) {
+    TornadoVMBytecodeResult(byte[] bytecode, int size, boolean serialTaskGraph) {
         this.bytecode = bytecode;
+        this.serialTaskGraph = serialTaskGraph;
         this.buffer = setupBytecodeBuffer(bytecode, size);
         TornadoInternalError.guarantee(buffer.get() == TornadoVMBytecodes.INIT.value(), "invalid code");
+    }
+
+    /**
+     * Whether this graph's tasks form a dependency chain (no two tasks are independent);
+     * always {@code false} for batched graphs. The interpreter runs such graphs single-stream
+     * even when the plan requested intra-plan concurrency, avoiding pure cross-stream event
+     * overhead.
+     */
+    public boolean isSerialTaskGraph() {
+        return serialTaskGraph;
     }
 
     /**

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
@@ -74,6 +74,12 @@ public class TornadoVMGraphCompiler {
 
         intermediateTornadoGraph.analyzeDependencies();
 
+        // A non-batched graph whose tasks form a pure dependency chain has no kernel-level
+        // concurrency to exploit: the interpreter runs it single-stream even under intra-plan
+        // concurrency. Batched graphs are never marked serial: the batch pipeline overlaps
+        // CHUNKS of the same task across a buffer ring, which needs the role streams.
+        final boolean serialTaskGraph = executionContext.getBatchSize() == TornadoExecutionContext.INIT_VALUE && intermediateTornadoGraph.isTaskChain();
+
         new TornadoLogger().debug("Compiling bytecodes...");
 
         int graphId = nextGraphId.getAndIncrement();
@@ -146,7 +152,7 @@ public class TornadoVMGraphCompiler {
             // Generate END bytecode
             tornadoVMBytecodeBuilder.end();
 
-            tornadoVMBytecodeResults[i] = new TornadoVMBytecodeResult(tornadoVMBytecodeBuilder.getCode(), tornadoVMBytecodeBuilder.getCodeSize());
+            tornadoVMBytecodeResults[i] = new TornadoVMBytecodeResult(tornadoVMBytecodeBuilder.getCode(), tornadoVMBytecodeBuilder.getCodeSize(), serialTaskGraph);
 
         }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -281,7 +281,7 @@ public class TornadoVMInterpreter {
     }
 
     /**
-     * Three conditions should be satisfied to allow intra-plan concurrency:
+     * Three conditions should be satisfied to allow intra-plan concurrency.
      * <ol>
      * <li> withIntraPlanConcurrency() API call</li>
      * <li>supported by backend</li>

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -280,8 +280,18 @@ public class TornadoVMInterpreter {
         return graphExecutionContext.isMemoryLimited();
     }
 
+    /**
+     * Three conditions should be satisfied to allow intra-plan concurrency:
+     * <ol>
+     * <li> withIntraPlanConcurrency() API call</li>
+     * <li>supported by backend</li>
+     * <li>TaskGraph can indeed be parallelized</li>
+     * </ol>
+     */
     private boolean isIntraPlanConcurrencyActive() {
-        return graphExecutionContext.isIntraPlanConcurrencyEnabled() && interpreterDevice.isIntraPlanConcurrencySupported();
+        return graphExecutionContext.isIntraPlanConcurrencyEnabled()
+                && interpreterDevice.isIntraPlanConcurrencySupported()
+                && !bytecodeResult.isSerialTaskGraph();
     }
 
     private Event execute(boolean isWarmup) {


### PR DESCRIPTION
#### Description

Removes the performance overhead `withIntraPlanConcurrency()` (multi-stream/CUDA-graph-compatible intra-plan concurrency, "IPC") previously added to serial (chain-shaped) task graphs, and trims general per-operation and per-join bookkeeping cost for all IPC plans. Stacked on the `vm.deps`/`WorkerGrid` correctness fix #932 .

Three changes:

1. **Width-1 auto-disable.** `IntermediateTornadoGraph.isTaskChain()` computes, at graph-compile time, whether a (non-batched) graph's tasks form a pure dependency chain (max antichain width 1 — no two tasks are mutually independent). Such a graph has no kernel-level concurrency for multi-stream issue to exploit; running it single-stream avoids cross-stream event overhead entirely. The result is threaded through `TornadoVMBytecodeResult` and consulted in `TornadoVMInterpreter.isIntraPlanConcurrencyActive()`, so a plan that requested IPC still runs its serial graphs on the default stream while any graph with real parallel width (e.g. batched prefill) keeps using the multi-stream path. Batched graphs are always excluded from the chain check (their pipeline overlaps chunks of one task and needs the role streams regardless of intra-task width).

2. **Dirty-queue joins (CUDA).** `CUDADeviceContext.joinRoleQueues` previously enqueued a marker + cross-stream wait on every secondary queue (up to 6: H2D/D2H role queues + the COMPUTE pool) on every `execute()`, even when only one was touched. Each `CUDACommandQueue` now carries a `dirty` flag set when it receives work; `joinRoleQueues` joins and clears only the queues actually touched since the last join.

3. **Removed a redundant full-buffer clear.** `CUDAEventPool`/`OCLEventPool`'s `serialiseEvents` cleared the entire `waitEventsBuffer` (sized by `-Dtornado.eventpool.maxwaitevents`, e.g. 256KB at a common `32000` setting) on every call, even though only `[0..index]` is ever read by the native side and those entries are freshly written in the same call.

#### Problem description

Not a bug fix — a performance regression introduced by IPC itself. Profiling (`nsys`) an IPC-enabled decode-chain workload (GPULlama3.java) against the same workload with IPC off showed +67k `cuStreamWaitEvent`, +34k `cuEventRecord` calls, and `cuStreamSynchronize` going from a 323ns median (in-order queue, effectively free) to 175µs (real cross-stream sync) for identical work — roughly 400ms of pure host-side blocking over a 2-second run. Net effect: IPC-on decode was 10-15% slower than IPC-off on small models, shrinking to ~1-3% on large models (the fixed per-op overhead amortizes over bigger kernels), even though IPC never produces wrong output once the correctness fix lands — it was strictly a self-inflicted cost on workloads with no parallel structure to exploit.

#### Backend/s tested

- [x] OpenCL
- [ ] PTX
- [x] CUDA
- [ ] SPIRV
- [ ] Metal

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### Did you check on FPGAs?

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
make BACKEND=cuda
source setvars.sh
tornado-test --ea uk.ac.manchester.tornado.unittests.kernelcontext.api.TestCombinedTaskGraph
tornado-test --ea uk.ac.manchester.tornado.unittests.streams.TestCUDAStreams
tornado-test --ea uk.ac.manchester.tornado.unittests.batches.TestBatches
```
All green (5/5, 11/11, 31/31).

End-to-end (GPULlama3.java, RTX 5090 Laptop, `-Dgpullama.intraPlanConcurrency=true` vs `=false`, `-Dtornado.cuda.host.pinning=false`), eval tok/s delta IPC-on vs IPC-off, before -> after this PR:

| model | mode | before | after |
|---|---|---|---|
| 1B | standard | -13.5% | 0.0% |
| 1B | prefill-decode | -11.6% | +0.2% |
| 1B | batched-prefill-decode | -10.2% | -0.7% |
| 3B | standard | -4.8% | +0.4% |
| 3B | batched-prefill-decode | -14.2% | +4.9% |
| 8B | standard | ~0% | ~parity |

Output verified coherent in every cell, including the all-features-on combination (IPC + cuda-graphs + staged transfers).