### PR TITLE
[cuda] Add atomicCAS, atomicExchange, atomicMin and atomicMax on local arrays to KernelContext

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
@@ -267,6 +267,98 @@ public class KernelContext implements ExecutionContext {
     }
 
     /**
+     * Atomic compare-and-swap on {@code array[index]}: if the element equals {@code expected} it is
+     * replaced with {@code value}. Returns the element's value before the call, so success is
+     * {@code atomicCAS(a, i, expected, v) == expected}.
+     * <p>
+     * The building block for anything atomics-with-add cannot express: locks, lock-free update loops
+     * ({@code do { old = a[i]; } while (atomicCAS(a, i, old, f(old)) != old);}), and claiming a slot exactly
+     * once.
+     * <p>
+     * CUDA equivalent: {@code atomicCAS(&array[index], expected, value)}
+     *
+     * @param array
+     *     local (shared) array to update
+     * @param index
+     *     element index
+     * @param expected
+     *     value the element must currently hold for the swap to happen
+     * @param value
+     *     value to store when the comparison succeeds
+     * @return the element's previous value
+     */
+    public int atomicCAS(int[] array, int index, int expected, int value) {
+        int previous = array[index];
+        if (previous == expected) {
+            array[index] = value;
+        }
+        return previous;
+    }
+
+    /**
+     * Atomically stores {@code value} into {@code array[index]} and returns the previous value.
+     * <p>
+     * CUDA equivalent: {@code atomicExch(&array[index], value)}
+     *
+     * @param array
+     *     local (shared) array to update
+     * @param index
+     *     element index
+     * @param value
+     *     value to store
+     * @return the element's previous value
+     */
+    public int atomicExchange(int[] array, int index, int value) {
+        int previous = array[index];
+        array[index] = value;
+        return previous;
+    }
+
+    /**
+     * Atomically replaces {@code array[index]} with the smaller of it and {@code value}, returning the
+     * previous value. One instruction instead of a compare-and-swap loop.
+     * <p>
+     * CUDA equivalent: {@code atomicMin(&array[index], value)}
+     *
+     * @param array
+     *     local (shared) array to update
+     * @param index
+     *     element index
+     * @param value
+     *     candidate minimum
+     * @return the element's previous value
+     */
+    public int atomicMin(int[] array, int index, int value) {
+        int previous = array[index];
+        if (value < previous) {
+            array[index] = value;
+        }
+        return previous;
+    }
+
+    /**
+     * Atomically replaces {@code array[index]} with the larger of it and {@code value}, returning the
+     * previous value.
+     * <p>
+     * CUDA equivalent: {@code atomicMax(&array[index], value)}
+     *
+     * @param array
+     *     local (shared) array to update
+     * @param index
+     *     element index
+     * @param value
+     *     candidate maximum
+     * @return the element's previous value
+     */
+    public int atomicMax(int[] array, int index, int value) {
+        int previous = array[index];
+        if (value > previous) {
+            array[index] = value;
+        }
+        return previous;
+    }
+
+    /**
      * Cooperative 8x8 single-precision matrix multiply for one SIMD group, using
      * Apple's {@code simdgroup_float8x8} hardware matrix units (MMA).
      * <p>

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -187,6 +187,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestCombinedTaskGraph"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestVectorAdditionKernelContext"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.KernelContextWorkGroupTests"),
+    TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestAtomicRmw"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.api.TestHalfFloatLocalArray"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.local.memory.TestSwizzledLocalArrays"),
     TestEntry("uk.ac.manchester.tornado.unittests.kernelcontext.matrices.TestMatrixMultiplicationKernelContext"),

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAGraphBuilderPlugins.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/plugins/CUDAGraphBuilderPlugins.java
@@ -93,6 +93,7 @@ import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAMMAStoreBSwizzledNo
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAMMAStoreNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAShuffleDownNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDASimdBroadcastFirstNode;
+import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAAtomicRmwNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDASimdSumNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.DecAtomicNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.GetAtomicNode;
@@ -878,10 +879,57 @@ public class CUDAGraphBuilderPlugins {
             }
         });
 
+        registerAtomicRmwPlugins(r);
+
         r.register(new InvocationPlugin("simdBroadcastFirst", InvocationPlugin.Receiver.class, float.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode val) {
                 b.addPush(JavaKind.Float, new CUDASimdBroadcastFirstNode(val));
+                return true;
+            }
+        });
+    }
+
+    /**
+     * Read-modify-write atomics over a local (shared) int array. Without these the KernelContext defaults
+     * apply the operation non-atomically, which is only correct for a single thread.
+     */
+    private static void registerAtomicRmwPlugins(Registration r) {
+        r.register(new InvocationPlugin("atomicCAS", InvocationPlugin.Receiver.class, int[].class, int.class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode array, ValueNode index, ValueNode expected, ValueNode value) {
+                if (!isLocalArray(array)) {
+                    return false;
+                }
+                receiver.get(true);
+                b.addPush(JavaKind.Int, new CUDAAtomicRmwNode(CUDALIRStmt.AtomicRmwStmt.Mode.CAS, array, index, expected, value));
+                return true;
+            }
+        });
+
+        registerAtomicRmwPlugin(r, "atomicExchange", CUDALIRStmt.AtomicRmwStmt.Mode.EXCHANGE);
+        registerAtomicRmwPlugin(r, "atomicMin", CUDALIRStmt.AtomicRmwStmt.Mode.MIN);
+        registerAtomicRmwPlugin(r, "atomicMax", CUDALIRStmt.AtomicRmwStmt.Mode.MAX);
+    }
+
+    /**
+     * Whether {@code array} is a local (shared) array declared inside the kernel. Only those are addressable
+     * as {@code &name[index]}; a global array parameter arrives as a raw address held in an integer, so the
+     * same emission would not compile. Global arrays keep their existing lowering.
+     */
+    private static boolean isLocalArray(ValueNode array) {
+        return GraphUtil.unproxify(array) instanceof LocalArrayNode;
+    }
+
+    private static void registerAtomicRmwPlugin(Registration r, String name, CUDALIRStmt.AtomicRmwStmt.Mode mode) {
+        r.register(new InvocationPlugin(name, InvocationPlugin.Receiver.class, int[].class, int.class, int.class) {
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode array, ValueNode index, ValueNode value) {
+                if (!isLocalArray(array)) {
+                    return false;
+                }
+                receiver.get(true);
+                b.addPush(JavaKind.Int, new CUDAAtomicRmwNode(mode, array, index, null, value));
                 return true;
             }
         });

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
@@ -872,6 +872,76 @@ public class CUDALIRStmt {
     }
 
     @Opcode("SHUFFLE_SYNC")
+    /**
+     * Read-modify-write atomic on one element of a local (shared) array:
+     * {@code atomicCAS} / {@code atomicExch} / {@code atomicMin} / {@code atomicMax}. All four return the
+     * element's previous value.
+     */
+    public static class AtomicRmwStmt extends AbstractInstruction {
+
+        public static final LIRInstructionClass<AtomicRmwStmt> TYPE = LIRInstructionClass.create(AtomicRmwStmt.class);
+
+        public enum Mode {
+            CAS("atomicCAS", true),
+            EXCHANGE("atomicExch", false),
+            MIN("atomicMin", false),
+            MAX("atomicMax", false);
+
+            private final String intrinsic;
+            private final boolean comparing;
+
+            Mode(String intrinsic, boolean comparing) {
+                this.intrinsic = intrinsic;
+                this.comparing = comparing;
+            }
+        }
+
+        private final Mode mode;
+        @Def
+        protected Value result;
+        @Use
+        protected Value array;
+        @Use
+        protected Value index;
+        @Use({ OperandFlag.REG, OperandFlag.ILLEGAL })
+        protected Value expected;
+        @Use
+        protected Value value;
+
+        public AtomicRmwStmt(Mode mode, Value result, Value array, Value index, Value expected, Value value) {
+            super(TYPE);
+            this.mode = mode;
+            this.result = result;
+            this.array = array;
+            this.index = index;
+            this.expected = (expected == null) ? Value.ILLEGAL : expected;
+            this.value = value;
+        }
+
+        @Override
+        public void emitCode(CUDACompilationResultBuilder crb, CUDAAssembler asm) {
+            asm.indent();
+            asm.emitValue(crb, result);
+            asm.space();
+            asm.assign();
+            asm.space();
+            asm.emit(mode.intrinsic);
+            asm.emit("(&");
+            asm.emitValue(crb, array);
+            asm.emit("[");
+            asm.emitValue(crb, index);
+            asm.emit("], ");
+            if (mode.comparing) {
+                asm.emitValue(crb, expected);
+                asm.emit(", ");
+            }
+            asm.emitValue(crb, value);
+            asm.emit(")");
+            asm.delimiter();
+            asm.eol();
+        }
+    }
+
     public static class ShuffleSyncStmt extends AbstractInstruction {
 
         public static final LIRInstructionClass<ShuffleSyncStmt> TYPE = LIRInstructionClass.create(ShuffleSyncStmt.class);

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/nodes/CUDAAtomicRmwNode.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/nodes/CUDAAtomicRmwNode.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.cuda.graal.nodes;
+
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.memory.SingleMemoryKill;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import org.graalvm.word.LocationIdentity;
+
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Value;
+import uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDALIRStmt;
+
+/**
+ * Graal IR node for the read-modify-write atomics on {@link uk.ac.manchester.tornado.api.KernelContext}:
+ * {@code atomicCAS}, {@code atomicExchange}, {@code atomicMin} and {@code atomicMax} over an element of a
+ * local (shared) array. Every one of them returns the element's previous value, which is what the CUDA
+ * intrinsics return.
+ *
+ * <p>Extends {@link FixedWithNextNode} because these have a side effect on memory: they must keep their
+ * position relative to other accesses and must not be duplicated or folded away. It is also a
+ * {@link SingleMemoryKill} over {@link LocationIdentity#any()}: without that the compiler treats an
+ * earlier load of the same element as still valid and reuses it, so a value the atomic (or another
+ * thread) wrote is never read back - the store after the atomic ends up writing the pre-atomic register.
+ */
+@NodeInfo(shortName = "CUDAAtomicRmw")
+public class CUDAAtomicRmwNode extends FixedWithNextNode implements LIRLowerable, SingleMemoryKill {
+
+    public static final NodeClass<CUDAAtomicRmwNode> TYPE = NodeClass.create(CUDAAtomicRmwNode.class);
+
+    private final CUDALIRStmt.AtomicRmwStmt.Mode mode;
+
+    @Input
+    private ValueNode array;
+    @Input
+    private ValueNode index;
+    @Input
+    private ValueNode value;
+    /** Only used by {@link CUDALIRStmt.AtomicRmwStmt.Mode#CAS}; null otherwise. */
+    @OptionalInput
+    private ValueNode expected;
+
+    public CUDAAtomicRmwNode(CUDALIRStmt.AtomicRmwStmt.Mode mode, ValueNode array, ValueNode index, ValueNode expected, ValueNode value) {
+        super(TYPE, StampFactory.forKind(JavaKind.Int));
+        this.mode = mode;
+        this.array = array;
+        this.index = index;
+        this.expected = expected;
+        this.value = value;
+    }
+
+    @Override
+    public LocationIdentity getKilledLocationIdentity() {
+        return LocationIdentity.any();
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool gen) {
+        LIRGeneratorTool tool = gen.getLIRGeneratorTool();
+        Variable result = tool.newVariable(tool.getLIRKind(stamp));
+        Value expectedOperand = (expected == null) ? null : gen.operand(expected);
+        tool.append(new CUDALIRStmt.AtomicRmwStmt(mode, result, gen.operand(array), gen.operand(index), expectedOperand, gen.operand(value)));
+        gen.setResult(this, result);
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestAtomicRmw.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestAtomicRmw.java
@@ -1,0 +1,282 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.kernelcontext.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Read-modify-write atomics on {@link KernelContext} over a local (shared) array: {@code atomicMax},
+ * {@code atomicMin}, {@code atomicExchange} and {@code atomicCAS}, lowered on the CUDA backend to
+ * {@code atomicMax} / {@code atomicMin} / {@code atomicExch} / {@code atomicCAS}.
+ *
+ * <p>Every test puts a whole block of threads on one shared element, so a non-atomic
+ * read-modify-write loses updates and the assertion fails. Before these intrinsics existed
+ * {@code atomicAdd} was the only atomic operation available.
+ *
+ * <p>How to run:
+ *
+ * <pre>
+ * tornado-test --printKernel -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestAtomicRmw
+ * </pre>
+ */
+public class TestAtomicRmw extends TornadoTestBase {
+
+    private static final int THREADS = 256;
+    private static final int BLOCKS = 4;
+    private static final int SIZE = THREADS * BLOCKS;
+
+    /** Per-block maximum of the input, computed with one contended shared accumulator. */
+    private static void blockMaxKernel(KernelContext ctx, IntArray in, IntArray out) {
+        int[] shared = ctx.allocateIntLocalArray(1);
+        if (ctx.localIdx == 0) {
+            shared[0] = Integer.MIN_VALUE;
+        }
+        ctx.localBarrier();
+        ctx.atomicMax(shared, 0, in.get(ctx.globalIdx));
+        ctx.localBarrier();
+        if (ctx.localIdx == 0) {
+            out.set(ctx.groupIdx, shared[0]);
+        }
+    }
+
+    /** Per-block minimum, same shape. */
+    private static void blockMinKernel(KernelContext ctx, IntArray in, IntArray out) {
+        int[] shared = ctx.allocateIntLocalArray(1);
+        if (ctx.localIdx == 0) {
+            shared[0] = Integer.MAX_VALUE;
+        }
+        ctx.localBarrier();
+        ctx.atomicMin(shared, 0, in.get(ctx.globalIdx));
+        ctx.localBarrier();
+        if (ctx.localIdx == 0) {
+            out.set(ctx.groupIdx, shared[0]);
+        }
+    }
+
+    /**
+     * Exactly one thread per block must win the claim. Every thread compare-and-swaps the sentinel with
+     * its own lane id; the winner is the one that observes the sentinel, and it records how many threads
+     * claimed to win.
+     */
+    private static void claimOnceKernel(KernelContext ctx, IntArray out, IntArray seen) {
+        int[] shared = ctx.allocateIntLocalArray(1);
+        if (ctx.localIdx == 0) {
+            shared[0] = -1; // slot to claim
+        }
+        ctx.localBarrier();
+        // Every thread records what it observed, so the host can count the winners.
+        seen.set(ctx.globalIdx, ctx.atomicCAS(shared, 0, -1, ctx.localIdx));
+        ctx.localBarrier();
+        if (ctx.localIdx == 0) {
+            out.set(ctx.groupIdx, shared[0]);
+        }
+    }
+
+    /**
+     * A lock-free maximum built from a compare-and-swap retry loop - the pattern that is impossible with
+     * only {@code atomicAdd}. Must agree with the single-instruction {@code atomicMax}.
+     */
+    private static void casLoopMaxKernel(KernelContext ctx, IntArray in, IntArray out) {
+        int[] shared = ctx.allocateIntLocalArray(1);
+        if (ctx.localIdx == 0) {
+            shared[0] = Integer.MIN_VALUE;
+        }
+        ctx.localBarrier();
+        int candidate = in.get(ctx.globalIdx);
+        int observed = shared[0];
+        while (candidate > observed) {
+            int previous = ctx.atomicCAS(shared, 0, observed, candidate);
+            if (previous == observed) {
+                break;
+            }
+            observed = previous;
+        }
+        ctx.localBarrier();
+        if (ctx.localIdx == 0) {
+            out.set(ctx.groupIdx, shared[0]);
+        }
+    }
+
+    /** The last exchange wins, and every thread must observe some previously written lane id. */
+    private static void exchangeKernel(KernelContext ctx, IntArray out, IntArray seen) {
+        int[] shared = ctx.allocateIntLocalArray(1);
+        if (ctx.localIdx == 0) {
+            shared[0] = -1;
+        }
+        ctx.localBarrier();
+        int previous = ctx.atomicExchange(shared, 0, ctx.localIdx);
+        seen.set(ctx.globalIdx, previous);
+        ctx.localBarrier();
+        if (ctx.localIdx == 0) {
+            out.set(ctx.groupIdx, shared[0]);
+        }
+    }
+
+    private void skipUnsupportedBackends() {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
+        assertNotBackend(TornadoVMBackendType.PTX);
+    }
+
+    private static IntArray input() {
+        IntArray in = new IntArray(SIZE);
+        for (int i = 0; i < SIZE; i++) {
+            // Non-monotonic, so the per-block extremes are not simply the first or last element.
+            in.set(i, (i * 7919) % 10007);
+        }
+        return in;
+    }
+
+    private static void run(String name, IntArray in, IntArray out, IntArray extra) throws TornadoExecutionPlanException {
+        KernelContext context = new KernelContext();
+        WorkerGrid worker = new WorkerGrid1D(SIZE);
+        worker.setLocalWork(THREADS, 1, 1);
+        GridScheduler grid = new GridScheduler("atomics." + name, worker);
+        TaskGraph taskGraph = new TaskGraph("atomics");
+        if (in != null) {
+            taskGraph.transferToDevice(DataTransferMode.EVERY_EXECUTION, in);
+        }
+        switch (name) {
+            case "max" -> taskGraph.task(name, TestAtomicRmw::blockMaxKernel, context, in, out);
+            case "min" -> taskGraph.task(name, TestAtomicRmw::blockMinKernel, context, in, out);
+            case "claim" -> taskGraph.task(name, TestAtomicRmw::claimOnceKernel, context, out, extra);
+            case "casLoop" -> taskGraph.task(name, TestAtomicRmw::casLoopMaxKernel, context, in, out);
+            case "exchange" -> taskGraph.task(name, TestAtomicRmw::exchangeKernel, context, out, extra);
+            default -> throw new IllegalArgumentException(name);
+        }
+        if (extra != null) {
+            taskGraph.transferToHost(DataTransferMode.EVERY_EXECUTION, out, extra);
+        } else {
+            taskGraph.transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+        }
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.withGridScheduler(grid).execute();
+        }
+    }
+
+    @Test
+    public void testAtomicMax() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray in = input();
+        IntArray out = new IntArray(BLOCKS);
+        run("max", in, out, null);
+        for (int block = 0; block < BLOCKS; block++) {
+            int expected = Integer.MIN_VALUE;
+            for (int i = block * THREADS; i < (block + 1) * THREADS; i++) {
+                expected = Math.max(expected, in.get(i));
+            }
+            assertEquals("block " + block, expected, out.get(block));
+        }
+    }
+
+    @Test
+    public void testAtomicMin() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray in = input();
+        IntArray out = new IntArray(BLOCKS);
+        run("min", in, out, null);
+        for (int block = 0; block < BLOCKS; block++) {
+            int expected = Integer.MAX_VALUE;
+            for (int i = block * THREADS; i < (block + 1) * THREADS; i++) {
+                expected = Math.min(expected, in.get(i));
+            }
+            assertEquals("block " + block, expected, out.get(block));
+        }
+    }
+
+    @Test
+    public void testAtomicCASClaimsSlotExactlyOnce() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray out = new IntArray(BLOCKS);
+        IntArray seen = new IntArray(SIZE);
+        seen.init(-2);
+        run("claim", null, out, seen);
+        for (int block = 0; block < BLOCKS; block++) {
+            int winners = 0;
+            for (int i = block * THREADS; i < (block + 1) * THREADS; i++) {
+                if (seen.get(i) == -1) {
+                    winners++;
+                }
+            }
+            assertEquals("exactly one thread of block " + block + " may win the claim", 1, winners);
+            assertTrue("the claimed slot must hold a lane id, but was " + out.get(block), //
+                    out.get(block) >= 0 && out.get(block) < THREADS);
+        }
+    }
+
+    @Test
+    public void testAtomicCASRetryLoopMatchesAtomicMax() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray in = input();
+        IntArray viaLoop = new IntArray(BLOCKS);
+        IntArray viaMax = new IntArray(BLOCKS);
+        run("casLoop", in, viaLoop, null);
+        run("max", in, viaMax, null);
+        for (int block = 0; block < BLOCKS; block++) {
+            assertEquals("block " + block, viaMax.get(block), viaLoop.get(block));
+        }
+    }
+
+    @Test
+    public void testAtomicExchange() throws TornadoExecutionPlanException {
+        skipUnsupportedBackends();
+        IntArray out = new IntArray(BLOCKS);
+        IntArray seen = new IntArray(SIZE);
+        seen.init(-2);
+        run("exchange", null, out, seen);
+        for (int block = 0; block < BLOCKS; block++) {
+            int winner = out.get(block);
+            assertTrue("the surviving value must be a lane id of block " + block + " but was " + winner, //
+                    winner >= 0 && winner < THREADS);
+        }
+        // Exactly one thread per block observes the sentinel; every other observes another lane's id.
+        for (int block = 0; block < BLOCKS; block++) {
+            int sentinelObservations = 0;
+            for (int i = block * THREADS; i < (block + 1) * THREADS; i++) {
+                int observed = seen.get(i);
+                assertTrue("unexpected observed value " + observed, observed == -1 || (observed >= 0 && observed < THREADS));
+                if (observed == -1) {
+                    sentinelObservations++;
+                }
+            }
+            assertEquals("exactly one thread of block " + block + " may see the sentinel", 1, sentinelObservations);
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Adds read-modify-write atomics over a local (shared) array to `KernelContext`: `atomicCAS`,
`atomicExchange`, `atomicMin`, `atomicMax`, lowered on the CUDA backend to `atomicCAS` / `atomicExch` /
`atomicMin` / `atomicMax`. All four return the element's previous value, matching the CUDA intrinsics.

First item from the roadmap in #990. Before this, `atomicAdd` was the **only** atomic operation the device
API offered, which rules out a whole class of kernels: locks, claim-a-slot-once, histogram min/max, and any
lock-free update loop.

```java
int[] shared = ctx.allocateIntLocalArray(1);
...
ctx.atomicMax(shared, 0, candidate);                 // one instruction, no CAS loop

int observed = shared[0];                            // lock-free update, previously impossible
while (candidate > observed) {
    int previous = ctx.atomicCAS(shared, 0, observed, candidate);
    if (previous == observed) {
        break;
    }
    observed = previous;
}
```

Implementation follows the pattern the newer intrinsics use (`simd*`, `mma*`, swizzles) rather than the
older `AtomicInteger`-inlining route: `CUDAAtomicRmwNode` (one node, mode enum) →
`CUDALIRStmt.AtomicRmwStmt` → three `InvocationPlugin` registrations plus one for the 4-argument
`atomicCAS`. Generated code:

```c
i_4  =  atomicCAS(&adi_1[0], -1, i_2);
i_13 =  atomicMax(&adi_2[0], i_10);
i_9  =  atomicExch(&adi_3[0], i_3);
```

Two details that are easy to get wrong and are worth reviewing:

- The node is a **`SingleMemoryKill` over `LocationIdentity.any()`**. Without it the compiler considers an
  earlier load of the same element still valid and reuses it, so the store after the atomic writes the
  *pre-atomic* register. That is not theoretical: the CAS retry-loop test failed with
  `expected:<9978> but was:<-2147483648>` and the emitted C ended in `*((int *) ul_20) = i_11;`, where
  `i_11` was the load from before the loop.
- The plugins are **gated to local (shared) arrays** (`GraphUtil.unproxify(array) instanceof
  LocalArrayNode`). A global `int[]` parameter arrives as a raw address held in an integer, so the
  `&name[index]` form does not compile there — the gate makes those calls fall through to the existing
  lowering instead.

#### Problem description

Feature, plus one bug found on the way that is **reported here and deliberately not fixed** (see below).

Without CAS there is no way to express "exactly one thread claims this slot", and without min/max the only
option is a CAS loop — which also was not available. `atomicAdd` alone covers counting and nothing else.

#### Found while building this: `atomicAdd(int[], index, val)` ignores the index

On a local array, `ctx.atomicAdd(shared, 1, 5)` adds to `shared[0]`, not `shared[1]`. With 32 threads
adding 5 at index 1, the observed state was `shared[0] == 160, shared[1] == 0`. So a shared-memory
histogram silently accumulates every count into one bin. The value is honoured; only the index is dropped.
It comes from `KernelContext.atomicAdd` being lowered through its inlined `AtomicInteger` body, which
addresses the array base.

I did **not** fix it in this PR, and the reason is worth recording. Lowering `atomicAdd` through the new
node fixes the local-array case (verified: `shared[0] == 0, shared[1] == 160`) but registering a plugin for
that method **regressed a global-array test** — `atomics.TestAtomics#testAtomic18_parallel_api_int_array`
went from passing to failing, first with `error: expression must have pointer-to-object type but it has
type "int"` on `atomicAdd(&ul_0[i_4], i_9)`, and then, once the local-array gate declined those calls,
with `unimplemented: address origin unimplemented: TornadoAtomicIntegerNode`. Declining is evidently not
equivalent to never registering for this method. Fixing `atomicAdd` properly therefore means handling the
global-array addressing form as well, which belongs in its own change with its own test rather than riding
along here. Tracked in #990.

#### Backend/s tested

- [ ] OpenCL
- [ ] PTX
- [x] CUDA
- [ ] Metal

The API is backend-neutral with single-threaded Java fallbacks (read, apply, write, return the old value),
so sequential execution of the same kernel is correct and other backends are unaffected. `TestAtomicRmw`
skips OpenCL, SPIR-V, Metal and PTX rather than asserting against lowerings that do not exist yet.
Follow-ups if wanted: PTX (`atom.shared.cas/exch/min/max.b32`), Metal
(`atomic_compare_exchange_weak_explicit`, `atomic_exchange_explicit`, `atomic_fetch_min/max_explicit`),
OpenCL (`atomic_cmpxchg`, `atomic_xchg`, `atomic_min/max`).

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?

```bash
make BACKEND=cuda
source setvars.sh

tornado-test --ea -V uk.ac.manchester.tornado.unittests.kernelcontext.api.TestAtomicRmw
```

Every test puts a whole 256-thread block on one shared element, so a non-atomic read-modify-write loses
updates and the assertion fails — the tests cannot pass by accident.

**`atomicMax` / `atomicMin`** — per-block extremes of a non-monotonic input (so the answer is not the first
or last element), checked against a CPU reference per block:

```bash
tornado-test --ea -V ...TestAtomicRmw#testAtomicMax
tornado-test --ea -V ...TestAtomicRmw#testAtomicMin
```

**`atomicCAS`, exactly-once semantics** — every thread compare-and-swaps a sentinel with its own lane id and
records what it observed; the host asserts that exactly one thread per block saw the sentinel and that the
surviving value is a valid lane id:

```bash
tornado-test --ea -V ...TestAtomicRmw#testAtomicCASClaimsSlotExactlyOnce
```

**`atomicCAS`, retry loop** — a lock-free maximum built from CAS, asserted to agree with the
single-instruction `atomicMax` on the same input. This is the test that catches a missing memory kill:

```bash
tornado-test --ea -V ...TestAtomicRmw#testAtomicCASRetryLoopMatchesAtomicMax
```

**`atomicExchange`** — the surviving value must be some lane id, and exactly one thread per block may
observe the sentinel:

```bash
tornado-test --ea -V ...TestAtomicRmw#testAtomicExchange
```

To see the emitted intrinsics:

```bash
tornado --printKernel -ea -m tornado.unittests/uk.ac.manchester.tornado.unittests.tools.TornadoTestRunner \
        --params "uk.ac.manchester.tornado.unittests.kernelcontext.api.TestAtomicRmw" | grep -E "atomic(CAS|Exch|Min|Max)"
```

Regression (RTX 4090, driver 565.57.01, CUDA 11.5, JDK 21.0.2): `tornado-test --quickPass` reports the same
86 pre-existing failures as `develop @ 06616ddd4`, same 22 classes — including
`atomics.TestAtomics#testAtomic18_parallel_api_int_array`, which was confirmed passing standalone on both
develop and this branch after the `atomicAdd` interception was removed. `mvn checkstyle:check` clean.
