### PR TITLE
Allocate wait-event lists on demand

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -182,7 +182,7 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
      */
     public TornadoExecutionResult execute() {
         tornadoExecutor.execute(executionFrame);
-        TornadoProfilerResult profilerResult = new TornadoProfilerResult(tornadoExecutor, this.getTraceExecutionPlan());
+        TornadoProfilerResult profilerResult = new TornadoProfilerResult(tornadoExecutor, this::getTraceExecutionPlan);
         TornadoExecutionResult executionResult = new TornadoExecutionResult(profilerResult);
         planResults.add(executionResult);
         tornadoExecutor.updateLastExecutedTaskGraph();

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoProfilerResult.java
@@ -17,6 +17,8 @@
  */
 package uk.ac.manchester.tornado.api;
 
+import java.util.function.Supplier;
+
 import uk.ac.manchester.tornado.api.enums.ProfilerMode;
 import uk.ac.manchester.tornado.api.profiler.ProfilerInterface;
 
@@ -41,11 +43,12 @@ import uk.ac.manchester.tornado.api.profiler.ProfilerInterface;
 public class TornadoProfilerResult implements ProfilerInterface {
 
     private final TornadoExecutor executor;
+    private Supplier<String> traceExecutionPlanSupplier;
     private String traceExecutionPlan;
 
-    TornadoProfilerResult(TornadoExecutor executor, String traceExecutionPlan) {
+    TornadoProfilerResult(TornadoExecutor executor, Supplier<String> traceExecutionPlanSupplier) {
         this.executor = executor;
-        this.traceExecutionPlan = traceExecutionPlan;
+        this.traceExecutionPlanSupplier = traceExecutionPlanSupplier;
     }
 
     /**
@@ -228,6 +231,11 @@ public class TornadoProfilerResult implements ProfilerInterface {
     }
 
     public String getTraceExecutionPlan() {
+        // Built on demand: rendering the plan description costs a lot of string garbage and almost no
+        // caller ever asks for it.
+        if (traceExecutionPlan == null && traceExecutionPlanSupplier != null) {
+            traceExecutionPlan = traceExecutionPlanSupplier.get();
+        }
         return traceExecutionPlan;
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -32,7 +32,6 @@ import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import uk.ac.manchester.tornado.api.GridScheduler;

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -693,7 +693,7 @@ public class TornadoVMInterpreter {
      * exactly like a list of -1 entries: no events to wait on.
      */
     private int[] waitListFor(int eventId) {
-        return (eventId >= 0 && eventId < events.length) ? waitListFor(eventId) : null;
+        return (eventId >= 0 && eventId < events.length) ? events[eventId] : null;
     }
 
     private int[] waitListForWrite(int eventId) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -152,17 +152,17 @@ public class TornadoVMInterpreter {
         this.bytecodeResult.getLong(); // Skips bytes not needed
 
         kernelStackFrame = graphExecutionContext.getKernelStackFrame();
-        events = new int[this.bytecodeResult.getInt()][MAX_EVENTS];
+        // Rows are allocated on first use: MAX_EVENTS defaults to 32768, so an eager matrix costs
+        // 131KB per dependency list even when a graph only ever fills a handful of entries.
+        events = new int[this.bytecodeResult.getInt()][];
         eventsIndexes = new int[events.length];
 
         localTaskList = graphExecutionContext.getTasksForDevice(interpreterDevice.getDeviceContext());
 
         installedCodes = new TornadoInstalledCode[localTaskList.size()];
 
-        for (int i = 0; i < events.length; i++) {
-            Arrays.fill(events[i], -1);
-            eventsIndexes[i] = 0;
-        }
+        // Wait-list rows are created on first use (already filled with -1) and eventsIndexes starts
+        // zeroed, so there is nothing to initialise here.
 
         logger.debug("created %d kernelStackFrame", kernelStackFrame.length);
         logger.debug("created %d event lists", events.length);
@@ -376,7 +376,7 @@ public class TornadoVMInterpreter {
                 final int eventId = bytecodeResult.getInt();
                 final long offset = bytecodeResult.getLong();
                 final long sizeBatch = bytecodeResult.getLong();
-                final int[] waitList = (useDependencies && eventId != -1) ? events[eventId] : null;
+                final int[] waitList = (useDependencies && eventId != -1) ? waitListFor(eventId) : null;
                 if (isWarmup) {
                     continue;
                 }
@@ -386,7 +386,7 @@ public class TornadoVMInterpreter {
                 final int eventId = bytecodeResult.getInt();
                 final long offset = bytecodeResult.getLong();
                 final long sizeBatch = bytecodeResult.getLong();
-                final int[] waitList = (useDependencies && eventId != -1) ? events[eventId] : null;
+                final int[] waitList = (useDependencies && eventId != -1) ? waitListFor(eventId) : null;
                 if (isWarmup) {
                     continue;
                 }
@@ -396,7 +396,7 @@ public class TornadoVMInterpreter {
                 final int eventId = bytecodeResult.getInt();
                 final long offset = bytecodeResult.getLong();
                 final long sizeBatch = bytecodeResult.getLong();
-                final int[] waitList = (useDependencies) ? events[eventId] : null;
+                final int[] waitList = (useDependencies) ? waitListFor(eventId) : null;
                 if (isWarmup) {
                     continue;
                 }
@@ -406,7 +406,7 @@ public class TornadoVMInterpreter {
                 final int eventId = bytecodeResult.getInt();
                 final long offset = bytecodeResult.getLong();
                 final long sizeBatch = bytecodeResult.getLong();
-                final int[] waitList = (useDependencies) ? events[eventId] : null;
+                final int[] waitList = (useDependencies) ? waitListFor(eventId) : null;
                 if (isWarmup) {
                     continue;
                 }
@@ -446,7 +446,7 @@ public class TornadoVMInterpreter {
                 lastEvent = executePersist(logBuilder, objectIndex, eventId);
             } else if (op == TornadoVMBytecodes.BARRIER.value()) {
                 final int eventId = bytecodeResult.getInt();
-                final int[] waitList = (useDependencies && eventId != -1) ? events[eventId] : null;
+                final int[] waitList = (useDependencies && eventId != -1) ? waitListFor(eventId) : null;
                 if (isWarmup) {
                     continue;
                 }
@@ -678,10 +678,33 @@ public class TornadoVMInterpreter {
     }
 
     private void initWaitEventList() {
+        // Clear whole rows, not just the prefix up to eventsIndexes: resetEventIndexes() rewinds an
+        // event list in the middle of an execution, so entries can live beyond the current index and a
+        // partial clear would leave stale event ids behind. Rows never used stay null and cost nothing.
         for (int[] waitList : events) {
-            Arrays.fill(waitList, -1);
+            if (waitList != null) {
+                Arrays.fill(waitList, -1);
+            }
         }
         Arrays.fill(eventsIndexes, 0);
+    }
+
+    /**
+     * Wait-list for a dependency list. A row that was never written stays null, which the drivers treat
+     * exactly like a list of -1 entries: no events to wait on.
+     */
+    private int[] waitListFor(int eventId) {
+        return (eventId >= 0 && eventId < events.length) ? waitListFor(eventId) : null;
+    }
+
+    private int[] waitListForWrite(int eventId) {
+        int[] waitList = events[eventId];
+        if (waitList == null) {
+            waitList = new int[MAX_EVENTS];
+            Arrays.fill(waitList, -1);
+            events[eventId] = waitList;
+        }
+        return waitList;
     }
 
     /**
@@ -702,7 +725,14 @@ public class TornadoVMInterpreter {
         if (graphExecutionContext == null || object == null) {
             return false;
         }
-        return graphExecutionContext.getPersistedTaskToObjectsMap().values().stream().filter(Objects::nonNull).anyMatch(taskObjects -> taskObjects.contains(object));
+        // Plain loops: this runs for every object of every ALLOC bytecode, and a stream pipeline per
+        // object allocated hundreds of MiB over a run.
+        for (List<Object> taskObjects : graphExecutionContext.getPersistedTaskToObjectsMap().values()) {
+            if (taskObjects != null && taskObjects.contains(object)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -1047,7 +1077,7 @@ public class TornadoVMInterpreter {
 
         boolean redeployOnDevice = graphExecutionContext.redeployOnDevice();
 
-        final int[] waitList = (useDependencies && eventId != -1) ? events[eventId] : null;
+        final int[] waitList = (useDependencies && eventId != -1) ? waitListFor(eventId) : null;
         final SchedulableTask task = taskExecutionContexts.get(taskIndex);
 
         if (task instanceof LibraryTask libraryTask) {
@@ -1363,8 +1393,9 @@ public class TornadoVMInterpreter {
             if (TornadoOptions.LOG_BYTECODES()) {
                 DebugInterpreter.logAddDependency(lastEvent, eventId, logBuilder);
             }
-            TornadoInternalError.guarantee(eventsIndexes[eventId] < events[eventId].length, "event list is too small");
-            events[eventId][eventsIndexes[eventId]] = lastEvent;
+            final int[] waitList = waitListForWrite(eventId);
+            TornadoInternalError.guarantee(eventsIndexes[eventId] < waitList.length, "event list is too small");
+            waitList[eventsIndexes[eventId]] = lastEvent;
             eventsIndexes[eventId]++;
         }
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -1732,9 +1732,18 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     }
 
-    private boolean isTaskNamePresent(String taskName) {
+    private boolean isTaskNamePresent(String qualifiedTaskName) {
+        // Compare in place instead of building "<graph>.<task>" for every task on every call.
+        final int prefixLength = taskGraphName.length();
+        if (qualifiedTaskName.length() <= prefixLength + 1 //
+                || qualifiedTaskName.charAt(prefixLength) != '.' //
+                || !qualifiedTaskName.startsWith(taskGraphName)) {
+            return false;
+        }
+        final int idLength = qualifiedTaskName.length() - prefixLength - 1;
         for (TaskPackage taskPackage : taskPackages) {
-            if (taskName.equals(taskGraphName + "." + taskPackage.getId())) {
+            final String id = taskPackage.getId();
+            if (id.length() == idLength && qualifiedTaskName.regionMatches(prefixLength + 1, id, 0, idLength)) {
                 return true;
             }
         }


### PR DESCRIPTION
A task-graph allocates its wait-event matrix eagerly:

```java
events = new int[this.bytecodeResult.getInt()][MAX_EVENTS];   // MAX_EVENTS defaults to 32768
```

That is **131 KB per dependency list**, allocated whether or not the graph ever uses it, filled with
`-1` in the constructor, and then filled again by `initWaitEventList()` on **every execution**. For a
plan made of many small graphs the memset dominates the per-execution cost.

Rows are now created on first append. A row that was never written stays `null`, which the drivers
already treat exactly like a list of `-1` entries — no events to wait on.

Three smaller items in the same area:

- `TornadoExecutionPlan.execute()` built the plan trace string unconditionally, on every execution;
  it is now supplied lazily and materialised only if `TornadoProfilerResult.getTraceExecutionPlan()`
  is actually called.
- `isPersistentObject` allocated a stream pipeline per object per ALLOC bytecode → plain loops.
- `isTaskNamePresent` concatenated `"<graph>.<task>"` for every task on every call → in-place compare
  with `regionMatches`.

## Throughput

GPULlama3 3B-Q8, 256 tokens, warm code cache, RTX 4090 / CUDA 11.5 / JDK 21:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| `develop` | 53.43 | 52.83 | 53.53 tok/s |
| **this branch** | **102.44** | **102.44** | **103.45 tok/s** |

**1.94x**, with byte-identical generated text.

KFusion (882 frames, ICL-NUIM): **316 → 424 FPS**, 2.82 → 2.09 ms per frame, and the trajectory is
**bit-identical** (`compareRuns.py` max deviation `0.000e+00`, ATE RMSE 0.019406 m unchanged).

### Attribution

I built a control with the interpreter change reverted but the other three kept: **53.50 / 51.50 /
53.28 tok/s**, i.e. unchanged. The entire throughput win is the lazy wait-event rows; the other three
items only remove garbage.

## Allocation

JFR `jdk.ObjectAllocationSample`, weight attributed to the deepest TornadoVM frame, same 256-token run:

| site | before | after |
|---|---|---|
| `GridScheduler.toString` | 244.4 MiB | 0 |
| `TornadoVMInterpreter.<init>` | 144.9 MiB | 0 |
| `TornadoTaskGraph.isTaskNamePresent` | 127.5 MiB | 0 |
| `WithGridScheduler.toString` | 23.2 MiB | 0 |
| `TornadoVMInterpreter.isPersistentObject` | 8.0 MiB | 0 |
| **total TornadoVM-attributed** | **777.0 MiB** | **3.0 MiB** |

## Side effects

- `tornado-test --quickPass` on an `opencl,cuda` build: 1026 run, 231 failed against a `develop`
  baseline of 230. The one difference is `branching.TestLoopConditions`, which is **pre-existing
  flaky**: I measured it 10 times on this branch (**3 failures**) and 10 times with the interpreter
  change reverted (**4 failures**). See the note below.
- GPULlama3 output byte-identical; KFusion trajectory bit-identical.

## Aside: `TestLoopConditions` is flaky and the symptom looks real

`testConditionBeforeSingleLoopReturn` fails roughly a third of runs on `develop` with garbage instead
of zero:

```
\_[REASON] expected:<0> but was:<1286959321>
\_[REASON] expected:<0> but was:<-1045729832>
\_[REASON] expected:<0> but was:<-184372750>
```

Values like that mean the assertion reads device memory that was never written, so this is worth
looking at on its own — either the test is missing a transfer or something is not synchronising. Happy
to open a separate issue with the reproduction if useful. (It is what made me double-check this PR
carefully: an early version of the change cleared only the used prefix of each wait list, which *did*
introduce the same symptom, because `resetEventIndexes()` rewinds a list mid-execution and entries can
live beyond the current index. That version is gone — whole rows are cleared, only allocated ones.)
