### PR TITLE
Packed half2 support for the CUDA backend

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionContext.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionContext.java
@@ -22,6 +22,7 @@ import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.arrays.LongArray;
+import uk.ac.manchester.tornado.api.types.vectors.Half2;
 
 /**
  * Generic interface for TornadoVM to implement a Thread-Context API. This
@@ -111,6 +112,15 @@ public interface ExecutionContext {
      * @return HalfFloat[]
      */
     HalfFloat[] allocateHalfFloatLocalArray(int size);
+
+    /**
+     * Array Allocation in Local Memory (OpenCL terminology).
+     *
+     * @param size
+     *     size of the {@link Half2}-array.
+     * @return Half2[]
+     */
+    Half2[] allocateHalf2LocalArray(int size);
 
     /**
      * Method used to read a memory address by using the array and the index,

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
@@ -27,6 +27,7 @@ import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.arrays.LongArray;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix8x8Float;
+import uk.ac.manchester.tornado.api.types.vectors.Half2;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -180,6 +181,20 @@ public class KernelContext implements ExecutionContext {
     @Override
     public HalfFloat[] allocateHalfFloatLocalArray(int size) {
         return new HalfFloat[size];
+    }
+
+    /**
+     * It allocates a single dimensional array of packed {@link Half2} pairs in
+     * local memory (known as shared memory in PTX). On backends with packed
+     * half2 support each element maps to a single 32-bit {@code __half2}.
+     *
+     * @param size
+     *     the size of the array, in {@link Half2} elements
+     * @return Half2[]: reference to the Half2 array
+     */
+    @Override
+    public Half2[] allocateHalf2LocalArray(int size) {
+        return new Half2[size];
     }
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -20,6 +20,7 @@ package uk.ac.manchester.tornado.api.types.arrays;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.vectors.Half2;
 
 import java.lang.foreign.MemorySegment;
 import java.util.Arrays;
@@ -234,6 +235,34 @@ public final class HalfFloatArray extends TornadoNativeArray {
     public HalfFloat get(int index) {
         short halfFloatValue = segment.getShortAtIndex(index, baseIndex);
         return new HalfFloat(halfFloatValue);
+    }
+
+    /**
+     * Gets two consecutive {@link HalfFloat} values starting at the specified element index as a packed {@link Half2}.
+     * On backends with packed half2 support this maps to a single 32-bit load; {@code index} must be even so the
+     * access is 4-byte aligned.
+     *
+     * @param index
+     *         The element index of the first lane; must be even.
+     * @return A {@link Half2} holding elements {@code index} and {@code index + 1}.
+     */
+    public Half2 getHalf2(int index) {
+        return new Half2(get(index), get(index + 1));
+    }
+
+    /**
+     * Stores a {@link Half2} into two consecutive elements starting at the specified element index.
+     * On backends with packed half2 support this maps to a single 32-bit store; {@code index} must be even so the
+     * access is 4-byte aligned.
+     *
+     * @param index
+     *         The element index of the first lane; must be even.
+     * @param value
+     *         The {@link Half2} whose lanes are stored at {@code index} and {@code index + 1}.
+     */
+    public void setHalf2(int index, Half2 value) {
+        set(index, value.getX());
+        set(index + 1, value.getY());
     }
 
     /**

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -247,6 +247,9 @@ public final class HalfFloatArray extends TornadoNativeArray {
      * @return A {@link Half2} holding elements {@code index} and {@code index + 1}.
      */
     public Half2 getHalf2(int index) {
+        if (index < 0 || index + 1 >= numberOfElements) {
+            throw new IndexOutOfBoundsException("HalfFloatArray.getHalf2 access [" + index + ", " + (index + 1) + "] out of bounds for length " + numberOfElements);
+        }
         return new Half2(get(index), get(index + 1));
     }
 
@@ -261,6 +264,9 @@ public final class HalfFloatArray extends TornadoNativeArray {
      *         The {@link Half2} whose lanes are stored at {@code index} and {@code index + 1}.
      */
     public void setHalf2(int index, Half2 value) {
+        if (index < 0 || index + 1 >= numberOfElements) {
+            throw new IndexOutOfBoundsException("HalfFloatArray.setHalf2 access [" + index + ", " + (index + 1) + "] out of bounds for length " + numberOfElements);
+        }
         set(index, value.getX());
         set(index + 1, value.getY());
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Half2.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/vectors/Half2.java
@@ -106,6 +106,31 @@ public final class Half2 implements TornadoVectorsInterface<ShortBuffer> {
         c.setY(HalfFloat.mult(a.getY(), b.getY()));
     }
 
+    public static Half2 fma(Half2 a, Half2 b, Half2 c) {
+        return new Half2(HalfFloat.add(HalfFloat.mult(a.getX(), b.getX()), c.getX()), HalfFloat.add(HalfFloat.mult(a.getY(), b.getY()), c.getY()));
+    }
+
+    /**
+     * Returns the first (low) lane of the vector converted to a 32-bit float.
+     */
+    public static float lowFloat(Half2 a) {
+        return a.getX().getFloat32();
+    }
+
+    /**
+     * Returns the second (high) lane of the vector converted to a 32-bit float.
+     */
+    public static float highFloat(Half2 a) {
+        return a.getY().getFloat32();
+    }
+
+    /**
+     * Builds a {@code Half2} from two 32-bit floats, converting each lane to half precision.
+     */
+    public static Half2 fromFloats(float x, float y) {
+        return new Half2(new HalfFloat(x), new HalfFloat(y));
+    }
+
     public static HalfFloat dot(Half2 a, Half2 b) {
         final Half2 m = mult(a, b);
         return HalfFloat.add(m.getX(), m.getY());

--- a/tornado-assembly/src/bin/test-native.sh
+++ b/tornado-assembly/src/bin/test-native.sh
@@ -34,6 +34,7 @@ if [[ $selected_backends == *"cuda"* ]]; then
   echo -e "\nTesting the Native CUDA API\n"
   tornado uk.ac.manchester.tornado.drivers.cuda.tests.TestCUDAJITCompiler
   tornado uk.ac.manchester.tornado.drivers.cuda.tests.TestCUDATornadoCompiler
+  tornado uk.ac.manchester.tornado.drivers.cuda.tests.TestHalf2PackedCodegen
 fi
 
 if [[ $selected_backends == *"spirv"* ]]; then

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/CUDADevice.cpp
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/CUDADevice.cpp
@@ -226,9 +226,18 @@ JNIEXPORT void JNICALL Java_uk_ac_manchester_tornado_drivers_cuda_CUDADevice_clG
         case CL_DEVICE_OPENCL_C_VERSION:
             put_string(buf, len, "CUDA C 1.0");
             break;
-        case CL_DEVICE_EXTENSIONS:
-            put_string(buf, len, "cl_khr_fp64");
+        case CL_DEVICE_EXTENSIONS: {
+            // FP16 arithmetic requires compute capability >= 5.3.
+            int major = 0, minor = 0;
+            cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, cuDevice);
+            cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, cuDevice);
+            std::string extensions = "cl_khr_fp64";
+            if (major > 5 || (major == 5 && minor >= 3)) {
+                extensions += " cl_khr_fp16";
+            }
+            put_string(buf, len, extensions);
             break;
+        }
         case CL_DEVICE_DOUBLE_FP_CONFIG:
             put_long(buf, len, CL_FP_NONZERO); // all NVIDIA GPUs support fp64
             break;

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/asm/CUDAAssembler.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/asm/CUDAAssembler.java
@@ -1057,6 +1057,7 @@ public final class CUDAAssembler extends Assembler {
         public static final CUDABinaryTemplate NEW_LOCAL_SHORT_ARRAY = new CUDABinaryTemplate("local memory array short", "__shared__ short %s[%s]");
         public static final CUDABinaryTemplate NEW_LOCAL_CHAR_ARRAY = new CUDABinaryTemplate("local memory array char", "__shared__ char %s[%s]");
         public static final CUDABinaryTemplate NEW_LOCAL_HALF_FLOAT_ARRAY = new CUDABinaryTemplate("local memory array half", "__shared__ half %s[%s]");
+        public static final CUDABinaryTemplate NEW_LOCAL_HALF2_ARRAY = new CUDABinaryTemplate("local memory array half2", "__shared__ __half2 %s[%s]");
         // @formatter:on
         private final String template;
 

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAGraphBuilderPlugins.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAGraphBuilderPlugins.java
@@ -74,6 +74,7 @@ import uk.ac.manchester.tornado.api.types.arrays.Int8Array;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.arrays.LongArray;
 import uk.ac.manchester.tornado.api.types.arrays.TornadoMemorySegment;
+import uk.ac.manchester.tornado.api.types.vectors.Half2;
 import uk.ac.manchester.tornado.api.utils.QuantizationUtils;
 import uk.ac.manchester.tornado.drivers.cuda.CUDAProgram;
 import uk.ac.manchester.tornado.drivers.cuda.graal.CUDAArchitecture;
@@ -433,6 +434,21 @@ public class CUDAGraphBuilderPlugins {
         });
     }
 
+    private static void registerHalf2LocalArray(Registration r, JavaKind returnedJavaKind) {
+        r.register(new InvocationPlugin("allocateHalf2LocalArray", InvocationPlugin.Receiver.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode size) {
+                receiver.get(true);
+                MetaAccessProvider metaAccess = b.getMetaAccess();
+                ResolvedJavaType resolvedElementType = metaAccess.lookupJavaType(Half2.class);
+                LocalArrayNode localArrayNode = new LocalArrayNode(CUDAArchitecture.localSpace, resolvedElementType, size, CUDAKind.HALF2);
+                b.getGraph().addOrUnique(localArrayNode);
+                b.push(returnedJavaKind, localArrayNode);
+                return true;
+            }
+        });
+    }
+
     private static void localArraysPlugins(Registration r) {
         JavaKind returnedJavaKind = JavaKind.Object;
 
@@ -452,6 +468,8 @@ public class CUDAGraphBuilderPlugins {
 
         returnedJavaKind = JavaKind.fromJavaClass(short.class);
         registerHalfFloatLocalArray(r, returnedJavaKind);
+
+        registerHalf2LocalArray(r, JavaKind.Object);
     }
 
     private static void registerKernelContextPlugins(InvocationPlugins plugins) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAVectorNodePlugin.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAVectorNodePlugin.java
@@ -23,14 +23,19 @@
  */
 package uk.ac.manchester.tornado.drivers.cuda.graal.compiler.plugins;
 
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.extended.GuardingNode;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderContext;
 import org.graalvm.compiler.nodes.graphbuilderconf.NodePlugin;
+import org.graalvm.compiler.nodes.java.StoreIndexedNode;
 
 import jdk.vm.ci.hotspot.HotSpotResolvedJavaType;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import uk.ac.manchester.tornado.api.internal.annotations.Vector;
 import uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDAKind;
+import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.LocalArrayNode;
+import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.vector.LoadIndexedVectorNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.vector.VectorValueNode;
 
 public class CUDAVectorNodePlugin implements NodePlugin {
@@ -39,6 +44,35 @@ public class CUDAVectorNodePlugin implements NodePlugin {
     public boolean handleNewInstance(GraphBuilderContext b, ResolvedJavaType type) {
         if (type.getAnnotation(Vector.class) != null) {
             return createVectorInstance(b, type);
+        }
+        return false;
+    }
+
+    /**
+     * Indexed loads on a packed half2 local array ({@link LocalArrayNode} of kind
+     * {@link CUDAKind#HALF2}) produce a packed 32-bit {@code __half2} element, so they
+     * are parsed as vector loads instead of object array accesses.
+     */
+    @Override
+    public boolean handleLoadIndexed(GraphBuilderContext b, ValueNode array, ValueNode index, GuardingNode boundsCheck, JavaKind elementKind) {
+        if (array instanceof LocalArrayNode localArrayNode && localArrayNode.getCUDAKind() == CUDAKind.HALF2) {
+            LoadIndexedVectorNode indexedLoad = new LoadIndexedVectorNode(CUDAKind.HALF2, array, index, JavaKind.Short);
+            b.push(JavaKind.Object, b.append(indexedLoad));
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Indexed stores on a packed half2 local array write the vector value as a single
+     * 32-bit {@code __half2} element.
+     */
+    @Override
+    public boolean handleStoreIndexed(GraphBuilderContext b, ValueNode array, ValueNode index, GuardingNode boundsCheck, GuardingNode storeCheck, JavaKind elementKind, ValueNode value) {
+        if (array instanceof LocalArrayNode localArrayNode && localArrayNode.getCUDAKind() == CUDAKind.HALF2) {
+            StoreIndexedNode indexedStore = new StoreIndexedNode(array, index, null, null, JavaKind.Short, value);
+            b.add(b.append(indexedStore));
+            return true;
         }
         return false;
     }

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAVectorPlugins.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAVectorPlugins.java
@@ -27,6 +27,7 @@ import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.compiler.core.common.type.ObjectStamp;
+import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.core.common.type.StampPair;
 import org.graalvm.compiler.nodes.ParameterNode;
 import org.graalvm.compiler.nodes.PiNode;
@@ -77,6 +78,7 @@ import uk.ac.manchester.tornado.api.types.vectors.Int8;
 import uk.ac.manchester.tornado.api.types.vectors.Short2;
 import uk.ac.manchester.tornado.drivers.cuda.graal.CUDAStampFactory;
 import uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDAKind;
+import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.Half2IntrinsicNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.vector.GetArrayNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.vector.LoadIndexedVectorNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.vector.VectorAddNode;
@@ -178,6 +180,8 @@ public final class CUDAVectorPlugins {
         registerVectorCollectionsPlugins(plugins, CUDAKind.VECTORDOUBLE16, DoubleArray.class, Double16.class);
 
         registerVectorCollectionsPlugins(plugins, CUDAKind.VECTORHALF2, HalfFloatArray.class, Half2.class);
+
+        registerHalf2PackedPlugins(plugins);
         registerVectorCollectionsPlugins(plugins, CUDAKind.VECTORHALF3, HalfFloatArray.class, Half3.class);
         registerVectorCollectionsPlugins(plugins, CUDAKind.VECTORHALF4, HalfFloatArray.class, Half4.class);
         registerVectorCollectionsPlugins(plugins, CUDAKind.VECTORHALF8, HalfFloatArray.class, Half8.class);
@@ -203,6 +207,70 @@ public final class CUDAVectorPlugins {
             registerGeometricBIFS(plugins, CUDAKind.FLOAT3);
             registerGeometricBIFS(plugins, CUDAKind.FLOAT4);
         }
+    }
+
+    /**
+     * Packed half2 support: single 32-bit loads/stores on {@link HalfFloatArray} plus the
+     * {@link Half2} fma/conversion helpers, mapped to cuda_fp16.h packed intrinsics.
+     */
+    private static void registerHalf2PackedPlugins(final InvocationPlugins plugins) {
+        final Registration arrayRegistration = new Registration(plugins, HalfFloatArray.class);
+
+        arrayRegistration.register(new InvocationPlugin("getHalf2", Receiver.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode index) {
+                LoadIndexedVectorNode indexedLoad = new LoadIndexedVectorNode(CUDAKind.HALF2, receiver.get(true), index, JavaKind.Short);
+                b.push(JavaKind.Object, b.append(indexedLoad));
+                return true;
+            }
+        });
+
+        arrayRegistration.register(new InvocationPlugin("setHalf2", Receiver.class, int.class, Half2.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode index, ValueNode value) {
+                StoreIndexedNode indexedStore = new StoreIndexedNode(receiver.get(true), index, null, null, JavaKind.Short, value);
+                b.append(indexedStore);
+                return true;
+            }
+        });
+
+        final Registration half2Registration = new Registration(plugins, Half2.class);
+
+        half2Registration.register(new InvocationPlugin("fma", Half2.class, Half2.class, Half2.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode a, ValueNode x, ValueNode c) {
+                Half2IntrinsicNode fmaNode = new Half2IntrinsicNode("__hfma2", CUDAStampFactory.getStampFor(CUDAKind.HALF2), a, x, c);
+                b.push(JavaKind.Object, b.append(fmaNode));
+                return true;
+            }
+        });
+
+        half2Registration.register(new InvocationPlugin("lowFloat", Half2.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode vector) {
+                Half2IntrinsicNode lowNode = new Half2IntrinsicNode("__low2float", StampFactory.forKind(JavaKind.Float), vector);
+                b.push(JavaKind.Float, b.append(lowNode));
+                return true;
+            }
+        });
+
+        half2Registration.register(new InvocationPlugin("highFloat", Half2.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode vector) {
+                Half2IntrinsicNode highNode = new Half2IntrinsicNode("__high2float", StampFactory.forKind(JavaKind.Float), vector);
+                b.push(JavaKind.Float, b.append(highNode));
+                return true;
+            }
+        });
+
+        half2Registration.register(new InvocationPlugin("fromFloats", float.class, float.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode x, ValueNode y) {
+                Half2IntrinsicNode packNode = new Half2IntrinsicNode("__floats2half2_rn", CUDAStampFactory.getStampFor(CUDAKind.HALF2), x, y);
+                b.push(JavaKind.Object, b.append(packNode));
+                return true;
+            }
+        });
     }
 
     private static VectorValueNode resolveReceiver(ValueNode thisObject) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAArithmeticTool.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAArithmeticTool.java
@@ -491,6 +491,10 @@ public class CUDAArithmeticTool extends ArithmeticLIRGenerator {
     private Value getOffsetValue(CUDAKind oclKind, MemoryAccess memoryAccess) {
         if (memoryAccess.getBase().getMemorySpace() == CUDAMemorySpace.GLOBAL.getBase().getMemorySpace()) {
             return new ConstantValue(LIRKind.value(CUDAKind.INT), PrimitiveConstant.INT_0);
+        } else if (oclKind == CUDAKind.HALF2) {
+            // __half2 local arrays are element-typed, so the index (possibly a runtime
+            // variable) is already in vector elements and is used as-is.
+            return memoryAccess.getIndex();
         } else {
             return getPrivateOffsetValue(oclKind, memoryAccess);
         }

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDABinary.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDABinary.java
@@ -111,6 +111,25 @@ public class CUDABinary {
             asm.endStackPush();
 
             String op = opcode.toString();
+
+            if (resultKind.getElementKind() == CUDAKind.HALF && length == 2) {
+                // cuda_fp16.h packed half2 intrinsics keep the pair in one 32-bit
+                // register instead of decomposing into scalar half lanes.
+                String intrinsic = switch (op) {
+                    case "+" -> "__hadd2";
+                    case "-" -> "__hsub2";
+                    case "*" -> "__hmul2";
+                    case "/" -> "__h2div";
+                    default -> null;
+                };
+                if (intrinsic != null) {
+                    String xe = xIsVector ? xs : "__half2half2(" + xs + ")";
+                    String ye = yIsVector ? ys : "__half2half2(" + ys + ")";
+                    asm.emit(intrinsic + "(" + xe + ", " + ye + ")");
+                    return;
+                }
+            }
+
             StringBuilder sb = new StringBuilder();
             sb.append("make_").append(resultKind.getElementKind().toString()).append(length).append("(");
             for (int i = 0; i < length; i++) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDABinary.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDABinary.java
@@ -89,7 +89,9 @@ public class CUDABinary {
         @Override
         public void emit(CUDACompilationResultBuilder crb, CUDAAssembler asm) {
             CUDAKind resultKind = getCUDAPlatformKind();
-            if (resultKind == null || !resultKind.isVector()) {
+            // Template opcodes (e.g. __shared__ array declarations) are plain format
+            // strings, not componentwise vector arithmetic, even for a vector kind.
+            if (resultKind == null || !resultKind.isVector() || opcode instanceof CUDAAssembler.CUDABinaryTemplate) {
                 super.emit(crb, asm);
                 return;
             }

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAKind.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAKind.java
@@ -292,6 +292,10 @@ public enum CUDAKind implements PlatformKind {
     }
 
     public static CUDAAssembler.CUDABinaryTemplate resolveTemplateType(JavaKind type, CUDAKind kind) {
+        if (kind == CUDAKind.HALF2) {
+            // Packed half2 local arrays are element-typed __half2, regardless of the Java-side type.
+            return CUDAAssembler.CUDABinaryTemplate.NEW_LOCAL_HALF2_ARRAY;
+        }
         if (type == JavaKind.Int) {
             return CUDAAssembler.CUDABinaryTemplate.NEW_LOCAL_INT_ARRAY;
         } else if (type == JavaKind.Double) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAKind.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAKind.java
@@ -530,15 +530,19 @@ public enum CUDAKind implements PlatformKind {
             return toString();
         }
         int len = getVectorLength();
+        CUDAKind element = getElementKind();
+        if (element == HALF) {
+            // cuda_fp16.h provides only __half2; report wider half vectors as an FP16
+            // device limitation (unsupported) rather than a hard compiler bailout.
+            if (len == 2) {
+                return "__half2";
+            }
+            throw new uk.ac.manchester.tornado.api.exceptions.TornadoDeviceFP16NotSupported(
+                    "CUDA backend does not support half-precision vector type " + name() + "; only __half2 is available.");
+        }
         if (len != 2 && len != 3 && len != 4) {
             throw new uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException(
                     "CUDA backend does not support vector width " + len + " (kind " + name() + "); only widths 2, 3 and 4 are supported.");
-        }
-        CUDAKind element = getElementKind();
-        if (element == HALF) {
-            // CUDA cuda_fp16.h only provides __half2 (no half3/half4 built-ins).
-            throw new uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException(
-                    "CUDA backend does not support half-precision vector type " + name() + ".");
         }
         return element.toString() + len;
     }

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
@@ -356,6 +356,50 @@ public class CUDALIRStmt {
         }
     }
 
+    /**
+     * Emits a call to a cuda_fp16.h intrinsic of the form {@code result = __fn(arg0, arg1, ...);}
+     * over packed half2 / float operands.
+     */
+    @Opcode("HALF2_INTRINSIC")
+    public static class Half2IntrinsicStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<Half2IntrinsicStmt> TYPE = LIRInstructionClass.create(Half2IntrinsicStmt.class);
+
+        @Def
+        protected Value result;
+        @Use
+        protected Value[] operands;
+
+        private final String function;
+
+        public Half2IntrinsicStmt(String function, Value result, Value... operands) {
+            super(TYPE);
+            this.function = function;
+            this.result = result;
+            this.operands = operands;
+        }
+
+        @Override
+        public void emitCode(CUDACompilationResultBuilder crb, CUDAAssembler asm) {
+            asm.indent();
+            asm.emitValue(crb, result);
+            asm.space();
+            asm.assign();
+            asm.space();
+            asm.emit(function);
+            asm.emit("(");
+            for (int i = 0; i < operands.length; i++) {
+                if (i > 0) {
+                    asm.emit(", ");
+                }
+                asm.emitValue(crb, operands[i]);
+            }
+            asm.emit(")");
+            asm.delimiter();
+            asm.eol();
+        }
+    }
+
     @Opcode("CONVERT_HALF")
     public static class ConvertHalfToFloatStmt extends AbstractInstruction {
 
@@ -1027,6 +1071,15 @@ public class CUDALIRStmt {
             asm.space();
             asm.assign();
             asm.space();
+            if (vectorKind.getElementKind() == CUDAKind.HALF && n == 2) {
+                // __half2 is only 4-byte aligned, so (unlike float4) the packed
+                // reinterpret load is safe on element-aligned buffers as long as
+                // the element index is even. Emit a single 32-bit load.
+                asm.emit("((__half2 *)(" + addr + "))[(" + idx + ")]");
+                asm.delimiter();
+                asm.eol();
+                return;
+            }
             StringBuilder sb = new StringBuilder();
             sb.append("make_").append(elem).append(n).append("(");
             for (int i = 0; i < n; i++) {
@@ -1642,6 +1695,19 @@ public class CUDALIRStmt {
             asm.emitValueWithFormat(crb, rhs);
             final String v = asm.getLastOp();
             asm.endStackPush();
+
+            if (vectorKind.getElementKind() == CUDAKind.HALF && n == 2) {
+                // Packed 32-bit store; see the matching VectorLoadStmt comment on
+                // __half2 alignment.
+                asm.emit(String.format("((__half2 *)(%s))[(%s)]", addr, idx));
+                asm.space();
+                asm.assign();
+                asm.space();
+                asm.emit(v);
+                asm.delimiter();
+                asm.eol();
+                return;
+            }
 
             for (int i = 0; i < n; i++) {
                 if (i > 0) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
@@ -23,6 +23,7 @@ package uk.ac.manchester.tornado.drivers.cuda.graal.lir;
 
 import jdk.vm.ci.meta.JavaKind;
 import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.lir.ConstantValue;
 import org.graalvm.compiler.lir.LIRInstruction;
 import org.graalvm.compiler.lir.LIRInstructionClass;
 import org.graalvm.compiler.lir.Opcode;
@@ -1687,14 +1688,19 @@ public class CUDALIRStmt {
             CUDAKind vectorKind = (CUDAKind) rhs.getPlatformKind();
             int n = vectorKind.getVectorLength();
             String elem = vectorKind.getElementKind().toString();
-            String idx = CUDAAssembler.getAbsoluteIndexFromValue(index);
 
             asm.beginStackPush();
             address.emit(crb);
             final String addr = asm.getLastOp();
             asm.emitValueWithFormat(crb, rhs);
             final String v = asm.getLastOp();
+            asm.emitValue(crb, index);
+            final String emittedIdx = asm.getLastOp();
             asm.endStackPush();
+
+            // The string-parsing fallback only understands constants; a runtime-variable
+            // index (packed __half2 local arrays) must be emitted as a proper value.
+            String idx = index instanceof ConstantValue ? CUDAAssembler.getAbsoluteIndexFromValue(index) : emittedIdx;
 
             if (vectorKind.getElementKind() == CUDAKind.HALF && n == 2) {
                 // Packed 32-bit store; see the matching VectorLoadStmt comment on

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/nodes/Half2IntrinsicNode.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/nodes/Half2IntrinsicNode.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.cuda.graal.nodes;
+
+import org.graalvm.compiler.core.common.type.Stamp;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.graph.NodeInputList;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+
+import jdk.vm.ci.meta.Value;
+import uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDALIRStmt;
+
+/**
+ * Calls a cuda_fp16.h packed-half2 intrinsic ({@code __hfma2}, {@code __floats2half2_rn},
+ * {@code __low2float}, {@code __high2float}, ...) over its inputs. The result stamp is
+ * supplied by the invocation plugin (a packed {@code __half2} or a scalar {@code float}).
+ */
+@NodeInfo
+public class Half2IntrinsicNode extends ValueNode implements LIRLowerable {
+
+    public static final NodeClass<Half2IntrinsicNode> TYPE = NodeClass.create(Half2IntrinsicNode.class);
+
+    @Input
+    private NodeInputList<ValueNode> operands;
+
+    private final String function;
+
+    public Half2IntrinsicNode(String function, Stamp stamp, ValueNode... operands) {
+        super(TYPE, stamp);
+        this.function = function;
+        this.operands = new NodeInputList<>(this, operands);
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable result = tool.newVariable(tool.getLIRKind(stamp));
+        Value[] values = new Value[operands.size()];
+        for (int i = 0; i < operands.size(); i++) {
+            values[i] = generator.operand(operands.get(i));
+        }
+        tool.append(new CUDALIRStmt.Half2IntrinsicStmt(function, result, values));
+        generator.setResult(this, result);
+    }
+}

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/phases/TornadoHalfFloatReplacement.java
@@ -469,6 +469,11 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
         // add after the loadindexedvector nodes the marker node to fix the offset of its read
 
         for (LoadIndexedVectorNode loadIndexedVectorNode : graph.getNodes().filter(LoadIndexedVectorNode.class)) {
+            // Local-memory arrays (e.g. packed __half2 tiles) have no object header, so the
+            // header-offset fix applied through VectorHalfRead must not be emitted for them.
+            if (loadIndexedVectorNode.array() instanceof LocalArrayNode) {
+                continue;
+            }
             if (loadIndexedVectorNode.getCUDAKind().isHalf()) {
                 VectorHalfRead vectorHalfRead;
                 if (loadIndexedVectorNode.index() instanceof ConstantNode constantNode) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/tests/TestHalf2PackedCodegen.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/tests/TestHalf2PackedCodegen.java
@@ -1,0 +1,148 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.cuda.tests;
+
+import java.lang.reflect.Method;
+
+import org.graalvm.compiler.phases.util.Providers;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.api.types.vectors.Half2;
+import uk.ac.manchester.tornado.drivers.common.utils.CompilerUtil;
+import uk.ac.manchester.tornado.drivers.cuda.CUDABackendImpl;
+import uk.ac.manchester.tornado.drivers.cuda.graal.CUDAProviders;
+import uk.ac.manchester.tornado.drivers.cuda.graal.backend.CUDABackend;
+import uk.ac.manchester.tornado.drivers.cuda.graal.compiler.CUDACompilationResult;
+import uk.ac.manchester.tornado.drivers.cuda.graal.compiler.CUDACompiler;
+import uk.ac.manchester.tornado.runtime.TornadoCoreRuntime;
+import uk.ac.manchester.tornado.runtime.graal.compiler.TornadoSuitesProvider;
+import uk.ac.manchester.tornado.runtime.profiler.EmptyProfiler;
+import uk.ac.manchester.tornado.runtime.sketcher.Sketch;
+import uk.ac.manchester.tornado.runtime.tasks.CompilableTask;
+import uk.ac.manchester.tornado.runtime.tasks.meta.ScheduleContext;
+import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
+
+/**
+ * Compiles kernels that use the packed half2 API and asserts the generated CUDA C
+ * actually contains the packed 32-bit accesses and cuda_fp16.h intrinsics, so the
+ * codegen cannot silently regress to scalar half code.
+ */
+public class TestHalf2PackedCodegen {
+
+    public static void dotFloatAccumulate(HalfFloatArray a, HalfFloatArray b, FloatArray result, int rowSize) {
+        for (@Parallel int row = 0; row < result.getSize(); row++) {
+            float acc = 0.0f;
+            int base = row * rowSize;
+            for (int d = 0; d < rowSize; d += 2) {
+                Half2 pa = a.getHalf2(base + d);
+                Half2 pb = b.getHalf2(base + d);
+                acc += Half2.lowFloat(pa) * Half2.lowFloat(pb);
+                acc += Half2.highFloat(pa) * Half2.highFloat(pb);
+            }
+            result.set(row, acc);
+        }
+    }
+
+    public static void mulAddPack(HalfFloatArray a, HalfFloatArray b, HalfFloatArray c, HalfFloatArray d, FloatArray e) {
+        for (@Parallel int i = 0; i < d.getSize() / 2; i++) {
+            Half2 fma = Half2.fma(a.getHalf2(i * 2), b.getHalf2(i * 2), c.getHalf2(i * 2));
+            Half2 sum = Half2.add(fma, Half2.fromFloats(e.get(i * 2), e.get(i * 2 + 1)));
+            d.setHalf2(i * 2, Half2.mult(sum, sum));
+        }
+    }
+
+    private static String compileToSource(String methodName, Object... parameters) {
+        Method method = CompilerUtil.getMethodForName(TestHalf2PackedCodegen.class, methodName);
+        TornadoCoreRuntime tornadoRuntime = TornadoCoreRuntime.getTornadoRuntime();
+        ResolvedJavaMethod resolvedJavaMethod = tornadoRuntime.resolveMethod(method);
+        CUDABackend backend = tornadoRuntime.getBackend(CUDABackendImpl.class).getDefaultBackend();
+        TornadoDevice device = tornadoRuntime.getBackend(CUDABackendImpl.class).getDefaultDevice();
+
+        ScheduleContext scheduleMetaData = new ScheduleContext("s0");
+        CompilableTask compilableTask = new CompilableTask(scheduleMetaData, "t0", method, parameters);
+        TaskDataContext taskMeta = compilableTask.meta();
+        taskMeta.setDevice(device);
+
+        Providers providers = backend.getProviders();
+        TornadoSuitesProvider suites = backend.getTornadoSuites();
+        Sketch sketch = CompilerUtil.buildSketchForJavaMethod(resolvedJavaMethod, taskMeta, providers, suites);
+        CUDACompilationResult result = CUDACompiler.compileSketchForDevice(sketch, compilableTask, (CUDAProviders) providers, backend, new EmptyProfiler());
+        return new String(result.getTargetCode());
+    }
+
+    private static boolean assertContains(String source, String kernelName, String... snippets) {
+        boolean ok = true;
+        for (String snippet : snippets) {
+            if (!source.contains(snippet)) {
+                System.out.println("[FAIL] kernel " + kernelName + " is missing \"" + snippet + "\"");
+                ok = false;
+            }
+        }
+        return ok;
+    }
+
+    public void test() {
+        boolean ok = true;
+
+        final int rowSize = 64;
+        HalfFloatArray a = new HalfFloatArray(rowSize * 4);
+        HalfFloatArray b = new HalfFloatArray(rowSize * 4);
+        HalfFloatArray c = new HalfFloatArray(rowSize * 4);
+        HalfFloatArray d = new HalfFloatArray(rowSize * 4);
+        FloatArray e = new FloatArray(rowSize * 4);
+        FloatArray result = new FloatArray(4);
+
+        String dotSource = compileToSource("dotFloatAccumulate", a, b, result, rowSize);
+        ok &= assertContains(dotSource, "dotFloatAccumulate", //
+                "#include <cuda_fp16.h>", //
+                "__half2", //
+                "((__half2 *)", //
+                "__low2float(", //
+                "__high2float(");
+
+        String fmaSource = compileToSource("mulAddPack", a, b, c, d, e);
+        ok &= assertContains(fmaSource, "mulAddPack", //
+                "#include <cuda_fp16.h>", //
+                "((__half2 *)", //
+                "__hfma2(", //
+                "__hadd2(", //
+                "__hmul2(", //
+                "__floats2half2_rn(");
+
+        if (!ok) {
+            System.out.println("Test failed");
+            System.exit(1);
+        }
+        System.out.println("Test success");
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Running Native: uk.ac.manchester.tornado.drivers.cuda.tests.TestHalf2PackedCodegen");
+        new TestHalf2PackedCodegen().test();
+    }
+}

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/tests/TestHalf2PackedCodegen.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/tests/TestHalf2PackedCodegen.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Method;
 import org.graalvm.compiler.phases.util.Providers;
 
 import jdk.vm.ci.meta.ResolvedJavaMethod;
+import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
@@ -74,6 +75,16 @@ public class TestHalf2PackedCodegen {
             Half2 sum = Half2.add(fma, Half2.fromFloats(e.get(i * 2), e.get(i * 2 + 1)));
             d.setHalf2(i * 2, Half2.mult(sum, sum));
         }
+    }
+
+    public static void localTileDot(KernelContext context, HalfFloatArray k, HalfFloatArray q, FloatArray out, int tileSize) {
+        Half2[] kTile = context.allocateHalf2LocalArray(tileSize);
+        int localId = context.localIdx;
+        kTile[localId] = k.getHalf2(localId * 2);
+        context.localBarrier();
+        Half2 pair = kTile[localId];
+        Half2 qPair = q.getHalf2(localId * 2);
+        out.set(context.globalIdx, Half2.lowFloat(pair) * Half2.lowFloat(qPair) + Half2.highFloat(pair) * Half2.highFloat(qPair));
     }
 
     private static String compileToSource(String methodName, Object... parameters) {
@@ -133,6 +144,16 @@ public class TestHalf2PackedCodegen {
                 "__hadd2(", //
                 "__hmul2(", //
                 "__floats2half2_rn(");
+
+        String localTileSource = compileToSource("localTileDot", new KernelContext(), a, b, result, 64);
+        if (Boolean.getBoolean("tornado.test.half2.printKernel")) {
+            System.out.println(localTileSource);
+        }
+        ok &= assertContains(localTileSource, "localTileDot", //
+                "#include <cuda_fp16.h>", //
+                "__shared__ __half2", //
+                "__low2float(", //
+                "__high2float(");
 
         if (!ok) {
             System.out.println("Test failed");

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalf2Packed.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalf2Packed.java
@@ -21,9 +21,13 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
@@ -101,6 +105,21 @@ public class TestHalf2Packed extends TornadoTestBase {
             float y = input.get(i * 2 + 1);
             output.setHalf2(i * 2, Half2.fromFloats(x - y, x + y));
         }
+    }
+
+    /**
+     * Local-memory tile pattern: stage packed pairs into a __half2 shared-memory
+     * tile, then consume them with FP32 accumulation after a barrier.
+     */
+    public static void localTileDot(KernelContext context, HalfFloatArray a, HalfFloatArray b, FloatArray result) {
+        Half2[] tile = context.allocateHalf2LocalArray(128);
+        int localId = context.localIdx;
+        int globalId = context.globalIdx;
+        tile[localId] = a.getHalf2(globalId * 2);
+        context.localBarrier();
+        Half2 pa = tile[localId];
+        Half2 pb = b.getHalf2(globalId * 2);
+        result.set(globalId, Half2.lowFloat(pa) * Half2.lowFloat(pb) + Half2.highFloat(pa) * Half2.highFloat(pb));
     }
 
     private static HalfFloatArray createSequenceArray(int numElements, float scale) {
@@ -220,6 +239,34 @@ public class TestHalf2Packed extends TornadoTestBase {
                 expected += a.get(row * rowSize + d).getFloat32() * b.get(row * rowSize + d).getFloat32();
             }
             assertEquals(expected, result.get(row), Math.abs(expected) * 0.01f + DELTA);
+        }
+    }
+
+    @Test
+    public void testLocalTileDot() throws TornadoExecutionPlanException {
+        final int numPairs = NUM_ELEMENTS / 2;
+        HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
+        HalfFloatArray b = createSequenceArray(NUM_ELEMENTS, 0.5f);
+        FloatArray result = new FloatArray(numPairs);
+
+        KernelContext context = new KernelContext();
+        WorkerGrid workerGrid = new WorkerGrid1D(numPairs);
+        workerGrid.setLocalWork(128, 1, 1);
+        GridScheduler gridScheduler = new GridScheduler("s0.t0", workerGrid);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestHalf2Packed::localTileDot, context, a, b, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withGridScheduler(gridScheduler).execute();
+        }
+
+        for (int i = 0; i < numPairs; i++) {
+            float expected = a.get(i * 2).getFloat32() * b.get(i * 2).getFloat32() + a.get(i * 2 + 1).getFloat32() * b.get(i * 2 + 1).getFloat32();
+            assertEquals(expected, result.get(i), Math.abs(expected) * 0.01f + DELTA);
         }
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalf2Packed.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalf2Packed.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.vectortypes;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.api.types.vectors.Half2;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Tests for the packed half2 accessors ({@link HalfFloatArray#getHalf2(int)},
+ * {@link HalfFloatArray#setHalf2(int, Half2)}) and the {@link Half2}
+ * fma/conversion helpers.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.vectortypes.TestHalf2Packed
+ * </code>
+ */
+public class TestHalf2Packed extends TornadoTestBase {
+
+    public static final int NUM_ELEMENTS = 4096;
+
+    private static final float DELTA = 0.01f;
+
+    public static void copyPairs(HalfFloatArray input, HalfFloatArray output) {
+        for (@Parallel int i = 0; i < input.getSize() / 2; i++) {
+            output.setHalf2(i * 2, input.getHalf2(i * 2));
+        }
+    }
+
+    public static void addPairs(HalfFloatArray a, HalfFloatArray b, HalfFloatArray c) {
+        for (@Parallel int i = 0; i < a.getSize() / 2; i++) {
+            c.setHalf2(i * 2, Half2.add(a.getHalf2(i * 2), b.getHalf2(i * 2)));
+        }
+    }
+
+    public static void multPairs(HalfFloatArray a, HalfFloatArray b, HalfFloatArray c) {
+        for (@Parallel int i = 0; i < a.getSize() / 2; i++) {
+            c.setHalf2(i * 2, Half2.mult(a.getHalf2(i * 2), b.getHalf2(i * 2)));
+        }
+    }
+
+    public static void fmaPairs(HalfFloatArray a, HalfFloatArray b, HalfFloatArray c, HalfFloatArray d) {
+        for (@Parallel int i = 0; i < a.getSize() / 2; i++) {
+            d.setHalf2(i * 2, Half2.fma(a.getHalf2(i * 2), b.getHalf2(i * 2), c.getHalf2(i * 2)));
+        }
+    }
+
+    /**
+     * Attention-style pattern: packed FP16 loads, FP32 accumulation of the pairwise products.
+     */
+    public static void dotRowsFloatAccumulate(HalfFloatArray a, HalfFloatArray b, FloatArray result, int rowSize) {
+        for (@Parallel int row = 0; row < result.getSize(); row++) {
+            float acc = 0.0f;
+            int base = row * rowSize;
+            for (int d = 0; d < rowSize; d += 2) {
+                Half2 pa = a.getHalf2(base + d);
+                Half2 pb = b.getHalf2(base + d);
+                acc += Half2.lowFloat(pa) * Half2.lowFloat(pb);
+                acc += Half2.highFloat(pa) * Half2.highFloat(pb);
+            }
+            result.set(row, acc);
+        }
+    }
+
+    /**
+     * RoPE-style pattern: compute a rotated pair in FP32, pack and store with one 32-bit write.
+     */
+    public static void packRotatedPairs(FloatArray input, HalfFloatArray output) {
+        for (@Parallel int i = 0; i < input.getSize() / 2; i++) {
+            float x = input.get(i * 2);
+            float y = input.get(i * 2 + 1);
+            output.setHalf2(i * 2, Half2.fromFloats(x - y, x + y));
+        }
+    }
+
+    private static HalfFloatArray createSequenceArray(int numElements, float scale) {
+        HalfFloatArray array = new HalfFloatArray(numElements);
+        for (int i = 0; i < numElements; i++) {
+            array.set(i, new HalfFloat((i % 32) * scale));
+        }
+        return array;
+    }
+
+    @Test
+    public void testPackedCopy() throws TornadoExecutionPlanException {
+        HalfFloatArray input = createSequenceArray(NUM_ELEMENTS, 0.5f);
+        HalfFloatArray output = new HalfFloatArray(NUM_ELEMENTS);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, input) //
+                .task("t0", TestHalf2Packed::copyPairs, input, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            assertEquals(input.get(i).getFloat32(), output.get(i).getFloat32(), 0.0f);
+        }
+    }
+
+    @Test
+    public void testPackedAdd() throws TornadoExecutionPlanException {
+        HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
+        HalfFloatArray b = createSequenceArray(NUM_ELEMENTS, 0.5f);
+        HalfFloatArray c = new HalfFloatArray(NUM_ELEMENTS);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestHalf2Packed::addPairs, a, b, c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            assertEquals(a.get(i).getFloat32() + b.get(i).getFloat32(), c.get(i).getFloat32(), DELTA);
+        }
+    }
+
+    @Test
+    public void testPackedMult() throws TornadoExecutionPlanException {
+        HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
+        HalfFloatArray b = createSequenceArray(NUM_ELEMENTS, 0.5f);
+        HalfFloatArray c = new HalfFloatArray(NUM_ELEMENTS);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestHalf2Packed::multPairs, a, b, c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            assertEquals(a.get(i).getFloat32() * b.get(i).getFloat32(), c.get(i).getFloat32(), DELTA * 16);
+        }
+    }
+
+    @Test
+    public void testPackedFma() throws TornadoExecutionPlanException {
+        HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
+        HalfFloatArray b = createSequenceArray(NUM_ELEMENTS, 0.5f);
+        HalfFloatArray c = createSequenceArray(NUM_ELEMENTS, 0.125f);
+        HalfFloatArray d = new HalfFloatArray(NUM_ELEMENTS);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b, c) //
+                .task("t0", TestHalf2Packed::fmaPairs, a, b, c, d) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, d);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            float expected = a.get(i).getFloat32() * b.get(i).getFloat32() + c.get(i).getFloat32();
+            assertEquals(expected, d.get(i).getFloat32(), DELTA * 16);
+        }
+    }
+
+    @Test
+    public void testDotRowsFloatAccumulate() throws TornadoExecutionPlanException {
+        final int rowSize = 128;
+        final int numRows = NUM_ELEMENTS / rowSize;
+        HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
+        HalfFloatArray b = createSequenceArray(NUM_ELEMENTS, 0.5f);
+        FloatArray result = new FloatArray(numRows);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestHalf2Packed::dotRowsFloatAccumulate, a, b, result, rowSize) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int row = 0; row < numRows; row++) {
+            float expected = 0.0f;
+            for (int d = 0; d < rowSize; d++) {
+                expected += a.get(row * rowSize + d).getFloat32() * b.get(row * rowSize + d).getFloat32();
+            }
+            assertEquals(expected, result.get(row), Math.abs(expected) * 0.01f + DELTA);
+        }
+    }
+
+    @Test
+    public void testPackRotatedPairs() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(NUM_ELEMENTS);
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            input.set(i, (i % 64) * 0.125f);
+        }
+        HalfFloatArray output = new HalfFloatArray(NUM_ELEMENTS);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, input) //
+                .task("t0", TestHalf2Packed::packRotatedPairs, input, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < NUM_ELEMENTS / 2; i++) {
+            float x = input.get(i * 2);
+            float y = input.get(i * 2 + 1);
+            assertEquals(x - y, output.get(i * 2).getFloat32(), DELTA);
+            assertEquals(x + y, output.get(i * 2 + 1).getFloat32(), DELTA);
+        }
+    }
+}


### PR DESCRIPTION
#### Description

This PR lets `Half2` values stay packed in a single 32-bit `__half2` register through
loads, stores, arithmetic and local-memory staging on the CUDA backend, instead of being
decomposed into scalar half lanes. This halves the memory instructions and local-memory
footprint of FP16 pair work (e.g. attention K/V dot-products and RoPE-style cache writes).

The change comes in three self-contained commits:

1. **Enable FP16 on the CUDA backend.** The CUDA JNI reported only `cl_khr_fp64`, so
   `CUDAFP16SupportPhase` rejected every FP16 vector kernel. It now reports `cl_khr_fp16`
   for compute capability >= 5.3, and `CUDAKind.getCUDATypeName` maps the width-2 half
   vector to the native `__half2`. Wider half vectors (half3/4/8/16) have no CUDA built-in
   and are surfaced as `TornadoDeviceFP16NotSupported` so they are treated as an
   unsupported device rather than a compiler failure.

2. **Packed loads, stores and intrinsics.**
   - `HalfFloatArray.getHalf2/setHalf2` lower to a single 32-bit `*((__half2 *)addr)` access
     (safe because `__half2` is 4-byte aligned and the element index is even); non-CUDA
     backends use the plain-Java pairwise bodies.
   - Vector load/store of `HALF2` and `Half2` add/sub/mult/div emit the packed access and
     `__hadd2/__hsub2/__hmul2/__h2div` (previously the width-2 half path emitted a broken
     `make___half2`).
   - New `Half2.fma/lowFloat/highFloat/fromFloats` lower to
     `__hfma2/__low2float/__high2float/__floats2half2_rn`, bridging FP16 pairs and FP32
     accumulation (attention-style dot products / RoPE-style packed stores).

3. **Packed half2 local memory arrays.** `KernelContext.allocateHalf2LocalArray(int)`
   declares a `__shared__ __half2` array so kernels can stage FP16 pairs in local memory
   without expanding them to FP32. Indexed accesses on the array become packed HALF2 vector
   load/stores. This commit also fixes a latent limitation where local/private vector
   accesses only supported constant indices (the index was string-parsed out of the LIR
   value), so a runtime index such as `threadIdx.x` was silently mis-emitted.

#### Problem description

Not a bug fix for a reported issue. Before this PR the CUDA backend could not keep FP16
pairs packed: `cl_khr_fp16` was never reported (all FP16 vector kernels were rejected), the
width-2 half vector had no native type mapping, and vector arithmetic on halves was emitted
componentwise. The packed path removes those limitations and the extra scalar traffic they
caused.

#### Backend/s tested

- [ ] OpenCL
- [ ] PTX
- [x] CUDA
- [ ] SPIRV
- [ ] Metal

The new codegen is CUDA-only. The API additions (`HalfFloatArray.getHalf2/setHalf2`,
`Half2` helpers, `KernelContext.allocateHalf2LocalArray`) have plain-Java fallback bodies,
so they build on other backends but are not accelerated there.

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

Ubuntu, JDK 21, RTX 5090 (sm_120), CUDA backend.

#### Did you check on FPGAs?

- [ ] Yes
- [x] No

#### How to test the new patch?

```bash
make BACKEND=cuda
source setvars.sh

# Functional: packed copy/add/mult/fma, FP32-accumulated row dot, packed RoPE store,
# and a __shared__ __half2 local tile behind a barrier.
tornado-test --verbose uk.ac.manchester.tornado.unittests.vectortypes.TestHalf2Packed

# Codegen: compiles kernels through the CUDA JIT and asserts the generated CUDA C keeps
# the packed accesses (((__half2 *)...), __shared__ __half2) and the cuda_fp16.h intrinsics
# (__hfma2, __hadd2, __hmul2, __floats2half2_rn, __low2float, __high2float), so the codegen
# cannot silently regress to scalar half code. Also wired into test-native.sh.
tornado uk.ac.manchester.tornado.drivers.cuda.tests.TestHalf2PackedCodegen
```

Both suites pass on the CUDA backend (`TestHalf2Packed`: 7/7; `TestHalf2PackedCodegen`:
Test success).