### PR TITLE
[cuda] Report rejected kernel launches and failed copies instead of only logging them

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -187,6 +187,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestCombinedTaskGraph"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestVectorAdditionKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.KernelContextWorkGroupTests"),
+    TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestLaunchFailureReporting"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestHalfFloatLocalArray"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.local.memory.TestSwizzledLocalArrays"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext"),

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/CUDACommandQueue.cpp
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/CUDACommandQueue.cpp
@@ -313,6 +313,13 @@ JNIEXPORT jlong JNICALL Java_uk_ac_manchester_tornado_drivers_cuda_CUDACommandQu
             params.empty() ? nullptr : params.data(),
             nullptr);
     LOG_CUDA_AND_VALIDATE("cuLaunchKernel", result);
+    if (result != CUDA_SUCCESS) {
+        // Do not hand back an event for work that was never launched: the caller would treat the
+        // kernel as done and read whatever the output buffer happened to contain.
+        delete ev;
+        tornado_throw_cuda(env, "cuLaunchKernel", result);
+        return 0;
+    }
 
     return end_event(ev, queue);
 }
@@ -349,6 +356,12 @@ static jlong transfer_to_device(JNIEnv *env, cuda_queue_t *queue, void *host_bas
             (size_t) num_bytes,
             queue->stream);
     LOG_CUDA_AND_VALIDATE("cuMemcpyHtoDAsync", result);
+    if (result != CUDA_SUCCESS) {
+        // A copy that never started must not be reported as an event the caller can wait on.
+        delete ev;
+        tornado_throw_cuda(env, "cuMemcpyHtoDAsync", result);
+        return 0;
+    }
     if (sync_after && !stream_is_capturing(queue)) {
         cuStreamSynchronize(queue->stream);
     }
@@ -373,6 +386,12 @@ static jlong transfer_to_host(JNIEnv *env, cuda_queue_t *queue, void *host_base,
             (size_t) num_bytes,
             queue->stream);
     LOG_CUDA_AND_VALIDATE("cuMemcpyDtoHAsync", result);
+    if (result != CUDA_SUCCESS) {
+        // A copy that never started must not be reported as an event the caller can wait on.
+        delete ev;
+        tornado_throw_cuda(env, "cuMemcpyDtoHAsync", result);
+        return 0;
+    }
     if (sync_after && !stream_is_capturing(queue)) {
         cuStreamSynchronize(queue->stream);
     }

--- a/tornado-drivers/cuda-jni/src/main/cpp/source/cuda_jni.h
+++ b/tornado-drivers/cuda-jni/src/main/cpp/source/cuda_jni.h
@@ -40,8 +40,29 @@
 #include <vector>
 #include <string>
 #include <cstring>
+#include <cstdio>
+#include <jni.h>
 
 #define LOG_CUDA 0
+
+/*
+ * Raises CUDAException on the Java side. The Java wrappers already translate that into a
+ * TornadoBailoutRuntimeException, so a failed driver call surfaces as a failure instead of leaving the
+ * caller with untouched (and therefore wrong) output buffers.
+ */
+static inline void tornado_throw_cuda(JNIEnv *env, const char *op, CUresult result) {
+    const char *name = nullptr;
+    const char *desc = nullptr;
+    cuGetErrorName(result, &name);
+    cuGetErrorString(result, &desc);
+    char message[512];
+    snprintf(message, sizeof(message), "%s failed: %s (%d)%s%s", op, name ? name : "?", (int) result, //
+            desc ? " - " : "", desc ? desc : "");
+    jclass exceptionClass = env->FindClass("uk/ac/manchester/tornado/drivers/cuda/exceptions/CUDAException");
+    if (exceptionClass != nullptr) {
+        env->ThrowNew(exceptionClass, message);
+    }
+}
 
 #define LOG_CUDA_AND_VALIDATE(name, result)                       \
     if (LOG_CUDA == 1) {                                          \

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestLaunchFailureReporting.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestLaunchFailureReporting.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.kernelcontext.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * A kernel launch the driver rejects must be reported, not silently skipped.
+ *
+ * <p>The CUDA JNI layer used to log every driver error and carry on, so a rejected
+ * {@code cuLaunchKernel} left the output buffer untouched and the caller read stale data as if the
+ * kernel had run - a wrong answer with no exception anywhere. Launch and transfer failures now raise
+ * {@code CUDAException}, which the queue wrappers translate into a bailout.
+ *
+ * <p>How to run:
+ *
+ * <pre>
+ * tornado-test --ea -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestLaunchFailureReporting
+ * </pre>
+ */
+public class TestLaunchFailureReporting extends TornadoTestBase {
+
+    private static final int SIZE = 256;
+    /**
+     * 16384 floats = 64 KB of shared memory. Local arrays are emitted as static {@code __shared__}, which
+     * the hardware caps at 48 KB per block, so the driver rejects the launch. (Reaching the 100 KB an
+     * sm_89 GPU has available needs dynamic shared memory, which the backend does not emit yet - when it
+     * does, this becomes a functional test instead of a failure-reporting one.)
+     */
+    private static final int OVERSIZED_LOCAL_FLOATS = 16384;
+
+    private static void oversizedLocalKernel(KernelContext ctx, FloatArray in, FloatArray out) {
+        float[] tile = ctx.allocateFloatLocalArray(OVERSIZED_LOCAL_FLOATS);
+        int localIdx = ctx.localIdx;
+        for (int i = localIdx; i < OVERSIZED_LOCAL_FLOATS; i += SIZE) {
+            tile[i] = in.get(i % in.getSize());
+        }
+        ctx.localBarrier();
+        out.set(ctx.globalIdx, tile[localIdx]);
+    }
+
+    @Test
+    public void testRejectedLaunchIsReported() {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
+
+        FloatArray in = new FloatArray(SIZE);
+        FloatArray out = new FloatArray(SIZE);
+        in.init(1.0f);
+        out.init(-1.0f);
+
+        KernelContext context = new KernelContext();
+        WorkerGrid worker = new WorkerGrid1D(SIZE);
+        worker.setLocalWork(SIZE, 1, 1);
+        GridScheduler grid = new GridScheduler("badLaunch.t0", worker);
+
+        TaskGraph taskGraph = new TaskGraph("badLaunch") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, in) //
+                .task("t0", TestLaunchFailureReporting::oversizedLocalKernel, context, in, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.withGridScheduler(grid).execute();
+            fail("a launch the driver rejects must not be reported as success (output stayed " + out.get(0) + ")");
+        } catch (TornadoExecutionPlanException | RuntimeException expected) {
+            // Expected: the driver error travels out as an exception rather than being logged and dropped.
+        }
+
+        // And the output must not look like a successful run either.
+        assertEquals("the rejected kernel must not have written anything", -1.0f, out.get(0), 0.0f);
+    }
+}


### PR DESCRIPTION
#### Description

A rejected `cuLaunchKernel` or a failed `cuMemcpy*Async` in the CUDA JNI layer was printed to stdout and
then ignored: the call returned an event as if the work had been enqueued, the runtime waited on it, and the
caller read an output buffer that nothing had written. A wrong answer, no exception anywhere.

This makes those three calls raise `CUDAException`, which the existing queue wrappers already translate into
`TornadoBailoutRuntimeException`, so a driver rejection surfaces as a failure.

```cpp
LOG_CUDA_AND_VALIDATE("cuLaunchKernel", result);
if (result != CUDA_SUCCESS) {
    // Do not hand back an event for work that was never launched: the caller would treat the
    // kernel as done and read whatever the output buffer happened to contain.
    delete ev;
    tornado_throw_cuda(env, "cuLaunchKernel", result);
    return 0;
}
```

`tornado_throw_cuda` (new, in `cuda_jni.h`) builds a message from `cuGetErrorName` + `cuGetErrorString` and
throws the exception class the Java native declarations have always declared (`throws CUDAException`) but
which was never actually thrown.

#### Problem description

Found while probing what happens above the 48 KB static shared-memory limit. A `KernelContext` kernel that
allocates a 64 KB local array compiles (NVRTC is happy), the launch is rejected, and the test read zeros:

```
[TornadoVM-CUDA-JNI] ERROR : cuLaunchKernel -> Returned: 1 (CUDA_ERROR_INVALID_VALUE)
...
[REASON] expected:<1.3422592E8> but was:<0.0>
```

The error message went to stdout, the plan "succeeded", and the only symptom was wrong data. After this
patch the same kernel fails with the driver's own error text attached.

`LOG_CUDA_AND_VALIDATE` is print-only for every call in this layer; this patch changes the three where a
swallowed error means silently wrong results (kernel launch, H2D copy, D2H copy). It deliberately leaves the
rest alone, because several treat a non-success result as a legitimate outcome —
`cuMemHostRegister` returning `CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED`, `cuEventQuery` returning
`CUDA_ERROR_NOT_READY` — and turning those into exceptions would break working paths. Auditing the remaining
call sites one by one is worth doing separately.

#### Two findings from the same investigation, reported not fixed

**1. Shared memory is capped at 48 KB per block.** `KernelContext.allocateFloatLocalArray(n)` is emitted as a
*static* `__shared__` array:

```c
extern "C" __global__ void threadgroupKernel(long long *_kernel_context, ..., unsigned char *_local_region, ...)
{
  __shared__ float adf_2[32];
```

and `cuLaunchKernel` is called with `0` dynamic shared bytes. Static shared memory is hardware-capped at
48 KB, so that is the ceiling for a TornadoVM kernel — while an sm_89 GPU offers 100 KB (sm_90: 228 KB),
reachable only through *dynamic* shared memory plus
`cuFuncSetAttribute(CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES)`. That matters for exactly the kernels
people hand-write `KernelContext` for: tiled GEMM and attention tiles. There is already a `_local_region`
kernel parameter threaded through the signature that nothing uses for these arrays, so the plumbing is
partly there. Emitting `extern __shared__` with per-array offsets, passing the total at launch, and opting in
above 48 KB is the follow-up.

**2. Oversized block requests are silently clamped.** Requesting a 2048-thread block gets quietly reduced —
`CUDAKernelScheduler#checkLocalWorkGroupFitsOnDevice` drops an unfittable local work size so the driver picks
its own, and the JNI additionally clamps the block to the global size. Defensible, but it means
`worker.setLocalWork(...)` is a hint rather than a request, and nothing tells the user their configuration
was overridden. Worth a warning at least; it is why the test below triggers the failure with shared memory
rather than with a block size.

#### Backend/s tested

- [ ] OpenCL
- [ ] PTX
- [x] CUDA
- [ ] Metal

CUDA JNI only; no Java-side behaviour changes beyond errors now arriving as exceptions where they were
previously dropped.

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?

```bash
make BACKEND=cuda
source setvars.sh

tornado-test --ea -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestLaunchFailureReporting
```

`testRejectedLaunchIsReported` launches a kernel with a 64 KB local array — above the static shared-memory
limit, so the driver rejects it — and asserts two things: that the execution raises rather than returning
normally, and that the output buffer still holds its sentinel (`-1.0f`), i.e. the failed kernel is not
mistaken for one that ran. Before this patch it failed on the first assertion, having read `0.0`.

To see the underlying driver error directly:

```bash
tornado --printKernel -ea -m tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner \
        --params "uk.ac.manchester.tornado.unittests.kernelcontext.api.TestLaunchFailureReporting" 2>&1 \
  | grep -E "__shared__|CUDA_ERROR"
# __shared__ float adf_2[16384];
# [TornadoVM-CUDA-JNI] ERROR : cuLaunchKernel -> Returned: 1 (CUDA_ERROR_INVALID_VALUE)
```

Note the test will need updating when dynamic shared memory lands: the same kernel should then run, and the
failure-reporting test should switch to another trigger.

Regression (RTX 4090, driver 565.57.01, CUDA 11.5, JDK 21.0.2): `tornado-test --quickPass` reports the same
86 pre-existing failures as `develop @ 06616ddd4`, same 22 classes. That matters more than usual here —
turning previously-swallowed driver errors into exceptions could have surfaced latent failures in unrelated
tests, and it did not. `mvn checkstyle:check` clean.
