### PR TITLE
Add TornadoVM contributor Claude skill (OpenCL/CUDA/Metal)

### DIFF
--- a/.claude/skills/tornadovm-nvidia/SKILL.md
+++ b/.claude/skills/tornadovm-nvidia/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: tornadovm-nvidia
+description: NVIDIA-specific TornadoVM workflows on the CUDA backend — profile with Nsight Systems (nsys) and read NVTX ranges, use the hybrid library-task API (cuBLAS/cuBLASLt/cuDNN/cuFFT/cuSPARSE/cuTENSOR/CUTLASS/NCCL native calls from Java), print the generated CUDA-C kernel, and fuzz-test the CUDA-C backend with tornado-fuzz. Use for anything about nsys/Nsight, hybrid/library tasks, cuBLAS & friends, inspecting CUDA kernels, or fuzzing. Requires an NVIDIA GPU + `make BACKEND=cuda`. For generic build/test/commit basics see the `tornadovm` skill.
+---
+
+# TornadoVM on NVIDIA (CUDA backend)
+
+All of this targets the **CUDA-C backend**: build with `make BACKEND=cuda` (which also builds the `*-jni` library modules under the `cuda-backend` Maven profile), then `source setvars.sh`. Repo-root refs: `HYBRID_API_GUIDE.md`, `NVIDIA_ROADMAP.md`, and `docs/source/hybrid-api.rst`.
+
+## 1. Profiling with Nsight Systems (nsys)
+
+TornadoVM labels its work with **NVTX ranges** (always on, no profiler flag): JIT kernels, host↔device transfers, *and* hybrid library calls. Library tasks appear as ranges like `:nvidia/cublas/cublasSgemm`. So an `nsys` timeline reads like the TornadoVM task graph.
+
+```bash
+source setvars.sh
+nsys profile --trace=cuda,nvtx -o run tornado -m <module>/<MainClass>   # → run.nsys-rep
+# also works with the test runner / examples, e.g.:
+nsys profile --trace=cuda,nvtx -o streams tornado-test uk.ac.manchester.tornado.unittests.streams.TestStreamsPerformance
+```
+
+Open `run.nsys-rep` in the Nsight Systems GUI. `--trace=cuda` alone gives kernel/API timing; add `nvtx` to get the TornadoVM labels. See `TestNvtx` (`tornado-unittests/.../unittests/nvtx/TestNvtx.java`) for the transparency contract (balanced push/pop across JIT / repeated / mixed / CUDA-graph runs).
+
+**Correctness profiling:** `compute-sanitizer` catches races/OOB/uninit that timing can't. Use the toolkit build, not the distro one, and trace the java child process:
+```bash
+/usr/local/cuda/bin/compute-sanitizer --tool racecheck --target-processes all tornado -m <module>/<MainClass>
+```
+(`racecheck`, `memcheck`, `initcheck`, `synccheck`.)
+
+## 2. Hybrid library-task API (NVIDIA CUDA-X from Java)
+
+A **library task** hands a step of the task graph to a native NVIDIA library instead of JIT-generating a kernel. It reuses the same TornadoVM device buffers and rides the normal LAUNCH pipeline (no unified-memory copies), dispatched through a ServiceLoader SPI (`TornadoLibraryProvider`).
+
+```java
+TaskGraph graph = new TaskGraph("g")
+    .transferToDevice(DataTransferMode.EVERY_EXECUTION, matrix, x)
+    .task("pre", MyKernels::prepare, x, tmp)            // ordinary JIT task
+    .libraryTask("sgemv", CuBlas::cublasSgemv,          // native cuBLAS call
+                 matrix, x, y, rows, cols)
+    .task("post", MyKernels::finish, y)                 // ordinary JIT task
+    .transferToHost(DataTransferMode.EVERY_EXECUTION, y);
+```
+
+`libraryTask(String id, LibraryTaskN code, args...)` — `code` is a method reference to a provider function; JIT `task(...)` and `libraryTask(...)` mix freely in one graph. Arities go up to 20.
+
+**Providers on `develop`** (module → provider id / entry class):
+
+| Library | Module | Provider id | Examples |
+|---|---|---|---|
+| cuBLAS | `tornado-cublas` | `nvidia/cublas` | `cublasSgemm`, `cublasSgemv`, GemmEx FP16/TF32, stridedBatched |
+| cuBLASLt | `tornado-cublas` | `nvidia/cublaslt` | fused BIAS / GELU_BIAS epilogues |
+| cuDNN | `tornado-cudnn` | `nvidia/cudnn` | SDPA (`cudnnSdpaForward` FP16), conv2d, softmax, pooling, activations |
+| cuFFT | `tornado-cufft` | `nvidia/cufft` | C2C/R2C/C2R/Z2Z 1D & 2D, batched |
+| cuSPARSE | `tornado-cusparse` | `nvidia/cusparse` | CSR SpMV / SpMM (FP32) |
+| cuTENSOR | `tornado-cutensor` | (see module) | FP32 tensor contractions (einsum) |
+| CUTLASS | `tornado-cutlass` | `nvidia/cutlass` | FP32/FP16 GEMM + fused epilogues (NVRTC track) |
+| NCCL | `tornado-nccl` | standalone `TornadoNccl` API | multi-GPU collectives |
+
+**Key patterns:**
+- **CUDA graphs:** library tasks are graph-capturable. Providers that allocate device workspace (cuFFT/cuDNN/cuSPARSE plans, cuBLAS handles) do it in the SPI `prepare(descriptor, context)` pre-compile hook (idempotent) *before* capture — never allocate mid-capture. Wrap with `withCUDAGraph`.
+- **Cross-graph device residency:** `persistOnDevice` / `consumeFromDevice` keep buffers on the GPU between graphs (avoid round-trips).
+- **Scalar outputs** (e.g. `cublas dot`) use `CUBLAS_POINTER_MODE_DEVICE` with a 1-element TornadoVM array to stay capture-safe.
+- **Every hybrid feature ships with a test** (validated vs sequential Java) and perf features with a **WoW benchmark** vs both Java and the best KernelContext kernel (patterns `BenchmarkSgemm`, `MatrixVectorRowMajorWithCuBlas`, `BenchmarkSdpa`). Tests: `tornado-unittests/.../unittests/{cublas,cudnn,cufft,cusparse,nvtx}/...`; benchmarks/examples in `tornado-examples`.
+
+Build note: library JNI modules link against the CUDA toolkit at `/usr/local/cuda` (prefer it over any older apt CUDA to avoid NVRTC-version mismatch); each JNI CMake is guarded — a missing library skips that provider.
+
+## 3. Print the generated CUDA-C kernel
+
+To see the CUDA-C that the JIT emits for a `task(...)`:
+
+```bash
+# via the test runner:
+tornado-test uk.ac.manchester.tornado.unittests.arrays.TestArrays#testAdd -V -pk
+# via any app (JVM property):
+tornado -m <module>/<MainClass> --jvm="-Dtornado.printKernel=true"
+# dump kernels to files instead of stdout:
+tornado -m <module>/<MainClass> --jvm="-Dtornado.printKernel=true -Dtornado.print.kernel.dir=/tmp/kernels"
+```
+
+Flags: `-pk`/`--printKernel` (test runner) ↔ `-Dtornado.printKernel=true` (`TornadoOptions.PRINT_KERNEL_SOURCE`); `-Dtornado.print.kernel.dir=<dir>` writes each kernel to a file; add `--printBytecodes`/`-pbc` to also see the TornadoVM bytecode. Library tasks emit no kernel (they call native code) — inspect those with nsys/NVTX instead.
+
+## 4. Fuzz-testing the CUDA-C backend (`tornado-fuzz`)
+
+`tornado-fuzz` (module `tornado.fuzz`) is a differential fuzzer for the **CUDA-C backend only**. Oracle: a kernel is a static Java method → run it as plain Java on the host (golden) and via the CUDA backend, then compare (int/bitwise exact; float rel+abs 1e-3; NaN==NaN); plus a crash/exception oracle.
+
+```bash
+source setvars.sh
+# Phase 1 — fixed KernelContext templates (elementwise/math/local-mem-reduce/atomic):
+tornado -m tornado.fuzz/uk.ac.manchester.tornado.fuzz.FuzzMain \
+        --params "seed=1 count=300 phase=1 outDir=/tmp/fuzz"
+
+# Phase 2 — generative: random int-expression kernels compiled in-process, run CUDA vs JVM reference.
+# The generated class dir MUST be on -cp AND passed via -Dtornado.fuzz.genDir (system classloader
+# requirement — ASM reads bytecode via getSystemClassLoader):
+tornado -cp /tmp/gen -m tornado.fuzz/uk.ac.manchester.tornado.fuzz.FuzzMain \
+        --jvm="-Dtornado.fuzz.genDir=/tmp/gen" \
+        --params "seed=1 count=200 phase=2 outDir=/tmp/fuzz2"
+```
+
+Each finding writes a bundle under `<outDir>/findings/<kind>-<seed>/`: `config.json`, `kernel.java`, `diff.txt`, `stacktrace`, and a standalone `Repro_*.java` (JUnit extending `TornadoTestBase` with the failing inputs + golden embedded as literals). Confirmed integer-codegen divergences it has surfaced (regression suite `tornado-unittests/.../unittests/fuzz/`): `min/max(NaN,x)` semantics, `a<<31`, `INT_MIN*b`, sign-bit masks, signed `>>` emitted as logical, and an `INT_MIN` division that crashes the CUDA reassociation phase.
+
+When adding an expression shape or template, keep the JVM `reference` method the single source of truth (identical loop to the emitted kernel), and use a **unique generated class name per compile** (the system loader caches by name).

--- a/.claude/skills/tornadovm/SKILL.md
+++ b/.claude/skills/tornadovm/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: tornadovm
+description: Build, test, and contribute to TornadoVM's OpenCL/CUDA/Metal backends — make BACKEND targets, tornado-test (quickPass/single-class), checkstyle-before-PR, one-line commits, the develop-branch PR flow, and the recurring graalJars/setvars build gotchas. Use when building the project, running or adding unit tests, or editing the OpenCL/CUDA/Metal code generators. PTX and SPIRV backends are intentionally out of scope.
+---
+
+# Working on TornadoVM
+
+TornadoVM JIT-compiles Java bytecode to GPU code (OpenCL C, CUDA/NVRTC, Apple Metal MSL) at runtime. This skill is the operational guide for building, testing, and contributing.
+
+**Backend scope:** this skill covers **OpenCL, CUDA, and Metal** only. **PTX and SPIRV are out of scope** (both are slated for removal in the 6.0.0 roadmap). Never suggest `make BACKEND=ptx` or `make BACKEND=spirv`.
+
+For backend internals (where codegen lives, how to add a node/intrinsic), see `references/codegen-map.md`.
+
+## Build
+
+Requires **JDK 21+** (`JAVA_HOME` must point at a JDK 21 build). Source the env once per shell, then build with `make`:
+
+```bash
+source setvars.sh                 # exports JAVA_HOME, TORNADOVM_HOME; prepends $TORNADOVM_HOME/bin to PATH
+make BACKEND=opencl,cuda          # comma-separated list; values in scope: opencl, cuda, metal
+```
+
+Convenience targets: `make cuda` (= `--backend cuda`), `make metal` (= `metal,opencl`). Default `BACKEND` is `opencl`.
+
+- **Incremental build ≈ 3 min.** Only a clean rebuild (Graal-jar pull + full recompile) is long — don't assume every build is slow.
+- Under the hood `make` calls `bin/compile --jdk jdk21 --backend <list>`. Useful flags: `--rebuild` (rebuild deps), `--sdk`, `--polyglot`, `--mvn_single_threaded`.
+- The built SDK lands in `dist/tornadovm-<version>-jdk21-dev-<variant>-<os>-<arch>/...`; `TORNADOVM_HOME` and the `bin/tornado*` launchers point into it.
+
+### Build gotchas
+1. **Stale `graalJars/`** — switching between branch families that vendor Graal differently leaves incompatible jars in the git-ignored `graalJars/` dir. Symptom: the *first* module (`tornado-api`) fails with `error: cannot access module-info` (not a code or JDK error). Fix: `rm -rf graalJars` then rebuild — `bin/pull_graal_jars.py` re-fetches the correct set.
+2. **Stale `setvars.sh` `JAVA_HOME`** — an out-of-date `setvars.sh` can export the wrong JDK (e.g. JDK 27 → `invalid source release 21 with --enable-preview`). After sourcing, verify `java -version`; pin `JAVA_HOME` to a JDK 21 explicitly if it's wrong.
+
+## Test
+
+`tornado-test` (in `$TORNADOVM_HOME/bin`, source `tornado-assembly/src/bin/tornado-test`). The backend is fixed by **what you built** (recorded in `$TORNADOVM_HOME/etc/tornado.backend`) — there is no `--backend` test flag.
+
+```bash
+tornado-test --quickPass                                              # fast sweep (~152s); skips heavy/memory tests
+tornado-test uk.ac.manchester.tornado.unittests.arrays.TestArrays -V # a single class, verbose
+tornado-test 'uk.ac...TestArrays#testInitByteArray' -V               # a single method
+```
+
+Useful flags: `-qp/--quickPass`, `-V/--verbose`, `--printExec` (execution times — the flag is `--printExec`, **not** `--printExecutionTimes`), `-pk/--printKernel`, `--device s0.t0.device=0:1` (pick device), `-J/--jvm "-Dtornado.<opt>=..."` (extra JVM flags), `--ea` (assertions).
+
+### Adding a unit test
+- Place it under `tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/<feature>/` (tests live in `src/main/java`, not `src/test`).
+- Class `Test<Feature> extends TornadoTestBase` (`.../unittests/common/TornadoTestBase.java`) with JUnit `@Test` methods; validate against a sequential Java reference.
+- To include it in the full "test the world" sweep, add a `TestEntry(...)` to the `__TEST_THE_WORLD__` list in `tornado-assembly/src/bin/tornado-test`. Running a single class by name needs no registration.
+
+## Checkstyle — run before every commit / PR
+
+```bash
+make checkstyle          # = ./mvnw checkstyle:check
+```
+
+Config: `tornado-assembly/src/etc/checkstyle.xml` (severity = error, extends GraalVM rules). Suppress a block with `// CHECKSTYLE.OFF: <Rule>` … `// CHECKSTYLE.ON: <Rule>`. Most common failure after edits: `UnusedImports` (remove imports orphaned by deleted code). A green checkstyle is required — CI enforces it.
+
+## Commit & PR conventions
+
+- **Commit message: a single line, no body, and NO `Co-Authored-By` / AI-attribution trailer.** The project keeps a clean human-authored history.
+- **Branch from and PR into `develop`** (not `master`/`main`). Open with `gh pr create --base develop`. A signed CLA is required — see `CONTRIBUTING.md`.
+- Auto-format with the project's Eclipse/IntelliJ config before committing (`CONTRIBUTING.md`; `make intellijinit` after `source setvars.sh`).
+
+## Backends (in scope)
+
+| Backend | Module | Maven profile | Build |
+|---|---|---|---|
+| OpenCL | `tornado-drivers/opencl` | `opencl-backend` | `make BACKEND=opencl` |
+| CUDA (CUDA-C / NVRTC) | `tornado-drivers/cuda` | `cuda-backend` | `make cuda` |
+| Metal (macOS only) | `tornado-drivers/metal` | `metal-backend` | `make metal` |
+
+Shared compiler phases/utilities live in `tornado-drivers/drivers-common`. Note: `tornado-drivers/cuda` (the standalone CUDA-C backend, classes `CUDA*`) is distinct from the PTX backend — "CUDA" here always means the `cuda` module.

--- a/.claude/skills/tornadovm/references/codegen-map.md
+++ b/.claude/skills/tornadovm/references/codegen-map.md
@@ -1,0 +1,51 @@
+# TornadoVM codegen map — OpenCL / CUDA / Metal
+
+Where code generation lives for the three in-scope backends, and how to add a new node or intrinsic. PTX and SPIRV are out of scope.
+
+## Package & module layout
+
+Uniform pattern per backend `<B>` ∈ {OpenCL→`opencl`/`OCL`, CUDA→`cuda`/`CUDA`, Metal→`metal`/`Metal`}:
+
+- Module dir: `tornado-drivers/<module>/src/main/java/uk/ac/manchester/tornado/drivers/<module>/`
+- Package root: `uk.ac.manchester.tornado.drivers.<module>`
+- Codegen packages: `.graal.backend`, `.graal.compiler`, `.graal.compiler.plugins`, `.graal` (lowering), `.runtime`
+- Shared phases/utilities: `tornado-drivers/drivers-common`
+- Maven profiles: `opencl-backend`, `cuda-backend`, `metal-backend`
+
+Class-name prefix per backend: OpenCL = `OCL`, CUDA = `CUDA`, Metal = `Metal`.
+
+## Key classes (verified present on all three backends)
+
+Paths are relative to each backend's package root. Replace `<P>` with the prefix (`OCL` / `CUDA` / `Metal`).
+
+| Role | Path |
+|---|---|
+| Backend (kernel prologue/epilogue, ABI) | `graal/backend/<P>Backend.java` |
+| High tier (arch-agnostic → arch phases) | `graal/compiler/<P>HighTier.java` |
+| Low tier (lowering to LIR-ready graph) | `graal/compiler/<P>LowTier.java` |
+| Node → LIR builder (emit per-node) | `graal/compiler/<P>NodeLIRBuilder.java` |
+| Compilation result builder (LIR → source/asm) | `graal/compiler/<P>CompilationResultBuilder.java` |
+| GraphBuilder plugins / intrinsics registration | `graal/compiler/plugins/<P>GraphBuilderPlugins.java` |
+| Lowering provider (load/store, snippets) | `graal/<P>LoweringProvider.java` |
+| Code cache (compile + install kernels) | `<P>CodeCache.java` |
+| TornadoDevice (runtime device driver) | `runtime/<P>TornadoDevice.java` |
+
+Example concrete paths:
+- OpenCL: `tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java`, `.../graal/OCLLoweringProvider.java`, `.../graal/compiler/plugins/OCLGraphBuilderPlugins.java`
+- CUDA: `tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDABackend.java`, `.../graal/CUDALoweringProvider.java`, `.../graal/compiler/plugins/CUDAGraphBuilderPlugins.java`
+- Metal: `tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/backend/MetalBackend.java`, `.../graal/MetalLoweringProvider.java`, `.../graal/compiler/plugins/MetalGraphBuilderPlugins.java`
+
+## Recipe: add a new node / intrinsic
+
+1. **Define the node** — a Graal node (often a `FloatingNode` or `FixedWithNextNode`) under `.graal.nodes` for the backend; give it a LIR-emitting counterpart if needed under `.graal.lir`.
+2. **Register the builtin** — map the Java method/pattern to the node in `<P>GraphBuilderPlugins` (an `InvocationPlugin`). This is also where the **reflection-path recovery** cases live (used on JDK 21+ where the sketcher can't descend into some FFM/`MemorySegment` internals).
+3. **Lower it** — in `<P>LoweringProvider` (e.g. `lowerLoad/StoreIndexed`, or a snippet) if the node needs lowering before LIR.
+4. **Emit LIR** — in `<P>NodeLIRBuilder.emitNode(...)`, add the case that appends the LIR op; the final source/asm text is produced in `<P>CompilationResultBuilder`.
+5. **Mirror across backends** — implement for **both OpenCL and CUDA** (Metal if applicable). OpenCL historically lagged CUDA on reflection-path recoveries: if a feature already works on CUDA and not OpenCL, find the matching CUDA commit and mirror it (register the same plugin, add the same lowering/LIR case). Put backend-agnostic phases in `tornado-drivers/drivers-common`.
+6. **Test** — add a `Test<Feature>` under `tornado-unittests/.../<feature>/` validating vs a sequential Java reference; run on each built backend with `tornado-test <class> -V` (and `-pk` to inspect the generated kernel).
+
+## Gotchas specific to codegen
+
+- **Half-float (`HalfFloat`) typing** — device-function (non-kernel) parameters and local `HALF` arrays need explicit HALF handling in `<P>Backend.emitMethodParameters` and `<P>LoweringProvider` (a plain SHORT path truncates fp16 values). The reflection path may wrap arrays in a `PiNode` — `GraphUtil.unproxify` before `instanceof` checks.
+- **`ByteArray.getHalfFloat/setHalfFloat`** and native-array get/set must be registered as InvocationPlugins in `<P>GraphBuilderPlugins` (byte-addressed read/write nodes) rather than fixed in the constant-reflection provider — folding host `MemorySegment`/`VarHandle` internals yields garbage.
+- **CUDA vs PTX** — `tornado-drivers/cuda` (CUDA-C via NVRTC) is a separate backend from PTX. Everything here refers to the `cuda` module.


### PR DESCRIPTION
## Summary

Adds a committed Claude Code **project skill** at `.claude/skills/tornadovm/` so any Claude Code session in the repo picks up TornadoVM's build/test/contribute workflow and backend-codegen map without re-deriving it each time.

Scope: **OpenCL, CUDA, and Metal** backends. PTX and SPIRV are intentionally out of scope (both are slated for removal in the 6.0.0 roadmap).

## Contents

- **`SKILL.md`** — the workflow guide:
  - Build: JDK 21+, `source setvars.sh`, `make BACKEND=opencl,cuda` (+ `make cuda`/`make metal`), incremental ≈ 3 min, `bin/compile` flags.
  - Build gotchas: stale `graalJars/` → `error: cannot access module-info` (fix: `rm -rf graalJars`); stale `setvars.sh` `JAVA_HOME`.
  - Test: `tornado-test --quickPass`, single class/method, `--printExec`/`--device`/`--jvm`; backend fixed at build time; how to add a unit test + register it in `__TEST_THE_WORLD__`.
  - Checkstyle before every commit/PR (`make checkstyle`).
  - Conventions: one-line commit messages, PR into `develop`, CLA.
- **`references/codegen-map.md`** — where OpenCL/CUDA/Metal code generation lives (Backend / HighTier / LowTier / NodeLIRBuilder / CompilationResultBuilder / GraphBuilderPlugins / LoweringProvider / CodeCache / TornadoDevice), the uniform package pattern, a step-by-step "add a node/intrinsic" recipe, and codegen-specific gotchas (HalfFloat typing, ByteArray fp16 access, CUDA-vs-PTX distinction).

## Notes

- Docs/skill only — no source or build changes. All file paths referenced in the skill were verified to exist on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
