### PR TITLE
Fix release pipeline: broken draft gate, duplicate-trigger fallout, and stale README updates

### DIFF
--- a/.github/workflows/1-prepare-release-jdk21.yml
+++ b/.github/workflows/1-prepare-release-jdk21.yml
@@ -96,7 +96,13 @@ jobs:
 
           # Update Maven Central dependency versions (io.github.beehive-lab groupId)
           sed -i 's|<version>[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\?</version>|<version>${{ env.VERSION }}</version>|g' README.md
-          
+
+          # Update SDKMAN! per-backend candidate versions (e.g. `4.0.1-jdk21-opencl`)
+          sed -i -E 's/`[0-9]+\.[0-9]+\.[0-9]+(-jdk21)?-(opencl|cuda|ptx|spirv|metal|full)`/`${{ env.VERSION }}-\2`/g' README.md
+
+          # Update the tornado-examples jar version in the "Run your first program" snippet
+          sed -i 's/tornado-examples-[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\?\.jar/tornado-examples-${{ env.VERSION }}.jar/g' README.md
+
           echo "✅ Updated README.md"
 
       - name: Update docs/source/conf.py

--- a/.github/workflows/1-prepare-release-jdk21.yml
+++ b/.github/workflows/1-prepare-release-jdk21.yml
@@ -90,9 +90,10 @@ jobs:
           # Update version badge
           sed -i 's/version-[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\?-purple/version-${{ env.VERSION }}-purple/g' README.md
 
-          # Update "Latest Release" line with current date (DD/MM/YYYY format)
-          RELEASE_DATE=$(date +"%d/%m/%Y")
-          sed -i "s|\*\*Latest Release:\*\* TornadoVM [0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\? - [0-9/]\+|**Latest Release:** TornadoVM ${{ env.VERSION }} - ${RELEASE_DATE}|" README.md
+          # Update the "Latest release" banner version number (top of README),
+          # keeping the hand-written highlight text after it untouched
+          BASE_VERSION="${VERSION%-jdk21}"
+          sed -i -E "s/(\*\*Latest [Rr]elease:\*\* TornadoVM )[0-9]+\.[0-9]+\.[0-9]+(-jdk21)?/\1${BASE_VERSION}/" README.md
 
           # Update Maven Central dependency versions (io.github.beehive-lab groupId)
           sed -i 's|<version>[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk21\)\?</version>|<version>${{ env.VERSION }}</version>|g' README.md

--- a/.github/workflows/1-prepare-release-jdk21.yml
+++ b/.github/workflows/1-prepare-release-jdk21.yml
@@ -139,10 +139,10 @@ jobs:
               const { data: releases } = await github.rest.repos.listReleases({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                per_page: 10
+                per_page: 20
               });
-              
-              const prevRelease = releases.find(r => 
+
+              const prevRelease = releases.find(r =>
                 r.tag_name === `v${prevVersion}` || r.tag_name === prevVersion
               );
               if (prevRelease) {

--- a/.github/workflows/1-prepare-release-jdk21.yml
+++ b/.github/workflows/1-prepare-release-jdk21.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     timeout-minutes: 15
     env:
       JAVA_HOME: /opt/jenkins/jdks/graal-23.1.0/jdk-21.0.3
@@ -379,3 +380,24 @@ jobs:
           echo ""
           echo "=== Full diff ==="
           git diff
+
+      - name: Dry run - continue pipeline
+        if: ${{ inputs.dry_run == true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # No PR was opened (and won't be merged) in dry-run mode, so simulate
+          # the "PR merged" trigger by dispatching finalize directly with
+          # dry_run=true. That in turn dispatches build-release-sdks with
+          # dry_run=true, which still builds the SDKs for real but never
+          # uploads/un-drafts/publishes anything.
+          BASE_VERSION="${VERSION%-jdk21}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+          NEXT_DEV="${MAJOR}.${MINOR}.$((PATCH + 1))-jdk21-dev"
+          echo "Dispatching 2-finalize-release-jdk21.yml with dry_run=true (version=${VERSION}, next_dev_version=${NEXT_DEV})..."
+          gh workflow run 2-finalize-release-jdk21.yml \
+            --repo "${{ github.repository }}" \
+            -f version="${VERSION}" \
+            -f next_dev_version="${NEXT_DEV}" \
+            -f dry_run=true

--- a/.github/workflows/1-prepare-release-jdk21.yml
+++ b/.github/workflows/1-prepare-release-jdk21.yml
@@ -11,8 +11,8 @@ on:
         description: 'Previous version for changelog (e.g., 4.0.0-jdk21)'
         required: true
         type: string
-      dry_run:
-        description: 'Dry run - show changes without creating PR'
+      draft_release_test:
+        description: 'Draft release (test): show changes without creating a PR, and continue the pipeline (finalize + a real SDK build) without tagging, creating a GitHub Release, or publishing anything.'
         required: false
         type: boolean
         default: false
@@ -292,14 +292,14 @@ jobs:
           echo "3. Create GitHub release with tag \`v${{ env.VERSION }}\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Commit and push
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.draft_release_test == false }}
         run: |
           git add -A
           git commit -m "Prepare release ${{ env.VERSION }}"
           git push origin release/${{ env.VERSION }}
 
       - name: Create Pull Request
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.draft_release_test == false }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -367,10 +367,10 @@ jobs:
               console.log('Could not add label:', e.message);
             }
 
-      - name: Dry run output
-        if: ${{ inputs.dry_run == true }}
+      - name: Draft release (test) - output
+        if: ${{ inputs.draft_release_test == true }}
         run: |
-          echo "🏃 DRY RUN MODE"
+          echo "🏃 DRAFT RELEASE (TEST) MODE"
           echo ""
           echo "=== Files changed ==="
           git diff --stat
@@ -381,23 +381,23 @@ jobs:
           echo "=== Full diff ==="
           git diff
 
-      - name: Dry run - continue pipeline
-        if: ${{ inputs.dry_run == true }}
+      - name: Draft release (test) - continue pipeline
+        if: ${{ inputs.draft_release_test == true }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           # No PR was opened (and won't be merged) in dry-run mode, so simulate
           # the "PR merged" trigger by dispatching finalize directly with
-          # dry_run=true. That in turn dispatches build-release-sdks with
-          # dry_run=true, which still builds the SDKs for real but never
+          # draft_release_test=true. That in turn dispatches build-release-sdks with
+          # draft_release_test=true, which still builds the SDKs for real but never
           # uploads/un-drafts/publishes anything.
           BASE_VERSION="${VERSION%-jdk21}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
           NEXT_DEV="${MAJOR}.${MINOR}.$((PATCH + 1))-jdk21-dev"
-          echo "Dispatching 2-finalize-release-jdk21.yml with dry_run=true (version=${VERSION}, next_dev_version=${NEXT_DEV})..."
+          echo "Dispatching 2-finalize-release-jdk21.yml with draft_release_test=true (version=${VERSION}, next_dev_version=${NEXT_DEV})..."
           gh workflow run 2-finalize-release-jdk21.yml \
             --repo "${{ github.repository }}" \
             -f version="${VERSION}" \
             -f next_dev_version="${NEXT_DEV}" \
-            -f dry_run=true
+            -f draft_release_test=true

--- a/.github/workflows/1-prepare-release-jdk25.yml
+++ b/.github/workflows/1-prepare-release-jdk25.yml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     timeout-minutes: 15
     env:
       JAVA_HOME: /opt/jenkins/jdks/jdk-25.0.2
@@ -375,3 +376,24 @@ jobs:
           echo ""
           echo "=== Full diff ==="
           git diff
+
+      - name: Dry run - continue pipeline
+        if: ${{ inputs.dry_run == true }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # No PR was opened (and won't be merged) in dry-run mode, so simulate
+          # the "PR merged" trigger by dispatching finalize directly with
+          # dry_run=true. That in turn dispatches build-release-sdks with
+          # dry_run=true, which still builds the SDKs for real but never
+          # uploads/un-drafts/publishes anything.
+          BASE_VERSION="${VERSION%-jdk25}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+          NEXT_DEV="${MAJOR}.${MINOR}.$((PATCH + 1))-jdk25-dev"
+          echo "Dispatching 2-finalize-release-jdk25.yml with dry_run=true (version=${VERSION}, next_dev_version=${NEXT_DEV})..."
+          gh workflow run 2-finalize-release-jdk25.yml \
+            --repo "${{ github.repository }}" \
+            -f version="${VERSION}" \
+            -f next_dev_version="${NEXT_DEV}" \
+            -f dry_run=true

--- a/.github/workflows/1-prepare-release-jdk25.yml
+++ b/.github/workflows/1-prepare-release-jdk25.yml
@@ -97,6 +97,12 @@ jobs:
           # Update Maven Central dependency versions (io.github.beehive-lab groupId)
           sed -i 's|<version>[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk25\)\?</version>|<version>${{ env.VERSION }}</version>|g' README.md
 
+          # Update SDKMAN! per-backend candidate versions (e.g. `4.0.1-jdk25-opencl`)
+          sed -i -E 's/`[0-9]+\.[0-9]+\.[0-9]+(-jdk25)?-(opencl|cuda|ptx|spirv|metal|full)`/`${{ env.VERSION }}-\2`/g' README.md
+
+          # Update the tornado-examples jar version in the "Run your first program" snippet
+          sed -i 's/tornado-examples-[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk25\)\?\.jar/tornado-examples-${{ env.VERSION }}.jar/g' README.md
+
           echo "✅ Updated README.md"
 
       - name: Update docs/source/conf.py

--- a/.github/workflows/1-prepare-release-jdk25.yml
+++ b/.github/workflows/1-prepare-release-jdk25.yml
@@ -90,9 +90,10 @@ jobs:
           # Update version badge
           sed -i 's/version-[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk25\)\?-purple/version-${{ env.VERSION }}-purple/g' README.md
 
-          # Update "Latest Release" line with current date (DD/MM/YYYY format)
-          RELEASE_DATE=$(date +"%d/%m/%Y")
-          sed -i "s|\*\*Latest Release:\*\* TornadoVM [0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk25\)\? - [0-9/]\+|**Latest Release:** TornadoVM ${{ env.VERSION }} - ${RELEASE_DATE}|" README.md
+          # Update the "Latest release" banner version number (top of README),
+          # keeping the hand-written highlight text after it untouched
+          BASE_VERSION="${VERSION%-jdk25}"
+          sed -i -E "s/(\*\*Latest [Rr]elease:\*\* TornadoVM )[0-9]+\.[0-9]+\.[0-9]+(-jdk25)?/\1${BASE_VERSION}/" README.md
 
           # Update Maven Central dependency versions (io.github.beehive-lab groupId)
           sed -i 's|<version>[0-9]\+\.[0-9]\+\.[0-9]\+\(-jdk25\)\?</version>|<version>${{ env.VERSION }}</version>|g' README.md

--- a/.github/workflows/1-prepare-release-jdk25.yml
+++ b/.github/workflows/1-prepare-release-jdk25.yml
@@ -11,8 +11,8 @@ on:
         description: 'Previous JDK 25 version for changelog (e.g., 2.0.0-jdk25)'
         required: true
         type: string
-      dry_run:
-        description: 'Dry run - show changes without creating PR'
+      draft_release_test:
+        description: 'Draft release (test) - show changes without creating PR'
         required: false
         type: boolean
         default: false
@@ -292,14 +292,14 @@ jobs:
           echo "3. \`deploy-maven-central-jdk25\` workflow deploys to Maven Central" >> $GITHUB_STEP_SUMMARY
 
       - name: Commit and push
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.draft_release_test == false }}
         run: |
           git add -A
           git commit -m "Prepare release ${{ env.VERSION }}"
           git push origin release-jdk25/${{ env.VERSION }}
 
       - name: Create Pull Request
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.draft_release_test == false }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -363,10 +363,10 @@ jobs:
               console.log('Could not add label:', e.message);
             }
 
-      - name: Dry run output
-        if: ${{ inputs.dry_run == true }}
+      - name: Draft release (test) - output
+        if: ${{ inputs.draft_release_test == true }}
         run: |
-          echo "🏃 DRY RUN MODE"
+          echo "🏃 DRAFT RELEASE (TEST) MODE"
           echo ""
           echo "=== Files changed ==="
           git diff --stat
@@ -377,23 +377,23 @@ jobs:
           echo "=== Full diff ==="
           git diff
 
-      - name: Dry run - continue pipeline
-        if: ${{ inputs.dry_run == true }}
+      - name: Draft release (test) - continue pipeline
+        if: ${{ inputs.draft_release_test == true }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           # No PR was opened (and won't be merged) in dry-run mode, so simulate
           # the "PR merged" trigger by dispatching finalize directly with
-          # dry_run=true. That in turn dispatches build-release-sdks with
-          # dry_run=true, which still builds the SDKs for real but never
+          # draft_release_test=true. That in turn dispatches build-release-sdks with
+          # draft_release_test=true, which still builds the SDKs for real but never
           # uploads/un-drafts/publishes anything.
           BASE_VERSION="${VERSION%-jdk25}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
           NEXT_DEV="${MAJOR}.${MINOR}.$((PATCH + 1))-jdk25-dev"
-          echo "Dispatching 2-finalize-release-jdk25.yml with dry_run=true (version=${VERSION}, next_dev_version=${NEXT_DEV})..."
+          echo "Dispatching 2-finalize-release-jdk25.yml with draft_release_test=true (version=${VERSION}, next_dev_version=${NEXT_DEV})..."
           gh workflow run 2-finalize-release-jdk25.yml \
             --repo "${{ github.repository }}" \
             -f version="${VERSION}" \
             -f next_dev_version="${NEXT_DEV}" \
-            -f dry_run=true
+            -f draft_release_test=true

--- a/.github/workflows/2-finalize-release-jdk21.yml
+++ b/.github/workflows/2-finalize-release-jdk21.yml
@@ -240,6 +240,7 @@ jobs:
           ./mvnw versions:set -DnewVersion=${NEXT} -DgenerateBackupPoms=false
 
           sed -i "s/__VERSION__ = \"[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9-]*\)\?\"/__VERSION__ = \"${NEXT}\"/" tornado-assembly/src/bin/tornado-test
+          sed -i "s/__VERSION__ = \"v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9-]*\)\?\"/__VERSION__ = \"v${NEXT}\"/" bin/tornadovm-installer
 
           git add -A
 

--- a/.github/workflows/2-finalize-release-jdk21.yml
+++ b/.github/workflows/2-finalize-release-jdk21.yml
@@ -14,6 +14,11 @@ on:
         description: 'Next development version (e.g., 4.0.2-jdk21-dev)'
         required: true
         type: string
+      dry_run:
+        description: 'Dry run: skip tag/GitHub Release/develop push, still exercise the rest of the pipeline (build-release-sdks runs for real but never uploads).'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   create-release-tag:
@@ -56,9 +61,13 @@ jobs:
       - name: Create and push tag
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
-          git tag -a "v${VERSION}" -m "Release ${VERSION}"
-          git push origin "v${VERSION}"
-          echo "✅ Created tag v${VERSION}"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "DRY RUN: would create and push tag v${VERSION} (skipped)."
+          else
+            git tag -a "v${VERSION}" -m "Release ${VERSION}"
+            git push origin "v${VERSION}"
+            echo "✅ Created tag v${VERSION}"
+          fi
 
       - name: Extract changelog for release notes
         id: changelog
@@ -146,6 +155,7 @@ jobs:
           sed -i "s|@@VERSION@@|${VERSION}|g" /tmp/release_notes_jdk21.md
 
       - name: Create GitHub Release
+        if: ${{ inputs.dry_run != true }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -174,6 +184,13 @@ jobs:
 
             console.log(`✅ Created release: ${release.html_url}`);
 
+      - name: Dry run - GitHub Release
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "DRY RUN: would create draft GitHub Release v${{ steps.get_version.outputs.version }} here (skipped)."
+          echo "Generated release notes (not published):"
+          cat /tmp/release_notes_jdk21.md
+
       - name: Dispatch Build Release SDKs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -181,10 +198,12 @@ jobs:
           set -euo pipefail
           VERSION="${{ steps.get_version.outputs.version }}"
           BASE_VERSION="${VERSION%-jdk21}"
-          echo "Dispatching build-release-sdks.yml for version=$BASE_VERSION..."
+          DRY_RUN="${{ inputs.dry_run == true }}"
+          echo "Dispatching build-release-sdks.yml for version=$BASE_VERSION (dry_run=$DRY_RUN)..."
           gh workflow run build-release-sdks.yml \
             --repo "${{ github.repository }}" \
-            -f version="$BASE_VERSION"
+            -f version="$BASE_VERSION" \
+            -f dry_run="$DRY_RUN"
 
   update-develop:
     if: github.repository == 'beehive-lab/TornadoVM'
@@ -246,22 +265,37 @@ jobs:
 
           if ! git diff --cached --quiet; then
             git commit -m "Bump version to ${NEXT} for development"
-            git push origin develop
-            echo "✅ Changes committed and pushed"
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              echo "DRY RUN: committed locally in this ephemeral checkout, not pushing to develop."
+            else
+              git push origin develop
+              echo "✅ Changes committed and pushed"
+            fi
           else
             echo "ℹ️ No changes to commit"
           fi
 
       - name: Summary
         run: |
-          echo "## 🎉 Release Finalized" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Tag created | ✅ v${{ needs.create-release-tag.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| GitHub Release | ✅ Created |" >> $GITHUB_STEP_SUMMARY
-          echo "| Develop bumped | ✅ ${{ steps.next_version.outputs.next_version }} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Remaining manual steps:" >> $GITHUB_STEP_SUMMARY
-          echo "1. Run **deploy-maven-central** workflow" >> $GITHUB_STEP_SUMMARY
-          echo "2. Announce release" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "## 🧪 Release Finalized (DRY RUN — nothing tagged, released, or pushed)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+            echo "| Tag | skipped (would be v${{ needs.create-release-tag.outputs.version }}) |" >> $GITHUB_STEP_SUMMARY
+            echo "| GitHub Release | skipped |" >> $GITHUB_STEP_SUMMARY
+            echo "| Develop bumped | skipped (would be ${{ steps.next_version.outputs.next_version }}) |" >> $GITHUB_STEP_SUMMARY
+            echo "| Build Release SDKs | dispatched with dry_run=true (builds for real, no upload) |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## 🎉 Release Finalized" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+            echo "| Tag created | ✅ v${{ needs.create-release-tag.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| GitHub Release | ✅ Created |" >> $GITHUB_STEP_SUMMARY
+            echo "| Develop bumped | ✅ ${{ steps.next_version.outputs.next_version }} |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Remaining manual steps:" >> $GITHUB_STEP_SUMMARY
+            echo "1. Run **deploy-maven-central** workflow" >> $GITHUB_STEP_SUMMARY
+            echo "2. Announce release" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/2-finalize-release-jdk21.yml
+++ b/.github/workflows/2-finalize-release-jdk21.yml
@@ -14,8 +14,8 @@ on:
         description: 'Next development version (e.g., 4.0.2-jdk21-dev)'
         required: true
         type: string
-      dry_run:
-        description: 'Dry run: skip tag/GitHub Release/develop push, still exercise the rest of the pipeline (build-release-sdks runs for real but never uploads).'
+      draft_release_test:
+        description: 'Draft release (test): skip tag/GitHub Release/develop push, still exercise the rest of the pipeline (build-release-sdks runs for real but never uploads).'
         required: false
         type: boolean
         default: false
@@ -61,8 +61,8 @@ jobs:
       - name: Create and push tag
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            echo "DRY RUN: would create and push tag v${VERSION} (skipped)."
+          if [ "${{ inputs.draft_release_test }}" = "true" ]; then
+            echo "DRAFT RELEASE (TEST): would create and push tag v${VERSION} (skipped)."
           else
             git tag -a "v${VERSION}" -m "Release ${VERSION}"
             git push origin "v${VERSION}"
@@ -155,7 +155,7 @@ jobs:
           sed -i "s|@@VERSION@@|${VERSION}|g" /tmp/release_notes_jdk21.md
 
       - name: Create GitHub Release
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ inputs.draft_release_test != true }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -184,10 +184,10 @@ jobs:
 
             console.log(`✅ Created release: ${release.html_url}`);
 
-      - name: Dry run - GitHub Release
-        if: ${{ inputs.dry_run == true }}
+      - name: Draft release (test) - GitHub Release
+        if: ${{ inputs.draft_release_test == true }}
         run: |
-          echo "DRY RUN: would create draft GitHub Release v${{ steps.get_version.outputs.version }} here (skipped)."
+          echo "DRAFT RELEASE (TEST): would create draft GitHub Release v${{ steps.get_version.outputs.version }} here (skipped)."
           echo "Generated release notes (not published):"
           cat /tmp/release_notes_jdk21.md
 
@@ -198,12 +198,12 @@ jobs:
           set -euo pipefail
           VERSION="${{ steps.get_version.outputs.version }}"
           BASE_VERSION="${VERSION%-jdk21}"
-          DRY_RUN="${{ inputs.dry_run == true }}"
-          echo "Dispatching build-release-sdks.yml for version=$BASE_VERSION (dry_run=$DRY_RUN)..."
+          DRY_RUN="${{ inputs.draft_release_test == true }}"
+          echo "Dispatching build-release-sdks.yml for version=$BASE_VERSION (draft_release_test=$DRY_RUN)..."
           gh workflow run build-release-sdks.yml \
             --repo "${{ github.repository }}" \
             -f version="$BASE_VERSION" \
-            -f dry_run="$DRY_RUN"
+            -f draft_release_test="$DRY_RUN"
 
   update-develop:
     if: github.repository == 'beehive-lab/TornadoVM'
@@ -265,8 +265,8 @@ jobs:
 
           if ! git diff --cached --quiet; then
             git commit -m "Bump version to ${NEXT} for development"
-            if [ "${{ inputs.dry_run }}" = "true" ]; then
-              echo "DRY RUN: committed locally in this ephemeral checkout, not pushing to develop."
+            if [ "${{ inputs.draft_release_test }}" = "true" ]; then
+              echo "DRAFT RELEASE (TEST): committed locally in this ephemeral checkout, not pushing to develop."
             else
               git push origin develop
               echo "✅ Changes committed and pushed"
@@ -277,15 +277,15 @@ jobs:
 
       - name: Summary
         run: |
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            echo "## 🧪 Release Finalized (DRY RUN — nothing tagged, released, or pushed)" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.draft_release_test }}" = "true" ]; then
+            echo "## 🧪 Release Finalized (DRAFT RELEASE TEST — nothing tagged, released, or pushed)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
             echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
             echo "| Tag | skipped (would be v${{ needs.create-release-tag.outputs.version }}) |" >> $GITHUB_STEP_SUMMARY
             echo "| GitHub Release | skipped |" >> $GITHUB_STEP_SUMMARY
             echo "| Develop bumped | skipped (would be ${{ steps.next_version.outputs.next_version }}) |" >> $GITHUB_STEP_SUMMARY
-            echo "| Build Release SDKs | dispatched with dry_run=true (builds for real, no upload) |" >> $GITHUB_STEP_SUMMARY
+            echo "| Build Release SDKs | dispatched with draft_release_test=true (builds for real, no upload) |" >> $GITHUB_STEP_SUMMARY
           else
             echo "## 🎉 Release Finalized" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/2-finalize-release-jdk25.yml
+++ b/.github/workflows/2-finalize-release-jdk25.yml
@@ -235,6 +235,7 @@ jobs:
           ./mvnw versions:set -DnewVersion=${NEXT} -DgenerateBackupPoms=false
 
           sed -i "s/__VERSION__ = \"[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9-]*\)\?\"/__VERSION__ = \"${NEXT}\"/" tornado-assembly/src/bin/tornado-test
+          sed -i "s/__VERSION__ = \"v[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9-]*\)\?\"/__VERSION__ = \"v${NEXT}\"/" bin/tornadovm-installer
 
           git add -A
           git commit -m "Bump version to ${NEXT} for development"

--- a/.github/workflows/2-finalize-release-jdk25.yml
+++ b/.github/workflows/2-finalize-release-jdk25.yml
@@ -14,8 +14,8 @@ on:
         description: 'Next development version (e.g., 2.0.2-jdk25-dev)'
         required: true
         type: string
-      dry_run:
-        description: 'Dry run: skip tag/GitHub Release/jdk25 push, still exercise the rest of the pipeline (build-release-sdks runs for real but never uploads).'
+      draft_release_test:
+        description: 'Draft release (test): skip tag/GitHub Release/jdk25 push, still exercise the rest of the pipeline (build-release-sdks runs for real but never uploads).'
         required: false
         type: boolean
         default: false
@@ -61,8 +61,8 @@ jobs:
       - name: Create and push tag
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            echo "DRY RUN: would create and push tag v${VERSION} (skipped)."
+          if [ "${{ inputs.draft_release_test }}" = "true" ]; then
+            echo "DRAFT RELEASE (TEST): would create and push tag v${VERSION} (skipped)."
           else
             git tag -a "v${VERSION}" -m "Release ${VERSION}"
             git push origin "v${VERSION}"
@@ -155,7 +155,7 @@ jobs:
           sed -i "s|@@VERSION@@|${VERSION}|g" /tmp/release_notes_jdk25.md
 
       - name: Create GitHub Release
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ inputs.draft_release_test != true }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -184,10 +184,10 @@ jobs:
 
             console.log(`✅ Created release: ${release.html_url}`);
 
-      - name: Dry run - GitHub Release
-        if: ${{ inputs.dry_run == true }}
+      - name: Draft release (test) - GitHub Release
+        if: ${{ inputs.draft_release_test == true }}
         run: |
-          echo "DRY RUN: would create draft GitHub Release v${{ steps.get_version.outputs.version }} here (skipped)."
+          echo "DRAFT RELEASE (TEST): would create draft GitHub Release v${{ steps.get_version.outputs.version }} here (skipped)."
           echo "Generated release notes (not published):"
           cat /tmp/release_notes_jdk25.md
 
@@ -198,12 +198,12 @@ jobs:
           set -euo pipefail
           VERSION="${{ steps.get_version.outputs.version }}"
           BASE_VERSION="${VERSION%-jdk25}"
-          DRY_RUN="${{ inputs.dry_run == true }}"
-          echo "Dispatching build-release-sdks.yml for version=$BASE_VERSION (dry_run=$DRY_RUN)..."
+          DRY_RUN="${{ inputs.draft_release_test == true }}"
+          echo "Dispatching build-release-sdks.yml for version=$BASE_VERSION (draft_release_test=$DRY_RUN)..."
           gh workflow run build-release-sdks.yml \
             --repo "${{ github.repository }}" \
             -f version="$BASE_VERSION" \
-            -f dry_run="$DRY_RUN"
+            -f draft_release_test="$DRY_RUN"
 
   bump-jdk25-version:
     if: github.repository == 'beehive-lab/TornadoVM'
@@ -258,23 +258,23 @@ jobs:
 
           git add -A
           git commit -m "Bump version to ${NEXT} for development"
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            echo "DRY RUN: committed locally in this ephemeral checkout, not pushing to jdk25."
+          if [ "${{ inputs.draft_release_test }}" = "true" ]; then
+            echo "DRAFT RELEASE (TEST): committed locally in this ephemeral checkout, not pushing to jdk25."
           else
             git push origin jdk25
           fi
 
       - name: Summary
         run: |
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            echo "## 🧪 Release Finalized (JDK 25, DRY RUN — nothing tagged, released, or pushed)" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.draft_release_test }}" = "true" ]; then
+            echo "## 🧪 Release Finalized (JDK 25, DRAFT RELEASE TEST — nothing tagged, released, or pushed)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
             echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
             echo "| Tag | skipped (would be v${{ needs.create-release-tag.outputs.version }}) |" >> $GITHUB_STEP_SUMMARY
             echo "| GitHub Release | skipped |" >> $GITHUB_STEP_SUMMARY
             echo "| jdk25 bumped | skipped (would be ${{ steps.next_version.outputs.next_version }}) |" >> $GITHUB_STEP_SUMMARY
-            echo "| Build Release SDKs | dispatched with dry_run=true (builds for real, no upload) |" >> $GITHUB_STEP_SUMMARY
+            echo "| Build Release SDKs | dispatched with draft_release_test=true (builds for real, no upload) |" >> $GITHUB_STEP_SUMMARY
           else
             echo "## 🎉 Release Finalized (JDK 25)" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/2-finalize-release-jdk25.yml
+++ b/.github/workflows/2-finalize-release-jdk25.yml
@@ -14,6 +14,11 @@ on:
         description: 'Next development version (e.g., 2.0.2-jdk25-dev)'
         required: true
         type: string
+      dry_run:
+        description: 'Dry run: skip tag/GitHub Release/jdk25 push, still exercise the rest of the pipeline (build-release-sdks runs for real but never uploads).'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   create-release-tag:
@@ -56,9 +61,13 @@ jobs:
       - name: Create and push tag
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
-          git tag -a "v${VERSION}" -m "Release ${VERSION}"
-          git push origin "v${VERSION}"
-          echo "✅ Created tag v${VERSION}"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "DRY RUN: would create and push tag v${VERSION} (skipped)."
+          else
+            git tag -a "v${VERSION}" -m "Release ${VERSION}"
+            git push origin "v${VERSION}"
+            echo "✅ Created tag v${VERSION}"
+          fi
 
       - name: Extract changelog for release notes
         id: changelog
@@ -146,6 +155,7 @@ jobs:
           sed -i "s|@@VERSION@@|${VERSION}|g" /tmp/release_notes_jdk25.md
 
       - name: Create GitHub Release
+        if: ${{ inputs.dry_run != true }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -174,6 +184,13 @@ jobs:
 
             console.log(`✅ Created release: ${release.html_url}`);
 
+      - name: Dry run - GitHub Release
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          echo "DRY RUN: would create draft GitHub Release v${{ steps.get_version.outputs.version }} here (skipped)."
+          echo "Generated release notes (not published):"
+          cat /tmp/release_notes_jdk25.md
+
       - name: Dispatch Build Release SDKs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -181,10 +198,12 @@ jobs:
           set -euo pipefail
           VERSION="${{ steps.get_version.outputs.version }}"
           BASE_VERSION="${VERSION%-jdk25}"
-          echo "Dispatching build-release-sdks.yml for version=$BASE_VERSION..."
+          DRY_RUN="${{ inputs.dry_run == true }}"
+          echo "Dispatching build-release-sdks.yml for version=$BASE_VERSION (dry_run=$DRY_RUN)..."
           gh workflow run build-release-sdks.yml \
             --repo "${{ github.repository }}" \
-            -f version="$BASE_VERSION"
+            -f version="$BASE_VERSION" \
+            -f dry_run="$DRY_RUN"
 
   bump-jdk25-version:
     if: github.repository == 'beehive-lab/TornadoVM'
@@ -239,19 +258,34 @@ jobs:
 
           git add -A
           git commit -m "Bump version to ${NEXT} for development"
-          git push origin jdk25
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "DRY RUN: committed locally in this ephemeral checkout, not pushing to jdk25."
+          else
+            git push origin jdk25
+          fi
 
       - name: Summary
         run: |
-          echo "## 🎉 Release Finalized (JDK 25)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Tag created | ✅ v${{ needs.create-release-tag.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| GitHub Release | ✅ Created |" >> $GITHUB_STEP_SUMMARY
-          echo "| jdk25 bumped | ✅ ${{ steps.next_version.outputs.next_version }} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Remaining steps:" >> $GITHUB_STEP_SUMMARY
-          echo "1. \`deploy-maven-central-jdk25\` workflow publishes to Maven Central" >> $GITHUB_STEP_SUMMARY
-          echo "2. \`publish-archives-to-sdkman-jdk25\` publishes to SDKMAN" >> $GITHUB_STEP_SUMMARY
-          echo "3. Announce release" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "## 🧪 Release Finalized (JDK 25, DRY RUN — nothing tagged, released, or pushed)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+            echo "| Tag | skipped (would be v${{ needs.create-release-tag.outputs.version }}) |" >> $GITHUB_STEP_SUMMARY
+            echo "| GitHub Release | skipped |" >> $GITHUB_STEP_SUMMARY
+            echo "| jdk25 bumped | skipped (would be ${{ steps.next_version.outputs.next_version }}) |" >> $GITHUB_STEP_SUMMARY
+            echo "| Build Release SDKs | dispatched with dry_run=true (builds for real, no upload) |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## 🎉 Release Finalized (JDK 25)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Step | Status |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+            echo "| Tag created | ✅ v${{ needs.create-release-tag.outputs.version }} |" >> $GITHUB_STEP_SUMMARY
+            echo "| GitHub Release | ✅ Created |" >> $GITHUB_STEP_SUMMARY
+            echo "| jdk25 bumped | ✅ ${{ steps.next_version.outputs.next_version }} |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Remaining steps:" >> $GITHUB_STEP_SUMMARY
+            echo "1. \`deploy-maven-central-jdk25\` workflow publishes to Maven Central" >> $GITHUB_STEP_SUMMARY
+            echo "2. \`publish-archives-to-sdkman-jdk25\` publishes to SDKMAN" >> $GITHUB_STEP_SUMMARY
+            echo "3. Announce release" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/build-release-sdks.yml
+++ b/.github/workflows/build-release-sdks.yml
@@ -100,9 +100,14 @@ jobs:
           set -euo pipefail
           PROCEED="true"
           if [ "${{ steps.derive.outputs.upload_to_release }}" = "true" ]; then
+            # `gh release view`/the "get release by tag" API never returns
+            # draft releases, and both jdk21/jdk25 Releases are created as
+            # drafts by finalize — so list all releases (which does include
+            # drafts) instead of looking each one up by tag directly.
+            existing_tags=$(gh api "repos/${{ github.repository }}/releases" --paginate -q '.[].tag_name')
             for jdk in jdk21 jdk25; do
               tag="${{ steps.derive.outputs.version_tag }}-$jdk"
-              if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+              if grep -qx "$tag" <<< "$existing_tags"; then
                 echo "Release $tag exists."
               else
                 echo "Release $tag does not exist yet."

--- a/.github/workflows/build-release-sdks.yml
+++ b/.github/workflows/build-release-sdks.yml
@@ -59,7 +59,9 @@ jobs:
     name: Preflight (derive version, gate on Releases)
     runs-on: [self-hosted, Linux, x64]
     permissions:
-      contents: read
+      # Draft releases are only visible to tokens with push (write) access —
+      # `contents: read` silently sees zero releases in the gate check below.
+      contents: write
     timeout-minutes: 5
     outputs:
       version: ${{ steps.derive.outputs.version }}
@@ -375,7 +377,7 @@ jobs:
             } elseif ($fname -match 'jdk25') {
               $tag = "$env:VERSION_TAG-jdk25"
             } else {
-              Write-Host "::warning::Skipping $fname — filename does not contain jdk21 or jdk25"
+              Write-Host "::warning::Skipping $fname - filename does not contain jdk21 or jdk25"
               return
             }
             Write-Host "-> $fname  ->  release $tag"

--- a/.github/workflows/build-release-sdks.yml
+++ b/.github/workflows/build-release-sdks.yml
@@ -48,6 +48,11 @@ on:
         required: false
         type: boolean
         default: true
+      dry_run:
+        description: 'Dry run: still build the SDKs for real, but never upload/un-draft/publish anything (forces upload_to_release off).'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: build-release-sdks
@@ -86,6 +91,10 @@ jobs:
           INCLUDE_LINUX="${{ inputs.include_linux }}"
           INCLUDE_WIN="${{ inputs.include_windows }}"
           UPLOAD="${{ inputs.upload_to_release }}"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "Dry run: forcing upload_to_release=false (still building for real, nothing gets uploaded/un-drafted/published)."
+            UPLOAD="false"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "version_tag=v$VERSION" >> "$GITHUB_OUTPUT"
           echo "include_macos=$INCLUDE_MACOS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-release-sdks.yml
+++ b/.github/workflows/build-release-sdks.yml
@@ -48,8 +48,8 @@ on:
         required: false
         type: boolean
         default: true
-      dry_run:
-        description: 'Dry run: still build the SDKs for real, but never upload/un-draft/publish anything (forces upload_to_release off).'
+      draft_release_test:
+        description: 'Draft release (test): still build the SDKs for real, but never upload/un-draft/publish anything (forces upload_to_release off).'
         required: false
         type: boolean
         default: false
@@ -76,6 +76,7 @@ jobs:
       include_linux: ${{ steps.derive.outputs.include_linux }}
       include_windows: ${{ steps.derive.outputs.include_windows }}
       upload_to_release: ${{ steps.derive.outputs.upload_to_release }}
+      draft_release_test: ${{ steps.derive.outputs.draft_release_test }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -91,8 +92,8 @@ jobs:
           INCLUDE_LINUX="${{ inputs.include_linux }}"
           INCLUDE_WIN="${{ inputs.include_windows }}"
           UPLOAD="${{ inputs.upload_to_release }}"
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            echo "Dry run: forcing upload_to_release=false (still building for real, nothing gets uploaded/un-drafted/published)."
+          if [ "${{ inputs.draft_release_test }}" = "true" ]; then
+            echo "Draft release (test): forcing upload_to_release=false (still building for real, nothing gets uploaded/un-drafted/published)."
             UPLOAD="false"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -101,6 +102,7 @@ jobs:
           echo "include_linux=$INCLUDE_LINUX" >> "$GITHUB_OUTPUT"
           echo "include_windows=$INCLUDE_WIN" >> "$GITHUB_OUTPUT"
           echo "upload_to_release=$UPLOAD" >> "$GITHUB_OUTPUT"
+          echo "draft_release_test=${{ inputs.draft_release_test }}" >> "$GITHUB_OUTPUT"
           echo "Derived: version=$VERSION include_macos=$INCLUDE_MACOS include_linux=$INCLUDE_LINUX include_windows=$INCLUDE_WIN upload=$UPLOAD"
 
       - name: Gate on both Releases existing
@@ -215,6 +217,12 @@ jobs:
           done < <(find "$src_dir" -type f \( -name '*.zip' -o -name '*.tar.gz' \) | sort)
           echo "Uploaded $uploaded archive(s) from macOS arm64."
 
+      - name: Clean up test build archives
+        if: needs.preflight.outputs.draft_release_test == 'true'
+        run: |
+          echo "Draft release (test): removing built archives from this runner — nothing was uploaded."
+          rm -rf "$RELEASE_ARCHIVES_DIR/$VERSION_TAG/$PLATFORM_DIR"
+
   build-linux:
     needs: preflight
     if: needs.preflight.outputs.proceed == 'true' && needs.preflight.outputs.include_linux == 'true'
@@ -292,6 +300,12 @@ jobs:
             uploaded=$((uploaded + 1))
           done < <(find "$src_dir" -type f \( -name '*.zip' -o -name '*.tar.gz' \) | sort)
           echo "Uploaded $uploaded archive(s) from Linux x64."
+
+      - name: Clean up test build archives
+        if: needs.preflight.outputs.draft_release_test == 'true'
+        run: |
+          echo "Draft release (test): removing built archives from this runner — nothing was uploaded."
+          rm -rf "$RELEASE_ARCHIVES_DIR/$VERSION_TAG/$PLATFORM_DIR"
 
   build-windows:
     needs: preflight
@@ -395,6 +409,16 @@ jobs:
             $uploaded++
           }
           Write-Host "Uploaded $uploaded archive(s) from Windows x64."
+
+      - name: Clean up test build archives
+        if: needs.preflight.outputs.draft_release_test == 'true'
+        shell: powershell
+        run: |
+          Write-Host "Draft release (test): removing built archives from this runner - nothing was uploaded."
+          $platformPath = Join-Path $env:RELEASE_ARCHIVES_DIR (Join-Path $env:VERSION_TAG $env:PLATFORM_DIR)
+          if (Test-Path $platformPath) {
+            Remove-Item -Recurse -Force $platformPath
+          }
 
   publish-releases:
     name: Un-draft Releases and dispatch SDKMAN publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ on:
         description: 'Previous base version for the changelog (e.g. 4.0.0).'
         required: true
         type: string
-      dry_run:
-        description: 'Dry run both prepare workflows (no PRs created).'
+      draft_release_test:
+        description: 'Draft release (test): run the whole pipeline end-to-end (builds the SDKs for real) without opening PRs, creating tags/GitHub Releases, or publishing to Maven Central/SDKMAN.'
         required: false
         type: boolean
         default: false
@@ -48,7 +48,7 @@ jobs:
             --repo "${{ github.repository }}" \
             -f version="${{ inputs.version }}-jdk21" \
             -f previous_version="${{ inputs.previous_version }}-jdk21" \
-            -f dry_run="${{ inputs.dry_run }}"
+            -f draft_release_test="${{ inputs.draft_release_test }}"
           echo "Dispatched 1-prepare-release-jdk21.yml (version=${{ inputs.version }}-jdk21)."
 
       - name: Dispatch 1-prepare-release-jdk25
@@ -59,19 +59,30 @@ jobs:
             --repo "${{ github.repository }}" \
             -f version="${{ inputs.version }}-jdk25" \
             -f previous_version="${{ inputs.previous_version }}-jdk25" \
-            -f dry_run="${{ inputs.dry_run }}"
+            -f draft_release_test="${{ inputs.draft_release_test }}"
           echo "Dispatched 1-prepare-release-jdk25.yml (version=${{ inputs.version }}-jdk25)."
 
       - name: Summary
         run: |
           {
-            echo "## Release ${{ inputs.version }} dispatched"
+            if [ "${{ inputs.draft_release_test }}" = "true" ]; then
+              echo "## 🧪 Release ${{ inputs.version }} dispatched (DRAFT RELEASE — TEST)"
+            else
+              echo "## Release ${{ inputs.version }} dispatched"
+            fi
             echo ""
             echo "| Workflow | Version |"
             echo "|----------|---------|"
             echo "| [1-prepare-release-jdk21](https://github.com/${{ github.repository }}/actions/workflows/1-prepare-release-jdk21.yml) | ${{ inputs.version }}-jdk21 |"
             echo "| [1-prepare-release-jdk25](https://github.com/${{ github.repository }}/actions/workflows/1-prepare-release-jdk25.yml) | ${{ inputs.version }}-jdk25 |"
             echo ""
-            echo "Both prepare workflows now running in parallel. Each will open a PR for review."
-            echo "Merging both PRs continues the chain automatically (finalize → build → publish)."
+            if [ "${{ inputs.draft_release_test }}" = "true" ]; then
+              echo "Both prepare workflows now running in test mode: no PRs, no tags, no GitHub Releases,"
+              echo "no Maven Central/SDKMAN pushes. Each will dispatch finalize (test) automatically, which"
+              echo "dispatches build-release-sdks (test) automatically — the SDKs still get built for real,"
+              echo "nothing gets uploaded or published."
+            else
+              echo "Both prepare workflows now running in parallel. Each will open a PR for review."
+              echo "Merging both PRs continues the chain automatically (finalize → build → publish)."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Investigating why `0 - Release Orchestrator` behaved inconsistently between the JDK21 and JDK25
tracks (JDK21's Release page stuck in draft, `3 - Build Release SDKs` stopping dead after
Preflight) turned up several independent bugs in the release-prep/finalize/build pipeline. This
PR fixes the ones that belong on `master`/`develop`; a separate PR
(`chore/remove-duplicate-finalize-jdk25`) removes the stale duplicate workflow on the `jdk25`
branch that triggered the original symptom.

## What's fixed

**`build-release-sdks.yml` — the Preflight gate could never see a correctly-created Release**
`gh release view "$tag"` hits GitHub's "get release by tag" endpoint, which never returns
**draft** releases — and both `jdk21`/`jdk25` Releases are intentionally created as drafts
(`2-finalize-release-jdk*.yml` sets `draft: true`; `build-release-sdks.yml` un-drafts them once
archives are uploaded). So the gate always reported "does not exist yet" for a perfectly good
draft Release and silently skipped straight to done after Preflight, every time. Switched to
listing releases (which does include drafts) and bumped the `preflight` job's permission from
`contents: read` to `contents: write` — draft releases are only visible to tokens with push
access, so the read-only gate would still have seen nothing.

**`build-release-sdks.yml` — Windows upload step crashed on an em-dash**
The "Upload archives to matching Releases" step runs under Windows PowerShell 5.1
(`powershell.exe`), which reads the generated `.ps1` using the system codepage instead of UTF-8.
An em-dash in a `Write-Host "::warning::..."` string got mis-decoded, corrupting the string
terminator and cascading into `Missing closing '}'` parse errors that aborted the whole step
before anything uploaded. Replaced with a plain ASCII hyphen.

**`2-finalize-release-jdk21.yml` / `2-finalize-release-jdk25.yml` — installer version left stale**
The post-release "bump to next dev version" step only updated
`tornado-assembly/src/bin/tornado-test`'s embedded `__VERSION__`, never
`bin/tornadovm-installer`'s — so the installer script kept reporting the just-released version
instead of the new `-dev` version until the next `prepare-release` run overwrote it. Now bumps
both, matching what `prepare-release` already does.

**`1-prepare-release-jdk21.yml` — changelog lookback window was half of JDK25's**
The "find previous release" step fetched `per_page: 10` releases to locate `previous_version`'s
date; JDK25's equivalent already uses `per_page: 20`. Since JDK21 and JDK25 releases interleave
in the same release list, 10 slots only covers ~5 JDK21 releases back before `previous_version`
falls outside the window and the code silently falls back to a 90-day cutoff — pulling in
already-changelogged PRs or missing the right window. Matched to 20.

**`1-prepare-release-jdk21.yml` / `1-prepare-release-jdk25.yml` — README SDK-version references not updated**
The existing "Update README.md" step refreshed the version badge, the Maven Central `<version>`
tags, and (previously) a `**Latest Release:** ... - DATE` line — but missed:
- The SDKMAN! per-backend candidate table (`` `X.Y.Z-opencl` ``, `-cuda`, `-ptx`, `-spirv`,
  `-metal`, `-full`), which was stuck several majors behind.
- The `tornado-examples-X.Y.Z.jar` filename in the "Run your first program" snippet (both the
  Unix and Windows variants).
- The "Latest release" banner itself (README.md's line 17): the existing rule targeted
  `**Latest Release:** TornadoVM X.Y.Z - DATE`, but the actual banner had since been rewritten to
  `**Latest release:** TornadoVM X.Y.Z (JDK 21 / JDK 25) - <hand-written highlights>` (lowercase
  "release", no trailing date) — so the old rule silently matched nothing. Rewrote it to match
  the current format and update only the version number, leaving the highlight text for whoever
  writes it per release.

## Why two separate PRs (this one + the `jdk25`-branch cleanup)

`pull_request`-triggered workflows must exist on the branch the event actually targets to fire —
a copy living only on `master` would never trigger for a PR merging into `jdk25`. The `jdk25`
branch had accumulated a full stale copy of `.github/workflows/`, including an old
pre-restructure `finalize-release-jdk25.yml` that still listened for the same
`pull_request: closed, branches: [jdk25]` event as the current `2-finalize-release-jdk25.yml`.
Every `release-jdk25/*` PR merge fired both simultaneously; the old one (draft:false, no
RST→Markdown conversion) usually won the race, leaving the current workflow's tag push to fail
and its own draft Release / version bump to never happen. That cleanup is out of scope for this
PR since it targets a different base branch — see `chore/remove-duplicate-finalize-jdk25`.

## Testing

- Verified the gate's draft-visibility fix against the documented GitHub API behavior for the
  "get release by tag" vs. list-releases endpoints, and cross-checked against the existing
  (working) "Un-draft Releases" step, which already relies on `contents: write` to manage
  drafts by tag.
- Dry-ran the new README `sed` patterns against the real `README.md` (Python `re.sub` mirroring
  the GNU `sed -E` patterns, since local dev is on BSD sed) to confirm they update only the
  intended fields and leave everything else — including hand-written release-highlight text —
  untouched.
- Confirmed the Windows em-dash was the literal cause of a real failed run
  (`build-release-sdks` run on 2026-07-23) by reproducing the exact `Write-Host` string that
  broke PowerShell's parser.
