### PR TITLE
Size the bytecode buffer for the graph: many-task graphs silently produce wrong results

### DIFF
--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMBytecodeBuilder.java
@@ -61,9 +61,33 @@ public class TornadoVMBytecodeBuilder {
      * TornadoVMBytecodeAssembler with the byte array.
      */
     public TornadoVMBytecodeBuilder(boolean isSingleContext) {
-        code = new byte[MAX_TORNADO_VM_BYTECODE_SIZE];
+        this(isSingleContext, MAX_TORNADO_VM_BYTECODE_SIZE);
+    }
+
+    /**
+     * Bytecode buffer sized for the graph being compiled rather than for a fixed default. A graph with
+     * many tasks (an unrolled iterative solver, for example) overflows the 4096-byte default, and the
+     * resulting failure is recoverable by default, so it surfaces as silently wrong results instead of
+     * an error.
+     *
+     * @param sizeInBytes
+     *     requested capacity; never smaller than {@code tornado.tvm.maxbytecodesize}, so an explicit
+     *     setting still wins.
+     */
+    public TornadoVMBytecodeBuilder(boolean isSingleContext, int sizeInBytes) {
+        code = new byte[Math.max(MAX_TORNADO_VM_BYTECODE_SIZE, sizeInBytes)];
         bitcodeASM = new TornadoVMBytecodeAssembler(code);
         this.isSingleContext = isSingleContext;
+    }
+
+    /**
+     * Capacity needed to emit a graph with the given number of tasks and objects. Every task emits a
+     * LAUNCH plus its dependency edges, and every object can emit ALLOC, a transfer and DEALLOC; the
+     * per-item budgets below are deliberately generous, because the cost of over-allocating is a few
+     * KiB while the cost of under-allocating is a wrong result.
+     */
+    public static int estimateBytecodeSize(int taskCount, int objectCount) {
+        return 1024 + (taskCount * 256) + (objectCount * 128);
     }
 
     public boolean isSingleContext() {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
@@ -85,7 +85,8 @@ public class TornadoVMGraphCompiler {
         int graphId = nextGraphId.getAndIncrement();
         for (int i = 0; i < tornadoVMBytecodeResults.length; i++) {
 
-            TornadoVMBytecodeBuilder tornadoVMBytecodeBuilder = new TornadoVMBytecodeBuilder(isSingleContextCompilation);
+            TornadoVMBytecodeBuilder tornadoVMBytecodeBuilder = new TornadoVMBytecodeBuilder(isSingleContextCompilation, //
+                    TornadoVMBytecodeBuilder.estimateBytecodeSize(executionContext.getTaskCount(), executionContext.getObjects().size()));
 
             // Generate Context + BEGIN bytecode
             tornadoVMBytecodeBuilder.begin(1, 1, intermediateTornadoGraph.getNumberOfDependencies() + 1);


### PR DESCRIPTION
A task-graph with many tasks silently produces **wrong results**.

`TornadoVMBytecodeBuilder` allocates its bytecode buffer as a fixed
`new byte[MAX_TORNADO_VM_BYTECODE_SIZE]`, default **4096 bytes**. Emitting a graph that needs more
throws `BufferOverflowException`, which becomes a `TornadoRuntimeException`, which
`TornadoTaskGraph.execute` hands to `bailout()` — and since `tornado.recover.bailout` defaults to
`true`, that failure is swallowed. Execution continues with **truncated bytecode**: kernels that were
never emitted simply do not run, so buffers keep whatever they had and the application computes
garbage without a single warning.

## Reproducer

An ICP solver in KFusion where each pyramid level unrolls its iterations into one graph — 5 tasks per
iteration, 10 iterations at the finest level, so 50 tasks:

```
level 2 (20 tasks): converged=0 failed=0 iters=4 tracked=3779   <- fine
level 1 (25 tasks): converged=1 failed=0 iters=4 tracked=15617  <- fine
level 0 (50 tasks): converged=0 failed=1 iters=0 tracked=0      <- reduction produced nothing
```

`tracked=0` at level 0 only, with no error. With `-Dtornado.tvm.maxbytecodesize=131072` the same run
is correct (`tracked=63776`), which is what pointed at the buffer. With
`-Dtornado.recover.bailout=False` the failure finally surfaces:

```
Exception in thread "main" TornadoBailoutRuntimeException: [TornadoVM] Error - Recover option disabled
        at TornadoTaskGraph.bailout(TornadoTaskGraph.java:1668)
        at TornadoTaskGraph.execute(TornadoTaskGraph.java:1714)
```

Two of the emitter call sites already catch the overflow and raise a clear
*"To increase the buffer size, use -Dtornado.tvm.maxbytecodesize="* message
(`TornadoVMGraphCompiler.java:211` and `:317`), so the intent is clearly that this should not pass
silently — but the resulting exception is recoverable, and recovery cannot fix truncated bytecode.

## Fix

Size the buffer for the graph actually being compiled:

```java
new TornadoVMBytecodeBuilder(isSingleContextCompilation,
        TornadoVMBytecodeBuilder.estimateBytecodeSize(executionContext.getTaskCount(), executionContext.getObjects().size()));
```

`estimateBytecodeSize` budgets 256 bytes per task and 128 per object over a 1 KiB base — deliberately
generous, since over-allocating costs a few KiB and under-allocating costs a wrong answer.
`tornado.tvm.maxbytecodesize` is kept as a **lower bound**, so an explicit setting still wins and
nobody's existing configuration changes meaning.

With this, the 50-task graph above runs correctly with no flags at all (ATE 0.0133 m, matching the run
that needed `-Dtornado.tvm.maxbytecodesize=131072`).

Worth considering separately, and deliberately not changed here: a bytecode-buffer overflow is not
something `bailout()` can recover from, so it is arguably a candidate for being unconditionally fatal.
I left that decision to you.

## Side effects

- `tornado-test --quickPass` on an `opencl,cuda` build (RTX 4090, CUDA 11.5, JDK 21): **1026 run / 231
  failed** against a `develop` baseline of **230**. The single difference is
  `branching.TestLoopConditions`, which is flaky on `develop` independently of this change — I measured
  it 10x on `develop` (4 failures) and 10x on a branch (3 failures).
- KFusion's normal (non-unrolled) pipeline is unaffected: 412 FPS and ATE 0.019406 m before and after,
  i.e. graphs that already fit keep exactly the same bytecode.
