### PR TITLE
Cache compiled CUDA modules on disk: 2.2x faster start-up for kernel-heavy applications

### DIFF
--- a/docs/source/flags.rst
+++ b/docs/source/flags.rst
@@ -136,6 +136,8 @@ TornadoVM's **CUDA C** backend targets NVIDIA GPUs: it emits CUDA C, compiled to
    ================================================================  ==================================================================================================================
    ``-Dtornado.cuda.compiler.flags=FLAGS``                           Passes additional flags to NVRTC when compiling the generated CUDA C source (default: none).
    ``-Dtornado.cuda.host.pinning=false``                             Disables pinning host memory for faster host↔device transfers (default: true).
+   ``-Dtornado.cuda.codecache.enable=false``                         Disables the on-disk cache of compiled CUDA modules, so every run re-compiles kernels with NVRTC (default: true).
+   ``-Dtornado.cuda.codecache.dir=PATH``                             Sets the directory used to store the on-disk CUDA module cache (default: ``/var/cuda-codecache``).
    ================================================================  ==================================================================================================================
 
 .. note::

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACodeCache.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACodeCache.java
@@ -32,9 +32,14 @@ import static uk.ac.manchester.tornado.runtime.common.Tornado.getProperty;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.ConcurrentHashMap;
 
 import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
@@ -49,6 +54,8 @@ import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 public class CUDACodeCache {
 
     private static final String FALSE = "False";
+    private static final String TRUE = "True";
+    private static final String CUBIN_SUFFIX = ".cubin";
     private static final int SPIRV_MAGIC_NUMBER = 119734787;
     private static final String OPENCL_SOURCE_SUFFIX = ".cl";
     private final boolean OPENCL_CACHE_ENABLE = Boolean.parseBoolean(getProperty("tornado.opencl.codecache.enable", FALSE));
@@ -57,6 +64,14 @@ public class CUDACodeCache {
     private final String OPENCL_CACHE_DIR = getProperty("tornado.opencl.codecache.dir", "/var/opencl-codecache");
     private final String OPENCL_SOURCE_DIR = getProperty("tornado.opencl.source.dir", "/var/opencl-compiler");
     private final String OPENCL_LOG_DIR = getProperty("tornado.opencl.log.dir", "/var/opencl-logs");
+
+    /**
+     * Persist compiled module images and reload them on the next run, so that a kernel is only handed to
+     * NVRTC once per (source, device, flags, toolkit). Without it every process pays full NVRTC
+     * compilation again, which dominates start-up for applications with many kernels.
+     */
+    private final boolean CUDA_CODE_CACHE_ENABLE = Boolean.parseBoolean(getProperty("tornado.cuda.codecache.enable", TRUE));
+    private final String CUDA_CODE_CACHE_DIR = getProperty("tornado.cuda.codecache.dir", "/var/cuda-codecache");
 
     private final ConcurrentHashMap<String, CUDAInstalledCode> cache;
     private final CUDADeviceContextInterface deviceContext;
@@ -91,6 +106,74 @@ public class CUDACodeCache {
 
     private Path resolveCacheDirectory() {
         return resolveDirectory(OPENCL_CACHE_DIR);
+    }
+
+    private Path resolveModuleCacheDirectory() {
+        return resolveDirectory(CUDA_CODE_CACHE_DIR);
+    }
+
+    /**
+     * Identity of everything that can change the compiled image: the kernel source, the device, its
+     * driver, and the compiler flags. A cubin is architecture-specific, so a cache hit on a different
+     * GPU or after a toolkit upgrade must be impossible.
+     */
+    private String moduleCacheKey(byte[] source, String compilerFlags) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(source);
+            final CUDATargetDevice device = deviceContext.getDevice();
+            final StringBuilder identity = new StringBuilder();
+            identity.append(device.getDeviceName()).append('|') //
+                    .append(device.getVersion()).append('|') //
+                    .append(device.getDriverVersion()).append('|') //
+                    .append(CUDAProgram.getNvrtcVersion()).append('|') //
+                    .append(compilerFlags == null ? "" : compilerFlags);
+            digest.update(identity.toString().getBytes(StandardCharsets.UTF_8));
+            final byte[] hash = digest.digest();
+            final StringBuilder hex = new StringBuilder(32);
+            for (int i = 0; i < 16; i++) {
+                hex.append(String.format("%02x", hash[i]));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+    }
+
+    private CUDAProgram loadCachedModule(Path cacheFile, String entryPoint) {
+        try {
+            final byte[] image = Files.readAllBytes(cacheFile);
+            if (image.length == 0) {
+                return null;
+            }
+            logger.info("loading cached module for %s from %s", entryPoint, cacheFile);
+            return deviceContext.createProgramWithBinary(image, new long[] { image.length });
+        } catch (IOException | RuntimeException e) {
+            // A stale or unreadable entry must never be fatal: fall back to compiling from source.
+            logger.warn("unable to load cached module for %s (%s), recompiling", entryPoint, e.getMessage());
+            return null;
+        }
+    }
+
+    private void storeCachedModule(Path cacheFile, CUDAProgram program, String entryPoint) {
+        final byte[] image = program.getModuleImage();
+        if (image == null || image.length == 0) {
+            return;
+        }
+        try {
+            // Write to a unique temporary file and move it into place, so that concurrent processes
+            // never observe a partially written module.
+            final Path temporary = Files.createTempFile(cacheFile.getParent(), cacheFile.getFileName().toString(), ".tmp");
+            Files.write(temporary, image);
+            try {
+                Files.move(temporary, cacheFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(temporary, cacheFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+            logger.info("cached module for %s in %s", entryPoint, cacheFile);
+        } catch (IOException e) {
+            logger.warn("unable to cache module for %s: %s", entryPoint, e.getMessage());
+        }
     }
 
     private Path resolveSourceDirectory() {
@@ -152,11 +235,28 @@ public class CUDACodeCache {
         logger.info("Installing code for %s into code cache", entryPoint);
 
         boolean isSPIRVBinary = isInputSourceSPIRVBinary(source);
-        final CUDAProgram program;
-        if (isSPIRVBinary) {
-            program = deviceContext.createProgramWithIL(source, new long[] { source.length });
-        } else {
-            program = deviceContext.createProgramWithSource(source, new long[] { source.length });
+        final String compilerFlags = meta.getCompilerFlags(TornadoVMBackendType.CUDA);
+
+        // Try the on-disk module cache first: a hit skips NVRTC entirely.
+        Path moduleCacheFile = null;
+        CUDAProgram program = null;
+        if (CUDA_CODE_CACHE_ENABLE && !isSPIRVBinary) {
+            final String key = moduleCacheKey(source, compilerFlags);
+            if (key != null) {
+                moduleCacheFile = resolveModuleCacheDirectory().resolve(entryPoint + "-" + key + CUBIN_SUFFIX);
+                if (Files.exists(moduleCacheFile)) {
+                    program = loadCachedModule(moduleCacheFile, entryPoint);
+                }
+            }
+        }
+
+        final boolean loadedFromCache = program != null;
+        if (program == null) {
+            if (isSPIRVBinary) {
+                program = deviceContext.createProgramWithIL(source, new long[] { source.length });
+            } else {
+                program = deviceContext.createProgramWithSource(source, new long[] { source.length });
+            }
         }
 
         if (OPENCL_DUMP_SOURCE) {
@@ -176,8 +276,8 @@ public class CUDACodeCache {
         if (meta.isPrintKernelEnabled()) {
             RuntimeUtilities.dumpKernel(source);
         }
-        logger.debug("\tOpenCL compiler flags = %s", meta.getCompilerFlags(TornadoVMBackendType.CUDA));
-        program.build(meta.getCompilerFlags(TornadoVMBackendType.CUDA));
+        logger.debug("\tOpenCL compiler flags = %s", compilerFlags);
+        program.build(compilerFlags);
         final CUDABuildStatus status = program.getStatus(deviceContext.getDeviceId());
         logger.debug("\tOpenCL compilation status = %s", status.toString());
 
@@ -192,6 +292,10 @@ public class CUDACodeCache {
         if (status == CL_BUILD_SUCCESS) {
             kernel = program.clCreateKernel(entryPoint);
             kernelAvailable = true;
+        }
+
+        if (status == CL_BUILD_SUCCESS && !loadedFromCache && moduleCacheFile != null) {
+            storeCachedModule(moduleCacheFile, program, entryPoint);
         }
 
         final CUDAInstalledCode code = new CUDAInstalledCode(entryPoint, source, (CUDADeviceContext) deviceContext, program, kernel, isSPIRVBinary);

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACodeCache.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACodeCache.java
@@ -49,6 +49,7 @@ import uk.ac.manchester.tornado.drivers.cuda.enums.CUDADeviceType;
 import uk.ac.manchester.tornado.drivers.cuda.graal.CUDAInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
 
 public class CUDACodeCache {
@@ -64,14 +65,6 @@ public class CUDACodeCache {
     private final String OPENCL_CACHE_DIR = getProperty("tornado.opencl.codecache.dir", "/var/opencl-codecache");
     private final String OPENCL_SOURCE_DIR = getProperty("tornado.opencl.source.dir", "/var/opencl-compiler");
     private final String OPENCL_LOG_DIR = getProperty("tornado.opencl.log.dir", "/var/opencl-logs");
-
-    /**
-     * Persist compiled module images and reload them on the next run, so that a kernel is only handed to
-     * NVRTC once per (source, device, flags, toolkit). Without it every process pays full NVRTC
-     * compilation again, which dominates start-up for applications with many kernels.
-     */
-    private final boolean CUDA_CODE_CACHE_ENABLE = Boolean.parseBoolean(getProperty("tornado.cuda.codecache.enable", TRUE));
-    private final String CUDA_CODE_CACHE_DIR = getProperty("tornado.cuda.codecache.dir", "/var/cuda-codecache");
 
     private final ConcurrentHashMap<String, CUDAInstalledCode> cache;
     private final CUDADeviceContextInterface deviceContext;
@@ -109,7 +102,7 @@ public class CUDACodeCache {
     }
 
     private Path resolveModuleCacheDirectory() {
-        return resolveDirectory(CUDA_CODE_CACHE_DIR);
+        return resolveDirectory(TornadoOptions.CUDA_CODE_CACHE_DIR);
     }
 
     /**
@@ -240,7 +233,7 @@ public class CUDACodeCache {
         // Try the on-disk module cache first: a hit skips NVRTC entirely.
         Path moduleCacheFile = null;
         CUDAProgram program = null;
-        if (CUDA_CODE_CACHE_ENABLE && !isSPIRVBinary) {
+        if (TornadoOptions.CUDA_CODE_CACHE_ENABLE && !isSPIRVBinary) {
             final String key = moduleCacheKey(source, compilerFlags);
             if (key != null) {
                 moduleCacheFile = resolveModuleCacheDirectory().resolve(entryPoint + "-" + key + CUBIN_SUFFIX);

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDAProgram.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDAProgram.java
@@ -205,6 +205,33 @@ public class CUDAProgram {
         return result;
     }
 
+    /**
+     * Returns the compiled module image (cubin, or PTX when the toolkit cannot emit cubin for this
+     * device) for the device this program was built for, or null when no image is available.
+     */
+    public byte[] getModuleImage() {
+        // A CUDA program holds exactly one module image, for the device it was built for. (Note that
+        // the device-matching loop in dumpBinaries() cannot work here: the driver does not implement
+        // CL_PROGRAM_DEVICES, so getDevices() returns zeros.)
+        final long[] sizes = getBinarySizes();
+        if (sizes.length == 0 || sizes[0] <= 0) {
+            return null;
+        }
+
+        try {
+            final int size = (int) sizes[0];
+            final ByteBuffer binary = ByteBuffer.allocateDirect(size);
+            getBinaries(programPointer, getNumDevices(), binary);
+            final byte[] image = new byte[size];
+            binary.position(0);
+            binary.get(image);
+            return image;
+        } catch (CUDAException e) {
+            logger.error("unable to retrieve module image: %s", e.getMessage());
+            return null;
+        }
+    }
+
     public void dumpBinaries(String filenamePrefix) {
 
         final long[] devices = getDevices();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -51,6 +51,17 @@ public class TornadoOptions {
     public static final String DEFAULT_CUDA_COMPILER_FLAGS = getProperty("tornado.cuda.compiler.flags", "");
 
     /**
+     * Persist compiled CUDA (NVRTC) module images on disk and reload them on the next run, so that a
+     * kernel is only handed to NVRTC once per (source, device, flags, toolkit). True by default.
+     */
+    public static final boolean CUDA_CODE_CACHE_ENABLE = getBooleanValue("tornado.cuda.codecache.enable", TRUE);
+
+    /**
+     * Directory used to store the on-disk CUDA module cache when {@link #CUDA_CODE_CACHE_ENABLE} is enabled.
+     */
+    public static final String CUDA_CODE_CACHE_DIR = getProperty("tornado.cuda.codecache.dir", "/var/cuda-codecache");
+
+    /**
      * Use internal timers for profiling in ns if enabled, in ms if disabled. Default is ns (enabled).
      */
     public static final boolean TIME_IN_NANOSECONDS = Boolean.parseBoolean(System.getProperty("tornado.ns.time", TRUE));


### PR DESCRIPTION
Every process hands each kernel to NVRTC again. `CUDACodeCache.installSource` always calls
`createProgramWithSource`, and the existing code cache only *dumps* binaries — the load-back path is
reachable only for `CL_DEVICE_TYPE_ACCELERATOR` (`CUDACodeCache.java:172`), so on a GPU it never
triggers. For applications with many kernels this dominates start-up.

**Stacked on #999** — without deterministic kernel source the cache key changes every run
and nothing ever hits.

## Measurements (RTX 4090, CUDA 11.5, JDK 21)

GPULlama3 3B-Q8, 61 tokens, wall clock:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| cold (populates 65 modules) | 11.59 s | | |
| **warm cache** | **5.21 s** | **5.16 s** | **5.17 s** |
| `-Dtornado.cuda.codecache.enable=false` | 11.47 s | 11.44 s | |

**2.2x faster start-up, 6.3 s saved per run**, and steady-state throughput is untouched (51–54 tok/s
either way — that part is kernel execution, not compilation). Cache size for the whole model: 1.3 MB.

KFusion (882 frames): 5.37 s → 4.77 s wall; only ~13 kernels, so the absolute win is smaller, and
per-frame FPS is unchanged (318 → 328, within noise) exactly as expected.

`nsys` on a warm run confirms where the time went: `cuModuleLoadDataEx` is 256 calls totalling
**11.3 ms (0.7%)** — loading cubins is essentially free compared with compiling them.

A note on JFR for anyone re-measuring this: `CUDAProgram.build` covers *both* NVRTC compilation and
`cuModuleLoadDataEx`, so its sample share stays high on a warm run and cannot be used to show the
effect; and JFR's own overhead (allocation sampling plus 1 ms native sampling) roughly doubles this
start-up-bound workload. Wall clock and the `nsys` CUDA API summary are the reliable instruments here.

## Implementation

- `CUDAProgram.getModuleImage()` returns the compiled image via the existing `getBinaries` native.
  (It deliberately does not reuse `dumpBinaries`' device-matching loop: the driver does not implement
  `CL_PROGRAM_DEVICES`, so `getDevices()` returns zeros and that loop never matches. A CUDA program
  holds exactly one image.)
- `installSource` looks the image up first and, on a hit, goes through the existing
  `createProgramWithBinary` path, skipping NVRTC entirely. On a miss it compiles and stores.
- Key is SHA-256 over the kernel source plus device name, device version, driver version, NVRTC
  version and the compiler flags, so a cubin can never be reused across GPUs, driver or toolkit
  upgrades, or different flags.
- Writes go to a temporary file and are then moved into place (`ATOMIC_MOVE`, falling back to a plain
  move), so concurrent processes never observe a partially written module.
- Every failure path — unreadable entry, stale entry, load error — falls back to compiling from
  source. A corrupt cache can only cost time, never correctness.
- Location `TORNADOVM_HOME/var/cuda-codecache/device-<platform>-<device>`, override with
  `-Dtornado.cuda.codecache.dir`. Disable with `-Dtornado.cuda.codecache.enable=false`.

Enabled by default, since that is where the benefit is; happy to flip it to opt-in if you would rather
it prove itself first.

## Side effects checked

- `tornado-test --quickPass` (`opencl,cuda` build): **1026 run / 230 failed**, identical to `develop`,
  no per-class differences.
- CUDA-default subset (78 tests: arrays, shared buffers, reductions, KernelContext reductions, matrix
  multiplication, conditionals) run **twice**: 0 failures both times, 83 modules written on the first
  pass and **zero added on the second**, i.e. every kernel came from the cache and still produced
  correct results.
- GPULlama3 generated text is byte-identical with and without the cache.
