### PR TITLE
Emit variable declarations in a deterministic order

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDABackend.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDABackend.java
@@ -34,6 +34,7 @@ import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEV
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -230,7 +231,7 @@ public class CUDABackend extends XPUBackend<CUDAProviders> implements FrameMap.R
             }
 
             if (!kindToVariable.containsKey(oclKind)) {
-                kindToVariable.put(oclKind, new HashSet<>());
+                kindToVariable.put(oclKind, new LinkedHashSet<>());
             }
 
             final Set<Variable> varList = kindToVariable.get(oclKind);
@@ -239,7 +240,10 @@ public class CUDABackend extends XPUBackend<CUDAProviders> implements FrameMap.R
     }
 
     private void emitVariableDefs(CUDACompilationResultBuilder crb, CUDAAssembler asm, LIR lir) {
-        Map<CUDAKind, Set<Variable>> kindToVariable = new HashMap<>();
+        // LinkedHashMap/LinkedHashSet: the declaration order of temporaries must not depend on
+        // identity hash codes, which differ on every JVM run and made the generated kernel source
+        // (and therefore any on-disk code cache keyed by it) unstable across processes.
+        Map<CUDAKind, Set<Variable>> kindToVariable = new LinkedHashMap<>();
         Map<Variable, CUDAKind> fragmentPhis = new LinkedHashMap<>();
 
         final int expectedVariables = lir.numVariables();

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/backend/MetalBackend.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/backend/MetalBackend.java
@@ -32,6 +32,8 @@ import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.ENABLE_EXCE
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEVICE_ENABLED;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -236,7 +238,7 @@ public class MetalBackend extends XPUBackend<MetalProviders> implements FrameMap
             }
 
             if (!kindToVariable.containsKey(metalKind)) {
-                kindToVariable.put(metalKind, new HashSet<>());
+                kindToVariable.put(metalKind, new LinkedHashSet<>());
             }
 
             final Set<Variable> varList = kindToVariable.get(metalKind);
@@ -260,7 +262,10 @@ public class MetalBackend extends XPUBackend<MetalProviders> implements FrameMap
     }
 
     private void emitVariableDefs(MetalCompilationResultBuilder crb, MetalAssembler asm, LIR lir) {
-        Map<MetalKind, Set<Variable>> kindToVariable = new HashMap<>();
+        // LinkedHashMap/LinkedHashSet: the declaration order of temporaries must not depend on
+        // identity hash codes, which differ on every JVM run and made the generated kernel source
+        // (and therefore any on-disk code cache keyed by it) unstable across processes.
+        Map<MetalKind, Set<Variable>> kindToVariable = new LinkedHashMap<>();
         final int expectedVariables = lir.numVariables();
         final AtomicInteger variableCount = new AtomicInteger();
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/backend/OCLBackend.java
@@ -32,6 +32,8 @@ import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.ENABLE_EXCE
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEVICE_ENABLED;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -226,7 +228,7 @@ public class OCLBackend extends XPUBackend<OCLProviders> implements FrameMap.Ref
             }
 
             if (!kindToVariable.containsKey(oclKind)) {
-                kindToVariable.put(oclKind, new HashSet<>());
+                kindToVariable.put(oclKind, new LinkedHashSet<>());
             }
 
             final Set<Variable> varList = kindToVariable.get(oclKind);
@@ -235,7 +237,10 @@ public class OCLBackend extends XPUBackend<OCLProviders> implements FrameMap.Ref
     }
 
     private void emitVariableDefs(OCLCompilationResultBuilder crb, OCLAssembler asm, LIR lir) {
-        Map<OCLKind, Set<Variable>> kindToVariable = new HashMap<>();
+        // LinkedHashMap/LinkedHashSet: the declaration order of temporaries must not depend on
+        // identity hash codes, which differ on every JVM run and made the generated kernel source
+        // (and therefore any on-disk code cache keyed by it) unstable across processes.
+        Map<OCLKind, Set<Variable>> kindToVariable = new LinkedHashMap<>();
         final int expectedVariables = lir.numVariables();
         final AtomicInteger variableCount = new AtomicInteger();
 


### PR DESCRIPTION
Two runs of the same application on the same machine currently produce **textually different kernel
sources** that are semantically identical. Example, `trackPose` from KFusion, same build, two
consecutive runs:

```diff
-  bool b_194, b_193, b_192, b_191;
+  bool b_192, b_191, b_194, b_193;
```

## Cause

`emitVariableDefs` collects the per-kind declaration groups in a `HashMap<Kind, Set<Variable>>` of
`HashSet`s. Both `Variable` and the platform `Kind` enums hash by identity, so their hash codes differ
in every JVM process, and with them the iteration order of the map and of each set — which is the
order the declarations are emitted in. Present identically in the CUDA, OpenCL and Metal backends
(`CUDABackend.java:241`, `OCLBackend.java:238`, `MetalBackend.java:263`).

## Fix

`LinkedHashMap` + `LinkedHashSet`, so declarations follow insertion order, which is the LIR traversal
order and therefore deterministic. No other behaviour changes.

## Why it matters

- `-Dtornado.opencl.source.dump=True` output can be diffed between runs — right now a diff of two runs
  is noise, which makes codegen changes hard to review.
- Any cache keyed on the generated source is defeated. Concretely, in the companion PR that adds an
  on-disk CUDA module cache, KFusion produced **22 cached modules after the first run and 13 more
  brand-new keys after an identical second run**; with this fix the second run adds none.

## Verification

Dumping every kernel of a full KFusion run twice, `diff -r`:

```
=== source diff across two runs ===
ALL SOURCES BYTE-IDENTICAL
```

`tornado-test --quickPass` on an `opencl,cuda` build (RTX 4090, CUDA 11.5, JDK 21): **1026 run / 230
failed**, unchanged from `develop` (those 230 are the pre-existing CUDA-library and MMA suites hitting
the OpenCL default backend of a combined build). A CUDA-default subset of 78 tests across arrays,
shared buffers, reductions, KernelContext reductions, matrix multiplication and conditionals passes
0 failures.
