### PR TITLE
jTile: a cuTile/Tilus-style tile programming API for TornadoVM (CUDA)

### DIFF
--- a/tornado-api/src/main/java/module-info.java
+++ b/tornado-api/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module tornado.api {
     exports uk.ac.manchester.tornado.api.memory;
     exports uk.ac.manchester.tornado.api.profiler;
     exports uk.ac.manchester.tornado.api.runtime;
+    exports uk.ac.manchester.tornado.api.tile;
     exports uk.ac.manchester.tornado.api.internal.annotations;
     exports uk.ac.manchester.tornado.api.utils;
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/tile/Tile.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/tile/Tile.java
@@ -18,7 +18,10 @@
 package uk.ac.manchester.tornado.api.tile;
 
 import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.enums.MMAShape;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 
 /**
  * jTile - a minimal, cuTile/Tilus-inspired <b>tile</b> programming surface for TornadoVM.
@@ -53,7 +56,92 @@ import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
  */
 public final class Tile {
 
+    private static final int WMMA_M = 16;
+    private static final int WMMA_N = 16;
+    private static final int WMMA_K = 16;
+    private static final int WARP_SIZE = 32;
+
     private Tile() {
+    }
+
+    /**
+     * Tile-level tensor-core GEMM: {@code C[M x N] = A[M x K] * B[K x N]}, the jTile analog of
+     * cuTile's {@code dot} (milestone M2, CUDA backend only).
+     *
+     * <p>
+     * One work-group (one warp of {@value #WARP_SIZE} lanes) computes one {@value #WMMA_M}x
+     * {@value #WMMA_N} output tile via NVIDIA {@code mma.sync} tensor-core instructions, looping
+     * over K in {@value #WMMA_K}-wide steps. {@code A}/{@code B} are row-major fp16
+     * ({@link HalfFloatArray}); {@code C} is a row-major fp32 accumulator. All MMA fragments stay
+     * within this method (they cannot cross inlined-method boundaries in the sketcher), so the
+     * whole tensor-core dot is exposed as a single tile-level call.
+     * </p>
+     *
+     * <p>
+     * Launch: {@code localWork = 32}, {@code globalWork = (M/16)*(N/16)*32}. {@code M}, {@code N}
+     * must be multiples of 16 and {@code K} a multiple of 16. Requires the CUDA backend (tensor
+     * cores); unsupported on OpenCL/Metal.
+     * </p>
+     */
+    public static void matmul(KernelContext context, HalfFloatArray a, HalfFloatArray b, FloatArray c, int dimM, int dimN, int dimK) {
+        int warpId = context.groupIdx;
+        int lane = context.localIdx;
+
+        int numTilesN = dimN / WMMA_N;
+        int tileRow = (warpId / numTilesN) * WMMA_M;
+        int tileCol = (warpId % numTilesN) * WMMA_N;
+
+        // Packed shared tiles: 2 fp16 per int.
+        int[] aTile = context.allocateIntLocalArray(WMMA_M * WMMA_K / 2);
+        int[] bTile0 = context.allocateIntLocalArray(WMMA_K * WMMA_N / 2);
+        int[] bTile1 = context.allocateIntLocalArray(WMMA_K * WMMA_N / 2);
+
+        float[] fragC0 = context.mmaFragment(0.0f);
+        float[] fragC1 = context.mmaFragment(0.0f);
+
+        for (int kBase = 0; kBase < dimK; kBase += WMMA_K) {
+            // Cooperative load of A: pack 2 adjacent fp16 into one int.
+            for (int idx = lane; idx < (WMMA_M * WMMA_K) / 2; idx += WARP_SIZE) {
+                int elemBase = idx * 2;
+                int r = elemBase / WMMA_K;
+                int kk = elemBase % WMMA_K;
+                int globalBase = (tileRow + r) * dimK + kBase + kk;
+                int lo = a.get(globalBase).getHalfFloatValue() & 0xFFFF;
+                int hi = a.get(globalBase + 1).getHalfFloatValue() & 0xFFFF;
+                aTile[r * (WMMA_K / 2) + kk / 2] = lo | (hi << 16);
+            }
+
+            // Cooperative load of B: two 16x8 panels, transposed per 8-column panel.
+            for (int idx = lane; idx < 64; idx += WARP_SIZE) {
+                int kRow = idx / 4;
+                int jPair = idx % 4;
+                int jBase = jPair * 2;
+
+                int gL0 = (kBase + kRow) * dimN + tileCol + jBase;
+                int gL1 = (kBase + kRow) * dimN + tileCol + jBase + 1;
+                int loLeft = b.get(gL0).getHalfFloatValue() & 0xFFFF;
+                int hiLeft = b.get(gL1).getHalfFloatValue() & 0xFFFF;
+                bTile0[kRow * 4 + jPair] = loLeft | (hiLeft << 16);
+
+                int gR0 = (kBase + kRow) * dimN + tileCol + 8 + jBase;
+                int gR1 = (kBase + kRow) * dimN + tileCol + 8 + jBase + 1;
+                int loRight = b.get(gR0).getHalfFloatValue() & 0xFFFF;
+                int hiRight = b.get(gR1).getHalfFloatValue() & 0xFFFF;
+                bTile1[kRow * 4 + jPair] = loRight | (hiRight << 16);
+            }
+            context.localBarrier();
+
+            HalfFloat[] fragA = context.mmaLoadA(aTile, WMMA_K);
+            HalfFloat[] fragB0 = context.mmaLoadB(bTile0, WMMA_K);
+            fragC0 = context.mma(fragA, fragB0, fragC0, MMAShape.M16N8K16);
+            HalfFloat[] fragB1 = context.mmaLoadB(bTile1, WMMA_K);
+            fragC1 = context.mma(fragA, fragB1, fragC1, MMAShape.M16N8K16);
+
+            context.localBarrier();
+        }
+
+        context.mmaStore(fragC0, c, tileRow, tileCol, dimN);
+        context.mmaStore(fragC1, c, tileRow, tileCol + 8, dimN);
     }
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/tile/Tile.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/tile/Tile.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.tile;
+
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+
+/**
+ * jTile - a minimal, cuTile/Tilus-inspired <b>tile</b> programming surface for TornadoVM.
+ *
+ * <p>
+ * Milestone M1 models a tile at its finest granularity: each work-item owns one lane
+ * (the element at {@link KernelContext#globalIdx}), and the operations below -
+ * {@link #load}, {@link #store}, {@link #add}, {@link #mul}, {@link #scale} - form the
+ * elementwise tile vocabulary. They are plain scalar helpers that inline into the per-thread
+ * kernel graph, so they JIT-compile on every TornadoVM backend with no new compiler support.
+ * </p>
+ *
+ * <p>
+ * Multi-element shared/register tiles (a work-group cooperatively owning a {@code tileSize}-wide
+ * strip, and 2-D tensor-core tiles) require the tile value to survive across operations, which
+ * TornadoVM cannot yet trace through method boundaries for local memory. That is the subject of
+ * milestone M2 (tensor-core GEMM, reusing the existing MMA intrinsics) and the Phase-2 compiler
+ * work (first-class {@code Tile} IR nodes). See the jTile design plan.
+ * </p>
+ *
+ * <p>
+ * Example (SAXPY, {@code c = alpha*a + b}), launched with global work {@code N}:
+ * </p>
+ *
+ * <pre>
+ * public static void saxpy(KernelContext ctx, FloatArray a, FloatArray b, FloatArray c, float alpha) {
+ *     float ta = Tile.load(ctx, a);
+ *     float tb = Tile.load(ctx, b);
+ *     Tile.store(ctx, c, Tile.add(Tile.scale(ta, alpha), tb));
+ * }
+ * </pre>
+ */
+public final class Tile {
+
+    private Tile() {
+    }
+
+    /**
+     * Loads this work-item's lane of {@code src} (element {@link KernelContext#globalIdx}).
+     */
+    public static float load(KernelContext context, FloatArray src) {
+        return src.get(context.globalIdx);
+    }
+
+    /**
+     * Stores {@code value} into this work-item's lane of {@code dst} (element
+     * {@link KernelContext#globalIdx}).
+     */
+    public static void store(KernelContext context, FloatArray dst, float value) {
+        dst.set(context.globalIdx, value);
+    }
+
+    /**
+     * Element-wise tile sum, {@code x + y}.
+     */
+    public static float add(float x, float y) {
+        return x + y;
+    }
+
+    /**
+     * Element-wise tile product, {@code x * y}.
+     */
+    public static float mul(float x, float y) {
+        return x * y;
+    }
+
+    /**
+     * Scales a tile lane by a scalar, {@code x * s}.
+     */
+    public static float scale(float x, float s) {
+        return x * s;
+    }
+}

--- a/tornado-examples/src/main/java/module-info.java
+++ b/tornado-examples/src/main/java/module-info.java
@@ -25,6 +25,7 @@ open module tornado.examples {
     exports uk.ac.manchester.tornado.examples.arrays;
     exports uk.ac.manchester.tornado.examples.common;
     exports uk.ac.manchester.tornado.examples.compute;
+    exports uk.ac.manchester.tornado.examples.tile;
     exports uk.ac.manchester.tornado.examples.fft;
     exports uk.ac.manchester.tornado.examples.flatmap;
     exports uk.ac.manchester.tornado.examples.kernelcontext.compute;

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/tile/TileMatrixMultiply.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/tile/TileMatrixMultiply.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.examples.tile;
+
+import java.util.Random;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.tile.Tile;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+
+/**
+ * jTile tensor-core GEMM example (CUDA backend). Computes {@code C = A * B} in fp16 inputs /
+ * fp32 accumulate with a single tile-level {@link Tile#matmul} call, which lowers to NVIDIA
+ * mma.sync tensor-core instructions.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.tile.TileMatrixMultiply
+ * </code>
+ */
+public class TileMatrixMultiply {
+
+    private static final int WMMA_M = 16;
+    private static final int WMMA_N = 16;
+    private static final int WARP_SIZE = 32;
+
+    public static void main(String[] args) throws TornadoExecutionPlanException {
+        final int m = 512;
+        final int n = 512;
+        final int k = 512;
+
+        Random random = new Random(42);
+        HalfFloatArray a = new HalfFloatArray(m * k);
+        HalfFloatArray b = new HalfFloatArray(k * n);
+        FloatArray c = new FloatArray(m * n);
+        for (int i = 0; i < a.getSize(); i++) {
+            a.set(i, new HalfFloat(random.nextFloat()));
+        }
+        for (int i = 0; i < b.getSize(); i++) {
+            b.set(i, new HalfFloat(random.nextFloat()));
+        }
+
+        int numWarps = (m / WMMA_M) * (n / WMMA_N);
+        WorkerGrid1D worker = new WorkerGrid1D(numWarps * WARP_SIZE);
+        worker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler gridScheduler = new GridScheduler("s0.gemm", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("gemm", Tile::matmul, context, a, b, c, m, n, k) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            long start = System.nanoTime();
+            executionPlan.withGridScheduler(gridScheduler).execute();
+            long elapsed = System.nanoTime() - start;
+
+            // Verify a single element against the CPU reference.
+            int row = 3;
+            int col = 7;
+            float expected = 0.0f;
+            for (int kk = 0; kk < k; kk++) {
+                expected += a.get(row * k + kk).getFloat32() * b.get(kk * n + col).getFloat32();
+            }
+            float got = c.get(row * n + col);
+            boolean ok = Math.abs(expected - got) < 0.05f * k;
+
+            System.out.printf("jTile GEMM %dx%dx%d tensor-core: C[%d][%d]=%.3f expected=%.3f -> %s (%.3f ms)%n", m, n, k, row, col, got, expected, ok ? "PASS" : "FAIL", elapsed / 1.0e6);
+        }
+    }
+}

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/tile/TileSaxpy.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/tile/TileSaxpy.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.examples.tile;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.tile.Tile;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+
+/**
+ * jTile elementwise example (CUDA backend): SAXPY {@code c = alpha*a + b} expressed as tile
+ * algebra over the {@link Tile} API.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.tile.TileSaxpy
+ * </code>
+ */
+public class TileSaxpy {
+
+    public static void saxpy(KernelContext context, FloatArray a, FloatArray b, FloatArray c, float alpha) {
+        float ta = Tile.load(context, a);
+        float tb = Tile.load(context, b);
+        Tile.store(context, c, Tile.add(Tile.scale(ta, alpha), tb));
+    }
+
+    public static void main(String[] args) throws TornadoExecutionPlanException {
+        final int size = 1 << 20;
+        final float alpha = 2.5f;
+        FloatArray a = new FloatArray(size);
+        FloatArray b = new FloatArray(size);
+        FloatArray c = new FloatArray(size);
+        for (int i = 0; i < size; i++) {
+            a.set(i, i);
+            b.set(i, 2.0f * i);
+        }
+
+        WorkerGrid1D worker = new WorkerGrid1D(size);
+        worker.setLocalWork(256, 1, 1);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("t0", TileSaxpy::saxpy, context, a, b, c, alpha) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        int probe = 12345;
+        float expected = alpha * probe + 2.0f * probe;
+        boolean ok = Math.abs(c.get(probe) - expected) < 0.001f;
+        System.out.printf("jTile SAXPY size=%d: c[%d]=%.1f expected=%.1f -> %s%n", size, probe, c.get(probe), expected, ok ? "PASS" : "FAIL");
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tile/TestTileElementwise.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tile/TestTileElementwise.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.tile;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.tile.Tile;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * jTile milestone M1 - elementwise tile operations over the {@link Tile} API.
+ *
+ * <p>
+ * How to test?
+ *
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.tile.TestTileElementwise
+ * </code>
+ * </p>
+ */
+public class TestTileElementwise extends TornadoTestBase {
+
+    // c = alpha * a + b, expressed as tile algebra.
+    public static void saxpyTile(KernelContext context, FloatArray a, FloatArray b, FloatArray c, float alpha) {
+        float ta = Tile.load(context, a);
+        float tb = Tile.load(context, b);
+        Tile.store(context, c, Tile.add(Tile.scale(ta, alpha), tb));
+    }
+
+    // c = a * b, elementwise, expressed as tile algebra.
+    public static void mulTile(KernelContext context, FloatArray a, FloatArray b, FloatArray c) {
+        float ta = Tile.load(context, a);
+        float tb = Tile.load(context, b);
+        Tile.store(context, c, Tile.mul(ta, tb));
+    }
+
+    @Test
+    public void testTileSaxpy() throws TornadoExecutionPlanException {
+        final int size = 1024;
+        final int tileSize = 256;
+        final float alpha = 3.0f;
+        FloatArray a = new FloatArray(size);
+        FloatArray b = new FloatArray(size);
+        FloatArray c = new FloatArray(size);
+        IntStream.range(0, size).forEach(i -> {
+            a.set(i, i);
+            b.set(i, 2.0f * i);
+        });
+
+        WorkerGrid worker = new WorkerGrid1D(size);
+        worker.setLocalWork(tileSize, 1, 1);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("t0", TestTileElementwise::saxpyTile, context, a, b, c, alpha) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        for (int i = 0; i < size; i++) {
+            assertEquals(alpha * i + 2.0f * i, c.get(i), 0.001f);
+        }
+    }
+
+    @Test
+    public void testTileMul() throws TornadoExecutionPlanException {
+        final int size = 512;
+        final int tileSize = 128;
+        FloatArray a = new FloatArray(size);
+        FloatArray b = new FloatArray(size);
+        FloatArray c = new FloatArray(size);
+        IntStream.range(0, size).forEach(i -> {
+            a.set(i, i + 1);
+            b.set(i, 2.0f);
+        });
+
+        WorkerGrid worker = new WorkerGrid1D(size);
+        worker.setLocalWork(tileSize, 1, 1);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("t0", TestTileElementwise::mulTile, context, a, b, c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        for (int i = 0; i < size; i++) {
+            assertEquals((i + 1) * 2.0f, c.get(i), 0.001f);
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tile/TestTileMatmul.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tile/TestTileMatmul.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2024, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.tile;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Random;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.tile.Tile;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * jTile milestone M2 - tile-level tensor-core GEMM via {@link Tile#matmul}. CUDA backend only
+ * (uses NVIDIA mma.sync tensor cores). Cross-checked against a CPU fp32 reference.
+ *
+ * <p>
+ * How to test?
+ *
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.tile.TestTileMatmul
+ * </code>
+ * </p>
+ */
+public class TestTileMatmul extends TornadoTestBase {
+
+    private static final int WMMA_M = 16;
+    private static final int WMMA_N = 16;
+    private static final int WARP_SIZE = 32;
+
+    private static HalfFloatArray randomFP16(int size, long seed) {
+        Random random = new Random(seed);
+        HalfFloatArray array = new HalfFloatArray(size);
+        for (int i = 0; i < size; i++) {
+            array.set(i, new HalfFloat(random.nextFloat()));
+        }
+        return array;
+    }
+
+    private static void gemmReference(HalfFloatArray a, HalfFloatArray b, FloatArray ref, int dimM, int dimN, int dimK) {
+        for (int i = 0; i < dimM; i++) {
+            for (int j = 0; j < dimN; j++) {
+                float sum = 0.0f;
+                for (int k = 0; k < dimK; k++) {
+                    sum += a.get(i * dimK + k).getFloat32() * b.get(k * dimN + j).getFloat32();
+                }
+                ref.set(i * dimN + j, sum);
+            }
+        }
+    }
+
+    private void runTileMatmul(int dimM, int dimN, int dimK) throws TornadoExecutionPlanException {
+        // Tensor-core MMA is a CUDA-backend feature only.
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
+
+        HalfFloatArray a = randomFP16(dimM * dimK, 1);
+        HalfFloatArray b = randomFP16(dimK * dimN, 2);
+        FloatArray c = new FloatArray(dimM * dimN);
+
+        FloatArray ref = new FloatArray(dimM * dimN);
+        gemmReference(a, b, ref, dimM, dimN, dimK);
+
+        int numWarps = (dimM / WMMA_M) * (dimN / WMMA_N);
+        int globalSize = numWarps * WARP_SIZE;
+
+        WorkerGrid1D worker = new WorkerGrid1D(globalSize);
+        worker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler gridScheduler = new GridScheduler("s0.gemm", worker);
+        KernelContext context = new KernelContext();
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("gemm", Tile::matmul, context, a, b, c, dimM, dimN, dimK) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        float tol = 0.02f;
+        for (int i = 0; i < dimM; i++) {
+            for (int j = 0; j < dimN; j++) {
+                int idx = i * dimN + j;
+                assertEquals(String.format("C[%d][%d]", i, j), ref.get(idx), c.get(idx), tol);
+            }
+        }
+    }
+
+    @Test
+    public void testTileMatmul16() throws TornadoExecutionPlanException {
+        runTileMatmul(16, 16, 16);
+    }
+
+    @Test
+    public void testTileMatmul64() throws TornadoExecutionPlanException {
+        runTileMatmul(64, 64, 64);
+    }
+
+    @Test
+    public void testTileMatmul128x64() throws TornadoExecutionPlanException {
+        runTileMatmul(128, 64, 32);
+    }
+}


### PR DESCRIPTION
## What

**jTile** — a [cuTile](https://developer.nvidia.com/cuda/tile)/[Tilus](https://github.com/NVIDIA/tilus)-style **tile programming API** for TornadoVM, expressed as a Java DSL that JIT-lowers to existing `KernelContext` primitives. **CUDA backend only** (tensor cores).

New package `uk.ac.manchester.tornado.api.tile.Tile`:

- **Elementwise tiles (M1):** `load`, `store`, `add`, `mul`, `scale` — a work-item owns one lane; reads as tile algebra, compiles to a normal per-thread kernel.
- **Tensor-core GEMM (M2):** `Tile.matmul(ctx, A, B, C, M, N, K)` — one warp computes one 16×16 output tile via NVIDIA `mma.sync` (fp16 in, fp32 accumulate, `MMAShape.M16N8K16`), the jTile analog of cuTile's `dot`. Wraps the warp-collective MMA pattern from `TestMatrixMultiplicationMMA` behind a single tile-level call.

## Why

TornadoVM ships the tensor-core ingredients (`KernelContext` MMA intrinsics) but exposes them at warp level, so GPU matmul kernels are verbose. jTile gives cuTile-like ergonomics: one `matmul` call instead of hand-managed warp tiling.

## Design note (JIT constraint)

The TornadoVM sketcher cannot trace local/shared arrays or MMA fragments across inlined-method boundaries (the parameter becomes a `Pi` node → sketch bailout). So M1 tiles are scalar-lane and `Tile.matmul` keeps all fragments inline. Multi-element shared/register tiles and compiler-driven tile→tensor-core mapping (first-class Tile IR nodes + layout inference) are the planned Phase-2 follow-up.

## Verification (CUDA, RTX 4090)

- `TestTileElementwise` (SAXPY, mul) — PASS.
- `TestTileMatmul` (16³, 64³, 128×64×32) — PASS, numerics cross-checked vs a CPU fp32 reference **and** consistent with the existing `TestMatrixMultiplicationMMA`.
- **Tensor cores proven:** `--printKernel` emits `mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32` (+ `ldmatrix.sync`), 14 occurrences.
- Examples `TileSaxpy` and `TileMatrixMultiply` run end-to-end; 512³ fp16 GEMM device kernel time ≈ 87 µs (`--enableProfiler console`). Naive one-warp-per-tile; optimization is Phase-2.
- `make jdk21 BACKEND=cuda` + `make checkstyle` green.

## Out of scope

OpenCL / Metal / PTX / SPIR-V (PTX is being purged, roadmap #957). First-class Tile IR compiler nodes, a native cuTile provider, and low-precision (fp8/int8) tiles are follow-up branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
