### PR TITLE
[cuda] Saturate CUTLASS provider: SiLU/Sigmoid/Tanh/HardSwish epilogues + batched FP16 GEMM

### DIFF
--- a/tornado-cutlass/README.md
+++ b/tornado-cutlass/README.md
@@ -23,10 +23,20 @@ maps to CUTLASS directly.
 |---|---|---|
 | `Cutlass.cutlassSgemm(m,n,k,alpha,a,b,beta,c)` | FP32 SIMT GEMM | Correctness baseline, no shape constraints |
 | `Cutlass.cutlassHgemm(m,n,k,alpha,a,b,beta,d)` | FP16 tensor-core GEMM, FP32 accumulate | Requires `k,n` multiples of 4 |
+| `Cutlass.cutlassHgemmBatched(m,n,k,alpha,a,b,beta,c,batchCount)` | Strided-batched FP16 tensor-core GEMM | `batchCount` matrices packed contiguously; requires `k,n` multiples of 4 |
 | `Cutlass.cutlassGemmBiasRelu(m,n,k,a,b,bias,d)` | Fused `relu(A·B + bias)` | `bias` is a length-`n` row vector |
 | `Cutlass.cutlassGemmBiasGelu(m,n,k,a,b,bias,d)` | Fused `gelu(A·B + bias)` | `bias` is a length-`n` row vector |
+| `Cutlass.cutlassGemmBiasSilu(m,n,k,a,b,bias,d)` | Fused `silu(A·B + bias)` (swish; SwiGLU gate) | `bias` is a length-`n` row vector |
+| `Cutlass.cutlassGemmBiasSigmoid(m,n,k,a,b,bias,d)` | Fused `sigmoid(A·B + bias)` | `bias` is a length-`n` row vector |
+| `Cutlass.cutlassGemmBiasTanh(m,n,k,a,b,bias,d)` | Fused `tanh(A·B + bias)` | `bias` is a length-`n` row vector |
+| `Cutlass.cutlassGemmBiasHardSwish(m,n,k,a,b,bias,d)` | Fused `hardswish(A·B + bias)` | `bias` is a length-`n` row vector |
 
-FP32 uses `FloatArray`; the FP16 kernels use `HalfFloatArray`.
+FP32 uses `FloatArray`; the FP16 kernels use `HalfFloatArray`. The fused epilogues
+cover the activation functions CUTLASS ships as ready-made `LinearCombination*`
+output operators (ReLU, GELU, SiLU/swish, Sigmoid, Tanh, HardSwish), computing
+`act(A·B + bias)` in a single tensor-core kernel with no extra global-memory round
+trip. SiLU in particular is the gate activation of the SwiGLU feed-forward block
+used across the LLaMA/Qwen LLM families.
 
 ### Alignment / shape constraint
 

--- a/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/Cutlass.java
+++ b/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/Cutlass.java
@@ -108,6 +108,67 @@ public final class Cutlass {
         return biasActivation("cutlassGemmBiasGelu", m, n, k, a, b, bias, d);
     }
 
+    /**
+     * Fused FP16 GEMM + bias + SiLU (a.k.a. swish): {@code D = silu(A * B + bias)},
+     * where {@code silu(x) = x * sigmoid(x)}. This is the gating activation used by
+     * SwiGLU feed-forward blocks in modern LLMs. Same shape and layout rules as
+     * {@link #cutlassGemmBiasRelu}.
+     */
+    public static LibraryTaskDescriptor cutlassGemmBiasSilu(int m, int n, int k, HalfFloatArray a, HalfFloatArray b, HalfFloatArray bias, HalfFloatArray d) {
+        return biasActivation("cutlassGemmBiasSilu", m, n, k, a, b, bias, d);
+    }
+
+    /**
+     * Fused FP16 GEMM + bias + Sigmoid: {@code D = sigmoid(A * B + bias)}, same
+     * shape and layout rules as {@link #cutlassGemmBiasRelu}.
+     */
+    public static LibraryTaskDescriptor cutlassGemmBiasSigmoid(int m, int n, int k, HalfFloatArray a, HalfFloatArray b, HalfFloatArray bias, HalfFloatArray d) {
+        return biasActivation("cutlassGemmBiasSigmoid", m, n, k, a, b, bias, d);
+    }
+
+    /**
+     * Fused FP16 GEMM + bias + Tanh: {@code D = tanh(A * B + bias)}, same shape
+     * and layout rules as {@link #cutlassGemmBiasRelu}.
+     */
+    public static LibraryTaskDescriptor cutlassGemmBiasTanh(int m, int n, int k, HalfFloatArray a, HalfFloatArray b, HalfFloatArray bias, HalfFloatArray d) {
+        return biasActivation("cutlassGemmBiasTanh", m, n, k, a, b, bias, d);
+    }
+
+    /**
+     * Fused FP16 GEMM + bias + HardSwish: {@code D = hardswish(A * B + bias)},
+     * where {@code hardswish(x) = x * relu6(x + 3) / 6}. A cheap, quantization
+     * friendly SiLU approximation used by MobileNet-v3 / EfficientNet families.
+     * Same shape and layout rules as {@link #cutlassGemmBiasRelu}.
+     */
+    public static LibraryTaskDescriptor cutlassGemmBiasHardSwish(int m, int n, int k, HalfFloatArray a, HalfFloatArray b, HalfFloatArray bias, HalfFloatArray d) {
+        return biasActivation("cutlassGemmBiasHardSwish", m, n, k, a, b, bias, d);
+    }
+
+    /**
+     * Strided-batched FP16 tensor-core GEMM: for each {@code i} in
+     * {@code [0, batchCount)}, {@code C[i] = alpha * A[i] * B[i] + beta * C[i]}.
+     * The {@code batchCount} matrices are packed contiguously in each array
+     * (batch strides {@code m*k}, {@code k*n}, {@code m*n}), so {@code a} has
+     * {@code batchCount*m*k} elements, {@code b} has {@code batchCount*k*n}, and
+     * {@code c} has {@code batchCount*m*n}. All operands row-major half; requires
+     * {@code k, n} multiples of 4. This is the primitive behind batched linear
+     * layers and multi-head attention projections.
+     */
+    public static LibraryTaskDescriptor cutlassHgemmBatched(int m, int n, int k, float alpha, HalfFloatArray a, HalfFloatArray b, float beta, HalfFloatArray c, int batchCount) {
+        checkHalfShape(n, k);
+        if (batchCount <= 0) {
+            throw new TornadoRuntimeException("[ERROR] CUTLASS batched GEMM requires batchCount > 0; got " + batchCount);
+        }
+        Access[] access = new Access[9];
+        Arrays.fill(access, Access.READ_ONLY);
+        access[7] = (beta == 0.0f) ? Access.WRITE_ONLY : Access.READ_WRITE;
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("cutlassHgemmBatched") //
+                .withParameters(new Object[] { m, n, k, alpha, a, b, beta, c, batchCount }) //
+                .withAccess(access);
+    }
+
     private static LibraryTaskDescriptor biasActivation(String function, int m, int n, int k, HalfFloatArray a, HalfFloatArray b, HalfFloatArray bias, HalfFloatArray d) {
         checkHalfShape(n, k);
         // params: m, n, k, a, b, bias, d - only d is written

--- a/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/provider/CutlassLibraryProvider.java
+++ b/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/provider/CutlassLibraryProvider.java
@@ -94,6 +94,11 @@ public final class CutlassLibraryProvider implements TornadoLibraryProvider {
             case "cutlassHgemm" -> ctx.growWorkspace(CutlassNativeLib.hgemmWorkspace(m, n, k));
             case "cutlassGemmBiasRelu" -> ctx.growWorkspace(CutlassNativeLib.gemmBiasReluWorkspace(m, n, k));
             case "cutlassGemmBiasGelu" -> ctx.growWorkspace(CutlassNativeLib.gemmBiasGeluWorkspace(m, n, k));
+            case "cutlassGemmBiasSilu" -> ctx.growWorkspace(CutlassNativeLib.gemmBiasSiluWorkspace(m, n, k));
+            case "cutlassGemmBiasSigmoid" -> ctx.growWorkspace(CutlassNativeLib.gemmBiasSigmoidWorkspace(m, n, k));
+            case "cutlassGemmBiasTanh" -> ctx.growWorkspace(CutlassNativeLib.gemmBiasTanhWorkspace(m, n, k));
+            case "cutlassGemmBiasHardSwish" -> ctx.growWorkspace(CutlassNativeLib.gemmBiasHardSwishWorkspace(m, n, k));
+            case "cutlassHgemmBatched" -> ctx.growWorkspace(CutlassNativeLib.hgemmBatchedWorkspace(m, n, k, (int) p[8]));
             default -> {
                 // no per-shape native state
             }
@@ -122,6 +127,24 @@ public final class CutlassLibraryProvider implements TornadoLibraryProvider {
                     context.workspacePtr, context.stream);
             case "cutlassGemmBiasGelu" -> CutlassNativeLib.gemmBiasGelu((int) invocation.getArg(0), (int) invocation.getArg(1), (int) invocation.getArg(2), //
                     invocation.getDevicePointer(3), invocation.getDevicePointer(4), invocation.getDevicePointer(5), invocation.getDevicePointer(6), //
+                    context.workspacePtr, context.stream);
+            case "cutlassGemmBiasSilu" -> CutlassNativeLib.gemmBiasSilu((int) invocation.getArg(0), (int) invocation.getArg(1), (int) invocation.getArg(2), //
+                    invocation.getDevicePointer(3), invocation.getDevicePointer(4), invocation.getDevicePointer(5), invocation.getDevicePointer(6), //
+                    context.workspacePtr, context.stream);
+            case "cutlassGemmBiasSigmoid" -> CutlassNativeLib.gemmBiasSigmoid((int) invocation.getArg(0), (int) invocation.getArg(1), (int) invocation.getArg(2), //
+                    invocation.getDevicePointer(3), invocation.getDevicePointer(4), invocation.getDevicePointer(5), invocation.getDevicePointer(6), //
+                    context.workspacePtr, context.stream);
+            case "cutlassGemmBiasTanh" -> CutlassNativeLib.gemmBiasTanh((int) invocation.getArg(0), (int) invocation.getArg(1), (int) invocation.getArg(2), //
+                    invocation.getDevicePointer(3), invocation.getDevicePointer(4), invocation.getDevicePointer(5), invocation.getDevicePointer(6), //
+                    context.workspacePtr, context.stream);
+            case "cutlassGemmBiasHardSwish" -> CutlassNativeLib.gemmBiasHardSwish((int) invocation.getArg(0), (int) invocation.getArg(1), (int) invocation.getArg(2), //
+                    invocation.getDevicePointer(3), invocation.getDevicePointer(4), invocation.getDevicePointer(5), invocation.getDevicePointer(6), //
+                    context.workspacePtr, context.stream);
+            // (m, n, k, alpha, a, b, beta, c, batchCount)
+            case "cutlassHgemmBatched" -> CutlassNativeLib.hgemmBatched((int) invocation.getArg(0), (int) invocation.getArg(1), (int) invocation.getArg(2), //
+                    (float) invocation.getArg(3), //
+                    invocation.getDevicePointer(4), invocation.getDevicePointer(5), //
+                    (float) invocation.getArg(6), invocation.getDevicePointer(7), (int) invocation.getArg(8), //
                     context.workspacePtr, context.stream);
             default -> throw new TornadoRuntimeException("[ERROR] CUTLASS function not supported: " + functionName);
         };

--- a/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/provider/CutlassNativeLib.java
+++ b/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/provider/CutlassNativeLib.java
@@ -65,6 +65,31 @@ final class CutlassNativeLib {
     /** Fused FP16 D = gelu(A*B + bias); bias is a length-n row vector (broadcast). */
     static native int gemmBiasGelu(int m, int n, int k, long dA, long dB, long dBias, long dD, long workspace, long stream);
 
+    static native long gemmBiasSiluWorkspace(int m, int n, int k);
+
+    /** Fused FP16 D = silu(A*B + bias); bias is a length-n row vector (broadcast). */
+    static native int gemmBiasSilu(int m, int n, int k, long dA, long dB, long dBias, long dD, long workspace, long stream);
+
+    static native long gemmBiasSigmoidWorkspace(int m, int n, int k);
+
+    /** Fused FP16 D = sigmoid(A*B + bias); bias is a length-n row vector (broadcast). */
+    static native int gemmBiasSigmoid(int m, int n, int k, long dA, long dB, long dBias, long dD, long workspace, long stream);
+
+    static native long gemmBiasTanhWorkspace(int m, int n, int k);
+
+    /** Fused FP16 D = tanh(A*B + bias); bias is a length-n row vector (broadcast). */
+    static native int gemmBiasTanh(int m, int n, int k, long dA, long dB, long dBias, long dD, long workspace, long stream);
+
+    static native long gemmBiasHardSwishWorkspace(int m, int n, int k);
+
+    /** Fused FP16 D = hardswish(A*B + bias); bias is a length-n row vector (broadcast). */
+    static native int gemmBiasHardSwish(int m, int n, int k, long dA, long dB, long dBias, long dD, long workspace, long stream);
+
+    static native long hgemmBatchedWorkspace(int m, int n, int k, int batchCount);
+
+    /** Strided-batched FP16 tensor-core GEMM: C[i] = alpha*A[i]*B[i] + beta*C[i], i in [0,batchCount). */
+    static native int hgemmBatched(int m, int n, int k, float alpha, long dA, long dB, float beta, long dC, int batchCount, long workspace, long stream);
+
     static native long allocateDeviceMemory(long bytes);
 
     static native int freeDeviceMemory(long ptr);

--- a/tornado-drivers/cutlass-jni/src/main/cpp/source/tornado-cutlass.cu
+++ b/tornado-drivers/cutlass-jni/src/main/cpp/source/tornado-cutlass.cu
@@ -42,6 +42,11 @@
 #include <cutlass/epilogue/thread/linear_combination.h>
 #include <cutlass/epilogue/thread/linear_combination_relu.h>
 #include <cutlass/epilogue/thread/linear_combination_gelu.h>
+#include <cutlass/epilogue/thread/linear_combination_silu.h>
+#include <cutlass/epilogue/thread/linear_combination_sigmoid.h>
+#include <cutlass/epilogue/thread/linear_combination_hardswish.h>
+#include <cutlass/epilogue/thread/linear_combination_generic.h>
+#include <cutlass/epilogue/thread/activation.h>
 #include <cutlass/gemm/threadblock/threadblock_swizzle.h>
 
 // Shared driver: can_implement -> initialize(workspace,stream) -> run(stream).
@@ -96,6 +101,15 @@ using GemmBiasRelu = HalfTensorOpGemm<
         cutlass::epilogue::thread::LinearCombinationRelu<ElementHalf, kAlign, ElementAccum, ElementCompute>>;
 using GemmBiasGelu = HalfTensorOpGemm<
         cutlass::epilogue::thread::LinearCombinationGELU<ElementHalf, kAlign, ElementAccum, ElementCompute>>;
+using GemmBiasSilu = HalfTensorOpGemm<
+        cutlass::epilogue::thread::LinearCombinationSilu<ElementHalf, kAlign, ElementAccum, ElementCompute>>;
+using GemmBiasSigmoid = HalfTensorOpGemm<
+        cutlass::epilogue::thread::LinearCombinationSigmoid<ElementHalf, kAlign, ElementAccum, ElementCompute>>;
+using GemmBiasTanh = HalfTensorOpGemm<
+        cutlass::epilogue::thread::LinearCombinationGeneric<
+                cutlass::epilogue::thread::Tanh, ElementHalf, kAlign, ElementAccum, ElementCompute>>;
+using GemmBiasHardSwish = HalfTensorOpGemm<
+        cutlass::epilogue::thread::LinearCombinationHardSwish<ElementHalf, kAlign, ElementAccum, ElementCompute>>;
 
 // Fused GEMM + bias + activation. The length-n bias vector is supplied as the C
 // source operand with ldc = 0 (row broadcast): every output row reads the same
@@ -244,6 +258,134 @@ JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNa
 JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_gemmBiasGelu
         (JNIEnv *env, jclass clazz, jint m, jint n, jint k, jlong dA, jlong dB, jlong dBias, jlong dD, jlong workspace, jlong stream) {
     return gemmBiasAct<GemmBiasGelu>(m, n, k, dA, dB, dBias, dD, workspace, stream);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    gemmBiasSiluWorkspace
+ * Signature: (III)J
+ */
+JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_gemmBiasSiluWorkspace
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k) {
+    GemmBiasSilu::Arguments args(
+            cutlass::gemm::GemmUniversalMode::kGemm, {m, n, k}, 1, {1.0f, 1.0f},
+            nullptr, nullptr, nullptr, nullptr, 0, 0, 0, 0, k, n, 0, n);
+    return (jlong) GemmBiasSilu::get_workspace_size(args);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    gemmBiasSilu
+ * Signature: (IIIJJJJJJ)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_gemmBiasSilu
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k, jlong dA, jlong dB, jlong dBias, jlong dD, jlong workspace, jlong stream) {
+    return gemmBiasAct<GemmBiasSilu>(m, n, k, dA, dB, dBias, dD, workspace, stream);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    gemmBiasSigmoidWorkspace
+ * Signature: (III)J
+ */
+JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_gemmBiasSigmoidWorkspace
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k) {
+    GemmBiasSigmoid::Arguments args(
+            cutlass::gemm::GemmUniversalMode::kGemm, {m, n, k}, 1, {1.0f, 1.0f},
+            nullptr, nullptr, nullptr, nullptr, 0, 0, 0, 0, k, n, 0, n);
+    return (jlong) GemmBiasSigmoid::get_workspace_size(args);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    gemmBiasSigmoid
+ * Signature: (IIIJJJJJJ)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_gemmBiasSigmoid
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k, jlong dA, jlong dB, jlong dBias, jlong dD, jlong workspace, jlong stream) {
+    return gemmBiasAct<GemmBiasSigmoid>(m, n, k, dA, dB, dBias, dD, workspace, stream);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    gemmBiasTanhWorkspace
+ * Signature: (III)J
+ */
+JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_gemmBiasTanhWorkspace
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k) {
+    GemmBiasTanh::Arguments args(
+            cutlass::gemm::GemmUniversalMode::kGemm, {m, n, k}, 1, {1.0f, 1.0f},
+            nullptr, nullptr, nullptr, nullptr, 0, 0, 0, 0, k, n, 0, n);
+    return (jlong) GemmBiasTanh::get_workspace_size(args);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    gemmBiasTanh
+ * Signature: (IIIJJJJJJ)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_gemmBiasTanh
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k, jlong dA, jlong dB, jlong dBias, jlong dD, jlong workspace, jlong stream) {
+    return gemmBiasAct<GemmBiasTanh>(m, n, k, dA, dB, dBias, dD, workspace, stream);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    gemmBiasHardSwishWorkspace
+ * Signature: (III)J
+ */
+JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_gemmBiasHardSwishWorkspace
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k) {
+    GemmBiasHardSwish::Arguments args(
+            cutlass::gemm::GemmUniversalMode::kGemm, {m, n, k}, 1, {1.0f, 1.0f},
+            nullptr, nullptr, nullptr, nullptr, 0, 0, 0, 0, k, n, 0, n);
+    return (jlong) GemmBiasHardSwish::get_workspace_size(args);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    gemmBiasHardSwish
+ * Signature: (IIIJJJJJJ)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_gemmBiasHardSwish
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k, jlong dA, jlong dB, jlong dBias, jlong dD, jlong workspace, jlong stream) {
+    return gemmBiasAct<GemmBiasHardSwish>(m, n, k, dA, dB, dBias, dD, workspace, stream);
+}
+
+// -----------------------------------------------------------------------------
+// Batched FP16 tensor-core GEMM (strided): batchCount independent m x n x k
+// GEMMs packed contiguously (batch strides m*k, k*n, m*n). Reuses the FP16
+// GemmUniversal kernel in kBatched mode - the core primitive behind batched
+// linear layers and multi-head attention projections.
+// -----------------------------------------------------------------------------
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    hgemmBatchedWorkspace
+ * Signature: (IIII)J
+ */
+JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_hgemmBatchedWorkspace
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k, jint batchCount) {
+    HgemmTensor::Arguments args(
+            cutlass::gemm::GemmUniversalMode::kBatched, {m, n, k}, batchCount, {1.0f, 0.0f},
+            nullptr, nullptr, nullptr, nullptr,
+            (int64_t) m * k, (int64_t) k * n, (int64_t) m * n, (int64_t) m * n, k, n, n, n);
+    return (jlong) HgemmTensor::get_workspace_size(args);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    hgemmBatched
+ * Signature: (IIIFJJFJIJJ)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_hgemmBatched
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k, jfloat alpha,
+         jlong dA, jlong dB, jfloat beta, jlong dC, jint batchCount, jlong workspace, jlong stream) {
+    HgemmTensor::Arguments args(
+            cutlass::gemm::GemmUniversalMode::kBatched, {m, n, k}, batchCount, {alpha, beta},
+            (void const *) dA, (void const *) dB, (void const *) dC, (void *) dC,
+            (int64_t) m * k, (int64_t) k * n, (int64_t) m * n, (int64_t) m * n, k, n, n, n);
+    return runGemm<HgemmTensor>(args, (void *) workspace, (cudaStream_t) stream);
 }
 
 // -----------------------------------------------------------------------------

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cutlass/TestCutlass.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cutlass/TestCutlass.java
@@ -312,6 +312,225 @@ public class TestCutlass extends TornadoTestBase {
         return Math.signum(x) * y;
     }
 
+    private static float sigmoid(float x) {
+        return 1.0f / (1.0f + (float) Math.exp(-x));
+    }
+
+    private static float silu(float x) {
+        return x * sigmoid(x);
+    }
+
+    @Test
+    public void testGemmBiasSilu() throws TornadoExecutionPlanException {
+        final int m = 64;
+        final int n = 64;
+        final int k = 64;
+        HalfFloatArray a = randomHalfArray(m * k);
+        HalfFloatArray b = randomHalfArray(k * n);
+        HalfFloatArray bias = randomHalfArray(n);
+        HalfFloatArray d = new HalfFloatArray(m * n);
+
+        float[] gemm = new float[m * n];
+        hgemmJava(m, n, k, a, b, gemm);
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b, bias) //
+                .libraryTask("fused", Cutlass::cutlassGemmBiasSilu, m, n, k, a, b, bias, d) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, d);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                float expected = silu(gemm[i * n + j] + bias.get(j).getFloat32());
+                assertEquals(expected, d.get(i * n + j).getFloat32(), 0.05f);
+            }
+        }
+    }
+
+    @Test
+    public void testGemmBiasSigmoid() throws TornadoExecutionPlanException {
+        final int m = 64;
+        final int n = 64;
+        final int k = 64;
+        HalfFloatArray a = randomHalfArray(m * k);
+        HalfFloatArray b = randomHalfArray(k * n);
+        HalfFloatArray bias = randomHalfArray(n);
+        HalfFloatArray d = new HalfFloatArray(m * n);
+
+        float[] gemm = new float[m * n];
+        hgemmJava(m, n, k, a, b, gemm);
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b, bias) //
+                .libraryTask("fused", Cutlass::cutlassGemmBiasSigmoid, m, n, k, a, b, bias, d) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, d);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                float expected = sigmoid(gemm[i * n + j] + bias.get(j).getFloat32());
+                assertEquals(expected, d.get(i * n + j).getFloat32(), 0.05f);
+            }
+        }
+    }
+
+    /** Elementwise Hadamard product of two half arrays (JIT task for SwiGLU). */
+    public static void mulHalf(HalfFloatArray gate, HalfFloatArray up, HalfFloatArray out) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, HalfFloat.mult(gate.get(i), up.get(i)));
+        }
+    }
+
+    /**
+     * SwiGLU feed-forward block as used by LLaMA-family LLMs:
+     * {@code out = silu(x*Wg + bg) ⊙ (x*Wu + bu)}. The gate projection runs as a
+     * fused CUTLASS GEMM+bias+SiLU library task, the up projection as a fused
+     * GEMM+bias (via bias-ReLU on non-negative-safe values is wrong, so we use a
+     * plain hgemm plus a JIT bias-add) and the Hadamard product as a JIT task on
+     * the same stream. Exercises two CUTLASS library tasks feeding a JIT kernel.
+     */
+    @Test
+    public void testSwiGluFeedForward() throws TornadoExecutionPlanException {
+        final int m = 64; // tokens
+        final int k = 64; // model dim
+        final int n = 128; // hidden dim
+        HalfFloatArray x = randomHalfArray(m * k);
+        HalfFloatArray wGate = randomHalfArray(k * n);
+        HalfFloatArray bGate = randomHalfArray(n);
+        HalfFloatArray wUp = randomHalfArray(k * n);
+        HalfFloatArray bUp = randomHalfArray(n);
+        HalfFloatArray gate = new HalfFloatArray(m * n);
+        HalfFloatArray up = new HalfFloatArray(m * n);
+        HalfFloatArray out = new HalfFloatArray(m * n);
+
+        TaskGraph taskGraph = new TaskGraph("swiglu") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, x, wGate, bGate, wUp, bUp) //
+                .libraryTask("gate", Cutlass::cutlassGemmBiasSilu, m, n, k, x, wGate, bGate, gate) //
+                .libraryTask("up", Cutlass::cutlassGemmBiasRelu, m, n, k, x, wUp, bUp, up) //
+                .task("mul", TestCutlass::mulHalf, gate, up, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+
+        float[] gateRef = new float[m * n];
+        float[] upRef = new float[m * n];
+        hgemmJava(m, n, k, x, wGate, gateRef);
+        hgemmJava(m, n, k, x, wUp, upRef);
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                float g = silu(gateRef[i * n + j] + bGate.get(j).getFloat32());
+                float u = Math.max(0.0f, upRef[i * n + j] + bUp.get(j).getFloat32());
+                float expected = g * u;
+                assertEquals(expected, out.get(i * n + j).getFloat32(), 0.1f);
+            }
+        }
+    }
+
+    @Test
+    public void testGemmBiasTanh() throws TornadoExecutionPlanException {
+        final int m = 64;
+        final int n = 64;
+        final int k = 64;
+        HalfFloatArray a = randomHalfArray(m * k);
+        HalfFloatArray b = randomHalfArray(k * n);
+        HalfFloatArray bias = randomHalfArray(n);
+        HalfFloatArray d = new HalfFloatArray(m * n);
+
+        float[] gemm = new float[m * n];
+        hgemmJava(m, n, k, a, b, gemm);
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b, bias) //
+                .libraryTask("fused", Cutlass::cutlassGemmBiasTanh, m, n, k, a, b, bias, d) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, d);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                float expected = (float) Math.tanh(gemm[i * n + j] + bias.get(j).getFloat32());
+                assertEquals(expected, d.get(i * n + j).getFloat32(), 0.05f);
+            }
+        }
+    }
+
+    @Test
+    public void testGemmBiasHardSwish() throws TornadoExecutionPlanException {
+        final int m = 64;
+        final int n = 64;
+        final int k = 64;
+        HalfFloatArray a = randomHalfArray(m * k);
+        HalfFloatArray b = randomHalfArray(k * n);
+        HalfFloatArray bias = randomHalfArray(n);
+        HalfFloatArray d = new HalfFloatArray(m * n);
+
+        float[] gemm = new float[m * n];
+        hgemmJava(m, n, k, a, b, gemm);
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b, bias) //
+                .libraryTask("fused", Cutlass::cutlassGemmBiasHardSwish, m, n, k, a, b, bias, d) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, d);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                float x = gemm[i * n + j] + bias.get(j).getFloat32();
+                float expected = x * Math.max(0.0f, Math.min(6.0f, x + 3.0f)) / 6.0f;
+                assertEquals(expected, d.get(i * n + j).getFloat32(), 0.05f);
+            }
+        }
+    }
+
+    /**
+     * Strided-batched FP16 GEMM: {@code batchCount} independent m x n x k GEMMs
+     * packed contiguously in one set of arrays. This is the shape of a batched
+     * linear projection / multi-head attention matmul.
+     */
+    @Test
+    public void testHgemmBatched() throws TornadoExecutionPlanException {
+        final int batch = 8;
+        final int m = 32;
+        final int n = 32;
+        final int k = 32;
+        HalfFloatArray a = randomHalfArray(batch * m * k);
+        HalfFloatArray b = randomHalfArray(batch * k * n);
+        HalfFloatArray c = new HalfFloatArray(batch * m * n);
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .libraryTask("batched", Cutlass::cutlassHgemmBatched, m, n, k, 1.0f, a, b, 0.0f, c, batch) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+
+        for (int bi = 0; bi < batch; bi++) {
+            int aOff = bi * m * k;
+            int bOff = bi * k * n;
+            int cOff = bi * m * n;
+            for (int i = 0; i < m; i++) {
+                for (int j = 0; j < n; j++) {
+                    float acc = 0.0f;
+                    for (int p = 0; p < k; p++) {
+                        acc += a.get(aOff + i * k + p).getFloat32() * b.get(bOff + p * n + j).getFloat32();
+                    }
+                    assertEquals(acc, c.get(cOff + i * n + j).getFloat32(), 0.05f);
+                }
+            }
+        }
+    }
+
     @Test
     public void testHgemmBadAlignmentShape() {
         // k = 62 is not a multiple of 4: the factory must reject it up front.


### PR DESCRIPTION
## What

Extends the CUTLASS hybrid-API library-task provider (added in #912) to cover more of the CUTLASS device-GEMM surface, so the provider exposes as much of what CUTLASS was designed for as the current TornadoVM host types allow.

### New fused activation epilogues (FP16 tensor-core, FP32 accumulate)
All compute `act(A·B + bias)` in a single tensor-core kernel — no extra global-memory round trip — reusing the existing bias-broadcast (`ldc = 0`) path:

| Factory | Kernel | Use |
|---|---|---|
| `cutlassGemmBiasSilu` | `silu(A·B + bias)` | **SwiGLU gate** (LLaMA/Qwen FFN) |
| `cutlassGemmBiasSigmoid` | `sigmoid(A·B + bias)` | gating |
| `cutlassGemmBiasTanh` | `tanh(A·B + bias)` | classic MLP |
| `cutlassGemmBiasHardSwish` | `hardswish(A·B + bias)` | MobileNet-v3 / EfficientNet |

These join the existing ReLU/GELU, so all six ready-made CUTLASS `LinearCombination*` activations are now available.

### Strided-batched FP16 GEMM
`cutlassHgemmBatched(m,n,k,alpha,a,b,beta,c,batchCount)` — `batchCount` independent `m×n×k` GEMMs packed contiguously, via the `GemmUniversal` `kBatched` mode. This is the primitive behind batched linear layers and multi-head attention projections.

## Why

The provider previously exposed only ReLU/GELU epilogues and single (non-batched) GEMM. SiLU in particular is the gate activation of the SwiGLU feed-forward block used across modern LLMs, directly relevant to the GPULlama3 / LLM showcase work. Batched GEMM unlocks attention-style workloads.

## Tests

`TestCutlass` grows **18 → 24**, all green on an RTX 4090 (sm_89):
- per-activation correctness (`testGemmBiasSilu/Sigmoid/Tanh/HardSwish`)
- `testHgemmBatched` (8 batched 32×32×32 GEMMs)
- `testSwiGluFeedForward` — end-to-end SwiGLU block wiring two CUTLASS library tasks (silu gate + up projection) into a JIT Hadamard product on the same stream

```
Test ran: 24, Failed: 0
```

## Notes

- Native `.cu` compiles clean under CUDA 12.6; the existing CUDA-11 CI guard (skip the native lib below CUDA 12) and `sm_80-real;80-virtual` arch fallback are unchanged, so behaviour on the mixed beehive `build-cuda` pool is unaffected.
- BF16 GEMM was scoped out: TornadoVM has no BF16 host array type yet, so it could not be fed correctly from Java — left for a follow-up once a `BFloat16Array` lands.