### PR TITLE
Fix consumeFromDevice silently reading a stale buffer when the named producer is not the previously executed graph

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -242,6 +242,14 @@ public class ImmutableTaskGraph {
         taskGraph.mapOnDeviceMemoryRegion(destArray, srcArray, offset, taskGraphSrc.taskGraph.taskGraphImpl);
     }
 
+    void setPlanTaskGraphs(java.util.List<TornadoTaskGraphInterface> planTaskGraphs) {
+        taskGraph.setPlanTaskGraphs(planTaskGraphs);
+    }
+
+    TornadoTaskGraphInterface getTaskGraphImplementation() {
+        return taskGraph.getTaskGraphImplementation();
+    }
+
     void setLastExecutedTaskGraph(ImmutableTaskGraph lastExecutedTaskGraph) {
         taskGraph.setLastExecutedTaskGraph(lastExecutedTaskGraph.taskGraph.taskGraphImpl);
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -1215,6 +1215,14 @@ public class TaskGraph implements TaskGraphInterface {
         taskGraphImpl.mapOnDeviceMemoryRegion(destArray, srcArray, offset, taskGraphSrc);
     }
 
+    void setPlanTaskGraphs(java.util.List<TornadoTaskGraphInterface> planTaskGraphs) {
+        taskGraphImpl.setPlanTaskGraphs(planTaskGraphs);
+    }
+
+    TornadoTaskGraphInterface getTaskGraphImplementation() {
+        return taskGraphImpl;
+    }
+
     void setLastExecutedTaskGraph(TornadoTaskGraphInterface lastExecutedTaskGraph) {
         taskGraphImpl.setLastExecutedTaskGraph(lastExecutedTaskGraph);
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -43,6 +43,21 @@ class TornadoExecutor {
     TornadoExecutor(ImmutableTaskGraph... immutableTaskGraphs) {
         immutableTaskGraphList = new ArrayList<>();
         Collections.addAll(immutableTaskGraphList, immutableTaskGraphs);
+        registerPlanTaskGraphs();
+    }
+
+    /**
+     * Lets every task-graph of this plan see its siblings, so that consumeFromDevice(producerName,
+     * ...) can resolve the producing graph by name regardless of the execution order.
+     */
+    private void registerPlanTaskGraphs() {
+        List<TornadoTaskGraphInterface> planGraphs = new ArrayList<>();
+        for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {
+            planGraphs.add(immutableTaskGraph.getTaskGraphImplementation());
+        }
+        for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {
+            immutableTaskGraph.setPlanTaskGraphs(planGraphs);
+        }
     }
 
     public void withCUDAGraph() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -147,6 +147,13 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void setLastExecutedTaskGraph(TornadoTaskGraphInterface lastExecutedTaskGraph);
 
+    /**
+     * Registers the other task-graphs of the same execution plan, so that
+     * {@code consumeFromDevice(producerName, ...)} can resolve its named producer directly instead of
+     * relying on the producer being the previously executed graph.
+     */
+    void setPlanTaskGraphs(java.util.List<TornadoTaskGraphInterface> planTaskGraphs);
+
     boolean isGridRegistered();
 
     void withIntraPlanConcurrency();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -692,6 +692,12 @@ public class TornadoVMInterpreter {
      *     The object to search for in the persistent tasks
      * @return true if the object is found in any persistent task, otherwise false
      */
+    /** Whether the object already has a device buffer in this interpreter's object state. */
+    private boolean hasDeviceBuffer(int arg) {
+        XPUDeviceBufferState state = resolveObjectState(arg);
+        return state != null && state.getXPUBuffer() != null;
+    }
+
     private boolean isPersistentObject(Object object) {
         if (graphExecutionContext == null || object == null) {
             return false;
@@ -708,11 +714,14 @@ public class TornadoVMInterpreter {
      * @return Information about objects to allocate including counts of persistent and non-persistent objects
      */
     private ObjectAllocationInfo countAndClassifyObjects(int[] args) {
-        // Count only persistent objects that are actually in the current args array
+        // Count only persistent objects that are actually in the current args array. An object that is
+        // persistent but has no device buffer yet (its producing task-graph has not executed - e.g. the
+        // first frames of a pipeline that raycasts only once a model exists) still has to be allocated
+        // here, otherwise the pre-allocated size lookup dereferences a null buffer.
         int persistentObjectsInArgs = 0;
         for (int arg : args) {
             Object dataObject = this.objects.get(arg);
-            if (isPersistentObject(dataObject)) {
+            if (isPersistentObject(dataObject) && hasDeviceBuffer(arg)) {
                 persistentObjectsInArgs++;
             }
         }
@@ -736,7 +745,7 @@ public class TornadoVMInterpreter {
 
         for (int arg : args) {
             Object dataObject = this.objects.get(arg);
-            if (!isPersistentObject(dataObject)) {
+            if (!isPersistentObject(dataObject) || !hasDeviceBuffer(arg)) {
                 objects[allocCounter] = this.objects.get(arg);
                 objectStates[allocCounter] = resolveObjectState(arg);
                 accesses[allocCounter] = this.objectAccesses.get(objects[allocCounter]);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -172,6 +172,9 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     private List<Object> streamInObjects;
     private Map<TornadoTaskGraph, List<Object>> taskToPersistentObjectMap;
     private TornadoTaskGraphInterface lastExecutedTaskGraph;
+
+    /** The other task-graphs of the same execution plan, used to resolve named producers. */
+    private List<TornadoTaskGraphInterface> planTaskGraphs;
     private Set<Object> argumentsLookUp;
     private List<StreamingObject> inputModesObjects; // List of objects with its data transfer mode (IN)
     private List<StreamingObject> outputModeObjects; // List of objects with its data transfer mode (OUT)
@@ -543,6 +546,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
+    public void setPlanTaskGraphs(List<TornadoTaskGraphInterface> planTaskGraphs) {
+        this.planTaskGraphs = planTaskGraphs;
+    }
+
+    @Override
     public long getTotalBytesTransferred() {
         return getProfilerValue(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES) + getProfilerValue(TOTAL_COPY_OUT_SIZE_BYTES);
     }
@@ -619,15 +627,31 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     @Override
     public void updatePersistedObjectState() {
+        // Objects declared with consumeFromDevice(producerName, ...) are resolved against the named
+        // producer directly. Relying on the producer being the *previously executed* graph (the old
+        // behaviour) breaks for any plan that revisits graphs, e.g. an iterative solver that runs
+        // producer -> consumerA -> consumerA -> consumerB: by the time consumerB runs, the previously
+        // executed graph is consumerA and the aliasing was silently skipped, so the consumer read a
+        // separate (stale) device buffer.
+        boolean aliasedByName = aliasNamedProducers();
+
         if (this.lastExecutedTaskGraph == null) {
             //this indicates that this is the first task-graph executed
             return;
         }
 
         TornadoTaskGraph graphSrc = (TornadoTaskGraph) this.lastExecutedTaskGraph;
+        if (graphSrc == this) {
+            // re-executing the same graph: nothing to import
+            return;
+        }
         List<Object> objectsToSync = executionContext.getPersistedTaskToObjectsMap().get(graphSrc.taskGraphName);
 
         if (objectsToSync == null) {
+            if (aliasedByName) {
+                // every consumed object was already resolved through its named producer
+                return;
+            }
             // Empty consumeFromDevice (no explicit source task-graph name): the objects to
             // synchronise from the previously executed task-graph are exactly the ones marked
             // as consumed/on-device. The graph's own persisted *outputs* must NOT be included:
@@ -647,29 +671,82 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         }
 
         for (Object objectToSync : objectsToSync) {
-            Access objectAccessSrc = graphSrc.getObjectAccess(objectToSync);
-            LocalObjectState localStateSrc = graphSrc.executionContext.getLocalStateObject(objectToSync, objectAccessSrc);
-            DataObjectState dataObjectStateSrc = localStateSrc.getDataObjectState();
+            importDeviceBuffer(graphSrc, objectToSync);
+        }
+    }
 
-            // The device is the same for both task-graphs
-            TornadoXPUDevice device = graphSrc.meta().getXPUDevice();
-            XPUDeviceBufferState deviceStateSrc = dataObjectStateSrc.getDeviceBufferState(device);
-
-            Access objectAccessDest = Access.READ_WRITE;
-            LocalObjectState localStateDest = executionContext.getLocalStateObject(objectToSync, objectAccessDest);
-            if (localStateDest == null) {
+    /**
+     * Points this graph's device buffers at the buffers of the named producing graphs, for every
+     * object registered through {@code consumeFromDevice(producerName, ...)}.
+     *
+     * @return whether at least one object was resolved this way.
+     */
+    private boolean aliasNamedProducers() {
+        if (planTaskGraphs == null) {
+            return false;
+        }
+        boolean aliased = false;
+        for (Map.Entry<String, List<Object>> entry : executionContext.getPersistedTaskToObjectsMap().entrySet()) {
+            final String producerName = entry.getKey();
+            if (producerName == null || producerName.equals(taskGraphName)) {
                 continue;
             }
-            if (!graphSrc.meta().getXPUDevice().equals(executionContext.meta().getXPUDevice())) {
-                throw new TornadoRuntimeException("[ERROR] Object " + objectsToSync + " is not on the same device pesisted and consumed: " + graphSrc.meta()
-                        .getXPUDevice() + " " + " vs " + executionContext.meta().getXPUDevice());
+            TornadoTaskGraph producer = null;
+            for (TornadoTaskGraphInterface candidate : planTaskGraphs) {
+                if (candidate instanceof TornadoTaskGraph taskGraph && producerName.equals(taskGraph.taskGraphName)) {
+                    producer = taskGraph;
+                    break;
+                }
             }
-
-            DataObjectState dataObjectStateDest = localStateDest.getDataObjectState();
-            XPUDeviceBufferState deviceStateDest = dataObjectStateDest.getDeviceBufferState(device);
-
-            deviceStateDest.setXPUBuffer(deviceStateSrc.getXPUBuffer());
+            if (producer == null || producer == this) {
+                continue;
+            }
+            for (Object objectToSync : entry.getValue()) {
+                aliased |= importDeviceBuffer(producer, objectToSync);
+            }
         }
+        return aliased;
+    }
+
+    /**
+     * Makes {@code objectToSync} in this graph refer to the device buffer that {@code graphSrc}
+     * allocated for it. Returns false when the producer has no buffer yet (it has not run).
+     */
+    private boolean importDeviceBuffer(TornadoTaskGraph graphSrc, Object objectToSync) {
+        Access objectAccessSrc = graphSrc.getObjectAccess(objectToSync);
+        if (objectAccessSrc == null) {
+            return false;
+        }
+        LocalObjectState localStateSrc = graphSrc.executionContext.getLocalStateObject(objectToSync, objectAccessSrc);
+        if (localStateSrc == null) {
+            return false;
+        }
+        DataObjectState dataObjectStateSrc = localStateSrc.getDataObjectState();
+
+        // The device is the same for both task-graphs
+        TornadoXPUDevice device = graphSrc.meta().getXPUDevice();
+        XPUDeviceBufferState deviceStateSrc = dataObjectStateSrc.getDeviceBufferState(device);
+
+        Access objectAccessDest = Access.READ_WRITE;
+        LocalObjectState localStateDest = executionContext.getLocalStateObject(objectToSync, objectAccessDest);
+        if (localStateDest == null) {
+            return false;
+        }
+        if (!graphSrc.meta().getXPUDevice().equals(executionContext.meta().getXPUDevice())) {
+            throw new TornadoRuntimeException("[ERROR] Object " + objectToSync + " is not on the same device persisted and consumed: " + graphSrc.meta()
+                    .getXPUDevice() + " " + " vs " + executionContext.meta().getXPUDevice());
+        }
+
+        if (deviceStateSrc.getXPUBuffer() == null) {
+            // the producer has not executed yet, so there is no device buffer to alias
+            return false;
+        }
+
+        DataObjectState dataObjectStateDest = localStateDest.getDataObjectState();
+        XPUDeviceBufferState deviceStateDest = dataObjectStateDest.getDeviceBufferState(device);
+
+        deviceStateDest.setXPUBuffer(deviceStateSrc.getXPUBuffer());
+        return true;
     }
 
     @Override

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestSharedBuffers.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
@@ -89,6 +90,107 @@ public class TestSharedBuffers extends TornadoTestBase {
     public static void processBuffer(IntArray input, IntArray output, IntArray context, int size) {
         for (int i = 0; i < size; i++) {
             output.set(i, input.get(i) + context.get(i));
+        }
+    }
+
+    public static void increment(IntArray array) {
+        for (@Parallel int i = 0; i < array.getSize(); i++) {
+            array.set(i, array.get(i) + 1);
+        }
+    }
+
+    public static void copy(IntArray source, IntArray destination) {
+        for (@Parallel int i = 0; i < source.getSize(); i++) {
+            destination.set(i, source.get(i));
+        }
+    }
+
+    /**
+     * The producing task-graph is not the previously executed one when the consumer runs.
+     *
+     * <p>
+     * A plan that revisits graphs - an iterative solver running
+     * {@code producer -> other -> other -> consumer} - must still see the producer's data. Resolving the
+     * producer from "whatever ran last" silently hands the consumer its own, separate device buffer.
+     * </p>
+     */
+    @Test
+    public void testConsumeFromNonAdjacentProducer() throws TornadoExecutionPlanException {
+        IntArray shared = new IntArray(numElements);
+        IntArray unrelated = new IntArray(numElements);
+        IntArray result = new IntArray(numElements);
+        shared.init(0);
+        unrelated.init(0);
+        result.init(-1);
+
+        TaskGraph producer = new TaskGraph("producer") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, shared) //
+                .task("produce", TestSharedBuffers::increment, shared) //
+                .persistOnDevice(shared);
+
+        TaskGraph other = new TaskGraph("other") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, unrelated) //
+                .task("touch", TestSharedBuffers::increment, unrelated) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, unrelated);
+
+        TaskGraph consumer = new TaskGraph("consumer") //
+                .consumeFromDevice("producer", shared) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, result) //
+                .task("copy", TestSharedBuffers::copy, shared, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(producer.snapshot(), other.snapshot(), consumer.snapshot())) {
+            plan.withGraph(0).execute();
+            plan.withGraph(0).execute();
+            plan.withGraph(0).execute();
+            // another graph runs in between, so the producer is no longer the previously executed graph
+            plan.withGraph(1).execute();
+            plan.withGraph(2).execute();
+        }
+
+        for (int i = 0; i < numElements; i++) {
+            assertEquals(3, result.get(i));
+        }
+    }
+
+    /**
+     * The consumer runs before its producer ever has.
+     *
+     * <p>
+     * A persisted object without a device buffer must be allocated rather than dereferenced: a pipeline
+     * can legitimately reach the consumer first (KFusion's ICP runs before the first raycast exists).
+     * The contents of that fresh buffer are undefined, so only the absence of a failure is asserted
+     * here; once the producer has run, its data must be visible.
+     * </p>
+     */
+    @Test
+    public void testConsumeBeforeProducerHasRun() throws TornadoExecutionPlanException {
+        IntArray shared = new IntArray(numElements);
+        IntArray result = new IntArray(numElements);
+        shared.init(0);
+        result.init(-1);
+
+        TaskGraph producer = new TaskGraph("producer") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, shared) //
+                .task("produce", TestSharedBuffers::increment, shared) //
+                .persistOnDevice(shared);
+
+        TaskGraph consumer = new TaskGraph("consumer") //
+                .consumeFromDevice("producer", shared) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, result) //
+                .task("copy", TestSharedBuffers::copy, shared, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(producer.snapshot(), consumer.snapshot())) {
+            // consumer first: must not throw, even though no device buffer exists yet
+            plan.withGraph(1).execute();
+
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+        }
+
+        for (int i = 0; i < numElements; i++) {
+            assertEquals(1, result.get(i));
         }
     }
 


### PR DESCRIPTION
`consumeFromDevice(producerName, ...)` only aliases the producer's device buffer when that producer
happens to be the **previously executed** task-graph. Any execution plan that revisits graphs — an
iterative solver, a per-layer or per-pyramid-level loop — violates that assumption, and when it does
the aliasing is skipped **silently**: the consumer keeps its own, separate device buffer and reads
stale data. There is no error and no warning.

## The failure

Consider a plan driven as `producer → other → other → consumer`, which is the shape of any iterative
pipeline:

```java
TaskGraph producer = new TaskGraph("producer")
        .transferToDevice(DataTransferMode.FIRST_EXECUTION, shared)
        .task("produce", Example::increment, shared)
        .persistOnDevice(shared);

TaskGraph consumer = new TaskGraph("consumer")
        .consumeFromDevice("producer", shared)          // <-- names its producer explicitly
        .task("copy", Example::copy, shared, result)
        .transferToHost(DataTransferMode.EVERY_EXECUTION, result);

try (TornadoExecutionPlan plan = new TornadoExecutionPlan(producer.snapshot(), other.snapshot(), consumer.snapshot())) {
    plan.withGraph(0).execute();   // produce
    plan.withGraph(1).execute();   // something else runs in between
    plan.withGraph(2).execute();   // consumer reads a stale buffer, not the producer's
}
```

`TornadoTaskGraph.updatePersistedObjectState()` looked the objects up with
`getPersistedTaskToObjectsMap().get(lastExecutedTaskGraph.taskGraphName)`. With `other` as the last
executed graph that returns `null`, so the method fell into the branch meant for the *unnamed*
`consumeFromDevice(...)` overload and no buffer was imported.

I hit this porting KFusion (`beehive-lab/kfusion-tornadovm#42`), whose per-frame order is
`preproc → icp2 (×N) → icp1 (×N) → icp0 (×N) → integrate → raycast`. Every ICP graph consumes the
pyramid produced by `preproc` and the reference view produced by `raycast`, and neither is ever the
immediately preceding graph. The whole tracking pipeline silently degenerated: the camera pose never
moved, while the benchmark happily reported ~500 FPS. It took an echo kernel to see it —

```
[dbg] verts inside preproc : -1.6735 -1.2583  3.3554     <- produced here
[dbg] verts inside icp0    :  0.0000  0.0000  0.0000     <- consumer sees zeros
```

— and `-Dtornado.print.bytecodes=True` then showed the consumer re-`ALLOC`ing its own 921 648-byte
buffer on every execution.

## The change

1. **Resolve named producers by name.** Each task-graph of a plan now knows its siblings
   (`setPlanTaskGraphs`, registered by `TornadoExecutor` at construction), so
   `updatePersistedObjectState()` walks its own `persistedTaskToObjectsMap` and imports the buffer from
   the graph that was actually named, whatever ran last. The behaviour of the unnamed overload is
   unchanged, and re-executing the same graph is now a no-op instead of importing from itself.
2. **Allocate persisted objects whose producer has not run yet.** `TornadoVMInterpreter.executeAlloc()`
   treated every persisted object as pre-allocated and did
   `state.getXPUBuffer().size()` on it, which NPEs when the consumer legitimately runs first
   (KFusion's ICP runs before any raycast output exists). Such objects are now allocated normally, and
   the buffer import is skipped while the producer has nothing to share:

```
java.lang.NullPointerException: Cannot invoke "XPUBuffer.size()" because the return value of
    "XPUDeviceBufferState.getXPUBuffer()" is null
        at TornadoVMInterpreter.executeAlloc(TornadoVMInterpreter.java:746)
```

`importDeviceBuffer()` also guards the null-access and access-lookup cases that made the previous code
throw `NullPointerException` from `updatePersistedObjectState` itself.

## Tests

Two regression tests in `TestSharedBuffers` (`uk.ac.manchester.tornado.unittests.api`):

- `testConsumeFromNonAdjacentProducer` — `producer ×3 → other → consumer`, asserts the consumer sees
  the producer's data.
- `testConsumeBeforeProducerHasRun` — consumer executes first (must not throw), then producer, then
  consumer again, asserting the data is visible. The contents of the freshly allocated buffer are
  undefined, so only the absence of a failure is asserted for the first execution.

Both **fail on `develop`** and pass with this change:

```
# develop
Running test: testConsumeFromNonAdjacentProducer ....... [FAILED]
Running test: testConsumeBeforeProducerHasRun ..........  [FAILED]
Test ran: 12, Failed: 2

# this branch
Test ran: 12, Failed: 0
```

## Regression check

`tornado-test --quickPass` on an `opencl,cuda` build, RTX 4090 / CUDA 11.5 / JDK 21:

| | tests run | failed |
|---|---|---|
| `develop` | 1026 | 230 |
| this branch | 1028 | 230 |

The 230 pre-existing failures are the CUDA-library and MMA suites (Cutlass, cuBLAS/cuBLASLt, cuDNN,
cuFFT, cuSPARSE, MMA*, half/bf16/fp8, SIMD-group) running against the OpenCL default backend of a
combined build; they are identical before and after. Per-class diffing showed only
`branching.TestLoopConditions` moving by one, which reproduces intermittently on `develop` and on this
branch alike (it passes on re-run) — a pre-existing flake, not a regression.

Also verified end to end: KFusion's tracking pipeline goes from a static trajectory to ATE RMSE
1.94 cm, and CUDA now matches OpenCL frame by frame to within 0.4 mm over 882 frames.
