### PR TITLE
[fix] Restore cutlass-jni build on GCC 15+ hosts (-Wtemplate-body)

### DIFF
--- a/tornado-drivers/cutlass-jni/src/main/cpp/CMakeLists.txt
+++ b/tornado-drivers/cutlass-jni/src/main/cpp/CMakeLists.txt
@@ -89,6 +89,15 @@ else()
 	set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3 --expt-relaxed-constexpr -Xcompiler=-fPIC -Xcompiler=-Wno-deprecated-declarations")
 endif()
 
+# GCC 14+ diagnoses invalid code inside uninstantiated template bodies
+# (-Wtemplate-body, an error by default). CUTLASS 3.5.1's matrix.h calls a
+# misspelled set_slice3x3 member from its rotation()/reflection() helpers;
+# nothing here instantiates them, and older GCC ignored the typo, so disable
+# just that diagnostic on the nvcc host-compiler pass.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0)
+	set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-Wno-template-body")
+endif()
+
 # CUTLASS 3.5.1's cuda_host_adapter.hpp casts function pointers loaded via
 # cudaGetDriverEntryPoint() to unversioned typedefs like
 # PFN_cuTensorMapEncodeTiled/PFN_cuTensorMapEncodeIm2col for CUDA 12.0-12.4.

--- a/tornado-drivers/cutlass-jni/src/main/cpp/CMakeLists.txt
+++ b/tornado-drivers/cutlass-jni/src/main/cpp/CMakeLists.txt
@@ -89,12 +89,13 @@ else()
 	set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -O3 --expt-relaxed-constexpr -Xcompiler=-fPIC -Xcompiler=-Wno-deprecated-declarations")
 endif()
 
-# GCC 14+ diagnoses invalid code inside uninstantiated template bodies
-# (-Wtemplate-body, an error by default). CUTLASS 3.5.1's matrix.h calls a
-# misspelled set_slice3x3 member from its rotation()/reflection() helpers;
-# nothing here instantiates them, and older GCC ignored the typo, so disable
-# just that diagnostic on the nvcc host-compiler pass.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0)
+# GCC 15+ diagnoses invalid code inside uninstantiated template bodies
+# (-Wtemplate-body, an error by default; GCC <= 14 never checked such bodies
+# and has no such flag). CUTLASS 3.5.1's matrix.h calls a misspelled
+# set_slice3x3 member from its rotation()/reflection() helpers; nothing here
+# instantiates them, so disable just that diagnostic on the nvcc
+# host-compiler pass.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0)
 	set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-Wno-template-body")
 endif()
 


### PR DESCRIPTION
#### Problem

  Building the CUDA backend on a host with GCC 15 or newer (e.g. Ubuntu 26.04, GCC 15.2) fails in `tornado-drivers-cutlass-jni`:

  ```
  cutlass/matrix.h:7828:3: error: 'struct cutlass::Matrix<Element_, 3, 3>' has no member named 'set_slice3x3'; did you mean 'set_slice_3x3'? [-Wtemplate-body]
  ```

  CUTLASS 3.5.1 (pinned in `cutlass-jni/src/main/cpp/CMakeLists.txt`) has a typo in `matrix.h`: the `rotation()`/`reflection()` helpers call `set_slice3x3` instead of `set_slice_3x3`. Nothing in our JNI library instantiates those helpers, and GCC 14 and
  earlier never semantically checked uninstantiated template bodies, so the typo was invisible. GCC 15 introduced the `-Wtemplate-body` diagnostic, which reports invalid code inside template bodies at definition time and treats it as an error by default —  so the header now fails to parse on newer toolchains.

  Verified the version boundary empirically: the same typo'd-member-in-uninstantiated- template pattern compiles silently on GCC 13.2, 14.1, 14.2 and 14.3, and errors only  from GCC 15.1. Matching that, `-Wno-template-body` is documented in the GCC 15.1 manual  but absent from the 14.x manuals (never backported).

  #### Fix

  Pass `-Xcompiler=-Wno-template-body` to nvcc's host-compiler pass, restoring the  pre-GCC-15 behavior for this diagnostic only. The flag is guarded by  `CMAKE_CXX_COMPILER_ID STREQUAL "GNU"` and version >= 15, so:     

  - GCC <= 14 never sees the (unknown) flag and builds exactly as before.
  - MSVC and Clang/AppleClang are unaffected (`STREQUAL "GNU"` excludes them; MSVC also
    keeps its separate flags branch).
  - Only the nvcc host pass gets the flag; no `.cpp` in the module includes CUTLASS
    headers, so `CMAKE_CXX_FLAGS` is left untouched and `-Wtemplate-body` stays active
    for our own C++ code.

Upgrading the CUTLASS pin would also fix this (the typo is corrected upstream), but  v3.5.1 is pinned deliberately for CUDA-toolkit compatibility (see comments in the  CMakeLists), so the targeted suppression is the safer change.

  #### Testing

  - Verified `-Xcompiler=-Wno-template-body` lands in the generated `flags.make`, the    previously failing `tornado-cutlass.cu.o` compiles, and `libtornado-cutlass.so` links.
  - Full reactor build (`mvn -Pjdk21,cuda-backend -Dtornado.backend=cuda install`) passes    on Linux x86_64 with GCC 15.2 / CUDA 13.
  - `tornado-test -V uk.ac.manchester.tornado.unittests.cutlass.TestCutlass`: 18 ran,    0 failed (native library built with `CUDA_ARCH=120` for the local RTX 5080 / sm_120;    the arch-80 default relies on a PTX JIT path that fails on Blackwell and is a    separate, pre-existing issue).