### PR TITLE
Extend TaskGraph task/libraryTask arity to 20 for hybrid API

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -37,6 +37,8 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask15;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask16;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask17;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask18;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask19;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask20;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask2;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask3;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask4;
@@ -50,7 +52,12 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task12;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task13;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task14;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task15;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task16;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task17;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task18;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task19;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task2;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task20;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task3;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task4;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task5;
@@ -621,6 +628,54 @@ public class TaskGraph implements TaskGraphInterface {
         return this;
     }
 
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> TaskGraph task(String id, Task16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> code, T1 arg1,
+            T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16) {
+        checkTaskName(id);
+        TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+        taskGraphImpl.addTask(taskPackage);
+        return this;
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> TaskGraph task(String id, Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code,
+            T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17) {
+        checkTaskName(id);
+        TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+        taskGraphImpl.addTask(taskPackage);
+        return this;
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> TaskGraph task(String id,
+            Task18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18) {
+        checkTaskName(id);
+        TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18);
+        taskGraphImpl.addTask(taskPackage);
+        return this;
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> TaskGraph task(String id,
+            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
+        checkTaskName(id);
+        TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19);
+        taskGraphImpl.addTask(taskPackage);
+        return this;
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> TaskGraph task(String id,
+            Task20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19, T20 arg20) {
+        checkTaskName(id);
+        TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20);
+        taskGraphImpl.addTask(taskPackage);
+        return this;
+    }
+
     /**
      *
      * @param id
@@ -812,6 +867,24 @@ public class TaskGraph implements TaskGraphInterface {
             T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18) {
         checkTaskName(id);
         taskGraphImpl.addLibraryTask(id, code.apply(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18));
+        return this;
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> TaskGraph libraryTask(String id,
+            LibraryTask19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
+        checkTaskName(id);
+        taskGraphImpl.addLibraryTask(id, code.apply(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19));
+        return this;
+    }
+
+    @Override
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> TaskGraph libraryTask(String id,
+            LibraryTask20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8,
+            T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19, T20 arg20) {
+        checkTaskName(id);
+        taskGraphImpl.addLibraryTask(id, code.apply(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20));
         return this;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -629,8 +629,9 @@ public class TaskGraph implements TaskGraphInterface {
     }
 
     @Override
-    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> TaskGraph task(String id, Task16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> code, T1 arg1,
-            T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16) {
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> TaskGraph task(String id,
+            Task16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
+            T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16) {
         checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
         taskGraphImpl.addTask(taskPackage);
@@ -638,8 +639,9 @@ public class TaskGraph implements TaskGraphInterface {
     }
 
     @Override
-    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> TaskGraph task(String id, Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code,
-            T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17) {
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> TaskGraph task(String id,
+            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17) {
         checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
         taskGraphImpl.addTask(taskPackage);
@@ -658,8 +660,8 @@ public class TaskGraph implements TaskGraphInterface {
 
     @Override
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> TaskGraph task(String id,
-            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
-            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
+            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
         checkTaskName(id);
         TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19);
         taskGraphImpl.addTask(taskPackage);
@@ -671,7 +673,8 @@ public class TaskGraph implements TaskGraphInterface {
             Task20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
             T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19, T20 arg20) {
         checkTaskName(id);
-        TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20);
+        TaskPackage taskPackage = TaskPackage.createPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19,
+                arg20);
         taskGraphImpl.addTask(taskPackage);
         return this;
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
@@ -500,16 +500,16 @@ public interface TaskGraphInterface {
             T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16);
 
     <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> TaskGraphInterface task(String id,
-            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
-            T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17);
+            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17);
 
     <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> TaskGraphInterface task(String id,
             Task18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
             T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18);
 
     <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> TaskGraphInterface task(String id,
-            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
-            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19);
+            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19);
 
     <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> TaskGraphInterface task(String id,
             Task20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraphInterface.java
@@ -29,6 +29,8 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask15;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask16;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask17;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask18;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask19;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask20;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask2;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask3;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.LibraryTask4;
@@ -41,7 +43,12 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task1;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task10;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task15;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task16;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task17;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task18;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task19;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task2;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task20;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task3;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task4;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task5;
@@ -488,6 +495,26 @@ public interface TaskGraphInterface {
     <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> TaskGraphInterface task(String id, Task15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> code, T1 arg1,
             T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15);
 
+    <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> TaskGraphInterface task(String id,
+            Task16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
+            T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16);
+
+    <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> TaskGraphInterface task(String id,
+            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
+            T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17);
+
+    <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> TaskGraphInterface task(String id,
+            Task18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18);
+
+    <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> TaskGraphInterface task(String id,
+            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19);
+
+    <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> TaskGraphInterface task(String id,
+            Task20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19, T20 arg20);
+
     TaskGraphInterface prebuiltTask(String id, String entryPoint, String filename, AccessorParameters accessorParameters);
 
     /**
@@ -565,6 +592,14 @@ public interface TaskGraphInterface {
     <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> TaskGraphInterface libraryTask(String id,
             LibraryTask18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
             T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18);
+
+    <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> TaskGraphInterface libraryTask(String id,
+            LibraryTask19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19);
+
+    <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> TaskGraphInterface libraryTask(String id,
+            LibraryTask20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8,
+            T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19, T20 arg20);
 
     /**
      * Obtains the task-schedule name that was assigned.

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TaskPackage.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TaskPackage.java
@@ -26,7 +26,12 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task12;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task13;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task14;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task15;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task16;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task17;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task18;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task19;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task2;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task20;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task3;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task4;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task5;
@@ -148,6 +153,45 @@ public class TaskPackage {
         this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15 };
     }
 
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> TaskPackage(String id, Task16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> code, T1 arg1,
+            T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16) {
+        this.id = id;
+        this.taskType = 16;
+        this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16 };
+    }
+
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> TaskPackage(String id,
+            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
+            T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17) {
+        this.id = id;
+        this.taskType = 17;
+        this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17 };
+    }
+
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> TaskPackage(String id,
+            Task18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18) {
+        this.id = id;
+        this.taskType = 18;
+        this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18 };
+    }
+
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> TaskPackage(String id,
+            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
+        this.id = id;
+        this.taskType = 19;
+        this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19 };
+    }
+
+    public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> TaskPackage(String id,
+            Task20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19, T20 arg20) {
+        this.id = id;
+        this.taskType = 20;
+        this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20 };
+    }
+
     public static TaskPackage createPackage(String id, Task code) {
         return new TaskPackage(id, code);
     }
@@ -218,6 +262,36 @@ public class TaskPackage {
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> TaskPackage createPackage(String id, Task15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> code,
             T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15) {
         return new TaskPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> TaskPackage createPackage(String id,
+            Task16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
+            T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16) {
+        return new TaskPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> TaskPackage createPackage(String id,
+            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
+            T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17) {
+        return new TaskPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> TaskPackage createPackage(String id,
+            Task18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18) {
+        return new TaskPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> TaskPackage createPackage(String id,
+            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
+        return new TaskPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> TaskPackage createPackage(String id,
+            Task20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19, T20 arg20) {
+        return new TaskPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20);
     }
 
     public static PrebuiltTaskPackage createPrebuiltTask(String id, String entryPoint, String filename, AccessorParameters accessorParameters) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TaskPackage.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TaskPackage.java
@@ -161,8 +161,8 @@ public class TaskPackage {
     }
 
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> TaskPackage(String id,
-            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
-            T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17) {
+            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17) {
         this.id = id;
         this.taskType = 17;
         this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17 };
@@ -177,8 +177,8 @@ public class TaskPackage {
     }
 
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> TaskPackage(String id,
-            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
-            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
+            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
         this.id = id;
         this.taskType = 19;
         this.taskParameters = new Object[] { code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19 };
@@ -271,8 +271,8 @@ public class TaskPackage {
     }
 
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> TaskPackage createPackage(String id,
-            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
-            T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17) {
+            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17) {
         return new TaskPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
     }
 
@@ -283,8 +283,8 @@ public class TaskPackage {
     }
 
     public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> TaskPackage createPackage(String id,
-            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
-            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
+            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
         return new TaskPackage(id, code, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19);
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoFunctions.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoFunctions.java
@@ -100,6 +100,33 @@ public final class TornadoFunctions {
     }
 
     @FunctionalInterface
+    public interface Task16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> {
+        void apply(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16);
+    }
+
+    @FunctionalInterface
+    public interface Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> {
+        void apply(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17);
+    }
+
+    @FunctionalInterface
+    public interface Task18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> {
+        void apply(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18);
+    }
+
+    @FunctionalInterface
+    public interface Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> {
+        void apply(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18,
+                T19 arg19);
+    }
+
+    @FunctionalInterface
+    public interface Task20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> {
+        void apply(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18,
+                T19 arg19, T20 arg20);
+    }
+
+    @FunctionalInterface
     public interface LibraryTask1<T1> {
         LibraryTaskDescriptor apply(T1 arg1);
     }
@@ -189,5 +216,17 @@ public final class TornadoFunctions {
     public interface LibraryTask18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> {
         LibraryTaskDescriptor apply(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16,
                 T17 arg17, T18 arg18);
+    }
+
+    @FunctionalInterface
+    public interface LibraryTask19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> {
+        LibraryTaskDescriptor apply(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16,
+                T17 arg17, T18 arg18, T19 arg19);
+    }
+
+    @FunctionalInterface
+    public interface LibraryTask20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> {
+        LibraryTaskDescriptor apply(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16,
+                T17 arg17, T18 arg18, T19 arg19, T20 arg20);
     }
 }

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -154,6 +154,8 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.virtualization.TestsVirtualLayer"),
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestSingleTaskSingleDevice"),
     TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestMultipleTasksSingleDevice"),
+    TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestLibraryTaskArity"),
+    TestEntry("uk.ac.manchester.tornado.unittests.tasks.TestManyArgumentTasks"),
     TestEntry("uk.ac.manchester.tornado.unittests.temporary.values.TestTemporaryValues"),
     TestEntry("uk.ac.manchester.tornado.unittests.images.TestImages"),
     TestEntry("uk.ac.manchester.tornado.unittests.images.TestResizeImage"),

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/analyzer/TaskUtils.java
@@ -44,7 +44,12 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task1;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task10;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task15;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task16;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task17;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task18;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task19;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task2;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task20;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task3;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task4;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task5;
@@ -273,6 +278,36 @@ public class TaskUtils {
             Task15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
             T12 arg12, T13 arg13, T14 arg14, T15 arg15) {
         return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> CompilableTask createTask(Method method, ScheduleContext meta, String id,
+            Task16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11,
+            T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16) {
+        return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> CompilableTask createTask(Method method, ScheduleContext meta, String id,
+            Task17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17) {
+        return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> CompilableTask createTask(Method method, ScheduleContext meta, String id,
+            Task18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10,
+            T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18) {
+        return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> CompilableTask createTask(Method method, ScheduleContext meta, String id,
+            Task19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19) {
+        return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19);
+    }
+
+    public static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> CompilableTask createTask(Method method, ScheduleContext meta, String id,
+            Task20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> code, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9,
+            T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16, T17 arg17, T18 arg18, T19 arg19, T20 arg20) {
+        return createTask(meta, id, method, code, true, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20);
     }
 
     private static Object[] extractCapturedVariables(Object code) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -74,7 +74,12 @@ import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task12;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task13;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task14;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task15;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task16;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task17;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task18;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task19;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task2;
+import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task20;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task3;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task4;
 import uk.ac.manchester.tornado.api.common.TornadoFunctions.Task5;
@@ -1746,6 +1751,44 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                         taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13], taskPackage
                                 .getTaskParameters()[14], taskPackage.getTaskParameters()[15]);
             }
+            case 16 -> {
+                @SuppressWarnings("rawtypes") Task16 task16 = (Task16) taskPackage.getTaskParameters()[0];
+                task16.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13], taskPackage
+                                .getTaskParameters()[14], taskPackage.getTaskParameters()[15], taskPackage.getTaskParameters()[16]);
+            }
+            case 17 -> {
+                @SuppressWarnings("rawtypes") Task17 task17 = (Task17) taskPackage.getTaskParameters()[0];
+                task17.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13], taskPackage
+                                .getTaskParameters()[14], taskPackage.getTaskParameters()[15], taskPackage.getTaskParameters()[16], taskPackage.getTaskParameters()[17]);
+            }
+            case 18 -> {
+                @SuppressWarnings("rawtypes") Task18 task18 = (Task18) taskPackage.getTaskParameters()[0];
+                task18.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13], taskPackage
+                                .getTaskParameters()[14], taskPackage.getTaskParameters()[15], taskPackage.getTaskParameters()[16], taskPackage.getTaskParameters()[17], taskPackage
+                                        .getTaskParameters()[18]);
+            }
+            case 19 -> {
+                @SuppressWarnings("rawtypes") Task19 task19 = (Task19) taskPackage.getTaskParameters()[0];
+                task19.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13], taskPackage
+                                .getTaskParameters()[14], taskPackage.getTaskParameters()[15], taskPackage.getTaskParameters()[16], taskPackage.getTaskParameters()[17], taskPackage
+                                        .getTaskParameters()[18], taskPackage.getTaskParameters()[19]);
+            }
+            case 20 -> {
+                @SuppressWarnings("rawtypes") Task20 task20 = (Task20) taskPackage.getTaskParameters()[0];
+                task20.apply(taskPackage.getTaskParameters()[1], taskPackage.getTaskParameters()[2], taskPackage.getTaskParameters()[3], taskPackage.getTaskParameters()[4], taskPackage
+                        .getTaskParameters()[5], taskPackage.getTaskParameters()[6], taskPackage.getTaskParameters()[7], taskPackage.getTaskParameters()[8], taskPackage.getTaskParameters()[9],
+                        taskPackage.getTaskParameters()[10], taskPackage.getTaskParameters()[11], taskPackage.getTaskParameters()[12], taskPackage.getTaskParameters()[13], taskPackage
+                                .getTaskParameters()[14], taskPackage.getTaskParameters()[15], taskPackage.getTaskParameters()[16], taskPackage.getTaskParameters()[17], taskPackage
+                                        .getTaskParameters()[18], taskPackage.getTaskParameters()[19], taskPackage.getTaskParameters()[20]);
+            }
             default -> throw new TornadoRuntimeException("Sequential Runner not supported yet. Number of parameters: " + type);
         }
     }
@@ -1783,6 +1826,18 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
                     parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14]));
             case 15 -> addInner(TaskUtils.createTask(method, meta, id, (Task15) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
                     parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14], parameters[15]));
+            case 16 -> addInner(TaskUtils.createTask(method, meta, id, (Task16) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
+                    parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14], parameters[15], parameters[16]));
+            case 17 -> addInner(TaskUtils.createTask(method, meta, id, (Task17) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
+                    parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14], parameters[15], parameters[16], parameters[17]));
+            case 18 -> addInner(TaskUtils.createTask(method, meta, id, (Task18) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
+                    parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14], parameters[15], parameters[16], parameters[17], parameters[18]));
+            case 19 -> addInner(TaskUtils.createTask(method, meta, id, (Task19) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
+                    parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14], parameters[15], parameters[16], parameters[17], parameters[18],
+                    parameters[19]));
+            case 20 -> addInner(TaskUtils.createTask(method, meta, id, (Task20) parameters[0], parameters[1], parameters[2], parameters[3], parameters[4], parameters[5], parameters[6], parameters[7],
+                    parameters[8], parameters[9], parameters[10], parameters[11], parameters[12], parameters[13], parameters[14], parameters[15], parameters[16], parameters[17], parameters[18],
+                    parameters[19], parameters[20]));
             default -> throw new TornadoRuntimeException("Task not supported yet. Type: " + type);
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestLibraryTaskArity.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestLibraryTaskArity.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.tasks;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.common.Access;
+import uk.ac.manchester.tornado.api.common.LibraryTaskDescriptor;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Validates the high-arity {@link TaskGraph#libraryTask} overloads (19 and 20
+ * arguments) added for the hybrid (native library) API. Library binding factory
+ * methods run at task-graph construction time and produce a
+ * {@link LibraryTaskDescriptor}; no device provider is required to build and
+ * snapshot the graph, so these tests are backend-agnostic.
+ *
+ * <p>
+ * How to test?
+ *
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.tasks.TestLibraryTaskArity
+ * </code>
+ * </p>
+ */
+public class TestLibraryTaskArity extends TornadoTestBase {
+
+    // The output array sits at parameter index 0; every other parameter is read-only.
+    private static Access[] writeOnlyFirst(int numArgs) {
+        Access[] accesses = new Access[numArgs];
+        Arrays.fill(accesses, Access.READ_ONLY);
+        accesses[0] = Access.WRITE_ONLY;
+        return accesses;
+    }
+
+    // Dummy library binding with 19 parameters, mirroring a real cuBLAS-style factory method.
+    public static LibraryTaskDescriptor bind19(IntArray out, int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16,
+            int a17, int a18) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary("test") //
+                .withFunction("bind19") //
+                .withParameters(new Object[] { out, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18 }) //
+                .withAccess(writeOnlyFirst(19));
+    }
+
+    // Dummy library binding with 20 parameters.
+    public static LibraryTaskDescriptor bind20(IntArray out, int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16,
+            int a17, int a18, int a19) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary("test") //
+                .withFunction("bind20") //
+                .withParameters(new Object[] { out, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19 }) //
+                .withAccess(writeOnlyFirst(20));
+    }
+
+    @Test
+    public void testLibraryTask19() {
+        IntArray out = new IntArray(16);
+        TaskGraph taskGraph = new TaskGraph("lt19") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, out) //
+                .libraryTask("t19", TestLibraryTaskArity::bind19, out, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        assertNotNull(immutableTaskGraph);
+        // 19 parameters captured in the descriptor (1 array + 18 scalars).
+        assertEquals(19, bind19(out, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18).getParameters().length);
+    }
+
+    @Test
+    public void testLibraryTask20() {
+        IntArray out = new IntArray(16);
+        TaskGraph taskGraph = new TaskGraph("lt20") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, out) //
+                .libraryTask("t20", TestLibraryTaskArity::bind20, out, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        assertNotNull(immutableTaskGraph);
+        // 20 parameters captured in the descriptor (1 array + 19 scalars).
+        assertEquals(20, bind20(out, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19).getParameters().length);
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestManyArgumentTasks.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tasks/TestManyArgumentTasks.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.tasks;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Tests for {@link TaskGraph#task} overloads with a high argument count (16 and 20
+ * arguments). These exercise the enumerated {@code Task16}/{@code Task20} functional
+ * interfaces and their corresponding runtime dispatch paths.
+ *
+ * <p>
+ * How to test?
+ *
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.tasks.TestManyArgumentTasks
+ * </code>
+ * </p>
+ */
+public class TestManyArgumentTasks extends TornadoTestBase {
+
+    // Kernel with 16 parameters: 1 output array + 15 integer scalars.
+    public static void add16(IntArray out, int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, i + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15);
+        }
+    }
+
+    // Kernel with 20 parameters: 1 output array + 19 integer scalars.
+    public static void add20(IntArray out, int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16, int a17, int a18,
+            int a19) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, i + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + a14 + a15 + a16 + a17 + a18 + a19);
+        }
+    }
+
+    @Test
+    public void testTask16() throws TornadoExecutionPlanException {
+        final int size = 256;
+        IntArray out = new IntArray(size);
+        out.init(0);
+
+        TaskGraph taskGraph = new TaskGraph("s16") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, out) //
+                .task("t16", TestManyArgumentTasks::add16, out, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        // Sum of 1..15 == 120
+        for (int i = 0; i < size; i++) {
+            assertEquals(i + 120, out.get(i));
+        }
+    }
+
+    @Test
+    public void testTask20() throws TornadoExecutionPlanException {
+        final int size = 256;
+        IntArray out = new IntArray(size);
+        out.init(0);
+
+        TaskGraph taskGraph = new TaskGraph("s20") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, out) //
+                .task("t20", TestManyArgumentTasks::add20, out, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        // Sum of 1..19 == 190
+        for (int i = 0; i < size; i++) {
+            assertEquals(i + 190, out.get(i));
+        }
+    }
+}


### PR DESCRIPTION
## What

Raises the `TaskGraph` argument-count ceilings to **20** for both task families:

- Compute path `task(...)`: **15 → 20** (`Task16..Task20`)
- Library/hybrid path `libraryTask(...)`: **18 → 20** (`LibraryTask19..LibraryTask20`)

## Why

The hybrid (native-library) API binds each `libraryTask(...)` call to a typed functional interface of a fixed arity, so a plain method reference (e.g. `CuBlas::cublasSgemmStridedBatched`, already 17 args) plus its typed arguments can be passed. Since a Java method reference only binds to a SAM of **matching arity**, there is no varargs shortcut — the `TaskN`/`LibraryTaskN` ladder is enumerated by hand. This PR continues the ladder to give hybrid providers (and future kernels) headroom.

Fixes #956.

## Change surface (purely additive, +311 lines)

- `TornadoFunctions.java` — `Task16..20`, `LibraryTask19..20`
- `TaskGraph.java` + `TaskGraphInterface.java` — `task(...)` / `libraryTask(...)` overloads
- `TaskPackage.java` — constructors + `createPackage(...)` factories 16..20
- `TaskUtils.java` — `createTask(...)` overloads 16..20 (delegate to the existing arity-agnostic varargs)
- `TornadoTaskGraph.java` — extend both `switch (type)` blocks (`addInner` + `runSequentialCodeInThread`) with cases 16..20. The library path needs no switch change (`addLibraryTask` takes a single `LibraryTaskDescriptor`).

Out of scope (noted in #956): the separate `case 1..15` switches for `transferToDevice`/`transferToHost` object counts — a different 15-cap, not task-arg arity.

## Tests

New under `tornado-unittests/.../tasks/`:

- `TestManyArgumentTasks` — executes 16-arg and 20-arg compute kernels on-device and checks results.
- `TestLibraryTaskArity` — builds `libraryTask(...)` graphs with 19 and 20 arguments (backend-agnostic: the descriptor is built at graph-construction time).

Verified with `make jdk21 BACKEND=opencl`; all four tests pass on OpenCL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
