### PR TITLE
[cuda] BFloat16Array: first-class bfloat16 native array + JIT conversions + cuBLAS/CUTLASS bf16 GEMM

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/BFloat16Array.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/BFloat16Array.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.api.types.arrays;
+
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.internal.annotations.SegmentElementSize;
+import uk.ac.manchester.tornado.api.types.BFloat16;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+/**
+ * A native array of bfloat16 values (see {@link BFloat16}) stored in off-heap memory. Each element is the two-byte raw bfloat16 bit pattern held in a {@link MemorySegment}; this is a type-safe
+ * container for what would otherwise be a {@link ShortArray} of bf16 bits.
+ *
+ * <p>bfloat16 is a <em>storage</em> type: {@link #get(int)}/{@link #set(int, short)} move the raw
+ * {@code short} bit pattern (so a device kernel can decode it with the hardware-accelerated
+ * {@link BFloat16#bf16ToFloat(short)}), while {@link #getFloat(int)}/{@link #setFloat(int, float)}
+ * are host-side conveniences that decode/encode through the software codec. The element size is two
+ * bytes, mirroring {@link HalfFloatArray}; the two differ only in the float conversion.</p>
+ */
+@SegmentElementSize(size = 2)
+public final class BFloat16Array extends TornadoNativeArray {
+
+    private static final int BF16_BYTES = 2;
+    private TornadoMemorySegment segment;
+
+    private int numberOfElements;
+
+    private int arrayHeaderSize;
+
+    private int baseIndex;
+
+    private long segmentByteSize;
+
+    /**
+     * Constructs a new instance of the {@link BFloat16Array} that will store a user-specified number of elements.
+     *
+     * @param numberOfElements
+     *         The number of elements in the array.
+     */
+    public BFloat16Array(int numberOfElements) {
+        this.numberOfElements = numberOfElements;
+        arrayHeaderSize = (int) TornadoNativeArray.ARRAY_HEADER;
+        baseIndex = arrayHeaderSize / BF16_BYTES;
+        segmentByteSize = (long) numberOfElements * BF16_BYTES + arrayHeaderSize;
+        segment = new TornadoMemorySegment(segmentByteSize, numberOfElements);
+    }
+
+    /**
+     * Constructs a new instance of the {@link BFloat16Array} by wrapping an existing {@link MemorySegment} without copying its contents.
+     *
+     * @param existingSegment
+     *         The {@link MemorySegment} containing *both* the off-heap bfloat16 *header* and *data*.
+     */
+    private BFloat16Array(MemorySegment existingSegment) {
+        this.arrayHeaderSize = (int) TornadoNativeArray.ARRAY_HEADER;
+        this.baseIndex = arrayHeaderSize / BF16_BYTES;
+
+        // Calculate number of elements from segment size
+        long dataSize = existingSegment.byteSize() - arrayHeaderSize;
+        ensureMultipleOfElementSize(dataSize, BF16_BYTES);
+        this.numberOfElements = (int) (dataSize / BF16_BYTES);
+
+        // Set up the segment and initialize header
+        this.segmentByteSize = existingSegment.byteSize();
+        this.segment = new TornadoMemorySegment(existingSegment);
+        this.segment.getSegment().setAtIndex(JAVA_INT, 0, numberOfElements);
+    }
+
+    /**
+     * Constructs a new {@link BFloat16Array} instance by concatenating the contents of the given array of {@link BFloat16Array} instances.
+     *
+     * @param arrays
+     *         An array of {@link BFloat16Array} instances to be concatenated into the new instance.
+     */
+    public BFloat16Array(BFloat16Array... arrays) {
+        concat(arrays);
+    }
+
+    /**
+     * Creates a new {@link BFloat16Array} from an array of raw bfloat16 bit patterns.
+     *
+     * @param bits
+     *         The raw bfloat16 {@code short} values.
+     * @return A new {@link BFloat16Array} initialized with the given bits.
+     */
+    public static BFloat16Array fromShorts(short... bits) {
+        BFloat16Array array = new BFloat16Array(bits.length);
+        for (int i = 0; i < bits.length; i++) {
+            array.set(i, bits[i]);
+        }
+        return array;
+    }
+
+    /**
+     * Creates a new {@link BFloat16Array} from an array of float values, each encoded to its nearest bfloat16 bit pattern.
+     *
+     * @param values
+     *         The float values to encode.
+     * @return A new {@link BFloat16Array} initialized with the encoded values.
+     */
+    public static BFloat16Array fromFloats(float... values) {
+        BFloat16Array array = new BFloat16Array(values.length);
+        for (int i = 0; i < values.length; i++) {
+            array.setFloat(i, values[i]);
+        }
+        return array;
+    }
+
+    /**
+     * Creates a new instance of the {@link BFloat16Array} class from a {@link MemorySegment}.
+     *
+     * @param segment
+     *         The {@link MemorySegment} containing the off-heap bfloat16 data.
+     * @return A new {@link BFloat16Array} instance, initialized with the segment data.
+     */
+    public static BFloat16Array fromSegment(MemorySegment segment) {
+        long byteSize = segment.byteSize();
+        int numElements = (int) (byteSize / BF16_BYTES);
+        ensureMultipleOfElementSize(byteSize, BF16_BYTES);
+        BFloat16Array bfloat16Array = new BFloat16Array(numElements);
+        MemorySegment.copy(segment, 0, bfloat16Array.segment.getSegment(), (long) bfloat16Array.baseIndex * BF16_BYTES, byteSize);
+        return bfloat16Array;
+    }
+
+    /**
+     * Creates a new instance of the {@link BFloat16Array} class by wrapping an existing {@link MemorySegment} without copying its contents.
+     *
+     * @param segment
+     *         The {@link MemorySegment} containing *both* the off-heap bfloat16 *header* and *data*.
+     * @return A new {@link BFloat16Array} instance that wraps the given segment.
+     */
+    public static BFloat16Array fromSegmentShallow(MemorySegment segment) {
+        return new BFloat16Array(segment);
+    }
+
+    /**
+     * Concatenates multiple {@link BFloat16Array} instances into a single {@link BFloat16Array}.
+     *
+     * @param arrays
+     *         Variable number of {@link BFloat16Array} objects to be concatenated.
+     * @return A new {@link BFloat16Array} instance containing all the elements of the input arrays, concatenated in the order they were provided.
+     */
+    public static BFloat16Array concat(BFloat16Array... arrays) {
+        int newSize = Arrays.stream(arrays).mapToInt(BFloat16Array::getSize).sum();
+        BFloat16Array concatArray = new BFloat16Array(newSize);
+        long currentPositionBytes = 0;
+        for (BFloat16Array array : arrays) {
+            MemorySegment.copy(array.getSegment(), 0, concatArray.getSegment(), currentPositionBytes, array.getNumBytesOfSegment());
+            currentPositionBytes += array.getNumBytesOfSegment();
+        }
+        return concatArray;
+    }
+
+    /**
+     * Initializes all elements of a {@link BFloat16Array} with a raw bfloat16 bit pattern. This method can be invoked from a Task-Graph.
+     *
+     * @param array
+     *         Input array.
+     * @param bits
+     *         The raw bfloat16 bit pattern to broadcast.
+     */
+    public static void initialize(BFloat16Array array, short bits) {
+        for (@Parallel int i = 0; i < array.getSize(); i++) {
+            array.set(i, bits);
+        }
+    }
+
+    /**
+     * Copies the raw bfloat16 bit patterns of this array into a new on-heap {@code short} array.
+     *
+     * @return A new {@code short} array with the raw bfloat16 bits.
+     */
+    public short[] toShortArray() {
+        short[] outputArray = new short[getSize()];
+        for (int i = 0; i < getSize(); i++) {
+            outputArray[i] = get(i);
+        }
+        return outputArray;
+    }
+
+    /**
+     * Sets the raw bfloat16 bit pattern at a specified index.
+     *
+     * @param index
+     *         The index at which to set the value.
+     * @param bits
+     *         The raw bfloat16 {@code short} bit pattern.
+     */
+    public void set(int index, short bits) {
+        segment.setAtIndex(index, bits, baseIndex);
+    }
+
+    /**
+     * Gets the raw bfloat16 bit pattern stored at the specified index. Inside a device kernel this is
+     * decoded to float with the hardware-accelerated {@link BFloat16#bf16ToFloat(short)}.
+     *
+     * @param index
+     *         The index to retrieve.
+     * @return The raw bfloat16 {@code short} bit pattern at the given index.
+     */
+    public short get(int index) {
+        return segment.getShortAtIndex(index, baseIndex);
+    }
+
+    /**
+     * Host-side convenience: encodes a float to bfloat16 and stores it at the given index.
+     *
+     * @param index
+     *         The index at which to set the value.
+     * @param value
+     *         The float value to encode and store.
+     */
+    public void setFloat(int index, float value) {
+        segment.setAtIndex(index, BFloat16.bf16FromFloat(value), baseIndex);
+    }
+
+    /**
+     * Host-side convenience: reads the raw bfloat16 bits at the given index and decodes them to float.
+     *
+     * @param index
+     *         The index to retrieve.
+     * @return The decoded float value.
+     */
+    public float getFloat(int index) {
+        return BFloat16.bf16ToFloat(get(index));
+    }
+
+    /**
+     * Sets all the values of the {@link BFloat16Array} instance to zero.
+     */
+    @Override
+    public void clear() {
+        init((short) 0);
+    }
+
+    @Override
+    public int getElementSize() {
+        return BF16_BYTES;
+    }
+
+    /**
+     * Initializes all the elements of the {@link BFloat16Array} instance with a raw bfloat16 bit pattern.
+     *
+     * @param bits
+     *         The raw bfloat16 bit pattern.
+     */
+    public void init(short bits) {
+        for (int i = 0; i < getSize(); i++) {
+            segment.setAtIndex(i, bits, baseIndex);
+        }
+    }
+
+    /**
+     * Returns the number of bfloat16 elements stored in the {@link BFloat16Array} instance.
+     *
+     * @return The number of elements.
+     */
+    @Override
+    public int getSize() {
+        return numberOfElements;
+    }
+
+    /**
+     * Returns the underlying {@link MemorySegment} of the {@link BFloat16Array} instance.
+     *
+     * @return The {@link MemorySegment} associated with the {@link BFloat16Array} instance.
+     */
+    @Override
+    public MemorySegment getSegment() {
+        return segment.getSegment().asSlice(TornadoNativeArray.ARRAY_HEADER);
+    }
+
+    /**
+     * Returns the underlying {@link MemorySegment} of the {@link BFloat16Array} instance, including the header.
+     *
+     * @return The {@link MemorySegment} associated with the {@link BFloat16Array} instance.
+     */
+    @Override
+    public MemorySegment getSegmentWithHeader() {
+        return segment.getSegment();
+    }
+
+    /**
+     * Returns the total number of bytes that the {@link MemorySegment}, associated with the {@link BFloat16Array} instance, occupies.
+     *
+     * @return The total number of bytes of the {@link MemorySegment}.
+     */
+    @Override
+    public long getNumBytesOfSegmentWithHeader() {
+        return segmentByteSize;
+    }
+
+    /**
+     * Returns the number of bytes of the {@link MemorySegment} that is associated with the {@link BFloat16Array} instance, excluding the header bytes.
+     *
+     * @return The number of bytes of the raw data in the {@link MemorySegment}.
+     */
+    @Override
+    public long getNumBytesOfSegment() {
+        return segmentByteSize - TornadoNativeArray.ARRAY_HEADER;
+    }
+
+    /**
+     * Extracts a slice of elements from a given {@link BFloat16Array}, creating a new {@link BFloat16Array} instance.
+     *
+     * @param offset
+     *         The starting index from which to begin the slice, inclusive.
+     * @param length
+     *         The number of elements to include in the slice.
+     * @return A new {@link BFloat16Array} instance representing the specified slice of the original array.
+     * @throws IllegalArgumentException
+     *         if the specified slice is out of the bounds of the original array.
+     */
+    public BFloat16Array slice(int offset, int length) {
+        if (offset < 0 || length < 0 || offset + length > getSize()) {
+            throw new IllegalArgumentException("Slice out of bounds");
+        }
+
+        long sliceOffsetInBytes = TornadoNativeArray.ARRAY_HEADER + (long) offset * BF16_BYTES;
+        long sliceByteLength = (long) length * BF16_BYTES;
+        MemorySegment sliceSegment = segment.getSegment().asSlice(sliceOffsetInBytes, sliceByteLength);
+        BFloat16Array slice = fromSegment(sliceSegment);
+        return slice;
+    }
+
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/TornadoNativeArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/TornadoNativeArray.java
@@ -38,7 +38,7 @@ import static java.lang.String.format;
 public abstract sealed class TornadoNativeArray //
         permits ByteArray, CharArray, DoubleArray, //
         FloatArray, HalfFloatArray, IntArray, //
-        LongArray, ShortArray, Int8Array, FP8Array {
+        LongArray, ShortArray, Int8Array, FP8Array, BFloat16Array {
 
     /**
      * The size of the header in bytes. It sets the default value either to 16 or 24, depending on whether the uncompressed flags are passed by the user. It can also be configurable through the

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/CuBlas.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/CuBlas.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.LibraryTaskDescriptor;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.cublas.enums.CuBlasMathMode;
 
@@ -273,6 +274,32 @@ public final class CuBlas {
         return new LibraryTaskDescriptor() //
                 .withLibrary(LIBRARY_NAME) //
                 .withFunction("cublasGemmExFP16FP32") //
+                .withParameters(new Object[] { transa, transb, m, n, k, alpha, matrixA, lda, matrixB, ldb, beta, matrixC, ldc }) //
+                .withAccess(readOnlyExcept(13, 11, beta));
+    }
+
+    /**
+     * Mixed-precision matrix-matrix multiplication via {@code cublasGemmEx}:
+     * bfloat16 inputs and output, FP32 accumulation ({@code CUBLAS_COMPUTE_32F})
+     * on Tensor Cores. BF16 keeps FP32's exponent range (no {@code +-65504}
+     * overflow boundary), which is why LLM inference/training favours it over FP16.
+     */
+    public static LibraryTaskDescriptor cublasGemmExBF16(int transa, //
+            int transb, //
+            int m, //
+            int n, //
+            int k, //
+            float alpha, //
+            BFloat16Array matrixA, //
+            int lda, //
+            BFloat16Array matrixB, //
+            int ldb, //
+            float beta, //
+            BFloat16Array matrixC, //
+            int ldc) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("cublasGemmExBF16") //
                 .withParameters(new Object[] { transa, transb, m, n, k, alpha, matrixA, lda, matrixB, ldb, beta, matrixC, ldc }) //
                 .withAccess(readOnlyExcept(13, 11, beta));
     }

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLibraryProvider.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLibraryProvider.java
@@ -69,7 +69,8 @@ public final class CuBlasLibraryProvider implements TornadoLibraryProvider {
             "cublasSgemm", CuBlasLibraryProvider::sgemm, //
             "cublasSgemmStridedBatched", CuBlasLibraryProvider::sgemmStridedBatched, //
             "cublasGemmExFP16", (handle, inv) -> gemmEx(handle, inv, CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_16F), //
-            "cublasGemmExFP16FP32", (handle, inv) -> gemmEx(handle, inv, CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_32F));
+            "cublasGemmExFP16FP32", (handle, inv) -> gemmEx(handle, inv, CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_32F), //
+            "cublasGemmExBF16", (handle, inv) -> gemmEx(handle, inv, CudaDataType.CUDA_R_16BF, CudaDataType.CUDA_R_16BF));
 
     /** cublasGemmAlgo_t CUBLAS_GEMM_DEFAULT: heuristic algorithm selection. */
     private static final int CUBLAS_GEMM_DEFAULT = -1;

--- a/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/Cutlass.java
+++ b/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/Cutlass.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.LibraryTaskDescriptor;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 
@@ -88,6 +89,25 @@ public final class Cutlass {
                 .withLibrary(LIBRARY_NAME) //
                 .withFunction("cutlassHgemm") //
                 .withParameters(new Object[] { m, n, k, alpha, a, b, beta, d }) //
+                .withAccess(access);
+    }
+
+    /**
+     * BF16 tensor-core GEMM (FP32 accumulate): {@code C = alpha * A * B + beta * C},
+     * all operands row-major bfloat16 ({@link BFloat16Array}). Requires
+     * {@code k, n} multiples of 4 (same 8-byte operand alignment as FP16). BF16
+     * keeps FP32's exponent range and is the standard LLM datatype; it runs on the
+     * tensor cores at FP16 throughput on Ampere (sm_80) and later.
+     */
+    public static LibraryTaskDescriptor cutlassBgemm(int m, int n, int k, float alpha, BFloat16Array a, BFloat16Array b, float beta, BFloat16Array c) {
+        checkHalfShape(n, k);
+        Access[] access = new Access[8];
+        Arrays.fill(access, Access.READ_ONLY);
+        access[7] = (beta == 0.0f) ? Access.WRITE_ONLY : Access.READ_WRITE;
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("cutlassBgemm") //
+                .withParameters(new Object[] { m, n, k, alpha, a, b, beta, c }) //
                 .withAccess(access);
     }
 

--- a/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/provider/CutlassLibraryProvider.java
+++ b/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/provider/CutlassLibraryProvider.java
@@ -92,6 +92,7 @@ public final class CutlassLibraryProvider implements TornadoLibraryProvider {
         switch (descriptor.getFunctionName()) {
             case "cutlassSgemm" -> ctx.growWorkspace(CutlassNativeLib.sgemmWorkspace(m, n, k));
             case "cutlassHgemm" -> ctx.growWorkspace(CutlassNativeLib.hgemmWorkspace(m, n, k));
+            case "cutlassBgemm" -> ctx.growWorkspace(CutlassNativeLib.bgemmWorkspace(m, n, k));
             case "cutlassGemmBiasRelu" -> ctx.growWorkspace(CutlassNativeLib.gemmBiasReluWorkspace(m, n, k));
             case "cutlassGemmBiasGelu" -> ctx.growWorkspace(CutlassNativeLib.gemmBiasGeluWorkspace(m, n, k));
             default -> {
@@ -112,6 +113,12 @@ public final class CutlassLibraryProvider implements TornadoLibraryProvider {
                     context.workspacePtr, context.stream);
             // (m, n, k, alpha, a, b, beta, d)
             case "cutlassHgemm" -> CutlassNativeLib.hgemm((int) invocation.getArg(0), (int) invocation.getArg(1), (int) invocation.getArg(2), //
+                    (float) invocation.getArg(3), //
+                    invocation.getDevicePointer(4), invocation.getDevicePointer(5), //
+                    (float) invocation.getArg(6), invocation.getDevicePointer(7), //
+                    context.workspacePtr, context.stream);
+            // (m, n, k, alpha, a, b, beta, c)
+            case "cutlassBgemm" -> CutlassNativeLib.bgemm((int) invocation.getArg(0), (int) invocation.getArg(1), (int) invocation.getArg(2), //
                     (float) invocation.getArg(3), //
                     invocation.getDevicePointer(4), invocation.getDevicePointer(5), //
                     (float) invocation.getArg(6), invocation.getDevicePointer(7), //

--- a/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/provider/CutlassNativeLib.java
+++ b/tornado-cutlass/src/main/java/uk/ac/manchester/tornado/cutlass/provider/CutlassNativeLib.java
@@ -55,6 +55,11 @@ final class CutlassNativeLib {
     /** Row-major FP16 tensor-core GEMM (FP32 accumulate): D = alpha*A*B + beta*D. */
     static native int hgemm(int m, int n, int k, float alpha, long dA, long dB, float beta, long dD, long workspace, long stream);
 
+    static native long bgemmWorkspace(int m, int n, int k);
+
+    /** Row-major BF16 tensor-core GEMM (FP32 accumulate): C = alpha*A*B + beta*C. */
+    static native int bgemm(int m, int n, int k, float alpha, long dA, long dB, float beta, long dC, long workspace, long stream);
+
     static native long gemmBiasReluWorkspace(int m, int n, int k);
 
     /** Fused FP16 D = relu(A*B + bias); bias is a length-n row vector (broadcast). */

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAGraphBuilderPlugins.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAGraphBuilderPlugins.java
@@ -102,6 +102,7 @@ import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.Dp4aNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.LocalArrayNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDABarrierNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAConvertBF16ToFloat;
+import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAConvertFloatToBF16;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAConvertFP8ToFloat;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDACpAsyncCommitGroupNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDACpAsyncCopyNode;
@@ -1004,6 +1005,16 @@ public class CUDAGraphBuilderPlugins {
                 CUDAConvertBF16ToFloat convert = new CUDAConvertBF16ToFloat(bits);
                 b.getGraph().addOrUnique(convert);
                 b.push(JavaKind.Float, convert);
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("bf16FromFloat", float.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                CUDAConvertFloatToBF16 convert = new CUDAConvertFloatToBF16(value);
+                b.getGraph().addOrUnique(convert);
+                b.push(JavaKind.Short, convert);
                 return true;
             }
         });

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAKind.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAKind.java
@@ -105,6 +105,7 @@ public enum CUDAKind implements PlatformKind {
     LONG(8, java.lang.Long.TYPE),
     ULONG(8, null),
     HALF(2, java.lang.Short.TYPE),
+    BF16(2, java.lang.Short.TYPE),
     FP8_E4M3(1, null),
     FP8_E5M2(1, null),
     FLOAT(4, java.lang.Float.TYPE),

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
@@ -462,6 +462,49 @@ public class CUDALIRStmt {
 
     }
 
+    @Opcode("CONVERT_FLOAT_TO_BF16")
+    public static class ConvertFloatToBF16Stmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<ConvertFloatToBF16Stmt> TYPE = LIRInstructionClass.create(ConvertFloatToBF16Stmt.class);
+
+        @Def
+        protected Value bf16Bits;
+        @Use
+        protected Value floatValue;
+
+        public ConvertFloatToBF16Stmt(Value bf16Bits, Value floatValue) {
+            super(TYPE);
+            this.bf16Bits = bf16Bits;
+            this.floatValue = floatValue;
+        }
+
+        @Override
+        public void emitCode(CUDACompilationResultBuilder crb, CUDAAssembler asm) {
+            // bf16 is the high half of the f32 bit pattern. Encode = round-to-nearest-even of
+            // the discarded low 16 bits, then truncate. Header-free: __float_as_uint is a core
+            // CUDA builtin (no cuda_bf16.h). NaN is forced to a canonical quiet NaN (0x7FC0)
+            // since the additive rounding would otherwise perturb its payload.
+            // s = isnan(f) ? 0x7FC0 : (short)((u + 0x7FFF + ((u >> 16) & 1)) >> 16), u=__float_as_uint(f)
+            asm.indent();
+            asm.emitValue(crb, bf16Bits);
+            asm.space();
+            asm.assign();
+            asm.space();
+            asm.emit("(");
+            asm.emitValue(crb, floatValue);
+            asm.emit(" != ");
+            asm.emitValue(crb, floatValue);
+            asm.emit(") ? (short) 0x7FC0 : (short) ((__float_as_uint(");
+            asm.emitValue(crb, floatValue);
+            asm.emit(") + 0x7FFFU + ((__float_as_uint(");
+            asm.emitValue(crb, floatValue);
+            asm.emit(") >> 16) & 1U)) >> 16)");
+            asm.delimiter();
+            asm.eol();
+        }
+
+    }
+
     @Opcode("CONVERT_FLOAT_TO_HALF")
     public static class ConvertFloatToHalfStmt extends AbstractInstruction {
 

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/nodes/CUDAConvertFloatToBF16.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/nodes/CUDAConvertFloatToBF16.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.cuda.graal.nodes;
+
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDAKind;
+import uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDALIRStmt;
+
+/**
+ * Native {@code float} to bfloat16 (raw bits in a {@code short}) conversion: bf16 is the high
+ * half of the f32 bit pattern, so the encode is a round-to-nearest-even of the low 16 bits
+ * followed by a truncation - emitted as one header-free expression over the {@code __float_as_uint}
+ * core builtin (no cuda_bf16.h). Replaces the software arithmetic encode of
+ * {@code BFloat16#bf16FromFloat} inside CUDA kernels (which inlines two 160-iteration
+ * normalisation loops per element); other backends keep inlining the Java encoder. Mirrors
+ * {@link CUDAConvertBF16ToFloat}.
+ *
+ * <p>The hardware path rounds ties to even, whereas the software {@code BFloat16} encoder rounds
+ * ties half away from zero, so the two can differ by one ULP on an exact tie.</p>
+ */
+@NodeInfo
+public class CUDAConvertFloatToBF16 extends ValueNode implements LIRLowerable {
+
+    public static final NodeClass<CUDAConvertFloatToBF16> TYPE = NodeClass.create(CUDAConvertFloatToBF16.class);
+
+    @Input
+    private ValueNode floatNode;
+
+    public CUDAConvertFloatToBF16(ValueNode floatNode) {
+        super(TYPE, StampFactory.forKind(JavaKind.Short));
+        this.floatNode = floatNode;
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool generator) {
+        LIRGeneratorTool tool = generator.getLIRGeneratorTool();
+        Variable bf16Bits = tool.newVariable(LIRKind.value(CUDAKind.SHORT));
+        Value floatValue = generator.operand(floatNode);
+        tool.append(new CUDALIRStmt.ConvertFloatToBF16Stmt(bf16Bits, floatValue));
+        generator.setResult(this, bf16Bits);
+    }
+}

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAFieldBuffer.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAFieldBuffer.java
@@ -49,6 +49,7 @@ import uk.ac.manchester.tornado.api.memory.XPUBuffer;
 import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.arrays.LongArray;
@@ -155,6 +156,10 @@ public class CUDAFieldBuffer implements XPUBuffer {
                 Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
                 long size = ((HalfFloatArray) objectFromField).getSegmentWithHeader().byteSize();
                 wrappedField = new CUDAMemorySegmentWrapper(size, device, 0, access, CUDAKind.SHORT.getSizeInBytes());
+            } else if (type == BFloat16Array.class) {
+                Object objectFromField = TornadoUtils.getObjectFromField(reflectedField, object);
+                long size = ((BFloat16Array) objectFromField).getSegmentWithHeader().byteSize();
+                wrappedField = new CUDAMemorySegmentWrapper(size, device, 0, access, CUDAKind.BF16.getSizeInBytes());
             } else if (object.getClass().getAnnotation(Vector.class) != null) {
                 wrappedField = new CUDAVectorWrapper(device, object, 0, access);
             } else if (field.getJavaKind().isObject()) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAVectorWrapper.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAVectorWrapper.java
@@ -42,6 +42,7 @@ import uk.ac.manchester.tornado.api.types.arrays.ByteArray;
 import uk.ac.manchester.tornado.api.types.arrays.CharArray;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.arrays.LongArray;
@@ -347,7 +348,7 @@ public class CUDAVectorWrapper implements XPUBuffer {
             } else {
                 warn("cannot wrap field: array type=%s", type.getName());
             }
-        } else if (type == FloatArray.class || type == IntArray.class || type == DoubleArray.class || type == LongArray.class || type == ShortArray.class || type == CharArray.class || type == ByteArray.class || type == HalfFloatArray.class) {
+        } else if (type == FloatArray.class || type == IntArray.class || type == DoubleArray.class || type == LongArray.class || type == ShortArray.class || type == CharArray.class || type == ByteArray.class || type == HalfFloatArray.class || type == BFloat16Array.class) {
             return JavaKind.Object;
         } else {
             TornadoInternalError.shouldNotReachHere("The type should be an array, but found: " + type);

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/runtime/CUDATornadoDevice.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/runtime/CUDATornadoDevice.java
@@ -59,6 +59,7 @@ import uk.ac.manchester.tornado.api.types.arrays.CharArray;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.FP8Array;
 import uk.ac.manchester.tornado.api.types.arrays.Int8Array;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
@@ -560,6 +561,8 @@ public class CUDATornadoDevice implements TornadoXPUDevice, TornadoNativeStreamS
                 result = new CUDAMemorySegmentWrapper(deviceContext, batchSize, access, CUDAKind.CHAR.getSizeInBytes());
             } else if (object instanceof HalfFloatArray) {
                 result = new CUDAMemorySegmentWrapper(deviceContext, batchSize, access, CUDAKind.HALF.getSizeInBytes());
+            } else if (object instanceof BFloat16Array) {
+                result = new CUDAMemorySegmentWrapper(deviceContext, batchSize, access, CUDAKind.BF16.getSizeInBytes());
             } else if (object instanceof Int8Array) {
                 result = new CUDAMemorySegmentWrapper(deviceContext, batchSize, access, CUDAKind.CHAR.getSizeInBytes());
             } else if (object instanceof FP8Array) {

--- a/tornado-drivers/cutlass-jni/src/main/cpp/source/tornado-cutlass.cu
+++ b/tornado-drivers/cutlass-jni/src/main/cpp/source/tornado-cutlass.cu
@@ -39,6 +39,7 @@
 #include <cutlass/gemm/gemm.h>
 #include <cutlass/layout/matrix.h>
 #include <cutlass/numeric_types.h>
+#include <cutlass/bfloat16.h>
 #include <cutlass/epilogue/thread/linear_combination.h>
 #include <cutlass/epilogue/thread/linear_combination_relu.h>
 #include <cutlass/epilogue/thread/linear_combination_gelu.h>
@@ -94,6 +95,21 @@ using HgemmTensor = HalfTensorOpGemm<
         cutlass::epilogue::thread::LinearCombination<ElementHalf, kAlign, ElementAccum, ElementCompute>>;
 using GemmBiasRelu = HalfTensorOpGemm<
         cutlass::epilogue::thread::LinearCombinationRelu<ElementHalf, kAlign, ElementAccum, ElementCompute>>;
+// BF16 tensor-core GEMM (FP32 accumulate). Same MMA shapes and 4-element (8-byte)
+// operand alignment as the FP16 path - bfloat16 is also 2 bytes, so the k/n
+// multiple-of-4 constraint is identical. BF16 keeps FP32's exponent range and is
+// the de-facto LLM datatype; Ampere (sm_80) and later run it on the tensor cores
+// at FP16 throughput.
+using ElementBF16 = cutlass::bfloat16_t;
+using BF16TensorOpGemm = cutlass::gemm::device::GemmUniversal<
+        ElementBF16, cutlass::layout::RowMajor,
+        ElementBF16, cutlass::layout::RowMajor,
+        ElementBF16, cutlass::layout::RowMajor,
+        ElementAccum, cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80,
+        ThreadblockShape, WarpShape, InstructionShape,
+        cutlass::epilogue::thread::LinearCombination<ElementBF16, kAlign, ElementAccum, ElementCompute>,
+        Swizzle, kStages, kAlign, kAlign>;
+
 using GemmBiasGelu = HalfTensorOpGemm<
         cutlass::epilogue::thread::LinearCombinationGELU<ElementHalf, kAlign, ElementAccum, ElementCompute>>;
 
@@ -198,6 +214,34 @@ JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNat
             (void const *) dA, (void const *) dB, (void const *) dC, (void *) dC,
             0, 0, 0, 0, k, n, n, n);
     return runGemm<HgemmTensor>(args, (void *) workspace, (cudaStream_t) stream);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    bgemmWorkspace
+ * Signature: (III)J
+ */
+JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_bgemmWorkspace
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k) {
+    BF16TensorOpGemm::Arguments args(
+            cutlass::gemm::GemmUniversalMode::kGemm, {m, n, k}, 1, {1.0f, 0.0f},
+            nullptr, nullptr, nullptr, nullptr, 0, 0, 0, 0, k, n, n, n);
+    return (jlong) BF16TensorOpGemm::get_workspace_size(args);
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib
+ * Method:    bgemm
+ * Signature: (IIIFJJFJJJ)I
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_cutlass_provider_CutlassNativeLib_bgemm
+        (JNIEnv *env, jclass clazz, jint m, jint n, jint k, jfloat alpha,
+         jlong dA, jlong dB, jfloat beta, jlong dC, jlong workspace, jlong stream) {
+    BF16TensorOpGemm::Arguments args(
+            cutlass::gemm::GemmUniversalMode::kGemm, {m, n, k}, 1, {alpha, beta},
+            (void const *) dA, (void const *) dB, (void const *) dC, (void *) dC,
+            0, 0, 0, 0, k, n, n, n);
+    return runGemm<BF16TensorOpGemm>(args, (void *) workspace, (cudaStream_t) stream);
 }
 
 /*

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestBFloat16.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestBFloat16.java
@@ -30,6 +30,7 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.BFloat16;
+import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
@@ -61,6 +62,20 @@ public class TestBFloat16 extends TornadoTestBase {
     public static void decodeBF16(ShortArray in, FloatArray out) {
         for (@Parallel int i = 0; i < out.getSize(); i++) {
             out.set(i, BFloat16.bf16ToFloat(in.get(i)));
+        }
+    }
+
+    /** Kernel: decode a typed {@link BFloat16Array} to float on the device. */
+    public static void decodeBFloat16Array(BFloat16Array in, FloatArray out) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, BFloat16.bf16ToFloat(in.get(i)));
+        }
+    }
+
+    /** Kernel: full bfloat16 round trip - read, decode, scale, re-encode, write - all in {@link BFloat16Array}. */
+    public static void scaleBFloat16Array(BFloat16Array in, BFloat16Array out) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, BFloat16.bf16FromFloat(BFloat16.bf16ToFloat(in.get(i)) * 2.0f));
         }
     }
 
@@ -158,6 +173,55 @@ public class TestBFloat16 extends TornadoTestBase {
         for (int i = 0; i < values.length; i++) {
             // Device output must match the host decode of the same bf16 bits, exactly.
             assertEquals(BFloat16.bf16ToFloat(in.get(i)), out.get(i), 0.0f);
+        }
+    }
+
+    @Test
+    public void testBFloat16ArrayDecodeOnDevice() throws TornadoExecutionPlanException {
+        assumeCudaBackend();
+        float[] values = { 0.0f, 1.0f, -1.0f, 0.5f, 2.0f, -3.5f, 0.125f, 100.0f, -0.25f, 3.0e38f, 1.0e-38f, -7.75f };
+        BFloat16Array in = BFloat16Array.fromFloats(values);
+        FloatArray out = new FloatArray(values.length);
+
+        TaskGraph tg = new TaskGraph("bfa0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, in) //
+                .task("t0", TestBFloat16::decodeBFloat16Array, in, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.execute();
+        }
+        for (int i = 0; i < values.length; i++) {
+            assertEquals(in.getFloat(i), out.get(i), 0.0f);
+        }
+    }
+
+    /**
+     * Full on-device bfloat16 round trip through the typed {@link BFloat16Array}: the kernel reads
+     * a bf16 element, decodes it to float (hardware {@code __int_as_float} node), scales, re-encodes
+     * to bf16 (software encoder) and writes it back to a bf16 array.
+     */
+    @Test
+    public void testBFloat16ArrayScaleOnDevice() throws TornadoExecutionPlanException {
+        assumeCudaBackend();
+        int n = 256;
+        java.util.Random rng = new java.util.Random(11);
+        BFloat16Array in = new BFloat16Array(n);
+        for (int i = 0; i < n; i++) {
+            in.setFloat(i, (rng.nextFloat() - 0.5f) * 10.0f);
+        }
+        BFloat16Array out = new BFloat16Array(n);
+
+        TaskGraph tg = new TaskGraph("bfa1") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, in) //
+                .task("t0", TestBFloat16::scaleBFloat16Array, in, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.execute();
+        }
+        for (int i = 0; i < n; i++) {
+            // Reference: same decode/scale/encode on the host.
+            short expected = BFloat16.bf16FromFloat(in.getFloat(i) * 2.0f);
+            assertEquals(BFloat16.bf16ToFloat(expected), out.getFloat(i), 0.0f);
         }
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestBFloat16.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestBFloat16.java
@@ -30,8 +30,10 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.BFloat16;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 import uk.ac.manchester.tornado.unittests.common.TornadoVMCUDANotSupported;
@@ -76,6 +78,27 @@ public class TestBFloat16 extends TornadoTestBase {
     public static void scaleBFloat16Array(BFloat16Array in, BFloat16Array out) {
         for (@Parallel int i = 0; i < out.getSize(); i++) {
             out.set(i, BFloat16.bf16FromFloat(BFloat16.bf16ToFloat(in.get(i)) * 2.0f));
+        }
+    }
+
+    /** Mixed precision kernel: {@code out(fp32) = a * x(bf16) + y(fp32)}. bf16 decode + FP32 math. */
+    public static void mixedAxpyBF16(BFloat16Array x, FloatArray y, FloatArray out, float a) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, a * BFloat16.bf16ToFloat(x.get(i)) + y.get(i));
+        }
+    }
+
+    /** Mixed precision kernel: sum a bf16 operand and an fp16 operand into fp32 (both decoded on device). */
+    public static void mixedBf16Fp16(BFloat16Array a, HalfFloatArray b, FloatArray out) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, BFloat16.bf16ToFloat(a.get(i)) + b.get(i).getFloat32());
+        }
+    }
+
+    /** Mixed precision kernel: fp16 -&gt; bf16. Decodes an FP16 {@link HalfFloatArray} to float, encodes as bf16. */
+    public static void fp16ToBf16(HalfFloatArray in, BFloat16Array out) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, BFloat16.bf16FromFloat(in.get(i).getFloat32()));
         }
     }
 
@@ -219,9 +242,90 @@ public class TestBFloat16 extends TornadoTestBase {
             plan.execute();
         }
         for (int i = 0; i < n; i++) {
-            // Reference: same decode/scale/encode on the host.
-            short expected = BFloat16.bf16FromFloat(in.getFloat(i) * 2.0f);
-            assertEquals(BFloat16.bf16ToFloat(expected), out.getFloat(i), 0.0f);
+            // The device encoder rounds ties to even (hardware node) while the host BFloat16
+            // encoder rounds half away from zero, so allow one bfloat16 step (1/128 relative).
+            float ref = in.getFloat(i) * 2.0f;
+            float tol = Math.max(1e-38f, Math.abs(ref) / 128.0f);
+            assertEquals(ref, out.getFloat(i), tol);
+        }
+    }
+
+    @Test
+    public void testMixedAxpyBF16OnDevice() throws TornadoExecutionPlanException {
+        assumeCudaBackend();
+        int n = 256;
+        java.util.Random rng = new java.util.Random(3);
+        BFloat16Array x = new BFloat16Array(n);
+        FloatArray y = new FloatArray(n);
+        FloatArray out = new FloatArray(n);
+        for (int i = 0; i < n; i++) {
+            x.setFloat(i, (rng.nextFloat() - 0.5f) * 4.0f);
+            y.set(i, rng.nextFloat() - 0.5f);
+        }
+        final float a = 3.0f;
+
+        TaskGraph tg = new TaskGraph("mix0") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, x, y) //
+                .task("t0", TestBFloat16::mixedAxpyBF16, x, y, out, a) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.execute();
+        }
+        for (int i = 0; i < n; i++) {
+            float expected = a * x.getFloat(i) + y.get(i);
+            assertEquals(expected, out.get(i), 1e-4f * Math.max(1.0f, Math.abs(expected)));
+        }
+    }
+
+    @Test
+    public void testMixedBf16Fp16OnDevice() throws TornadoExecutionPlanException {
+        assumeCudaBackend();
+        int n = 256;
+        java.util.Random rng = new java.util.Random(5);
+        BFloat16Array a = new BFloat16Array(n);
+        HalfFloatArray b = new HalfFloatArray(n);
+        FloatArray out = new FloatArray(n);
+        for (int i = 0; i < n; i++) {
+            a.setFloat(i, (rng.nextFloat() - 0.5f) * 8.0f);
+            b.set(i, new HalfFloat((rng.nextFloat() - 0.5f) * 8.0f));
+        }
+
+        TaskGraph tg = new TaskGraph("mix1") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("t0", TestBFloat16::mixedBf16Fp16, a, b, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.execute();
+        }
+        for (int i = 0; i < n; i++) {
+            float expected = a.getFloat(i) + b.get(i).getFloat32();
+            assertEquals(expected, out.get(i), 1e-3f * Math.max(1.0f, Math.abs(expected)));
+        }
+    }
+
+    @Test
+    public void testFp16ToBf16OnDevice() throws TornadoExecutionPlanException {
+        assumeCudaBackend();
+        int n = 256;
+        java.util.Random rng = new java.util.Random(6);
+        HalfFloatArray in = new HalfFloatArray(n);
+        for (int i = 0; i < n; i++) {
+            in.set(i, new HalfFloat((rng.nextFloat() - 0.5f) * 8.0f));
+        }
+        BFloat16Array out = new BFloat16Array(n);
+
+        TaskGraph tg = new TaskGraph("mix2") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, in) //
+                .task("t0", TestBFloat16::fp16ToBf16, in, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.execute();
+        }
+        for (int i = 0; i < n; i++) {
+            // fp16 value re-encoded to bf16: within one bf16 step (1/128 relative).
+            float ref = in.get(i).getFloat32();
+            float tol = Math.max(1e-38f, Math.abs(ref) / 128.0f);
+            assertEquals(ref, out.getFloat(i), tol);
         }
     }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlas.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlas.java
@@ -31,6 +31,7 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.cublas.CuBlas;
@@ -272,6 +273,39 @@ public class TestCuBlas extends TornadoTestBase {
                     sum += matrixA.get(i * SIZE + p).getFloat32() * matrixB.get(p * SIZE + j).getFloat32();
                 }
                 assertEquals(sum, matrixC.get(i * SIZE + j).getFloat32(), 2e-3f * Math.max(1.0f, Math.abs(sum)));
+            }
+        }
+    }
+
+    @Test
+    public void testGemmExBF16() throws TornadoExecutionPlanException {
+        BFloat16Array matrixA = new BFloat16Array(SIZE * SIZE);
+        BFloat16Array matrixB = new BFloat16Array(SIZE * SIZE);
+        BFloat16Array matrixC = new BFloat16Array(SIZE * SIZE);
+        for (int i = 0; i < SIZE * SIZE; i++) {
+            matrixA.setFloat(i, random.nextFloat());
+            matrixB.setFloat(i, random.nextFloat());
+        }
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, matrixA, matrixB) //
+                .libraryTask("gemmEx", CuBlas::cublasGemmExBF16, //
+                        CuBlasOperation.CUBLAS_OP_N.operation(), CuBlasOperation.CUBLAS_OP_N.operation(), //
+                        SIZE, SIZE, SIZE, 1.0f, matrixB, SIZE, matrixA, SIZE, 0.0f, matrixC, SIZE) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+
+        // bfloat16 inputs, FP32 Tensor Core accumulation: 7 mantissa bits give a looser bound.
+        for (int i = 0; i < SIZE; i++) {
+            for (int j = 0; j < SIZE; j++) {
+                float sum = 0.0f;
+                for (int p = 0; p < SIZE; p++) {
+                    sum += matrixA.getFloat(i * SIZE + p) * matrixB.getFloat(p * SIZE + j);
+                }
+                assertEquals(sum, matrixC.getFloat(i * SIZE + j), 6e-2f * Math.max(1.0f, Math.abs(sum)));
             }
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cutlass/TestCutlass.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cutlass/TestCutlass.java
@@ -33,6 +33,7 @@ import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.cutlass.Cutlass;
@@ -243,6 +244,58 @@ public class TestCutlass extends TornadoTestBase {
         }
         for (int i = 0; i < m * n; i++) {
             assertEquals(expected[i], d.get(i).getFloat32(), 2e-2f * Math.max(1.0f, Math.abs(expected[i])));
+        }
+    }
+
+    private static BFloat16Array randomBFloat16Array(int size) {
+        BFloat16Array array = new BFloat16Array(size);
+        for (int i = 0; i < size; i++) {
+            array.setFloat(i, random.nextFloat() - 0.5f);
+        }
+        return array;
+    }
+
+    /** Row-major reference GEMM over the BF16 inputs, accumulated in float. */
+    private static void bgemmJava(int m, int n, int k, BFloat16Array a, BFloat16Array b, float[] out) {
+        for (int i = 0; i < m; i++) {
+            for (int j = 0; j < n; j++) {
+                float acc = 0.0f;
+                for (int p = 0; p < k; p++) {
+                    acc += a.getFloat(i * k + p) * b.getFloat(p * n + j);
+                }
+                out[i * n + j] = acc;
+            }
+        }
+    }
+
+    /**
+     * End-to-end BF16: host {@code float -> bfloat16}, device transfer, CUTLASS
+     * bfloat16 tensor-core GEMM, {@code bfloat16 -> float} readback, checked against
+     * an FP32 reference. Exercises the {@link BFloat16Array} interop path on CUDA.
+     */
+    @Test
+    public void testBgemm() throws TornadoExecutionPlanException {
+        final int m = 128;
+        final int n = 96;
+        final int k = 64;
+        BFloat16Array a = randomBFloat16Array(m * k);
+        BFloat16Array b = randomBFloat16Array(k * n);
+        BFloat16Array c = new BFloat16Array(m * n);
+
+        float[] expected = new float[m * n];
+        bgemmJava(m, n, k, a, b, expected);
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .libraryTask("bgemm", Cutlass::cutlassBgemm, m, n, k, 1.0f, a, b, 0.0f, c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+        // bfloat16 has 7 mantissa bits, so the tolerance is looser than the FP16 path.
+        for (int i = 0; i < m * n; i++) {
+            assertEquals(expected[i], c.getFloat(i), 5e-2f * Math.max(1.0f, Math.abs(expected[i])));
         }
     }
 


### PR DESCRIPTION
## What

Adds a first-class **bfloat16 native array** (`BFloat16Array`) for the CUDA backend, on top of the existing `BFloat16` scalar codec, and wires it through JIT codegen and the hybrid GEMM providers.

Closes #966 (scoped to the CUDA backend; other backends tracked there).

### API
- **`BFloat16Array`** — 2-byte native array (sealed `TornadoNativeArray` permit), mirrors `HalfFloatArray`. `get`/`set` move the raw bf16 `short` bits (so a kernel decodes with the hardware plugin); `getFloat`/`setFloat` are host float conveniences; `fromFloats`/`fromShorts`/`slice`/`concat`.

### JIT codegen (CUDA)
- **Decode** `BFloat16.bf16ToFloat(short)` → `__int_as_float(bits << 16)` (pre-existing).
- **Encode** `BFloat16.bf16FromFloat(float)` → **new** `CUDAConvertFloatToBF16` node → one header-free round-to-nearest-even expression over `__float_as_uint` (NaN → `0x7FC0`). Previously the software encoder was inlined as two 160-iteration loops per element; the `scaleBFloat16Array` kernel drops **198 → 36 lines**. Both scalar conversions are now single-instruction. In-kernel arithmetic stays in float (header-free, no `cuda_bf16.h`); MMA bf16 tensor-core already existed.
- Interop: `CUDAKind.BF16` + `BFloat16Array` dispatch in `CUDATornadoDevice`/`CUDAFieldBuffer`/`CUDAVectorWrapper`.

### Hybrid providers
- **CUTLASS** `Cutlass.cutlassBgemm` — bfloat16 tensor-core GEMM (`GemmUniversal`, FP32 accumulate).
- **cuBLAS** `CuBlas.cublasGemmExBF16` — `cublasGemmEx` with `CUDA_R_16BF`, FP32 Tensor Core accumulate (native is datatype-generic, so Java-only).

## How to run

```bash
make BACKEND=cuda

tornado-test -V uk.ac.manchester.tornado.unittests.arrays.TestBFloat16
tornado-test -V uk.ac.manchester.tornado.unittests.cutlass.TestCutlass
tornado-test -V uk.ac.manchester.tornado.unittests.cublas.TestCuBlas
```

Inspect the generated bf16 kernels (hardware decode/encode):

```bash
tornado --printKernel -m tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner \
    uk.ac.manchester.tornado.unittests.arrays.TestBFloat16#testBFloat16ArrayScaleOnDevice
```

## Tests (RTX 4090, sm_89)

- `TestBFloat16` **12/12** — on-device decode/scale of a `BFloat16Array`; full read→decode→scale→encode→write round trip; mixed precision (`bf16+fp32` axpy, `bf16+fp16`→fp32, `fp16→bf16`).
- `TestCutlass` **19/19** — `testBgemm` (bf16 tensor-core GEMM).
- `TestCuBlas` **12/12** — `testGemmExBF16` (bf16 mixed-precision GEMM).

## Notes / follow-ups

- Scope is the **CUDA backend only** (as requested). OpenCL/PTX/Metal/SPIRV bf16, vector bf16 types, and cuBLASLt/cuDNN bf16 remain in #966.
- The device encoder rounds ties to even (hardware) while the host `BFloat16` software encoder rounds half away from zero, so the two can differ by one ULP on an exact tie.
- While adding mixed-precision tests I hit a pre-existing **FP16** limitation (unrelated to bf16): constructing `new HalfFloat(f)` inside a kernel fails with `GraalError: node is not LIRLowerable: NewHalfFloatInstance`. Fixed in a follow-up PR.