### PR TITLE
Add warp-vote intrinsics (simdAny, simdAll, simdBallot) to KernelContext on the CUDA backend

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
@@ -383,6 +383,54 @@ public class KernelContext implements ExecutionContext {
     }
 
     /**
+     * Returns whether {@code predicate} holds for at least one active lane of the SIMD group.
+     * <p>
+     * Warp/SIMD-group vote. Useful to skip work that no lane in the group needs, without a
+     * shared-memory round trip: every lane gets the same answer.
+     * <p>
+     * CUDA equivalent: {@code __any_sync(0xffffffff, predicate)}
+     *
+     * @param predicate
+     *     per-lane condition
+     * @return true when any active lane passes {@code predicate}
+     */
+    public boolean simdAny(boolean predicate) {
+        return predicate;
+    }
+
+    /**
+     * Returns whether {@code predicate} holds for every active lane of the SIMD group.
+     * <p>
+     * CUDA equivalent: {@code __all_sync(0xffffffff, predicate)}
+     *
+     * @param predicate
+     *     per-lane condition
+     * @return true when all active lanes pass {@code predicate}
+     */
+    public boolean simdAll(boolean predicate) {
+        return predicate;
+    }
+
+    /**
+     * Returns a bit mask with one bit per lane of the SIMD group, set where {@code predicate} holds.
+     * Bit {@code i} corresponds to lane {@code i}, so on a 32-lane warp the result covers bits 0-31.
+     * <p>
+     * This is the building block for warp-aggregated atomics and stream compaction:
+     * {@code Integer.bitCount(simdBallot(p))} counts the lanes that pass without any atomic, and
+     * {@code Integer.bitCount(simdBallot(p) & ((1 << laneId) - 1))} gives each lane its rank among
+     * them, so one lane can reserve space for the whole group with a single atomic.
+     * <p>
+     * CUDA equivalent: {@code __ballot_sync(0xffffffff, predicate)}
+     *
+     * @param predicate
+     *     per-lane condition
+     * @return lane mask of the lanes that pass {@code predicate}
+     */
+    public int simdBallot(boolean predicate) {
+        return predicate ? 1 : 0;
+    }
+
+    /**
      * Cooperative 8x8 single-precision matrix multiply for one SIMD group, using
      * Apple's {@code simdgroup_float8x8} hardware matrix units (MMA).
      * <p>

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -207,6 +207,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestLocalArrayDynamicIndexAtomics"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestAsyncCopyToLocal"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestFlashAttentionKernelContext"),
+    TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestWarpVote"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestHalfFloatLocalArray"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.local.memory.TestSwizzledLocalArrays"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext"),

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAGraphBuilderPlugins.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAGraphBuilderPlugins.java
@@ -96,6 +96,7 @@ import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAShuffleDownNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDASimdBroadcastFirstNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAAtomicRmwNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDASimdSumNode;
+import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAWarpVoteNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.DecAtomicNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.GetAtomicNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.GlobalThreadIdNode;
@@ -937,6 +938,32 @@ public class CUDAGraphBuilderPlugins {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode val) {
                 b.addPush(JavaKind.Float, new CUDASimdBroadcastFirstNode(val));
+                return true;
+            }
+        });
+
+        // Warp votes. Same reasoning as above: the KernelContext defaults answer for a single lane,
+        // so without these plugins a vote would silently reduce to its own predicate.
+        r.register(new InvocationPlugin("simdAny", InvocationPlugin.Receiver.class, boolean.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode predicate) {
+                b.addPush(JavaKind.Boolean, new CUDAWarpVoteNode(CUDALIRStmt.WarpVoteStmt.Mode.ANY, predicate));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("simdAll", InvocationPlugin.Receiver.class, boolean.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode predicate) {
+                b.addPush(JavaKind.Boolean, new CUDAWarpVoteNode(CUDALIRStmt.WarpVoteStmt.Mode.ALL, predicate));
+                return true;
+            }
+        });
+
+        r.register(new InvocationPlugin("simdBallot", InvocationPlugin.Receiver.class, boolean.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode predicate) {
+                b.addPush(JavaKind.Int, new CUDAWarpVoteNode(CUDALIRStmt.WarpVoteStmt.Mode.BALLOT, predicate));
                 return true;
             }
         });

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
@@ -873,6 +873,69 @@ public class CUDALIRStmt {
 
     @Opcode("SHUFFLE_SYNC")
     /**
+     * Warp vote: {@code __any_sync} / {@code __all_sync} / {@code __ballot_sync}. All three take the
+     * full member mask and a per-lane predicate; the first two yield a boolean (the intrinsic returns
+     * non-zero, so the result is compared against 0), the third a lane mask.
+     */
+    public static class WarpVoteStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<WarpVoteStmt> TYPE = LIRInstructionClass.create(WarpVoteStmt.class);
+
+        public enum Mode {
+            ANY("__any_sync", true),
+            ALL("__all_sync", true),
+            BALLOT("__ballot_sync", false);
+
+            private final String intrinsic;
+            private final boolean booleanResult;
+
+            Mode(String intrinsic, boolean booleanResult) {
+                this.intrinsic = intrinsic;
+                this.booleanResult = booleanResult;
+            }
+        }
+
+        // All active lanes participate (CUDA 9+ requires an explicit member mask).
+        private static final String FULL_MASK = "0xffffffff";
+
+        private final Mode mode;
+        @Def
+        protected Value result;
+        @Use
+        protected Value predicate;
+
+        public WarpVoteStmt(Mode mode, Value result, Value predicate) {
+            super(TYPE);
+            this.mode = mode;
+            this.result = result;
+            this.predicate = predicate;
+        }
+
+        @Override
+        public void emitCode(CUDACompilationResultBuilder crb, CUDAAssembler asm) {
+            asm.indent();
+            asm.emitValue(crb, result);
+            asm.space();
+            asm.assign();
+            asm.space();
+            if (mode.booleanResult) {
+                asm.emit("(");
+            }
+            asm.emit(mode.intrinsic);
+            asm.emit("(");
+            asm.emit(FULL_MASK);
+            asm.emit(", ");
+            asm.emitValue(crb, predicate);
+            asm.emit(")");
+            if (mode.booleanResult) {
+                asm.emit(" != 0)");
+            }
+            asm.delimiter();
+            asm.eol();
+        }
+    }
+
+    /**
      * Read-modify-write atomic on one element of a local (shared) array:
      * {@code atomicCAS} / {@code atomicExch} / {@code atomicMin} / {@code atomicMax}. All four return the
      * element's previous value.

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/nodes/CUDAWarpVoteNode.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/nodes/CUDAWarpVoteNode.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.cuda.graal.nodes;
+
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Value;
+import uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDALIRStmt;
+
+/**
+ * Graal IR node for the {@code KernelContext} warp-vote intrinsics
+ * {@code simdAny(boolean)}, {@code simdAll(boolean)} and {@code simdBallot(boolean)}.
+ *
+ * <p>Lowered to {@code __any_sync} / {@code __all_sync} / {@code __ballot_sync} over the full member
+ * mask. {@code ANY} and {@code ALL} produce a boolean, {@code BALLOT} a lane mask.
+ *
+ * <p>Extends {@link FixedWithNextNode} because warp votes are convergent — every lane of the warp has
+ * to execute the same vote, so the node must not be reordered or duplicated across control flow.
+ */
+@NodeInfo(shortName = "CUDAWarpVote")
+public class CUDAWarpVoteNode extends FixedWithNextNode implements LIRLowerable {
+
+    public static final NodeClass<CUDAWarpVoteNode> TYPE = NodeClass.create(CUDAWarpVoteNode.class);
+
+    private final CUDALIRStmt.WarpVoteStmt.Mode mode;
+
+    @Input
+    private ValueNode predicate;
+
+    public CUDAWarpVoteNode(CUDALIRStmt.WarpVoteStmt.Mode mode, ValueNode predicate) {
+        super(TYPE, StampFactory.forKind(mode == CUDALIRStmt.WarpVoteStmt.Mode.BALLOT ? JavaKind.Int : JavaKind.Boolean));
+        this.mode = mode;
+        this.predicate = predicate;
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool gen) {
+        LIRGeneratorTool tool = gen.getLIRGeneratorTool();
+        Value source = gen.operand(predicate);
+        Variable result = tool.newVariable(tool.getLIRKind(stamp));
+        tool.append(new CUDALIRStmt.WarpVoteStmt(mode, result, source));
+        gen.setResult(this, result);
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestWarpVote.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestWarpVote.java
@@ -107,12 +107,92 @@ public class TestWarpVote extends TornadoTestBase {
         out.set(globalIdx, rank);
     }
 
+    /**
+     * A block of four warps, where the predicate holds for every lane of the odd warps and no lane
+     * of the even ones. A warp-wide vote therefore answers differently for warps of the <b>same
+     * block</b>: 3 (any and all) against 0 (neither). A vote lowered to a block-wide reduction
+     * would answer 2 (any but not all) everywhere, and a per-lane no-op would answer 3 in the odd
+     * warps and 0 in the even ones only by accident of the predicate - so the companion
+     * {@link #voteInLoopKernel} covers that case.
+     */
+    private static void multiWarpBlockKernel(KernelContext ctx, IntArray out) {
+        int globalIdx = ctx.globalIdx;
+        int localIdx = ctx.localIdx;
+        int warpId = localIdx / WARP_SIZE;
+        boolean predicate = (warpId % 2) == 1;
+        int any = ctx.simdAny(predicate) ? 1 : 0;
+        int all = ctx.simdAll(predicate) ? 1 : 0;
+        out.set(globalIdx, any * 2 + all);
+    }
+
+    /**
+     * Ballot over a predicate the compiler cannot fold: it comes from device memory, so the mask
+     * has to be built at runtime. Each lane reports the population count of its warp's mask, which
+     * every lane of a warp must agree on.
+     */
+    private static void dataBallotKernel(KernelContext ctx, IntArray input, IntArray out) {
+        int globalIdx = ctx.globalIdx;
+        int mask = ctx.simdBallot(input.get(globalIdx) > 0);
+        out.set(globalIdx, Integer.bitCount(mask));
+    }
+
+    /**
+     * Votes inside a loop, with one result driving a branch and another feeding arithmetic. Over
+     * the four steps every residue class is covered, so {@code simdAny} holds on each step and
+     * {@code simdAll} never does, and each ballot selects exactly a quarter of the warp.
+     *
+     * <p>The {@code simdAll} branch is the discriminator: a lowering that returned the calling
+     * lane's own predicate would fire it on the one step where the lane passes, adding 100.
+     */
+    private static void voteInLoopKernel(KernelContext ctx, IntArray out) {
+        int globalIdx = ctx.globalIdx;
+        int localIdx = ctx.localIdx;
+        int acc = 0;
+        for (int step = 0; step < 4; step++) {
+            boolean predicate = (localIdx % 4) == step;
+            if (ctx.simdAny(predicate)) {
+                acc += 1;
+            }
+            if (ctx.simdAll(predicate)) {
+                acc += 100;
+            }
+            acc += Integer.bitCount(ctx.simdBallot(predicate));
+        }
+        out.set(globalIdx, acc);
+    }
+
+    /**
+     * Warp leader election over a compound predicate: the ballot argument is {@code &&} of a
+     * data-dependent test and a lane test, so it has to be materialised as a single boolean rather
+     * than folded per operand.
+     *
+     * <p>The leader is the lowest passing lane. {@code Integer.numberOfTrailingZeros} is not
+     * registered as an intrinsic on this backend, so it is derived from the lowest set bit with
+     * {@code bitCount}, which is.
+     */
+    private static void leaderElectionKernel(KernelContext ctx, IntArray input, IntArray out) {
+        int globalIdx = ctx.globalIdx;
+        int localIdx = ctx.localIdx;
+        boolean predicate = (input.get(globalIdx) > 0) && ((localIdx & 1) == 0);
+        int mask = ctx.simdBallot(predicate);
+        int leader = -1;
+        if (mask != 0) {
+            int lowestSetBit = mask & (-mask);
+            leader = Integer.bitCount(lowestSetBit - 1);
+        }
+        out.set(globalIdx, leader);
+    }
+
     private static IntArray runKernel(String name, KernelTask task) throws TornadoExecutionPlanException {
-        IntArray out = new IntArray(SIZE);
+        return runKernel(name, task, SIZE, WARP_SIZE);
+    }
+
+    private static IntArray runKernel(String name, KernelTask task, int size, int localSize) throws TornadoExecutionPlanException {
+        IntArray out = new IntArray(size);
         out.init(-1);
         KernelContext context = new KernelContext();
-        WorkerGrid worker = new WorkerGrid1D(SIZE);
-        worker.setLocalWork(WARP_SIZE, 1, 1);
+        WorkerGrid worker = new WorkerGrid1D(size);
+        worker.setLocalWork(localSize, 1, 1);
         GridScheduler grid = new GridScheduler("warpVote." + name, worker);
 
         TaskGraph taskGraph = new TaskGraph("warpVote") //
@@ -127,8 +207,32 @@ public class TestWarpVote extends TornadoTestBase {
         return out;
     }
 
+    private static IntArray runKernel(String name, InputKernelTask task, IntArray input) throws TornadoExecutionPlanException {
+        IntArray out = new IntArray(input.getSize());
+        out.init(-1);
+        KernelContext context = new KernelContext();
+        WorkerGrid worker = new WorkerGrid1D(input.getSize());
+        worker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler grid = new GridScheduler("warpVote." + name, worker);
+
+        TaskGraph taskGraph = new TaskGraph("warpVote") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input, out) //
+                .task(name, task, context, input, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            plan.withGridScheduler(grid).execute();
+        }
+        return out;
+    }
+
     /** Signature of the kernels above, so {@link #runKernel} can build the task graph for each. */
     private interface KernelTask extends uk.ac.manchester.tornado.api.common.TornadoFunctions.Task2<KernelContext, IntArray> {
+    }
+
+    /** Same, for the kernels that vote on a value read from device memory. */
+    private interface InputKernelTask extends uk.ac.manchester.tornado.api.common.TornadoFunctions.Task3<KernelContext, IntArray, IntArray> {
     }
 
     private void skipUnsupportedBackends() {
@@ -172,6 +276,83 @@ public class TestWarpVote extends TornadoTestBase {
             int lane = i % WARP_SIZE;
             // Lanes 0, 3, 6, ... pass; a lane's rank is how many passing lanes precede it.
             int expected = (lane + 2) / 3;
+            assertEquals("lane " + i, expected, out.get(i));
+        }
+    }
+
+    /**
+     * Four warps per block, voting differently from one another. Confirms the vote is warp-wide and
+     * not block-wide, which a single-warp block cannot distinguish.
+     */
+    @Test
+    public void testMultipleWarpsPerBlock() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        final int blockSize = WARP_SIZE * WARPS;
+        final int size = blockSize * 2;
+        IntArray out = runKernel("multiWarpBlock", TestWarpVote::multiWarpBlockKernel, size, blockSize);
+        for (int i = 0; i < size; i++) {
+            int warpInBlock = (i % blockSize) / WARP_SIZE;
+            // Odd warps: every lane passes, so any and all hold (1 * 2 + 1). Even warps: neither.
+            int expected = (warpInBlock % 2 == 1) ? 3 : 0;
+            assertEquals("lane " + i, expected, out.get(i));
+        }
+    }
+
+    /** Ballot over values read from device memory, so the mask cannot be constant-folded. */
+    @Test
+    public void testDataDependentBallot() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray input = new IntArray(SIZE);
+        for (int i = 0; i < SIZE; i++) {
+            input.set(i, (i % 5 == 0) ? 1 : 0);
+        }
+
+        IntArray out = runKernel("dataBallot", TestWarpVote::dataBallotKernel, input);
+
+        for (int i = 0; i < SIZE; i++) {
+            int warpStart = (i / WARP_SIZE) * WARP_SIZE;
+            int expected = 0;
+            for (int lane = 0; lane < WARP_SIZE; lane++) {
+                if (input.get(warpStart + lane) > 0) {
+                    expected++;
+                }
+            }
+            assertEquals("lane " + i, expected, out.get(i));
+        }
+    }
+
+    /** Votes issued from inside a loop, one of them driving a branch. */
+    @Test
+    public void testVoteInsideLoop() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray out = runKernel("voteInLoop", TestWarpVote::voteInLoopKernel);
+        // Per step: simdAny holds (+1), simdAll does not (+0), and the ballot selects a quarter of
+        // the warp (+8). Four steps: 4 * (1 + 8) = 36.
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals("lane " + i, 36, out.get(i));
+        }
+    }
+
+    /** Leader election from a ballot over a compound, data-dependent predicate. */
+    @Test
+    public void testWarpLeaderElection() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray input = new IntArray(SIZE);
+        for (int i = 0; i < SIZE; i++) {
+            input.set(i, (i % 7 == 0) ? 1 : 0);
+        }
+
+        IntArray out = runKernel("leaderElection", TestWarpVote::leaderElectionKernel, input);
+
+        for (int i = 0; i < SIZE; i++) {
+            int warpStart = (i / WARP_SIZE) * WARP_SIZE;
+            int expected = -1;
+            for (int lane = 0; lane < WARP_SIZE; lane++) {
+                if (input.get(warpStart + lane) > 0 && (lane % 2 == 0)) {
+                    expected = lane;
+                    break;
+                }
+            }
             assertEquals("lane " + i, expected, out.get(i));
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestWarpVote.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestWarpVote.java
@@ -1,0 +1,178 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.kernelcontext.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Warp-vote intrinsics on {@link KernelContext}: {@code simdAny}, {@code simdAll} and
+ * {@code simdBallot}, lowered on the CUDA backend to {@code __any_sync} / {@code __all_sync} /
+ * {@code __ballot_sync}.
+ *
+ * <p>Every test asserts a value that a single lane could not produce on its own, so a missing
+ * lowering (the {@link KernelContext} default answers for one lane) fails rather than silently
+ * returning the caller's own predicate.
+ *
+ * <p>How to run:
+ *
+ * <pre>
+ * tornado-test --printKernel -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestWarpVote
+ * </pre>
+ */
+public class TestWarpVote extends TornadoTestBase {
+
+    private static final int WARP_SIZE = 32;
+    private static final int WARPS = 4;
+    private static final int SIZE = WARP_SIZE * WARPS;
+
+    /** Lane mask of the even lanes of a 32-lane warp: 0x55555555. */
+    private static final int EVEN_LANES = 0x55555555;
+
+    /**
+     * Each lane votes on "my lane index is even". Every lane of the warp must see the same mask, so
+     * the result is the even-lane mask regardless of which lane wrote it.
+     */
+    private static void ballotKernel(KernelContext ctx, IntArray out) {
+        int globalIdx = ctx.globalIdx;
+        int localIdx = ctx.localIdx;
+        out.set(globalIdx, ctx.simdBallot(localIdx % 2 == 0));
+    }
+
+    /**
+     * One lane per warp holds a true predicate. {@code simdAny} must be true for every lane of the
+     * warp - including the 31 whose own predicate is false - and {@code simdAll} false for all of
+     * them. Encoded as {@code any * 2 + all} so one buffer covers both.
+     */
+    private static void anyAllKernel(KernelContext ctx, IntArray out) {
+        int globalIdx = ctx.globalIdx;
+        int localIdx = ctx.localIdx;
+        boolean predicate = localIdx == 7;
+        int any = ctx.simdAny(predicate) ? 1 : 0;
+        int all = ctx.simdAll(predicate) ? 1 : 0;
+        out.set(globalIdx, any * 2 + all);
+    }
+
+    /** Predicate true on every lane: {@code simdAll} must hold. */
+    private static void allTrueKernel(KernelContext ctx, IntArray out) {
+        int globalIdx = ctx.globalIdx;
+        out.set(globalIdx, ctx.simdAll(globalIdx >= 0) ? 1 : 0);
+    }
+
+    /**
+     * Warp-aggregated counting, the reason ballot exists: each lane derives its rank among the
+     * passing lanes of its warp from the ballot mask, with no atomics and no shared memory.
+     */
+    private static void laneRankKernel(KernelContext ctx, IntArray out) {
+        int globalIdx = ctx.globalIdx;
+        int localIdx = ctx.localIdx;
+        int lane = localIdx % 32;
+        int mask = ctx.simdBallot(localIdx % 3 == 0);
+        int rank = Integer.bitCount(mask & ((1 << lane) - 1));
+        out.set(globalIdx, rank);
+    }
+
+    private static IntArray runKernel(String name, KernelTask task) throws TornadoExecutionPlanException {
+        IntArray out = new IntArray(SIZE);
+        out.init(-1);
+        KernelContext context = new KernelContext();
+        WorkerGrid worker = new WorkerGrid1D(SIZE);
+        worker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler grid = new GridScheduler("warpVote." + name, worker);
+
+        TaskGraph taskGraph = new TaskGraph("warpVote") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, out) //
+                .task(name, task, context, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            plan.withGridScheduler(grid).execute();
+        }
+        return out;
+    }
+
+    /** Signature of the kernels above, so {@link #runKernel} can build the task graph for each. */
+    private interface KernelTask extends uk.ac.manchester.tornado.api.common.TornadoFunctions.Task2<KernelContext, IntArray> {
+    }
+
+    private void skipUnsupportedBackends() {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.METAL);
+    }
+
+    @Test
+    public void testBallotEvenLanes() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray out = runKernel("ballot", TestWarpVote::ballotKernel);
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals("lane " + i, EVEN_LANES, out.get(i));
+        }
+    }
+
+    @Test
+    public void testAnyAndAll() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray out = runKernel("anyAll", TestWarpVote::anyAllKernel);
+        // any = true (lane 7 passes), all = false: encoded as 1 * 2 + 0.
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals("lane " + i, 2, out.get(i));
+        }
+    }
+
+    @Test
+    public void testAllTrue() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray out = runKernel("allTrue", TestWarpVote::allTrueKernel);
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals("lane " + i, 1, out.get(i));
+        }
+    }
+
+    @Test
+    public void testWarpAggregatedLaneRank() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray out = runKernel("laneRank", TestWarpVote::laneRankKernel);
+        for (int i = 0; i < SIZE; i++) {
+            int lane = i % WARP_SIZE;
+            // Lanes 0, 3, 6, ... pass; a lane's rank is how many passing lanes precede it.
+            int expected = (lane + 2) / 3;
+            assertEquals("lane " + i, expected, out.get(i));
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Adds warp-vote intrinsics to `KernelContext` on the CUDA backend: `simdAny`, `simdAll` and
`simdBallot`, lowered to `__any_sync`, `__all_sync` and `__ballot_sync` over the full member mask.

These complete the warp-level primitive set the backend already had. `simdSum`, `simdShuffleDown` and
`simdBroadcastFirst` move *data* between lanes; there was no way to ask a *question* of the warp. Vote
is what makes lane-cooperative patterns expressible without a shared-memory round trip:

- **warp-aggregated atomics** — one atomic per warp instead of one per lane, which is the standard fix
  for atomics-bound kernels (histograms, appends, compaction). `Integer.bitCount(simdBallot(p))` is the
  group's count and `Integer.bitCount(simdBallot(p) & ((1 << lane) - 1))` is a lane's rank within it, so
  one lane reserves space for the whole warp.
- **early exit** — `if (!ctx.simdAny(needsWork))` skips a block that no lane in the warp needs, with
  every lane agreeing on the answer.
- **uniformity checks** — `simdAll(...)` to take a fast path only when it holds for the whole warp.

`Integer.bitCount` already lowers to `__popc`, so the aggregation idiom composes with no further work.

#### API

```java
public boolean simdAny(boolean predicate)    // true if any active lane passes
public boolean simdAll(boolean predicate)    // true if every active lane passes
public int     simdBallot(boolean predicate) // bit i set when lane i passes
```

Same shape and conventions as the existing `simd*` family: the `KernelContext` bodies answer for a
single lane (`simdAny`/`simdAll` return the predicate, `simdBallot` returns `p ? 1 : 0`) so sequential
Java execution of the same kernel still works, and the CUDA graph-builder plugin replaces the call with
the real intrinsic. Backends without a lowering keep the single-lane default, which is why the tests skip
them explicitly rather than asserting wrong answers.

Implementation follows `CUDASimdBroadcastFirstNode` / `CUDALIRStmt.ShuffleSyncStmt` exactly:

- `CUDAWarpVoteNode` — one node, mode enum (`ANY`/`ALL`/`BALLOT`), stamp `Boolean` or `Int` per mode.
  `FixedWithNextNode` because votes are convergent and must not be reordered or duplicated across
  control flow.
- `CUDALIRStmt.WarpVoteStmt` — emits the intrinsic with the `0xffffffff` member mask; `ANY`/`ALL` wrap
  the result in `(... != 0)` since the intrinsics return `int` and the Java result is `boolean`.
- `CUDAGraphBuilderPlugins#registerSIMDPlugins` — three `InvocationPlugin` registrations.

Generated CUDA-C, from `--printKernel`:

```c
// simdBallot(localIdx % 2 == 0)
i_3  =  __ballot_sync(0xffffffff, i_2);

// simdAny(localIdx == 7) / simdAll(localIdx == 7)
i_3  =  (__any_sync(0xffffffff, i_2) != 0);
i_4  =  (__all_sync(0xffffffff, i_2) != 0);

// Integer.bitCount(mask & ((1 << lane) - 1)) — warp-aggregated rank
i_14 =  __popc(i_13);
```

#### Problem description

Feature, not a bug fix. Before this, a kernel that needed any warp-wide decision had to fake it through
a local array plus `localBarrier()`, which costs shared memory and a block-wide barrier for something the
hardware answers in one instruction — and it is not even equivalent, since a barrier synchronises the
whole block rather than the warp.

#### Backend/s tested

- [ ] OpenCL
- [ ] PTX
- [x] CUDA
- [ ] Metal

CUDA-only by design. The API and the single-lane defaults are backend-neutral, so nothing changes for
other backends, and `TestWarpVote` skips OpenCL, SPIR-V, Metal and PTX rather than asserting against a
lowering that does not exist yet. Natural follow-ups if wanted: PTX (`vote.sync.any/all/ballot.b32`),
Metal (`simd_any` / `simd_all` / `simd_ballot`), OpenCL (`sub_group_any` / `sub_group_all`, no ballot in
core).

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?

```bash
make BACKEND=cuda
source setvars.sh

# all four tests
tornado-test --ea -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestWarpVote
```

Each test asserts a value a single lane cannot produce, so a missing or wrong lowering fails rather than
returning the caller's own predicate.

**`simdBallot`** — every lane votes "my lane index is even"; all 32 lanes of every warp must read back
the same even-lane mask `0x55555555`:

```bash
tornado-test --ea -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestWarpVote#testBallotEvenLanes
tornado --printKernel -ea -m tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner \
        --params "uk.ac.manchester.tornado.unittests.kernelcontext.api.TestWarpVote#testBallotEvenLanes" \
  | grep __ballot_sync
# i_3  =  __ballot_sync(0xffffffff, i_2);
```

**`simdAny` and `simdAll`** — only lane 7 holds a true predicate, so `any` must be true on all 32 lanes
(including the 31 whose own predicate is false) and `all` false on all of them; encoded as `any*2 + all`,
asserted as `2`:

```bash
tornado-test --ea -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestWarpVote#testAnyAndAll
tornado --printKernel -ea -m tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner \
        --params "uk.ac.manchester.tornado.unittests.kernelcontext.api.TestWarpVote#testAnyAndAll" \
  | grep -E "_any_sync|_all_sync"
```

**`simdAll`, true everywhere** — the complementary case, so a lowering that always returned false would
not pass:

```bash
tornado-test --ea -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestWarpVote#testAllTrue
```

**Warp-aggregated rank** — the pattern the feature exists for: lanes where `localIdx % 3 == 0` pass, and
each lane derives its rank among them from the ballot mask with no atomic and no shared memory. Checked
against a CPU reference per lane:

```bash
tornado-test --ea -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestWarpVote#testWarpAggregatedLaneRank
```

Regression check (RTX 4090, driver 565.57.01, CUDA 11.5, JDK 21.0.2): `tornado-test --quickPass` reports the same
86 pre-existing failures on this branch as on `develop @ 06616ddd4` (same 22 classes, unrelated CUDA
backend gaps: vector types, prebuilt kernels, virtual layer, Metal-only simdgroup tests) — the new tests are additive and the plugin registrations only fire
for the three new `KernelContext` methods. `mvn checkstyle:check` clean.

Usage shape, for reviewers who want to see what the intrinsics are for — the ballot/rank half is exactly
what `testWarpAggregatedLaneRank` exercises:

```java
int lane  = ctx.localIdx % 32;
boolean keep = predicate(input.get(ctx.globalIdx));
int mask  = ctx.simdBallot(keep);            // which lanes of my warp keep their element
int count = Integer.bitCount(mask);          // how many, no atomic involved
int rank  = Integer.bitCount(mask & ((1 << lane) - 1));  // my slot within the group

if (ctx.simdAny(keep)) {                     // whole warp agrees; skip the block otherwise
    // reserve `count` slots once per warp (one atomic instead of 32), then each keeping
    // lane writes at base + rank
}
```
