### PR TITLE
[cuda] Fix HalfFloat codegen for inline new HalfFloat(computedExpr) writes

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -138,6 +138,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.arrays.TestArrays"),
     TestEntry("uk.ac.manchester.tornado.unittests.arrays.TestFP8"),
     TestEntry("uk.ac.manchester.tornado.unittests.arrays.TestBFloat16"),
+    TestEntry("uk.ac.manchester.tornado.unittests.arrays.TestHalfFloatInlineWrite"),
     TestEntry("uk.ac.manchester.tornado.unittests.arrays.TestArrayCopies"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestFloats"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestHalfFloats"),

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/phases/TornadoHalfFloatReplacement.java
@@ -428,17 +428,26 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
                 // This casting is safe to do as it is already checked by the isWriteHalfFloat function
                 HalfFloatPlaceholder placeholder = (HalfFloatPlaceholder) javaWrite.value();
                 ValueNode writingValue;
-                if (javaWrite.predecessor() instanceof NewHalfFloatInstance) {
-                    // if a new HalfFloat instance is written
-                    NewHalfFloatInstance newHalfFloatInstance = (NewHalfFloatInstance) javaWrite.predecessor();
+                // A written HalfFloat that comes from `new HalfFloat(x)` shows up as a
+                // NewHalfFloatInstance, either as the write's control-flow predecessor (simple
+                // read argument) or, when the ctor argument is a computed expression that
+                // reorders the fixed nodes, only as the placeholder's data input. Handle both,
+                // and drop the instance unconditionally: leaving it (as happened when the
+                // NewInstanceNode was not adjacent) makes it reach LIR with
+                // "node is not LIRLowerable: NewHalfFloatInstance".
+                NewHalfFloatInstance newHalfFloatInstance = null;
+                if (javaWrite.predecessor() instanceof NewHalfFloatInstance predInstance) {
+                    newHalfFloatInstance = predInstance;
+                } else if (placeholder.getInput() instanceof NewHalfFloatInstance inputInstance) {
+                    newHalfFloatInstance = inputInstance;
+                }
+                if (newHalfFloatInstance != null) {
                     writingValue = newHalfFloatInstance.getValue();
-                    if (newHalfFloatInstance.predecessor() instanceof NewInstanceNode) {
-                        NewInstanceNode newInstanceNode = (NewInstanceNode) newHalfFloatInstance.predecessor();
-                        if (newInstanceNode.instanceClass().toString().contains("HalfFloat")) {
-                            deleteFixed(newInstanceNode);
-                            deleteFixed(newHalfFloatInstance);
-                        }
+                    if (newHalfFloatInstance.predecessor() instanceof NewInstanceNode newInstanceNode //
+                            && newInstanceNode.instanceClass().toString().contains("HalfFloat")) {
+                        deleteFixed(newInstanceNode);
                     }
+                    deleteFixed(newHalfFloatInstance);
                 } else {
                     // if the result of an operation or a stored value is written
                     writingValue = placeholder.getInput();
@@ -450,6 +459,16 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
                 graph.addWithoutUnique(writeHalfFloatNode);
                 replaceFixed(javaWrite, writeHalfFloatNode);
                 deleteFixed(javaWrite);
+            }
+        }
+
+        // A `new HalfFloat(computedExpr)` leaves the HalfFloat allocation (NewInstanceNode) in the
+        // fixed control flow when the computed argument breaks the adjacency the matching above
+        // relies on. Once its usages have been rewired it is a dead allocation that would otherwise
+        // lower as an (unsupported) on-device object allocation, so remove any leftover.
+        for (NewInstanceNode newInstanceNode : graph.getNodes().filter(NewInstanceNode.class)) {
+            if (newInstanceNode.instanceClass().getAnnotation(HalfType.class) != null && newInstanceNode.hasNoUsages()) {
+                deleteFixed(newInstanceNode);
             }
         }
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestHalfFloatInlineWrite.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestHalfFloatInlineWrite.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.arrays;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Regression tests for writing a {@code new HalfFloat(...)} straight into a {@link HalfFloatArray}.
+ * When the constructor argument is a computed expression (rather than a local variable or a plain
+ * array read) the {@code NewHalfFloatInstance} carrier is no longer the store's control-flow
+ * predecessor, and the HalfFloat replacement phase used to leave it in the graph, failing code
+ * generation with {@code node is not LIRLowerable: NewHalfFloatInstance}.
+ *
+ * <p>How to run: {@code tornado-test -V uk.ac.manchester.tornado.unittests.arrays.TestHalfFloatInlineWrite}</p>
+ */
+public class TestHalfFloatInlineWrite extends TornadoTestBase {
+
+    // Local variable, computed input.
+    public static void localComputed(FloatArray a, HalfFloatArray out) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            float v = a.get(i) * 2.0f;
+            HalfFloat h = new HalfFloat(v);
+            out.set(i, h);
+        }
+    }
+
+    // Inline new HalfFloat directly in set(), direct read input.
+    public static void inlineDirect(FloatArray a, HalfFloatArray out) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, new HalfFloat(a.get(i)));
+        }
+    }
+
+    // Inline new HalfFloat in set(), computed input.
+    public static void inlineComputed(FloatArray a, HalfFloatArray out) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            out.set(i, new HalfFloat(a.get(i) * 2.0f));
+        }
+    }
+
+    private static FloatArray input(int n) {
+        FloatArray a = new FloatArray(n);
+        for (int i = 0; i < n; i++) {
+            a.set(i, i * 0.5f - 8.0f);
+        }
+        return a;
+    }
+
+    private static void check(FloatArray a, HalfFloatArray out, boolean doubled) {
+        for (int i = 0; i < a.getSize(); i++) {
+            float expected = doubled ? a.get(i) * 2.0f : a.get(i);
+            assertEquals(expected, out.get(i).getFloat32(), 1e-2f * Math.max(1.0f, Math.abs(expected)));
+        }
+    }
+
+    @Test
+    public void testLocalComputed() throws TornadoExecutionPlanException {
+        FloatArray a = input(64);
+        HalfFloatArray out = new HalfFloatArray(64);
+        TaskGraph tg = new TaskGraph("lc").transferToDevice(DataTransferMode.FIRST_EXECUTION, a) //
+                .task("t0", TestHalfFloatInlineWrite::localComputed, a, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.execute();
+        }
+        check(a, out, true);
+    }
+
+    @Test
+    public void testInlineDirect() throws TornadoExecutionPlanException {
+        FloatArray a = input(64);
+        HalfFloatArray out = new HalfFloatArray(64);
+        TaskGraph tg = new TaskGraph("id").transferToDevice(DataTransferMode.FIRST_EXECUTION, a) //
+                .task("t0", TestHalfFloatInlineWrite::inlineDirect, a, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.execute();
+        }
+        check(a, out, false);
+    }
+
+    @Test
+    public void testInlineComputed() throws TornadoExecutionPlanException {
+        FloatArray a = input(64);
+        HalfFloatArray out = new HalfFloatArray(64);
+        TaskGraph tg = new TaskGraph("ic").transferToDevice(DataTransferMode.FIRST_EXECUTION, a) //
+                .task("t0", TestHalfFloatInlineWrite::inlineComputed, a, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tg.snapshot())) {
+            plan.execute();
+        }
+        check(a, out, true);
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestHalfFloatInlineWrite.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/arrays/TestHalfFloatInlineWrite.java
@@ -25,11 +25,13 @@ import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+import uk.ac.manchester.tornado.unittests.common.TornadoVMCUDANotSupported;
 
 /**
  * Regression tests for writing a {@code new HalfFloat(...)} straight into a {@link HalfFloatArray}.
@@ -41,6 +43,22 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  * <p>How to run: {@code tornado-test -V uk.ac.manchester.tornado.unittests.arrays.TestHalfFloatInlineWrite}</p>
  */
 public class TestHalfFloatInlineWrite extends TornadoTestBase {
+
+    /**
+     * The inline {@code new HalfFloat(computedExpr)} fix is applied to the CUDA backend only; the
+     * OpenCL/PTX/Metal/SPIRV HalfFloat replacement phases share the pattern and are not fixed here,
+     * so skip them rather than trip the same code-generation error.
+     */
+    private void assumeCudaBackend() {
+        TornadoVMBackendType backendType = getTornadoRuntime().getDefaultDevice().getTornadoVMBackend();
+        if (backendType != TornadoVMBackendType.CUDA) {
+            String message = "This HalfFloat inline-write fix targets the CUDA backend (default device is " + backendType + ")";
+            switch (backendType) {
+                case OPENCL, PTX, SPIRV, METAL -> assertNotBackend(backendType, message);
+                default -> throw new TornadoVMCUDANotSupported(message);
+            }
+        }
+    }
 
     // Local variable, computed input.
     public static void localComputed(FloatArray a, HalfFloatArray out) {
@@ -82,6 +100,7 @@ public class TestHalfFloatInlineWrite extends TornadoTestBase {
 
     @Test
     public void testLocalComputed() throws TornadoExecutionPlanException {
+        assumeCudaBackend();
         FloatArray a = input(64);
         HalfFloatArray out = new HalfFloatArray(64);
         TaskGraph tg = new TaskGraph("lc").transferToDevice(DataTransferMode.FIRST_EXECUTION, a) //
@@ -95,6 +114,7 @@ public class TestHalfFloatInlineWrite extends TornadoTestBase {
 
     @Test
     public void testInlineDirect() throws TornadoExecutionPlanException {
+        assumeCudaBackend();
         FloatArray a = input(64);
         HalfFloatArray out = new HalfFloatArray(64);
         TaskGraph tg = new TaskGraph("id").transferToDevice(DataTransferMode.FIRST_EXECUTION, a) //
@@ -108,6 +128,7 @@ public class TestHalfFloatInlineWrite extends TornadoTestBase {
 
     @Test
     public void testInlineComputed() throws TornadoExecutionPlanException {
+        assumeCudaBackend();
         FloatArray a = input(64);
         HalfFloatArray out = new HalfFloatArray(64);
         TaskGraph tg = new TaskGraph("ic").transferToDevice(DataTransferMode.FIRST_EXECUTION, a) //


### PR DESCRIPTION
## Problem

Writing a freshly constructed `HalfFloat` straight into a `HalfFloatArray`, where the constructor argument is a **computed expression**, fails code generation on the CUDA backend:

```java
out.set(i, new HalfFloat(a.get(i) * 2.0f));   // FAILS
```

```
org.graalvm.compiler.debug.GraalError: should not reach here: node is not LIRLowerable: NewHalfFloatInstance
```

The local-variable form and a plain array-read argument both work:

```java
float v = a.get(i) * 2.0f; HalfFloat h = new HalfFloat(v); out.set(i, h);  // OK
out.set(i, new HalfFloat(a.get(i)));                                        // OK
```

## Cause

`TornadoHalfFloatReplacement` only unwrapped the `NewHalfFloatInstance` carrier when it was the store's **control-flow predecessor** and the `HalfFloat` allocation (`NewInstanceNode`) was directly adjacent to it. A computed constructor argument evaluates between the `NEW`/`DUP` and the `<init>`, so the `NewHalfFloatInstance` is no longer adjacent; the phase left it in the graph and it reached LIR, where it has no lowering.

## Fix

In the write-replacement loop, resolve the `NewHalfFloatInstance` from **either** the store predecessor or the placeholder's data input, delete it **unconditionally**, and add a final cleanup that removes any orphaned `HalfFloat` `NewInstanceNode` (a dead on-device allocation). CUDA backend only.

## How to run

```bash
make BACKEND=cuda
tornado-test -V uk.ac.manchester.tornado.unittests.arrays.TestHalfFloatInlineWrite
tornado-test -V uk.ac.manchester.tornado.unittests.foundation.TestHalfFloats
```

## Tests (RTX 4090, sm_89)

- New `TestHalfFloatInlineWrite` **3/3** — `localComputed`, `inlineDirect`, `inlineComputed` (the last reproduced the crash; now passes).
- `TestHalfFloats` **4/4** regression.

## Notes

- Found while adding bf16 mixed-precision tests (#967); the bug is pre-existing and independent of bf16.
- The OpenCL/PTX/Metal/SPIRV backends carry the same `TornadoHalfFloatReplacement` pattern and likely share this bug; this PR fixes the CUDA backend only.