### PR TITLE
Fix develop build: TestAtomicRmw references the removed SPIRV and PTX backend types

### DIFF
--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestAtomicRmw.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/api/TestAtomicRmw.java
@@ -149,10 +149,9 @@ public class TestAtomicRmw extends TornadoTestBase {
     }
 
     private void skipUnsupportedBackends() {
+        // These intrinsics are CUDA-only. SPIRV and PTX are no longer TornadoVMBackendType constants.
         assertNotBackend(TornadoVMBackendType.OPENCL);
-        assertNotBackend(TornadoVMBackendType.SPIRV);
         assertNotBackend(TornadoVMBackendType.METAL);
-        assertNotBackend(TornadoVMBackendType.PTX);
     }
 
     private static IntArray input() {


### PR DESCRIPTION
`develop` does not compile. #991 landed `TestAtomicRmw` with guards against `TornadoVMBackendType.SPIRV` and `.PTX`, but those constants no longer exist, so `tornado-unittests` fails:

```
[ERROR] TestAtomicRmw.java:[153,45] error: cannot find symbol
[ERROR]   symbol:   variable SPIRV
[ERROR]   location: class TornadoVMBackendType
[ERROR] TestAtomicRmw.java:[155,45] error: cannot find symbol
[ERROR]   symbol:   variable PTX
```

My mistake in #991 — the branch predated the removal of those enum constants and I rebased without
rechecking. The intrinsics under test are CUDA-only, and the remaining `OPENCL` and `METAL` guards
already express that, so the two lines are simply dropped.

Verified: `make BACKEND=opencl,cuda` BUILD SUCCESS, `./mvnw checkstyle:check` 0 violations, and
`TestAtomicRmw` runs 5/5 on the CUDA backend. Swept the repository for other
`TornadoVMBackendType.SPIRV`/`.PTX` references: none remain.