### PR TITLE
Asynchronous execution: TornadoExecutionPlan.executeAsync() completed by a CUDA host callback

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -50,6 +50,14 @@ public class ImmutableTaskGraph {
         this.taskGraph.execute(executionPackage);
     }
 
+    boolean executeAsync(ExecutorFrame executionPackage, Runnable onCompletion) {
+        return this.taskGraph.executeAsync(executionPackage, onCompletion);
+    }
+
+    void waitOnExecution() {
+        this.taskGraph.waitOnExecution();
+    }
+
     void withPreCompilation(ExecutorFrame executionPackage) {
         taskGraph.withPreCompilation(executionPackage);
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -1048,6 +1048,24 @@ public class TaskGraph implements TaskGraphInterface {
         taskGraphImpl.execute(executionPackage).waitOn();
     }
 
+    /**
+     * Issues the work and arms {@code onCompletion} instead of waiting for it. Returns false when the
+     * backend cannot notify, in which case nothing was armed and the work has still been issued - the
+     * caller must then wait for it itself.
+     */
+    boolean executeAsync(ExecutorFrame executionPackage, Runnable onCompletion) {
+        taskGraphImpl.setAsyncCompletion(true);
+        try {
+            return taskGraphImpl.execute(executionPackage).armCompletionCallback(onCompletion);
+        } finally {
+            taskGraphImpl.setAsyncCompletion(false);
+        }
+    }
+
+    void waitOnExecution() {
+        taskGraphImpl.waitOn();
+    }
+
     void withPreCompilation(ExecutorFrame executionPackage) {
         taskGraphImpl.withPreCompilation(executionPackage);
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -190,6 +190,52 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
     }
 
     /**
+     * Issues this execution plan and returns immediately, handing back a future that completes once the
+     * device has finished the plan's work. Unlike {@link #execute()}, the calling thread is not parked
+     * waiting for the GPU: it is free to prepare the next batch of work, run unrelated CPU work, or
+     * submit to another device.
+     *
+     * <p>The device signals completion itself (on the CUDA backend, through a host callback placed
+     * behind the plan's work), so no thread is spent waiting on either side. This is not
+     * {@code CompletableFuture.supplyAsync(plan::execute)} - that would move the blocking wait to a pool
+     * thread rather than remove it.
+     *
+     * <p><b>The data is only valid once the future completes.</b> The plan's device-to-host copies have
+     * been issued, not finished, when this method returns, so reading the host buffers before joining
+     * the future reads whatever was there before. Join first, then read:
+     *
+     * <pre>
+     * CompletableFuture&lt;TornadoExecutionResult&gt; pending = plan.executeAsync();
+     * prepareNextInput();          // overlaps with the GPU
+     * pending.join();              // buffers are valid from here on
+     * </pre>
+     *
+     * <p>Backends that cannot notify on completion (everything except CUDA today), plans spread over
+     * several devices, and plans capturing into a CUDA graph fall back transparently: the work is issued,
+     * then waited for on a runtime thread, and the future completes after that. Semantics are identical
+     * in both cases; only the "no thread is blocked" property is lost.
+     *
+     * @return a future carrying the same {@link TornadoExecutionResult} that {@link #execute()} returns
+     */
+    public java.util.concurrent.CompletableFuture<TornadoExecutionResult> executeAsync() {
+        TornadoProfilerResult profilerResult = new TornadoProfilerResult(tornadoExecutor, this.getTraceExecutionPlan());
+        TornadoExecutionResult executionResult = new TornadoExecutionResult(profilerResult);
+        planResults.add(executionResult);
+        java.util.concurrent.CompletableFuture<TornadoExecutionResult> future = new java.util.concurrent.CompletableFuture<>();
+        boolean armed = tornadoExecutor.executeAsync(executionFrame, () -> future.complete(executionResult));
+        if (!armed) {
+            // The work is already issued; wait for it off the caller's thread so the contract still
+            // holds, then complete.
+            java.util.concurrent.CompletableFuture.runAsync(() -> {
+                tornadoExecutor.waitOnExecution();
+                future.complete(executionResult);
+            });
+        }
+        tornadoExecutor.updateLastExecutedTaskGraph();
+        return future;
+    }
+
+    /**
      * Select a graph from the {@link TornadoExecutionPlan} to execute.
      * This method allows developers to select a specific graph from the
      * execution plan to launch. Developers can choose which graph from

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -69,6 +69,35 @@ class TornadoExecutor {
         immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.execute(executionPackage));
     }
 
+    /**
+     * Issues every task graph of the plan and completes {@code onAllCompleted} once the last one has
+     * finished on the device. Graphs are issued in order, as {@link #execute} does; only the terminal
+     * wait is replaced by a notification.
+     *
+     * <p>Returns false as soon as one graph cannot be armed. The work of that graph has still been
+     * issued, so the caller must fall back to waiting rather than assume nothing happened.
+     */
+    boolean executeAsync(ExecutorFrame executionPackage, Runnable onAllCompleted) {
+        final int graphs = immutableTaskGraphList.size();
+        final java.util.concurrent.atomic.AtomicInteger remaining = new java.util.concurrent.atomic.AtomicInteger(graphs);
+        for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {
+            boolean armed = immutableTaskGraph.executeAsync(executionPackage, () -> {
+                if (remaining.decrementAndGet() == 0) {
+                    onAllCompleted.run();
+                }
+            });
+            if (!armed) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Blocking wait for every task graph of the plan; the fallback when a plan cannot be armed. */
+    void waitOnExecution() {
+        immutableTaskGraphList.forEach(ImmutableTaskGraph::waitOnExecution);
+    }
+
     boolean withGridScheduler(GridScheduler gridScheduler) {
         boolean checkGridRegistered = false;
         for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -73,6 +73,18 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void clearProfiles();
 
+    /**
+     * Arms a completion notification for the work this task graph has issued, instead of waiting for it.
+     *
+     * @param action
+     *     what to run once the device has finished
+     * @return true when armed; false when the backend or device layout cannot notify
+     */
+    /** Marks the next issue of this task graph as asynchronous, so the issue path does not block. */
+    void setAsyncCompletion(boolean enabled);
+
+    boolean armCompletionCallback(Runnable action);
+
     void waitOn();
 
     void transferToDevice(int mode, Object... objects);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/common/TornadoDevice.java
@@ -149,6 +149,24 @@ public interface TornadoDevice {
 
     void sync(long executionPlanId);
 
+    /**
+     * Arranges for {@code action} to run once the device has finished every operation this execution
+     * plan has issued so far, without the calling thread waiting for it. The action runs on a runtime
+     * thread, never on the caller's and never on a driver thread.
+     *
+     * <p>Backends without a completion-notification mechanism return false, and the caller is expected
+     * to fall back to {@link #sync(long)} on a thread of its own.
+     *
+     * @param executionPlanId
+     *     the execution plan whose work should be waited for
+     * @param action
+     *     what to run on completion
+     * @return true when the notification was armed, false when the backend cannot do it
+     */
+    default boolean enqueueCompletionCallback(long executionPlanId, Runnable action) {
+        return false;
+    }
+
     void flush(long executionPlanId);
 
     void clean();

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -180,6 +180,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestInitDataTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.memory.TestMemoryLimit"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestIO"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestAsyncExecution"),
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGrid"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGridScheduler"),

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAHostFunc.cpp
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/CUDAHostFunc.cpp
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <jni.h>
+#include "cuda_jni.h"
+
+/*
+ * Host callbacks: cuLaunchHostFunc enqueues a host function into a stream, and the driver runs it on
+ * one of its own threads once the stream reaches that point. This lets the Java side learn that
+ * device work has completed without parking a thread in cuEventSynchronize.
+ *
+ * Two hard rules from the CUDA driver, both of which shape the code below:
+ *   1. The callback must not call any CUDA API. Doing so may deadlock.
+ *   2. The callback must not block. It runs on a driver thread that other streams depend on.
+ * So the callback does the minimum: attach to the JVM, hand the token to Java, detach. The Java side
+ * (CUDAHostCallbacks) immediately moves the actual work onto its own executor thread, so no user code
+ * ever runs on the driver's thread.
+ */
+
+static JavaVM *javaVM = nullptr;
+static jclass callbackClass = nullptr;
+static jmethodID callbackMethod = nullptr;
+
+extern "C" {
+
+/*
+ * Caches the JavaVM and the static dispatch method the first time a callback is enqueued. Global
+ * references are intentionally never released: they live as long as the driver library.
+ */
+static bool ensure_callback_binding(JNIEnv *env) {
+    if (callbackMethod != nullptr) {
+        return true;
+    }
+    if (env->GetJavaVM(&javaVM) != JNI_OK) {
+        return false;
+    }
+    jclass localClass = env->FindClass("uk/ac/manchester/tornado/drivers/cuda/CUDAHostCallbacks");
+    if (localClass == nullptr) {
+        env->ExceptionClear();
+        return false;
+    }
+    callbackClass = (jclass) env->NewGlobalRef(localClass);
+    env->DeleteLocalRef(localClass);
+    if (callbackClass == nullptr) {
+        return false;
+    }
+    callbackMethod = env->GetStaticMethodID(callbackClass, "fireFromDriverThread", "(J)V");
+    if (callbackMethod == nullptr) {
+        env->ExceptionClear();
+        return false;
+    }
+    return true;
+}
+
+/*
+ * Runs on a CUDA driver thread. No CUDA calls, no blocking: attach (as a daemon, so a pending
+ * callback can never keep the JVM alive), dispatch the token, detach.
+ */
+static void tornado_host_callback(void *userData) {
+    if (javaVM == nullptr || callbackMethod == nullptr) {
+        return;
+    }
+    jlong token = (jlong) (intptr_t) userData;
+    JNIEnv *env = nullptr;
+    bool attached = false;
+    jint status = javaVM->GetEnv((void **) &env, JNI_VERSION_1_8);
+    if (status == JNI_EDETACHED) {
+        if (javaVM->AttachCurrentThreadAsDaemon((void **) &env, nullptr) != JNI_OK) {
+            return;
+        }
+        attached = true;
+    } else if (status != JNI_OK) {
+        return;
+    }
+    env->CallStaticVoidMethod(callbackClass, callbackMethod, token);
+    if (env->ExceptionCheck()) {
+        // An exception must not propagate across the C ABI into the driver.
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
+    if (attached) {
+        javaVM->DetachCurrentThread();
+    }
+}
+
+/*
+ * Class:     uk_ac_manchester_tornado_drivers_cuda_CUDACommandQueue
+ * Method:    cuLaunchHostFunc
+ * Signature: (JJ)I
+ *
+ * Enqueues a host callback carrying `token` into the queue's stream. Returns the CUresult so the
+ * caller can fall back to a blocking wait when the driver refuses the callback.
+ */
+JNIEXPORT jint JNICALL Java_uk_ac_manchester_tornado_drivers_cuda_CUDACommandQueue_cuLaunchHostFunc
+        (JNIEnv *env, jclass clazz, jlong queue_id, jlong token) {
+    cuda_queue_t *queue = (cuda_queue_t *) queue_id;
+    if (queue == nullptr) {
+        return (jint) CUDA_ERROR_INVALID_VALUE;
+    }
+    if (!ensure_callback_binding(env)) {
+        return (jint) CUDA_ERROR_NOT_INITIALIZED;
+    }
+    CUresult result = cuLaunchHostFunc(queue->stream, tornado_host_callback, (void *) (intptr_t) token);
+    LOG_CUDA_AND_VALIDATE("cuLaunchHostFunc", result);
+    return (jint) result;
+}
+
+} // extern "C"

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACommandQueue.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACommandQueue.java
@@ -101,6 +101,21 @@ public class CUDACommandQueue extends CommandQueue {
 
     private static native void nvtxNameStream(long queueId, String name);
 
+    /**
+     * Enqueues a host callback carrying {@code token} into this queue's stream: the driver runs it once
+     * the stream reaches this point. See {@link CUDAHostCallbacks} for what the callback may do.
+     *
+     * @param token
+     *     token obtained from {@link CUDAHostCallbacks#register(Runnable)}
+     * @return true when the driver accepted the callback; the caller must fall back to a blocking wait
+     *     otherwise
+     */
+    public boolean enqueueHostCallback(long token) {
+        return cuLaunchHostFunc(commandQueuePtr, token) == 0;
+    }
+
+    private static native int cuLaunchHostFunc(long queueId, long token);
+
     /** Opens a host-side NVTX range labelled {@code name} (no-op without a profiler). */
     public static native void nvtxRangePush(String name);
 

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContext.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContext.java
@@ -84,6 +84,12 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
 
     /** Execution plans that requested intra-plan concurrency (multi-queue issue). */
     private final Set<Long> intraPlanConcurrencyPlans = Collections.synchronizedSet(new HashSet<>());
+    /**
+     * Execution plans issued through {@code executeAsync()}. Copy-out for these must not block the
+     * issuing thread: the plan's completion is reported by a host callback, and the data is only
+     * promised to be valid once that callback has fired.
+     */
+    private final Set<Long> asyncCompletionPlans = Collections.synchronizedSet(new HashSet<>());
 
     /**
      * Whether large one-shot H2D uploads go through the pinned staging ring. Defaults to the
@@ -359,6 +365,15 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
                 warnedUnsupportedConcurrency = true;
             }
             intraPlanConcurrencyPlans.remove(executionPlanId);
+        }
+    }
+
+    /** Records whether this plan is issued asynchronously; see {@link #asyncCompletionPlans}. */
+    public void setAsyncCompletion(long executionPlanId, boolean enabled) {
+        if (enabled) {
+            asyncCompletionPlans.add(executionPlanId);
+        } else {
+            asyncCompletionPlans.remove(executionPlanId);
         }
     }
 
@@ -814,8 +829,11 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
     public int readBuffer(long executionPlanId, long bufferId, long offset, long bytes, long hostPointer, long hostOffset, int[] waitEvents) {
         CUDACommandQueue commandQueue = getCommandQueue(executionPlanId, CUDAStreamType.DATA_TRANSFER_D2H);
         CUDAEventPool eventPool = getCUDAEventPool(executionPlanId);
-        // non-blocking/async copy-out for off-heap (and therefore pinned) buffers when we go multi-stream
-        boolean blocking = (isMultiStreamEnabled(executionPlanId) && waitEvents != null) ? CUDABlocking.FALSE : CUDABlocking.TRUE;
+        // Non-blocking/async copy-out for off-heap (and therefore pinned) buffers, either because the plan
+        // runs multi-stream or because it was issued asynchronously. Both cases have something that
+        // guarantees host visibility later: the plan-end wait, or the completion callback.
+        boolean asyncPlan = isMultiStreamEnabled(executionPlanId) || asyncCompletionPlans.contains(executionPlanId);
+        boolean blocking = (asyncPlan && waitEvents != null) ? CUDABlocking.FALSE : CUDABlocking.TRUE;
         return eventPool.registerEvent(commandQueue.enqueueRead(bufferId, blocking, offset, bytes, hostPointer, hostOffset, eventPool.serialiseEvents(waitEvents, commandQueue, isMultiStreamEnabled(executionPlanId))
                 ? eventPool.waitEventsBuffer
                 : null), EventDescriptor.DESC_READ_SEGMENT, commandQueue);
@@ -839,6 +857,31 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
         return commandQueue.getOpenclVersion() < 120 ? -1 : eventPool.registerEvent(oclEvent, EventDescriptor.DESC_SYNC_MARKER, commandQueue);
     }
 
+    /**
+     * Arms a host callback that fires once this plan's work has completed. All of the plan's secondary
+     * queues are joined into the default queue first, so the callback covers the whole plan rather than
+     * one stream, and the callback goes behind that join.
+     *
+     * <p>{@code cuLaunchHostFunc} serialises the stream it is enqueued on - work after it does not start
+     * until the callback returns - so it belongs exactly here, at the end of a plan, and not in the
+     * middle of a transfer or launch sequence.
+     */
+    public boolean enqueueCompletionCallback(long executionPlanId, Runnable action) {
+        if (isStreamCapturing(executionPlanId)) {
+            // A host callback would be captured as a graph node and replayed, which is not what a
+            // one-shot completion notification means.
+            return false;
+        }
+        CUDACommandQueue commandQueue = getCommandQueue(executionPlanId);
+        joinRoleQueues(executionPlanId, commandQueue);
+        long token = CUDAHostCallbacks.register(action);
+        if (commandQueue.enqueueHostCallback(token)) {
+            return true;
+        }
+        CUDAHostCallbacks.cancel(token);
+        return false;
+    }
+
     @Override
     public void reset(long executionPlanId) {
         CUDAEventPool eventPool = getCUDAEventPool(executionPlanId);
@@ -857,6 +900,7 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
         }
         computeCursor.remove(executionPlanId);
         intraPlanConcurrencyPlans.remove(executionPlanId);
+        asyncCompletionPlans.remove(executionPlanId);
         oclEventPool.remove(executionPlanId);
         CUDACommandQueueTable table = commandQueueTable.get(executionPlanId);
         if (table != null) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContextInterface.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContextInterface.java
@@ -94,6 +94,19 @@ public interface CUDADeviceContextInterface extends TornadoDeviceContext {
         // no-op by default
     }
 
+    /** Records whether this plan is issued asynchronously, so copy-out does not block the issuer. */
+    default void setAsyncCompletion(long executionPlanId, boolean enabled) {
+        // no-op by default
+    }
+
+    /**
+     * Arms a host callback that runs once the device has finished this plan's issued work. Returns false
+     * when the device context cannot notify.
+     */
+    default boolean enqueueCompletionCallback(long executionPlanId, Runnable action) {
+        return false;
+    }
+
     /**
      * Records whether large one-shot H2D uploads are routed through the pinned staging ring.
      */

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDAHostCallbacks.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDAHostCallbacks.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.cuda;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+
+/**
+ * Registry for actions that run when a CUDA stream reaches a given point, using
+ * {@code cuLaunchHostFunc}. A caller registers an action, gets a token, and enqueues that token on a
+ * queue; the driver invokes the native trampoline when the preceding stream work has completed, and
+ * the trampoline calls {@link #fireFromDriverThread(long)}.
+ *
+ * <p>The action is <b>not</b> run on the driver's thread. That thread may not call into CUDA and may
+ * not block without stalling other streams, so this class only hands the action to its own
+ * single-threaded executor. Everything the action does is therefore ordinary Java on an ordinary
+ * thread, at the cost of a hand-off.
+ *
+ * <p>Tokens are one-shot: firing removes the registration. A token that is registered but never
+ * enqueued (or whose enqueue failed) leaks its entry, so callers that fail to enqueue must
+ * {@link #cancel(long)} it.
+ */
+public final class CUDAHostCallbacks {
+
+    private static final Map<Long, Runnable> ACTIONS = new ConcurrentHashMap<>();
+    private static final AtomicLong NEXT_TOKEN = new AtomicLong(1);
+    private static final TornadoLogger LOGGER = new TornadoLogger(CUDAHostCallbacks.class);
+
+    /**
+     * Single daemon thread: callbacks are rare (one per staged chunk at most) and running them in
+     * order keeps the ordering of stream completions they were enqueued in.
+     */
+    private static final ExecutorService DISPATCHER = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "TornadoVM-CUDA-host-callbacks");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private CUDAHostCallbacks() {
+    }
+
+    /**
+     * Registers {@code action} and returns its token. The token must be enqueued on a queue with
+     * {@link CUDACommandQueue#enqueueHostCallback(long)}, or released with {@link #cancel(long)}.
+     */
+    public static long register(Runnable action) {
+        long token = NEXT_TOKEN.getAndIncrement();
+        ACTIONS.put(token, action);
+        return token;
+    }
+
+    /** Drops a registration whose enqueue did not happen, so the action is never run. */
+    public static void cancel(long token) {
+        ACTIONS.remove(token);
+    }
+
+    /**
+     * Called by the native trampoline on a CUDA driver thread. Does nothing but move the action to
+     * {@link #DISPATCHER}; must stay free of CUDA calls, blocking and anything that can throw into the
+     * driver.
+     *
+     * @param token
+     *     the token the callback was enqueued with
+     */
+    @SuppressWarnings("unused") // invoked from CUDAHostFunc.cpp
+    static void fireFromDriverThread(long token) {
+        Runnable action = ACTIONS.remove(token);
+        if (action == null) {
+            return;
+        }
+        try {
+            DISPATCHER.execute(() -> {
+                try {
+                    action.run();
+                } catch (RuntimeException e) {
+                    LOGGER.warn("host callback action failed: %s", e);
+                }
+            });
+        } catch (RuntimeException e) {
+            // Executor rejected the task (JVM shutting down): run nothing rather than risk the
+            // driver thread.
+            LOGGER.warn("host callback could not be dispatched: %s", e);
+        }
+    }
+
+    /** Number of registered-but-not-yet-fired tokens. Diagnostics and tests only. */
+    public static int pending() {
+        return ACTIONS.size();
+    }
+}

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/runtime/CUDATornadoDevice.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/runtime/CUDATornadoDevice.java
@@ -789,6 +789,16 @@ public class CUDATornadoDevice implements TornadoXPUDevice, TornadoNativeStreamS
     }
 
     @Override
+    public void setAsyncCompletion(long executionPlanId, boolean enabled) {
+        getDeviceContext().setAsyncCompletion(executionPlanId, enabled);
+    }
+
+    @Override
+    public boolean enqueueCompletionCallback(long executionPlanId, Runnable action) {
+        return getDeviceContext().enqueueCompletionCallback(executionPlanId, action);
+    }
+
+    @Override
     public boolean isIntraPlanConcurrencySupported() {
         return true;
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoXPUDevice.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoXPUDevice.java
@@ -215,6 +215,14 @@ public interface TornadoXPUDevice extends TornadoDevice {
     }
 
     /**
+     * Records whether this plan is being issued asynchronously (through {@code executeAsync()}), so the
+     * backend can avoid host-blocking operations on the issue path - copy-out in particular.
+     */
+    default void setAsyncCompletion(long executionPlanId, boolean enabled) {
+        // no-op by default
+    }
+
+    /**
      * Whether this backend implements intra-plan concurrency (role streams and cross-stream
      * event dependencies). When false, a plan-level {@code withIntraPlanConcurrency()} request
      * is ignored and the plan runs on the backend's default single-queue path.

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -98,6 +98,12 @@ public class TornadoExecutionContext {
     private boolean isExecutionGraphEnabled;
     private boolean isIntraPlanConcurrencyEnabled;
     private boolean isStagedTransfersEnabled;
+    /**
+     * Set while the plan is issued through {@code executeAsync()}. The issue path must not block, so the
+     * end-of-execution flush is skipped, dependency events are generated (the backend needs them to make
+     * copy-out asynchronous), and completion is reported by a callback instead of a wait.
+     */
+    private boolean isAsyncCompletion;
 
     public TornadoExecutionContext(String id) {
         name = id;
@@ -126,6 +132,7 @@ public class TornadoExecutionContext {
         // Defaults to the -Dtornado.staged.transfers property, so the plan-level API overrides it
         // rather than replacing it.
         this.isStagedTransfersEnabled = TornadoOptions.ENABLE_STAGED_TRANSFERS;
+        this.isAsyncCompletion = false;
     }
 
     public KernelStackFrame[] getKernelStackFrame() {
@@ -696,6 +703,7 @@ public class TornadoExecutionContext {
         newExecutionContext.isExecutionGraphEnabled = this.isExecutionGraphEnabled;
         newExecutionContext.isIntraPlanConcurrencyEnabled = this.isIntraPlanConcurrencyEnabled;
         newExecutionContext.isStagedTransfersEnabled = this.isStagedTransfersEnabled;
+        newExecutionContext.isAsyncCompletion = this.isAsyncCompletion;
 
         return newExecutionContext;
     }
@@ -747,6 +755,14 @@ public class TornadoExecutionContext {
 
     public boolean isStagedTransfersEnabled() {
         return this.isStagedTransfersEnabled;
+    }
+
+    public void setAsyncCompletion(boolean enabled) {
+        this.isAsyncCompletion = enabled;
+    }
+
+    public boolean isAsyncCompletion() {
+        return this.isAsyncCompletion;
     }
 
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -143,7 +143,7 @@ public class TornadoVMInterpreter {
 
         // NOTE: useDependencies is (re)computed at the start of execute() rather than latched here,
         // because plan-level withIntraPlanConcurrency() is applied after this interpreter is built.
-        useDependencies = VM_USE_DEPS || isIntraPlanConcurrencyActive();
+        useDependencies = VM_USE_DEPS || isIntraPlanConcurrencyActive() || graphExecutionContext.isAsyncCompletion();
         totalTime = 0;
         invocations = 0;
 
@@ -301,6 +301,7 @@ public class TornadoVMInterpreter {
         // Push the per-plan intra-plan-concurrency setting to the backend before issuing any
         // bytecode, so transfer/launch routing (single- vs multi-stream) is decided per plan.
         interpreterDevice.setIntraPlanConcurrency(graphExecutionContext.getExecutionPlanId(), isIntraPlanConcurrencyActive());
+        interpreterDevice.setAsyncCompletion(graphExecutionContext.getExecutionPlanId(), graphExecutionContext.isAsyncCompletion());
 
         // Push the staged-transfer setting before the plan's ALLOCs: it also decides whether a
         // staged buffer skips the whole-segment host pin, which is settled at allocation time.
@@ -309,7 +310,7 @@ public class TornadoVMInterpreter {
         // Recompute here (not just in the constructor): plan-level withIntraPlanConcurrency() is
         // applied after this interpreter is built, so latching it at construction misses it and the
         // dependency DAG (waitList -> cross-stream events) would never engage for concurrent plans.
-        useDependencies = VM_USE_DEPS || isIntraPlanConcurrencyActive();
+        useDependencies = VM_USE_DEPS || isIntraPlanConcurrencyActive() || graphExecutionContext.isAsyncCompletion();
 
         // Batched plans: reset the per-object chunk counters so every execution behaves like the
         // first (per-chunk DEALLOCs stay no-ops until the last even chunk). Without this reset the
@@ -511,7 +512,10 @@ public class TornadoVMInterpreter {
                 barrier = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), event);
             }
 
-            if (TornadoOptions.USE_VM_FLUSH) {
+            // The flush is a stream synchronise on the CUDA backend, so under async completion it would
+            // park the very thread executeAsync() promises to release. Completion is reported by the
+            // callback armed after issue instead.
+            if (TornadoOptions.USE_VM_FLUSH && !graphExecutionContext.isAsyncCompletion()) {
                 interpreterDevice.flush(graphExecutionContext.getExecutionPlanId());
             }
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -1007,6 +1007,35 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         vm.clearProfiles();
     }
 
+    /**
+     * Arms {@code action} to run when this task graph's issued work completes, instead of blocking the
+     * caller in {@link #waitOn()}. Returns false when the plan's device cannot notify (or the plan spans
+     * several devices, where a single notification would not cover all of them), leaving the caller to
+     * fall back to a blocking wait.
+     */
+    @Override
+    public void setAsyncCompletion(boolean enabled) {
+        executionContext.setAsyncCompletion(enabled);
+    }
+
+    @Override
+    public boolean armCompletionCallback(Runnable action) {
+        TornadoXPUDevice single = null;
+        for (TornadoXPUDevice device : executionContext.getDevices()) {
+            if (device == null) {
+                continue;
+            }
+            if (single != null && single != device) {
+                return false;
+            }
+            single = device;
+        }
+        if (single == null) {
+            return false;
+        }
+        return single.enqueueCompletionCallback(executionPlanId, action);
+    }
+
     @Override
     public void waitOn() {
         if ((TornadoOptions.VM_USE_DEPS || executionContext.isIntraPlanConcurrencyEnabled()) && event != null) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAsyncExecution.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestAsyncExecution.java
@@ -1,0 +1,228 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * {@link TornadoExecutionPlan#executeAsync()}: issue a plan and get a future instead of a blocked
+ * thread. On the CUDA backend the device signals completion through a host callback; other backends
+ * fall back to waiting on a runtime thread, which these tests also accept - what is asserted is the
+ * contract (results correct after joining, caller released before the GPU is done), not the mechanism.
+ *
+ * <p>How to run:
+ *
+ * <pre>
+ * tornado-test --ea -V uk.ac.manchester.tornado.unittests.api.TestAsyncExecution
+ * </pre>
+ */
+public class TestAsyncExecution extends TornadoTestBase {
+
+    private static final int SIZE = 1024 * 1024;
+    /** Long enough per element that the plan runs for tens of milliseconds, so the timings are unambiguous. */
+    private static final int ITERATIONS = 1 << 18;
+    private static final float DELTA = 1e-2f;
+
+    public static void spin(FloatArray in, FloatArray out, float alpha) {
+        for (@Parallel int i = 0; i < out.getSize(); i++) {
+            float value = in.get(i);
+            for (int j = 0; j < ITERATIONS; j++) {
+                value = value * alpha + 1.0f;
+            }
+            out.set(i, value);
+        }
+    }
+
+    private static float expected(float in, float alpha) {
+        float value = in;
+        for (int j = 0; j < ITERATIONS; j++) {
+            value = value * alpha + 1.0f;
+        }
+        return value;
+    }
+
+    private static ImmutableTaskGraph buildGraph(FloatArray in, FloatArray out) {
+        return new TaskGraph("async") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, in) //
+                .task("spin", TestAsyncExecution::spin, in, out, 0.5f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out) //
+                .snapshot();
+    }
+
+    /** The future completes and carries the same result object shape {@code execute()} returns. */
+    @Test
+    public void testAsyncCompletesWithCorrectResult() throws Exception {
+        FloatArray in = new FloatArray(SIZE);
+        FloatArray out = new FloatArray(SIZE);
+        in.init(2.0f);
+        out.init(-1.0f);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(buildGraph(in, out))) {
+            CompletableFuture<TornadoExecutionResult> pending = plan.executeAsync();
+            TornadoExecutionResult result = pending.get(60, TimeUnit.SECONDS);
+            assertTrue("the future must carry a result", result != null);
+            float want = expected(2.0f, 0.5f);
+            for (int i = 0; i < SIZE; i += 1024) {
+                assertEquals(want, out.get(i), DELTA * Math.max(1.0f, Math.abs(want)));
+            }
+        }
+    }
+
+    /**
+     * The point of the API: the call returns well before the device is finished, so the caller's thread
+     * is free. Asserted as a ratio rather than an absolute time - the submit must take a small fraction
+     * of the blocking execution it replaces.
+     */
+    @Test
+    public void testAsyncReturnsBeforeCompletion() throws Exception {
+        FloatArray in = new FloatArray(SIZE);
+        FloatArray out = new FloatArray(SIZE);
+        in.init(2.0f);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(buildGraph(in, out))) {
+            // Warm up: the first execution pays JIT and allocation, which would dwarf everything else.
+            plan.execute();
+
+            long blockingStart = System.nanoTime();
+            plan.execute();
+            long blockingNanos = System.nanoTime() - blockingStart;
+
+            long submitStart = System.nanoTime();
+            CompletableFuture<TornadoExecutionResult> pending = plan.executeAsync();
+            long submitNanos = System.nanoTime() - submitStart;
+
+            pending.get(60, TimeUnit.SECONDS);
+            long totalNanos = System.nanoTime() - submitStart;
+
+            System.out.printf("  blocking execute : %.2f ms%n", blockingNanos / 1e6);
+            System.out.printf("  async submit     : %.2f ms%n", submitNanos / 1e6);
+            System.out.printf("  async total      : %.2f ms%n", totalNanos / 1e6);
+
+            assertTrue(String.format("executeAsync should return well before completion, but submit took %.2f ms of %.2f ms", //
+                    submitNanos / 1e6, blockingNanos / 1e6), submitNanos < blockingNanos / 2);
+        }
+    }
+
+    /** Host work placed between submit and join overlaps the GPU instead of queueing behind it. */
+    @Test
+    public void testHostWorkOverlapsDeviceWork() throws Exception {
+        FloatArray in = new FloatArray(SIZE);
+        FloatArray out = new FloatArray(SIZE);
+        in.init(2.0f);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(buildGraph(in, out))) {
+            plan.execute(); // warm up
+
+            long deviceOnlyStart = System.nanoTime();
+            plan.execute();
+            long deviceOnlyNanos = System.nanoTime() - deviceOnlyStart;
+
+            long hostOnlyStart = System.nanoTime();
+            double hostResult = hostWork();
+            long hostOnlyNanos = System.nanoTime() - hostOnlyStart;
+
+            long overlappedStart = System.nanoTime();
+            CompletableFuture<TornadoExecutionResult> pending = plan.executeAsync();
+            hostResult += hostWork();
+            pending.get(60, TimeUnit.SECONDS);
+            long overlappedNanos = System.nanoTime() - overlappedStart;
+
+            System.out.printf("  device only      : %.2f ms%n", deviceOnlyNanos / 1e6);
+            System.out.printf("  host only        : %.2f ms%n", hostOnlyNanos / 1e6);
+            System.out.printf("  overlapped       : %.2f ms (sum would be %.2f ms)%n", //
+                    overlappedNanos / 1e6, (deviceOnlyNanos + hostOnlyNanos) / 1e6);
+
+            assertTrue("overlapping should beat running host and device work back to back", //
+                    overlappedNanos < (deviceOnlyNanos + hostOnlyNanos));
+            assertTrue("host work must actually have run", hostResult != 0.0);
+
+            float want = expected(2.0f, 0.5f);
+            for (int i = 0; i < SIZE; i += 1024) {
+                assertEquals(want, out.get(i), DELTA * Math.max(1.0f, Math.abs(want)));
+            }
+        }
+    }
+
+    /** Several plans in flight at once: every future must complete and every result must be correct. */
+    @Test
+    public void testMultiplePlansInFlight() throws Exception {
+        final int plans = 3;
+        FloatArray[] in = new FloatArray[plans];
+        FloatArray[] out = new FloatArray[plans];
+        TornadoExecutionPlan[] executionPlans = new TornadoExecutionPlan[plans];
+        @SuppressWarnings("unchecked")
+        CompletableFuture<TornadoExecutionResult>[] pending = new CompletableFuture[plans];
+
+        try {
+            for (int p = 0; p < plans; p++) {
+                in[p] = new FloatArray(SIZE);
+                out[p] = new FloatArray(SIZE);
+                in[p].init(p + 1.0f);
+                executionPlans[p] = new TornadoExecutionPlan(buildGraph(in[p], out[p]));
+            }
+            for (int p = 0; p < plans; p++) {
+                pending[p] = executionPlans[p].executeAsync();
+            }
+            CompletableFuture.allOf(pending).get(120, TimeUnit.SECONDS);
+
+            for (int p = 0; p < plans; p++) {
+                float want = expected(p + 1.0f, 0.5f);
+                for (int i = 0; i < SIZE; i += 4096) {
+                    assertEquals("plan " + p, want, out[p].get(i), DELTA * Math.max(1.0f, Math.abs(want)));
+                }
+            }
+        } finally {
+            for (TornadoExecutionPlan plan : executionPlans) {
+                if (plan != null) {
+                    plan.close();
+                }
+            }
+        }
+    }
+
+    /** Host-side busy work of roughly the same order as the kernel, with a result to keep it alive. */
+    private static double hostWork() {
+        double acc = 1.0;
+        for (int i = 1; i < 40_000_000; i++) {
+            acc += 1.0 / i;
+        }
+        return acc;
+    }
+}


### PR DESCRIPTION
#### Description

Adds asynchronous execution to the API: `TornadoExecutionPlan.executeAsync()` issues a plan and returns a
`CompletableFuture<TornadoExecutionResult>` that completes when the **device** signals it is done, through
a `cuLaunchHostFunc` callback placed behind the plan's work. The calling thread is not parked waiting for
the GPU at any point.

Two commits:

| commit | what |
|---|---|
| `[cuda] Add host callbacks backed by cuLaunchHostFunc` | the primitive: JNI wrapper, JVM upcall trampoline, `CUDAHostCallbacks` registry |
| `[api] Add TornadoExecutionPlan.executeAsync() completed by a device callback` | the consumer, plus the async issue path and 4 tests |

```java
CompletableFuture<TornadoExecutionResult> pending = plan.executeAsync();
prepareNextBatch();     // runs while the GPU works
pending.join();         // host buffers are valid from here on
```

#### Problem description

Feature. Today `execute()` is the only option and it blocks the caller for the whole GPU execution. The
nearest thing a user can write themselves is `CompletableFuture.supplyAsync(plan::execute)`, which does not
solve the problem — it *moves* the blocked thread to a pool thread. There was no way to submit work and get
on with something else, which is what you want for:

- **producer/consumer host work** — decoding the next input, or post-processing the previous result, while
  the current kernel runs. Measured below: a 7.5 ms plan disappears entirely behind 52 ms of host work.
- **keeping several plans in flight** — submit N plans, then join them, instead of serialising N host waits.
- **event-driven pipelines** — chain with `thenApply`/`thenCompose` rather than blocking a thread per stage.
- **not burning a thread per in-flight plan** — the completion signal comes from the driver, so the cost of
  an outstanding plan is one registry entry, not a parked thread.

#### Measurements

RTX 4090, driver 565.57.01, CUDA 11.5, JDK 21.0.2, baseline `develop @ 06616ddd4`. Numbers printed by the
tests themselves (`TestAsyncExecution`), 1 M-element kernel of ~7.5 ms.

**Submit cost versus blocking execution** (`testAsyncReturnsBeforeCompletion`):

| | time |
|---|---|
| `execute()` — blocking | 7.50 ms |
| `executeAsync()` — submit only | **0.30 ms** |
| `executeAsync()` + `join()` | 8.00 ms |

The caller gets its thread back **25x sooner**, and end-to-end costs ~0.5 ms more than the blocking path
(the callback hop plus the deps the async path needs). That 0.5 ms is the price of the feature; it is only
worth paying if the freed thread has something to do — which is the next table.

**Overlapping host work with device work** (`testHostWorkOverlapsDeviceWork`):

| | time |
|---|---|
| device work alone | 7.67 ms |
| host work alone | 52.86 ms |
| sequential (what `execute()` forces) | 60.53 ms |
| overlapped via `executeAsync()` | **54.95 ms** |

The GPU execution is essentially free: 5.6 ms of the 7.7 ms hides inside the host work.

**nsys, `cuda_api_sum` over that same test** (two blocking executions plus one async one):

<details><summary>API counters and GPU timeline</summary>

```
  cuStreamSynchronize      calls=    6 total=   14.25 ms  avg=  2374.9 us
  cuLaunchHostFunc         calls=    1 total=    0.20 ms  avg=   203.4 us
  cuLaunchKernel           calls=    3 total=    0.05 ms  avg=    15.6 us
  cuMemcpyDtoHAsync_v2     calls=    3 total=    0.01 ms  avg=     5.0 us
  cuEventRecord            calls=   14 total=    0.01 ms  avg=     0.7 us
```

Exactly one `cuLaunchHostFunc` — the async execution — against three kernel launches. All six
`cuStreamSynchronize` calls belong to the two blocking `execute()` calls and teardown; the async execution
contributes none, which is the property the feature is about.

GPU timeline tail: the async execution's kernel starts at 61.58 ms (after the host work that preceded it in
the test) and the copy-out follows immediately, with no host round trip between them:

```
  start    0.00 ms  dur  6.90 ms  strm 14  spin
  start    6.90 ms  dur  0.22 ms  strm 14  [CUDA memcpy Device-to-Host]
  start   61.35 ms  dur  0.22 ms  strm 14  [CUDA memcpy Host-to-Device]
  start   61.58 ms  dur  6.90 ms  strm 14  spin
  start   68.49 ms  dur  0.22 ms  strm 14  [CUDA memcpy Device-to-Host]
```
</details>

#### What had to change for the submit to actually be non-blocking

Returning a future is the easy part; the issue path had three places that parked the caller, and all three
had to be handled or the "async" submit measured **7.48 ms of a 7.51 ms** blocking execution — i.e. no
async at all. This is worth stating because it is the substance of the patch:

1. **The end-of-execution flush.** `TornadoOptions.USE_VM_FLUSH` is on by default and
   `interpreterDevice.flush()` is a `cuStreamSynchronize` on the CUDA backend. Skipped under async
   completion; the callback replaces it.
2. **Blocking copy-out.** `CUDADeviceContext#readBuffer` only takes the async path when the plan is
   multi-stream, so a plain plan's `transferToHost` blocked until the kernel ahead of it finished. Async
   plans now qualify for the same non-blocking path.
3. **No dependency events.** The non-blocking copy-out needs a wait list, and `tornado.vm.deps` is off by
   default, so async completion now forces dependency generation the way intra-plan concurrency does.

The async flag rides on `TornadoExecutionContext` and is pushed to the backend next to the existing
intra-plan-concurrency flag, so it is per plan and per execution.

#### Where the callback may and may not be used

The CUDA driver forbids two things inside a host callback: calling any CUDA API, and blocking. The
trampoline therefore does the minimum — attach to the JVM as a daemon, hand the token to Java, detach — and
`CUDAHostCallbacks` immediately moves the action to its own executor thread, so nothing a user or the
runtime does ever runs on a driver thread, and no exception can cross the C ABI.

Those rules also rule out the use I tried first and **dropped**: `cuLaunchHostFunc` is stream-serialising —
work behind it does not start until the callback returns — so using it per staged-transfer chunk to retire
pinned ring slots inserted 64 host round trips into the DMA pipeline. Measured on a 1 GB staged upload:
blocking event waits dropped from 68 to 23, but time spent in them was unchanged (10.20 → 10.14 ms; those
waits were returning immediately) and upload throughput fell **11.07 → 9.90 GB/s**. The same experiment also
found that a per-slot "drained" flag is unsound — a callback from a slot's previous upload can land after the
flag was cleared for the current one, which corrupted uploads (`expected 282.0 but was 102.0`) until it was
keyed by a per-slot generation. End of a plan is the right place for a stream-serialising callback; the
middle of a transfer sequence is not.

#### Backend/s tested

- [ ] OpenCL
- [ ] PTX
- [x] CUDA
- [ ] Metal

`executeAsync()` is available on every backend and behaves identically everywhere; only the *mechanism*
differs. `TornadoDevice#enqueueCompletionCallback` defaults to returning false, and the API then issues the
work and waits for it on a runtime thread before completing the future — same semantics, minus the "no
thread is blocked" property. The fallback also covers plans spanning several devices (a single notification
would not cover all of them) and plans capturing into a CUDA graph (a host callback would be captured and
replayed, which is not what a one-shot completion means). PTX could implement the same primitive as-is.

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?

```bash
make BACKEND=cuda
source setvars.sh

tornado-test --ea -V uk.ac.manchester.tornado.unittests.api.TestAsyncExecution
```

Four tests, and what each is for:

**Correctness of the contract** — `testAsyncCompletesWithCorrectResult`: the future completes, carries a
`TornadoExecutionResult`, and every sampled output element matches the sequential reference. This is what
catches a callback that fires before the copy-out has landed.

```bash
tornado-test --ea -V ...TestAsyncExecution#testAsyncCompletesWithCorrectResult
```

**The submit really returns early** — `testAsyncReturnsBeforeCompletion`: times a warmed-up blocking
`execute()`, then the `executeAsync()` submit, and asserts the submit is under half the blocking time
(measured: 0.30 ms vs 7.50 ms). Fails loudly if any host-blocking call creeps back onto the issue path,
which is exactly how the three blockers above were found.

```bash
tornado-test --ea -V ...TestAsyncExecution#testAsyncReturnsBeforeCompletion
```

**The freed thread is usable** — `testHostWorkOverlapsDeviceWork`: runs host work between submit and join
and asserts the total beats running host and device work back to back.

```bash
tornado-test --ea -V ...TestAsyncExecution#testHostWorkOverlapsDeviceWork
```

**Several plans in flight** — `testMultiplePlansInFlight`: three plans submitted before any is joined, then
`CompletableFuture.allOf(...)`; every result checked against its own reference.

```bash
tornado-test --ea -V ...TestAsyncExecution#testMultiplePlansInFlight
```

Profiling the mechanism:

```bash
nsys profile --trace=cuda,nvtx -o async tornado -ea \
  -m tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner \
  --params "uk.ac.manchester.tornado.unittests.api.TestAsyncExecution#testHostWorkOverlapsDeviceWork"
nsys stats --report cuda_api_sum --report cuda_gpu_trace async.nsys-rep
```

Expect one `cuLaunchHostFunc` per `executeAsync()` and no `cuStreamSynchronize` attributable to it.

Regression: `tornado-test --quickPass` reports the same 86 pre-existing failures as `develop @ 06616ddd4`
(same 22 classes — vector types, prebuilt kernels, virtual layer, Metal-only simdgroup tests).
`mvn checkstyle:check` clean. The staged-transfer suite
(`TestCUDAStreams`, 13 tests) passes, including under a deliberately hostile ring configuration
(`-Dtornado.staged.chunk.size=1048576 -Dtornado.staged.ring.depth=2`, 8 consecutive runs) and under
`compute-sanitizer --tool memcheck` (0 errors).
