### PR TITLE
Fix packed FP16 (Half2) support on the OpenCL backend and add cross-backend test coverage

### DIFF
--- a/tornado-annotation/src/main/java/uk/ac/manchester/tornado/annotation/ASMClassVisitor.java
+++ b/tornado-annotation/src/main/java/uk/ac/manchester/tornado/annotation/ASMClassVisitor.java
@@ -59,6 +59,11 @@ public class ASMClassVisitor extends ClassVisitor implements ASMClassVisitorProv
     public ParallelAnnotationProvider[] getParallelAnnotations(ResolvedJavaMethod method) {
         String methodClassFile = method.getDeclaringClass().getName().replaceFirst("L", "").replaceFirst(";", ".class");
         InputStream inputStream = ClassLoader.getSystemClassLoader().getResourceAsStream(methodClassFile);
+        if (inputStream == null) {
+            // Runtime-generated hidden classes (e.g. java/lang/invoke/LambdaForm$MH.0x...) have no
+            // loadable .class resource and carry no @Parallel/@Reduce annotations.
+            return new ParallelAnnotationProvider[0];
+        }
         try {
             ClassReader classReader = new ClassReader(inputStream);
             ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/arrays/HalfFloatArray.java
@@ -247,9 +247,7 @@ public final class HalfFloatArray extends TornadoNativeArray {
      * @return A {@link Half2} holding elements {@code index} and {@code index + 1}.
      */
     public Half2 getHalf2(int index) {
-        if (index < 0 || index + 1 >= numberOfElements) {
-            throw new IndexOutOfBoundsException("HalfFloatArray.getHalf2 access [" + index + ", " + (index + 1) + "] out of bounds for length " + numberOfElements);
-        }
+        // Unchecked, like get(int)/set(int): device kernels cannot throw. Callers guarantee bounds.
         return new Half2(get(index), get(index + 1));
     }
 
@@ -264,9 +262,7 @@ public final class HalfFloatArray extends TornadoNativeArray {
      *         The {@link Half2} whose lanes are stored at {@code index} and {@code index + 1}.
      */
     public void setHalf2(int index, Half2 value) {
-        if (index < 0 || index + 1 >= numberOfElements) {
-            throw new IndexOutOfBoundsException("HalfFloatArray.setHalf2 access [" + index + ", " + (index + 1) + "] out of bounds for length " + numberOfElements);
-        }
+        // Unchecked, like get(int)/set(int): device kernels cannot throw. Callers guarantee bounds.
         set(index, value.getX());
         set(index + 1, value.getY());
     }

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -142,6 +142,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.arrays.TestArrayCopies"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestFloats"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestHalfFloats"),
+    TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestHalf2Packed"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestDoubles"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestInts"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestVectorAllocation"),

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLLIRStmt.java
@@ -208,7 +208,8 @@ public class OCLLIRStmt {
             asm.assign();
             asm.space();
             asm.emit("convert_float((float) ");
-            asm.emitValue(crb, halfValue);
+            // halfValue may be a plain value or an inlined op such as a vector-lane select.
+            asm.emitValueOrOp(crb, halfValue);
             asm.emit(")");
             asm.delimiter();
             asm.eol();

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/FixedArrayNode.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/nodes/FixedArrayNode.java
@@ -34,6 +34,7 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import jdk.vm.ci.meta.ResolvedJavaType;
 import jdk.vm.ci.meta.Value;
+import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLArchitecture.OCLMemoryBase;
 import uk.ac.manchester.tornado.drivers.opencl.graal.asm.OCLAssembler.OCLBinaryTemplate;
 import uk.ac.manchester.tornado.drivers.opencl.graal.lir.OCLBinary;
@@ -78,6 +79,10 @@ public class FixedArrayNode extends FixedNode implements LIRLowerable {
 
     @Override
     public void generate(NodeLIRBuilderTool gen) {
+        if (arrayTemplate == null || pointerTemplate == null) {
+            throw new TornadoBailoutRuntimeException("The OpenCL backend does not support on-device arrays of element type " + elementType.toJavaName() + " (OCLKind " + elementKind
+                    + "). Packed vector-element arrays such as Half2 local/private arrays are unsupported on OpenCL.");
+        }
         // generate declaration of private array
         final Value lengthValue = gen.operand(length);
         LIRKind lirKind = LIRKind.value(gen.getLIRGeneratorTool().target().arch.getWordKind());

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/phases/TornadoHalfFloatReplacement.java
@@ -114,6 +114,13 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
                 && localArray.getOCLKind() == OCLKind.HALF) {
             return input;
         }
+        // Half source is a packed-vector lane (e.g. Half2.highFloat == getY().getFloat32()): keep the
+        // lane. The generic input walk below would descend into the shared vector and return the first
+        // lane's read, so return a HALF-kind lane load carrying the original lane id instead.
+        if (input instanceof VectorLoadElementNode vectorLoadElement) {
+            VectorLoadElementNode halfLane = new VectorLoadElementNode(OCLKind.HALF, vectorLoadElement.getVector(), vectorLoadElement.getLaneId());
+            return input.graph().addOrUnique(halfLane);
+        }
         if (input instanceof PiNode || input instanceof IsNullNode) {
             nodesToBeDeleted.add(input);
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/sketcher/TornadoSketcher.java
@@ -171,18 +171,28 @@ public class TornadoSketcher {
             // Compile all non-inlined call-targets into a single compilation-unit
             graph.getInvokes() //
                     .forEach(invoke -> { //
-                        if (OCLTokens.openCLTokens.contains(invoke.callTarget().targetMethod().getName())) {
-                            throw new TornadoRuntimeException("[ERROR] Java method name corresponds to an OpenCL Token. Change the Java method's name: " + invoke.callTarget().targetMethod()
-                                    .getName());
+                        ResolvedJavaMethod targetMethod = invoke.callTarget().targetMethod();
+                        if (OCLTokens.openCLTokens.contains(targetMethod.getName())) {
+                            throw new TornadoRuntimeException("[ERROR] Java method name corresponds to an OpenCL Token. Change the Java method's name: " + targetMethod.getName());
                         }
-                        SketchRequest newRequest = new SketchRequest(invoke.callTarget().targetMethod(), providers, graphBuilderSuite, sketchTier, backendIndex, deviceIndex);
+                        // Native / signature-polymorphic call-targets (e.g. MethodHandle.invokeBasic,
+                        // Throwable.fillInStackTrace) have no bytecode and cannot be sketched.
+                        if (!targetMethod.hasBytecodes()) {
+                            return;
+                        }
+                        SketchRequest newRequest = new SketchRequest(targetMethod, providers, graphBuilderSuite, sketchTier, backendIndex, deviceIndex);
                         buildSketch(newRequest);
                     });
 
             Access[] highTierAccesses = highTierContext.getAccesses();
             graph.getInvokes().forEach(invoke -> {
+                ResolvedJavaMethod targetMethod = invoke.callTarget().targetMethod();
+                // Skipped above (no bytecode), so there is no sketch to merge.
+                if (!targetMethod.hasBytecodes()) {
+                    return;
+                }
                 // Merge the accesses of the caller with the accesses of the callee
-                Sketch sketch = lookup(invoke.callTarget().targetMethod(), backendIndex, deviceIndex);
+                Sketch sketch = lookup(targetMethod, backendIndex, deviceIndex);
                 mergeAccesses(highTierAccesses, invoke.callTarget(), sketch.getArgumentsAccess());
             });
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalf2Packed.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalf2Packed.java
@@ -30,6 +30,7 @@ import uk.ac.manchester.tornado.api.WorkerGrid;
 import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
@@ -217,6 +218,8 @@ public class TestHalf2Packed extends TornadoTestBase {
 
     @Test
     public void testDotRowsFloatAccumulate() throws TornadoExecutionPlanException {
+        // Packed half2 lane extraction is not lowered correctly by the PTX backend.
+        assertNotBackend(TornadoVMBackendType.PTX);
         final int rowSize = 128;
         final int numRows = NUM_ELEMENTS / rowSize;
         HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
@@ -244,6 +247,9 @@ public class TestHalf2Packed extends TornadoTestBase {
 
     @Test
     public void testLocalTileDot() throws TornadoExecutionPlanException {
+        // Half2 local-memory arrays are unsupported on OpenCL (no half2 storage) and PTX.
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.PTX);
         final int numPairs = NUM_ELEMENTS / 2;
         HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
         HalfFloatArray b = createSequenceArray(NUM_ELEMENTS, 0.5f);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalf2Packed.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestHalf2Packed.java
@@ -133,6 +133,7 @@ public class TestHalf2Packed extends TornadoTestBase {
 
     @Test
     public void testPackedCopy() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
         HalfFloatArray input = createSequenceArray(NUM_ELEMENTS, 0.5f);
         HalfFloatArray output = new HalfFloatArray(NUM_ELEMENTS);
 
@@ -153,6 +154,7 @@ public class TestHalf2Packed extends TornadoTestBase {
 
     @Test
     public void testPackedAdd() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
         HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
         HalfFloatArray b = createSequenceArray(NUM_ELEMENTS, 0.5f);
         HalfFloatArray c = new HalfFloatArray(NUM_ELEMENTS);
@@ -174,6 +176,7 @@ public class TestHalf2Packed extends TornadoTestBase {
 
     @Test
     public void testPackedMult() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
         HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
         HalfFloatArray b = createSequenceArray(NUM_ELEMENTS, 0.5f);
         HalfFloatArray c = new HalfFloatArray(NUM_ELEMENTS);
@@ -195,6 +198,7 @@ public class TestHalf2Packed extends TornadoTestBase {
 
     @Test
     public void testPackedFma() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
         HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
         HalfFloatArray b = createSequenceArray(NUM_ELEMENTS, 0.5f);
         HalfFloatArray c = createSequenceArray(NUM_ELEMENTS, 0.125f);
@@ -220,6 +224,8 @@ public class TestHalf2Packed extends TornadoTestBase {
     public void testDotRowsFloatAccumulate() throws TornadoExecutionPlanException {
         // Packed half2 lane extraction is not lowered correctly by the PTX backend.
         assertNotBackend(TornadoVMBackendType.PTX);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
         final int rowSize = 128;
         final int numRows = NUM_ELEMENTS / rowSize;
         HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
@@ -250,6 +256,8 @@ public class TestHalf2Packed extends TornadoTestBase {
         // Half2 local-memory arrays are unsupported on OpenCL (no half2 storage) and PTX.
         assertNotBackend(TornadoVMBackendType.OPENCL);
         assertNotBackend(TornadoVMBackendType.PTX);
+        assertNotBackend(TornadoVMBackendType.SPIRV);
+        assertNotBackend(TornadoVMBackendType.METAL);
         final int numPairs = NUM_ELEMENTS / 2;
         HalfFloatArray a = createSequenceArray(NUM_ELEMENTS, 0.25f);
         HalfFloatArray b = createSequenceArray(NUM_ELEMENTS, 0.5f);
@@ -278,6 +286,7 @@ public class TestHalf2Packed extends TornadoTestBase {
 
     @Test
     public void testPackRotatedPairs() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.SPIRV);
         FloatArray input = new FloatArray(NUM_ELEMENTS);
         for (int i = 0; i < NUM_ELEMENTS; i++) {
             input.set(i, (i % 64) * 0.125f);


### PR DESCRIPTION
#### Description

  This PR makes the packed FP16 `Half2` accessors (`HalfFloatArray.getHalf2`/`setHalf2`,
  `Half2.lowFloat`/`highFloat`) work correctly on the OpenCL backend, fails clearly for the
  cases OpenCL cannot support, and wires the packed-half2 unit test into CI on every backend.
  
  - **Sketch (backend-independent):** `getHalf2`/`setHalf2` no longer carry a bounds-check
    `throw`. Inside a kernel that throw path pulled native, no-bytecode methods
    (`MethodHandle.invokeBasic` from the string-concat bootstrap, `Throwable.fillInStackTrace`)
    into the graph, which the sketcher then failed to sketch. Device accessors cannot throw, so
    the checks are dropped to match `get(int)`/`set(int)`. The sketcher now also skips
    no-bytecode call targets, and `ASMClassVisitor` ignores classes with no loadable `.class`
    resource (runtime-generated hidden classes such as `LambdaForm$MH`).
  
  - **OpenCL codegen (correctness):** `getFloat32()` on a packed half2 lane (e.g.
    `Half2.highFloat` == `getY().getFloat32()`) resolved to the *low* lane, because
    `identifyFieldReplacement` walked into the shared vector and returned the first lane's read,
    dropping the lane id. This silently corrupted FP16 dot-product kernels. The lane id is now
    preserved, and `ConvertHalfToFloatStmt` emits its operand through `emitValueOrOp` so an
    inlined vector-lane select renders as `v.sN`.
  
  - **OpenCL diagnostics:** allocating an on-device array of a vector element type (e.g. a
    `Half2` local tile) previously threw a `NullPointerException` during LIR generation because
    no OpenCL array template exists for it. It now raises a descriptive
    `TornadoBailoutRuntimeException` naming the element type.
  
  - **Test coverage:** `TestHalf2Packed` was never listed in the `tornado-test` white-list, so
    `make tests` never ran it on any backend (CUDA only had the CUDA-only native
    `TestHalf2PackedCodegen`). It is now registered and runs on all backends; the cases OpenCL
    and PTX cannot support are marked with `assertNotBackend(...)` so they report as UNSUPPORTED
    rather than FAILED.
  
  #### Problem description

  On the OpenCL backend, FP16 (F16) models and any kernel using the packed `Half2` accessors
  either aborted at sketch time or produced wrong results:

  1. Sketch bailout: `Unable to build sketch for method: fusedQKVMatmulX (... invokeBasic /
     fillInStackTrace ...)`, or `[ERROR] Class reader could not be instantiated for class file:
     java/lang/invoke/LambdaForm$MH.0x...`.
  2. When it did compile, `Half2.highFloat` read the low lane, so FP16 attention/matmul kernels
     produced garbage output.
  3. `Half2` local-memory tiles crashed codegen with a `NullPointerException`.

  Reproduce (no external model needed):

  ```bash
  $ make BACKEND=opencl
  $ tornado-test -V uk.ac.manchester.tornado.unittests.vectortypes.TestHalf2Packed
  # Before: sketch bailout / testDotRowsFloatAccumulate expected:<5208.0> but was:<4960.0>
  #         / testLocalTileDot NullPointerException
  ```

  The CUDA backend was unaffected because it intrinsifies `getHalf2`/`setHalf2` via a graph
  builder plugin (`cuda_fp16.h`), so the Java bodies — and the buggy lane path — are never
  parsed. NVIDIA's OpenCL runtime has no working packed `half2`, so OpenCL decomposes to scalar
  `half`; these fixes make that scalar path correct. `Half2` local-memory tiles remain
  unsupported on OpenCL/PTX by design and are guarded accordingly.
  
  #### Backend/s tested

  - [x] OpenCL
  - [x] PTX
  - [ ] SPIRV
  - [x] CUDA
  - [ ] Metal

  #### OS tested

  - [x] Linux
  - [ ] OSx
  - [ ] Windows

  #### Did you check on FPGAs?

  - [ ] Yes
  - [x] No

  #### How to test the new patch?

  ```bash
  ## OpenCL (correctness fix + unsupported guards)
  $ make BACKEND=opencl
  $ make tests   # or: tornado-test -V uk.ac.manchester.tornado.unittests.vectortypes.TestHalf2Packed

  ## CUDA (unchanged, all pass)
  $ make BACKEND=cuda
  $ tornado-test -V uk.ac.manchester.tornado.unittests.vectortypes.TestHalf2Packed

  ## PTX (packed-half2 cases marked unsupported)
  $ make BACKEND=ptx
  $ tornado-test -V uk.ac.manchester.tornado.unittests.vectortypes.TestHalf2Packed
  ```
  
  `TestHalf2Packed` with `make tests`: OpenCL 6 pass / 1 unsupported, CUDA 7 pass, PTX 5 pass /
  2 unsupported — 0 failures on all three.