### PR TITLE
Make --printBytecodes readable: verbosity modes, per-execution summaries and a Graphviz export

### DIFF
--- a/docs/source/dev-tools.rst
+++ b/docs/source/dev-tools.rst
@@ -308,6 +308,11 @@ TornadoViz (bytecode visualizer)
 
 Feed it the bytecode log produced by running with ``--printBytecodes``.
 
+.. note::
+   TornadoViz parses the bytecode log textually. It has not yet been updated for the
+   ``compact``/``full``/``trace`` formats, so use ``--printBytecodes`` together with ``--dumpBC`` and the
+   format TornadoViz expects when driving it.
+
 Third-Party Profilers
 -------------------------
 

--- a/docs/source/flags.rst
+++ b/docs/source/flags.rst
@@ -49,7 +49,8 @@ Debugging and Logging
    ``-Dtornado.print.kernel.dir=FILENAME``           Saves generated kernels to the specified file.
    ``-Dtornado.cuda.compile.profile=PROFILE``        Named NVRTC option bundle for the CUDA backend: ``default`` (no extra options), ``fast`` (``--use_fast_math --extra-device-vectorization``), ``debug`` (``-lineinfo``, so Nsight can attribute samples to the generated CUDA C) or ``repro`` (``--fmad=false``). Flags in ``tornado.cuda.compiler.flags`` are appended after the profile and win.
    ``-Dtornado.threadInfo=true``                     Displays the number of threads used.
-   ``-Dtornado.print.bytecodes=true``                Prints TornadoVM Internal Bytecodes to stdout.
+   ``-Dtornado.print.bytecodes=MODE``                Prints TornadoVM Internal Bytecodes to stdout. MODE is ``true``/``full`` (every field), ``compact`` (short names, human sizes, per-execution summary), ``trace`` (adds skipped bytecodes and wait-lists) or ``dot`` (Graphviz dependency graph).
+   ``-Dtornado.print.bytecodes.color=POLICY``        Colouring of the bytecode log: ``auto`` (default, only on a terminal), ``always`` or ``never``.
    ``-Dtornado.dump.bytecodes.dir=FILENAME``         Dumps TornadoVM Internal Bytecodes to the specified file.
    ================================================  ============================================================================
 

--- a/docs/source/flags.rst
+++ b/docs/source/flags.rst
@@ -48,7 +48,8 @@ Debugging and Logging
    ``-Dtornado.printKernel=true``                    Prints generated OpenCL/CUDA kernels.
    ``-Dtornado.print.kernel.dir=FILENAME``           Saves generated kernels to the specified file.
    ``-Dtornado.threadInfo=true``                     Displays the number of threads used.
-   ``-Dtornado.print.bytecodes=true``                Prints TornadoVM Internal Bytecodes to stdout.
+   ``-Dtornado.print.bytecodes=MODE``                Prints TornadoVM Internal Bytecodes to stdout. MODE is ``true``/``full`` (every field), ``compact`` (short names, human sizes, per-execution summary), ``trace`` (adds skipped bytecodes and wait-lists) or ``dot`` (Graphviz dependency graph).
+   ``-Dtornado.print.bytecodes.color=POLICY``        Colouring of the bytecode log: ``auto`` (default, only on a terminal), ``always`` or ``never``.
    ``-Dtornado.dump.bytecodes.dir=FILENAME``         Dumps TornadoVM Internal Bytecodes to the specified file.
    ================================================  ============================================================================
 

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -451,7 +451,7 @@ __PRINT_EXECUTION_TIMER__ = "-Dtornado.debug.executionTime=True "
 __GC__ = "-Xmx6g "
 __BASE_OPTIONS__ = "-Dtornado.recover.bailout=False "
 __VERBOSE_OPTION__ = "-Dtornado.unittests.verbose="
-__TORNADOVM_PRINT_BC__ = "-Dtornado.print.bytecodes=True "
+__TORNADOVM_PRINT_BC__ = "-Dtornado.print.bytecodes="
 __TORNADOVM_ENABLE_PROFILER_SILENT__ = " -Dtornado.profiler=True -Dtornado.log.profiler=True "
 __TORNADOVM_ENABLE_PROFILER_CONSOLE__ = " -Dtornado.profiler=True "
 # ################################################################################################################
@@ -524,7 +524,7 @@ def composeAllOptions(args):
         options = options + __PRINT_EXECUTION_TIMER__
 
     if (args.printBytecodes):
-        options = options + __TORNADOVM_PRINT_BC__
+        options = options + __TORNADOVM_PRINT_BC__ + args.printBytecodes + " "
 
     if (args.jvmFlags != None):
         options = options + args.jvmFlags
@@ -812,6 +812,26 @@ def runTestTheWorldWithJunit(args):
             os.system(command)
 
 
+__BYTECODE_LOG_MODES__ = ("compact", "full", "trace", "dot", "true", "false")
+
+
+def normalizeBytecodeFlag(argv):
+    """Make the optional value of --printBytecodes explicit.
+
+    The flag takes an optional verbosity, and argparse's nargs='?' would otherwise consume whatever
+    follows it - so `--printBytecodes some.Test.Class` silently swallowed the positional and ran
+    everything. Inserting the default here keeps the bare flag working without that ambiguity.
+    """
+    normalized = []
+    for index, argument in enumerate(argv):
+        normalized.append(argument)
+        if argument in ("--printBytecodes", "-pbc"):
+            following = argv[index + 1] if index + 1 < len(argv) else None
+            if following is None or following.startswith("-") or following.lower() not in __BYTECODE_LOG_MODES__:
+                normalized.append("full")
+    return normalized
+
+
 def parseArguments():
     """ Parse command line arguments """
     parser = argparse.ArgumentParser(description='Tool to execute tests in Tornado')
@@ -832,8 +852,8 @@ def parseArguments():
     parser.add_argument('--igv', action="store_true", dest="igv", default=False, help="Dump GraalIR into IGV")
     parser.add_argument('--igvLowTier', action="store_true", dest="dumpIGVLastTier", default=False,
                         help="Dump OpenCL Low-TIER GraalIR into IGV")
-    parser.add_argument('--printBytecodes', "-pbc", action="store_true", dest="printBytecodes", default=False,
-                        help="Print TornadoVM internal bytecodes")
+    parser.add_argument('--printBytecodes', "-pbc", nargs='?', const="full", default=None, dest="printBytecodes",
+                        help="Print TornadoVM internal bytecodes. Optional verbosity: compact|full|trace|dot (default: full)")
     parser.add_argument('--debug', "-d", action="store_true", dest="debugTornado", default=False,
                         help="Enable the Debug mode in Tornado")
     parser.add_argument('--fullDebug', action="store_true", dest="fullDebug", default=False,
@@ -851,7 +871,7 @@ def parseArguments():
                         help="Enable the profiler {silent|console}")
     parser.add_argument("--monitorClass", action="store", dest="monitorClass", default=None,
                         help="Monitor class to monitor the JVM process. Options: outOfMemoryMonitor")
-    args = parser.parse_args()
+    args = parser.parse_args(normalizeBytecodeFlag(sys.argv[1:]))
     return args
 
 

--- a/tornado-assembly/src/bin/tornado.py
+++ b/tornado-assembly/src/bin/tornado.py
@@ -38,7 +38,7 @@ __TORNADOVM_THREAD_INFO__ = " -Dtornado.threadInfo=True "
 __TORNADOVM_IGV__ = " -Dgraal.Dump=*:5 -Dgraal.PrintGraph=Network -Dgraal.PrintBackendCFG=true "
 __TORNADOVM__IGV_LOW_TIER = " -Dgraal.Dump=*:1 -Dgraal.PrintGraph=Network -Dgraal.PrintBackendCFG=true -Dtornado.debug.lowtier=True "
 __TORNADOVM_PRINT_KERNEL__ = " -Dtornado.printKernel=True "
-__TORNADOVM_PRINT_BC__ = " -Dtornado.print.bytecodes=True "
+__TORNADOVM_PRINT_BC__ = " -Dtornado.print.bytecodes="
 __TORNADOVM_DUMP_PROFILER__ = " -Dtornado.profiler=True -Dtornado.log.profiler=True -Dtornado.profiler.dump.dir="
 __TORNADOVM_ENABLE_PROFILER_SILENT__ = " -Dtornado.profiler=True -Dtornado.log.profiler=True "
 __TORNADOVM_ENABLE_PROFILER_CONSOLE__ = " -Dtornado.profiler=True "
@@ -1063,7 +1063,7 @@ class TornadoVMRunnerTool():
             tornadoFlags = tornadoFlags + __TORNADOVM__IGV_LOW_TIER
 
         if (args.printBytecodes):
-            tornadoFlags = tornadoFlags + __TORNADOVM_PRINT_BC__
+            tornadoFlags = tornadoFlags + __TORNADOVM_PRINT_BC__ + args.printBytecodes + " "
 
         if (args.dump_bytecodes_dir != None):
             tornadoFlags = tornadoFlags + __TORNADOVM_DUMP_BYTECODES_DIR__ + args.dump_bytecodes_dir + " "
@@ -1473,8 +1473,9 @@ def parseArguments():
                         help="Debug Low Tier Compilation Graphs using Ideal Graph Visualizer (IGV)")
     parser.add_argument('--printKernel', '-pk', action="store_true", dest="printKernel", default=False,
                         help="Print generated kernel (OpenCL, CUDA or Metal)")
-    parser.add_argument('--printBytecodes', '-pbc', action="store_true", dest="printBytecodes", default=False,
-                        help="Print the generated TornadoVM bytecodes from the Task-Graphs")
+    parser.add_argument('--printBytecodes', '-pbc', nargs='?', const="full", default=None, dest="printBytecodes",
+                        help="Print the generated TornadoVM bytecodes from the Task-Graphs. "
+                             "Optional verbosity: compact|full|trace|dot (default: full)")
     parser.add_argument('--enableProfiler', action="store", dest="enable_profiler", default=None,
                         help="Enable the profiler {silent|console}")
     parser.add_argument('--dumpProfiler', action="store", dest="dump_profiler", default=None,

--- a/tornado-assembly/src/bin/tornado.py
+++ b/tornado-assembly/src/bin/tornado.py
@@ -1455,6 +1455,26 @@ class TornadoVMRunnerTool():
         sys.exit(status)
 
 
+__BYTECODE_LOG_MODES__ = ("compact", "full", "trace", "dot", "true", "false")
+
+
+def normalizeBytecodeFlag(argv):
+    """Make the optional value of --printBytecodes explicit.
+
+    The flag takes an optional verbosity, and argparse's nargs='?' would otherwise consume whatever
+    follows it - so `--printBytecodes some.Test.Class` silently swallowed the positional and ran
+    everything. Inserting the default here keeps the bare flag working without that ambiguity.
+    """
+    normalized = []
+    for index, argument in enumerate(argv):
+        normalized.append(argument)
+        if argument in ("--printBytecodes", "-pbc"):
+            following = argv[index + 1] if index + 1 < len(argv) else None
+            if following is None or following.startswith("-") or following.lower() not in __BYTECODE_LOG_MODES__:
+                normalized.append("full")
+    return normalized
+
+
 def parseArguments():
     """ Parse command line arguments """
     parser = argparse.ArgumentParser(
@@ -1525,7 +1545,7 @@ def parseArguments():
         parser.print_help()
         sys.exit(0)
 
-    args = parser.parse_args()
+    args = parser.parse_args(normalizeBytecodeFlag(sys.argv[1:]))
     return args
 
 

--- a/tornado-assembly/src/bin/tornado.py
+++ b/tornado-assembly/src/bin/tornado.py
@@ -38,7 +38,7 @@ __TORNADOVM_THREAD_INFO__ = " -Dtornado.threadInfo=True "
 __TORNADOVM_IGV__ = " -Dgraal.Dump=*:5 -Dgraal.PrintGraph=Network -Dgraal.PrintBackendCFG=true "
 __TORNADOVM__IGV_LOW_TIER = " -Dgraal.Dump=*:1 -Dgraal.PrintGraph=Network -Dgraal.PrintBackendCFG=true -Dtornado.debug.lowtier=True "
 __TORNADOVM_PRINT_KERNEL__ = " -Dtornado.printKernel=True "
-__TORNADOVM_PRINT_BC__ = " -Dtornado.print.bytecodes=True "
+__TORNADOVM_PRINT_BC__ = " -Dtornado.print.bytecodes="
 __TORNADOVM_DUMP_PROFILER__ = " -Dtornado.profiler=True -Dtornado.log.profiler=True -Dtornado.profiler.dump.dir="
 __TORNADOVM_ENABLE_PROFILER_SILENT__ = " -Dtornado.profiler=True -Dtornado.log.profiler=True "
 __TORNADOVM_ENABLE_PROFILER_CONSOLE__ = " -Dtornado.profiler=True "
@@ -1017,7 +1017,7 @@ class TornadoVMRunnerTool():
             tornadoFlags = tornadoFlags + __TORNADOVM__IGV_LOW_TIER
 
         if (args.printBytecodes):
-            tornadoFlags = tornadoFlags + __TORNADOVM_PRINT_BC__
+            tornadoFlags = tornadoFlags + __TORNADOVM_PRINT_BC__ + args.printBytecodes + " "
 
         if (args.dump_bytecodes_dir != None):
             tornadoFlags = tornadoFlags + __TORNADOVM_DUMP_BYTECODES_DIR__ + args.dump_bytecodes_dir + " "
@@ -1386,8 +1386,9 @@ def parseArguments():
                         help="Debug Low Tier Compilation Graphs using Ideal Graph Visualizer (IGV)")
     parser.add_argument('--printKernel', '-pk', action="store_true", dest="printKernel", default=False,
                         help="Print generated kernel (OpenCL, CUDA or Metal)")
-    parser.add_argument('--printBytecodes', '-pbc', action="store_true", dest="printBytecodes", default=False,
-                        help="Print the generated TornadoVM bytecodes from the Task-Graphs")
+    parser.add_argument('--printBytecodes', '-pbc', nargs='?', const="full", default=None, dest="printBytecodes",
+                        help="Print the generated TornadoVM bytecodes from the Task-Graphs. "
+                             "Optional verbosity: compact|full|trace|dot (default: full)")
     parser.add_argument('--enableProfiler', action="store", dest="enable_profiler", default=None,
                         help="Enable the profiler {silent|console}")
     parser.add_argument('--dumpProfiler', action="store", dest="dump_profiler", default=None,

--- a/tornado-bytecodes.dot
+++ b/tornado-bytecodes.dot
@@ -1,0 +1,27 @@
+digraph tornado_bytecodes {
+  rankdir=LR;
+  node [fontname="monospace", fontsize=10];
+  edge [fontname="monospace", fontsize=9];
+  buf_IntArray_2b43529a [label="IntArray@2b43529a\n528 B", shape=ellipse];
+  subgraph cluster_0 {
+    label="task-graph s0";
+    color=blue;
+    task_task_s0_t0___addAccumulator [label="task s0.t0 - addAccumulator", shape=box, style=rounded];
+    task_task_s0_t1___addAccumulator [label="task s0.t1 - addAccumulator", shape=box, style=rounded];
+    task_task_s0_t2___addAccumulator [label="task s0.t2 - addAccumulator", shape=box, style=rounded];
+    task_task_s0_t3___addAccumulator [label="task s0.t3 - addAccumulator", shape=box, style=rounded];
+    task_task_s0_t4___addAccumulator [label="task s0.t4 - addAccumulator", shape=box, style=rounded];
+    task_task_s0_t5___addAccumulator [label="task s0.t5 - addAccumulator", shape=box, style=rounded];
+    task_task_s0_t6___addAccumulator [label="task s0.t6 - addAccumulator", shape=box, style=rounded];
+    task_task_s0_t7___addAccumulator [label="task s0.t7 - addAccumulator", shape=box, style=rounded];
+  }
+  buf_IntArray_2b43529a -> task_task_s0_t0___addAccumulator;
+  task_task_s0_t0___addAccumulator -> task_task_s0_t1___addAccumulator [style=dotted, color=gray, label="order"];
+  task_task_s0_t1___addAccumulator -> task_task_s0_t2___addAccumulator [style=dotted, color=gray, label="order"];
+  task_task_s0_t2___addAccumulator -> task_task_s0_t3___addAccumulator [style=dotted, color=gray, label="order"];
+  task_task_s0_t3___addAccumulator -> task_task_s0_t4___addAccumulator [style=dotted, color=gray, label="order"];
+  task_task_s0_t4___addAccumulator -> task_task_s0_t5___addAccumulator [style=dotted, color=gray, label="order"];
+  task_task_s0_t5___addAccumulator -> task_task_s0_t6___addAccumulator [style=dotted, color=gray, label="order"];
+  task_task_s0_t6___addAccumulator -> task_task_s0_t7___addAccumulator [style=dotted, color=gray, label="order"];
+  task_task_s0_t7___addAccumulator -> buf_IntArray_2b43529a;
+}

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BytecodeLogMode.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/BytecodeLogMode.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.runtime.common;
+
+/**
+ * Verbosity of the TornadoVM bytecode log, selected with
+ * {@code -Dtornado.print.bytecodes=<mode>} (or {@code --printBytecodes <mode>}).
+ *
+ * <p>
+ * The legacy boolean values are still accepted: {@code True} maps to {@link #FULL} and {@code False}
+ * to {@link #OFF}, so existing scripts keep working unchanged.
+ * </p>
+ */
+public enum BytecodeLogMode {
+
+    /** No bytecode logging. */
+    OFF,
+
+    /** One aligned line per bytecode, zero-valued fields elided, per-execution summary. */
+    COMPACT,
+
+    /** Every field of every executed bytecode. This is what {@code =True} selects. */
+    FULL,
+
+    /** As {@link #FULL} plus skipped bytecodes, resolved wait-lists and thread identity. */
+    TRACE,
+
+    /** Emit a Graphviz DOT dependency graph per execution instead of text. */
+    DOT;
+
+    public static BytecodeLogMode parse(String value) {
+        if (value == null || value.isBlank()) {
+            return OFF;
+        }
+        return switch (value.trim().toLowerCase()) {
+            case "false", "off", "no", "0" -> OFF;
+            case "true", "on", "yes", "1", "full" -> FULL;
+            case "compact" -> COMPACT;
+            case "trace" -> TRACE;
+            case "dot", "graph" -> DOT;
+            default -> {
+                System.err.println("[TornadoVM] unknown tornado.print.bytecodes value '" + value + "', using 'full'. " //
+                        + "Valid values: false, compact, full, trace, dot.");
+                yield FULL;
+            }
+        };
+    }
+
+    /** True when this mode produces the textual log (as opposed to a DOT file). */
+    public boolean isTextual() {
+        return this == COMPACT || this == FULL || this == TRACE;
+    }
+
+    /** True when fields that carry no information (zero batch size, empty event list) are elided. */
+    public boolean isTerse() {
+        return this == COMPACT;
+    }
+}

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -113,9 +113,19 @@ public class TornadoOptions {
      */
     public static final boolean ENABLE_EXCEPTIONS = Boolean.parseBoolean(System.getProperty("tornado.exceptions", FALSE));
     /**
+     * Verbosity of the TornadoVM Internal Bytecode log: false|compact|full|trace|dot. The legacy
+     * boolean values are still accepted, with {@code True} meaning {@link BytecodeLogMode#FULL}.
+     */
+    public static final BytecodeLogMode BYTECODE_LOG_MODE = BytecodeLogMode.parse(getProperty("tornado.print.bytecodes", FALSE));
+    /**
      * Option to print TornadoVM Internal Bytecodes.
      */
-    public static final boolean PRINT_BYTECODES = getBooleanValue("tornado.print.bytecodes", FALSE);
+    public static final boolean PRINT_BYTECODES = BYTECODE_LOG_MODE != BytecodeLogMode.OFF;
+    /**
+     * Whether the bytecode log is coloured: auto (only when attached to a terminal and NO_COLOR is
+     * unset), always or never. Bytecodes dumped to a file are never coloured.
+     */
+    public static final String BYTECODE_LOG_COLOUR = getProperty("tornado.print.bytecodes.color", "auto");
 
     /**
      * Experimental (CUDA backend): route large one-shot host-to-device transfers (e.g. FIRST_EXECUTION

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -107,9 +107,19 @@ public class TornadoOptions {
      */
     public static final boolean ENABLE_EXCEPTIONS = Boolean.parseBoolean(System.getProperty("tornado.exceptions", FALSE));
     /**
+     * Verbosity of the TornadoVM Internal Bytecode log: false|compact|full|trace|dot. The legacy
+     * boolean values are still accepted, with {@code True} meaning {@link BytecodeLogMode#FULL}.
+     */
+    public static final BytecodeLogMode BYTECODE_LOG_MODE = BytecodeLogMode.parse(getProperty("tornado.print.bytecodes", FALSE));
+    /**
      * Option to print TornadoVM Internal Bytecodes.
      */
-    public static final boolean PRINT_BYTECODES = getBooleanValue("tornado.print.bytecodes", FALSE);
+    public static final boolean PRINT_BYTECODES = BYTECODE_LOG_MODE != BytecodeLogMode.OFF;
+    /**
+     * Whether the bytecode log is coloured: auto (only when attached to a terminal and NO_COLOR is
+     * unset), always or never. Bytecodes dumped to a file are never coloured.
+     */
+    public static final String BYTECODE_LOG_COLOUR = getProperty("tornado.print.bytecodes.color", "auto");
 
     /**
      * Experimental (CUDA backend): route large one-shot host-to-device transfers (e.g. FIRST_EXECUTION

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeDotWriter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeDotWriter.java
@@ -1,0 +1,163 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.runtime.interpreter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
+import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
+
+/**
+ * Emits a Graphviz DOT view of what the interpreter executed, selected with
+ * {@code -Dtornado.print.bytecodes=dot}.
+ *
+ * <p>
+ * Tasks are clustered per task-graph while buffers are global nodes, so a buffer that two task-graphs
+ * both touch — the {@code persistOnDevice} / {@code consumeFromDevice} case that the textual log cannot
+ * show — appears as a single node with edges crossing the cluster boundary. Every execution of every
+ * graph is merged into one file, which is rewritten after each execution so it is always valid:
+ * </p>
+ *
+ * <pre>
+ * dot -Tsvg tornado-bytecodes.dot -o bytecodes.svg
+ * </pre>
+ *
+ * <p>
+ * Insertion-ordered collections are used throughout so that two runs of the same application produce
+ * byte-identical files and can be diffed.
+ * </p>
+ */
+final class BytecodeDotWriter {
+
+    private static final String FILE_NAME = "tornado-bytecodes.dot";
+
+    private static final Map<String, Set<String>> TASKS_PER_GRAPH = new LinkedHashMap<>();
+    private static final Map<String, String> BUFFER_NODES = new LinkedHashMap<>();
+    private static final Set<String> EDGES = new LinkedHashSet<>();
+    private static final Set<String> PERSISTED = new LinkedHashSet<>();
+
+    private BytecodeDotWriter() {
+    }
+
+    static synchronized void write(String graphName, long execution, List<BytecodeLogEntry> entries) {
+        record(graphName, entries);
+        Path target = Path.of(TornadoOptions.DUMP_BYTECODES.isBlank() ? "." : TornadoOptions.DUMP_BYTECODES, FILE_NAME);
+        try {
+            if (target.getParent() != null) {
+                Files.createDirectories(target.getParent());
+            }
+            try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(target))) {
+                emit(writer);
+            }
+        } catch (IOException e) {
+            new TornadoLogger().error("unable to write %s: %s", target, e.getMessage());
+        }
+    }
+
+    private static void record(String graphName, List<BytecodeLogEntry> entries) {
+        Set<String> tasks = TASKS_PER_GRAPH.computeIfAbsent(graphName, key -> new LinkedHashSet<>());
+        List<String> pendingInputs = new ArrayList<>();
+        String previousTask = null;
+        String lastTask = null;
+
+        for (BytecodeLogEntry entry : entries) {
+            if (entry.object() != null) {
+                declareBuffer(entry);
+            }
+            switch (entry.op()) {
+                case "LAUNCH" -> {
+                    String task = nodeId("task", entry.taskName());
+                    tasks.add(String.format("    %s [label=\"%s\", shape=box, style=rounded];", task, entry.taskName()));
+                    for (String input : pendingInputs) {
+                        EDGES.add(String.format("  %s -> %s;", input, task));
+                    }
+                    pendingInputs.clear();
+                    if (previousTask != null) {
+                        EDGES.add(String.format("  %s -> %s [style=dotted, color=gray, label=\"order\"];", previousTask, task));
+                    }
+                    previousTask = task;
+                    lastTask = task;
+                }
+                case "PERSIST", "ON_DEVICE" -> PERSISTED.add(nodeId("buf", BytecodeRenderer.objectLabel(entry.object())));
+                default -> {
+                    if (entry.object() == null) {
+                        continue;
+                    }
+                    String buffer = nodeId("buf", BytecodeRenderer.objectLabel(entry.object()));
+                    // Only transfers carry data flow: an ALLOC just declares the buffer node.
+                    if (entry.op().startsWith("TRANSFER_HOST_TO_DEVICE")) {
+                        pendingInputs.add(buffer);
+                    } else if (entry.op().startsWith("TRANSFER_DEVICE_TO_HOST") && lastTask != null) {
+                        EDGES.add(String.format("  %s -> %s;", lastTask, buffer));
+                    }
+                }
+            }
+        }
+    }
+
+    private static void declareBuffer(BytecodeLogEntry entry) {
+        String label = BytecodeRenderer.objectLabel(entry.object());
+        String id = nodeId("buf", label);
+        String size = entry.size() > 0 ? "\\n" + RuntimeUtilities.humanReadableByteCount(entry.size(), false) : "";
+        BUFFER_NODES.putIfAbsent(id, String.format("  %s [label=\"%s%s\", shape=ellipse];", id, label, size));
+    }
+
+    private static String nodeId(String prefix, String label) {
+        return prefix + "_" + label.replaceAll("[^A-Za-z0-9]", "_");
+    }
+
+    private static void emit(PrintWriter writer) {
+        writer.println("digraph tornado_bytecodes {");
+        writer.println("  rankdir=LR;");
+        writer.println("  node [fontname=\"monospace\", fontsize=10];");
+        writer.println("  edge [fontname=\"monospace\", fontsize=9];");
+        for (Map.Entry<String, String> buffer : BUFFER_NODES.entrySet()) {
+            String declaration = buffer.getValue();
+            if (PERSISTED.contains(buffer.getKey())) {
+                declaration = declaration.replace("];", ", style=filled, fillcolor=\"#ffe0b2\"];");
+            }
+            writer.println(declaration);
+        }
+        int cluster = 0;
+        for (Map.Entry<String, Set<String>> graph : TASKS_PER_GRAPH.entrySet()) {
+            writer.printf("  subgraph cluster_%d {%n", cluster++);
+            writer.printf("    label=\"task-graph %s\";%n", graph.getKey());
+            writer.println("    color=blue;");
+            graph.getValue().forEach(writer::println);
+            writer.println("  }");
+        }
+        EDGES.forEach(writer::println);
+        writer.println("}");
+    }
+}

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeDotWriter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeDotWriter.java
@@ -44,8 +44,8 @@ import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
  *
  * <p>
  * Tasks are clustered per task-graph while buffers are global nodes, so a buffer that two task-graphs
- * both touch — the {@code persistOnDevice} / {@code consumeFromDevice} case that the textual log cannot
- * show — appears as a single node with edges crossing the cluster boundary. Every execution of every
+ * both touch - the {@code persistOnDevice} / {@code consumeFromDevice} case that the textual log cannot
+ * show - appears as a single node with edges crossing the cluster boundary. Every execution of every
  * graph is merged into one file, which is rewritten after each execution so it is always valid:
  * </p>
  *

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeLog.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeLog.java
@@ -1,0 +1,167 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.runtime.interpreter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import uk.ac.manchester.tornado.runtime.common.BytecodeLogMode;
+import uk.ac.manchester.tornado.runtime.common.ColoursTerminal;
+import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
+import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
+
+/**
+ * Accumulates the bytecode log of a single interpreter execution: the header naming the task-graph and
+ * device, one rendered line per bytecode, and a closing summary of what the execution actually did.
+ *
+ * <p>
+ * The device is declared once in the header and referred to by a short stable identifier
+ * ({@code D0}, {@code D1}, ...) rather than repeated on every line, which is where most of the width of
+ * the historical format went.
+ * </p>
+ */
+final class BytecodeLog {
+
+    private static final Map<String, String> DEVICE_IDS = new ConcurrentHashMap<>();
+    private static final AtomicInteger DEVICE_COUNTER = new AtomicInteger();
+
+    private final BytecodeLogMode mode;
+    private final boolean colour;
+    private final String graphName;
+    private final long execution;
+    private final String threadName;
+    private final String deviceId;
+    private final StringBuilder text = new StringBuilder(4096);
+    private final List<BytecodeLogEntry> entries;
+
+    private String indent = "";
+    private int sequence;
+    private int allocations;
+    private int deallocations;
+    private int launches;
+    private int skipped;
+    private int hostToDevice;
+    private int deviceToHost;
+    private int persisted;
+    private long bytesToDevice;
+    private long bytesToHost;
+
+    BytecodeLog(BytecodeLogMode mode, String graphName, long execution, TornadoXPUDevice device) {
+        this.mode = mode;
+        this.colour = InterpreterUtilities.isColourEnabled();
+        this.graphName = graphName;
+        this.execution = execution;
+        this.threadName = Thread.currentThread().getName();
+        this.deviceId = deviceIdFor(device);
+        this.entries = mode == BytecodeLogMode.DOT ? new ArrayList<>() : null;
+
+        if (mode.isTextual()) {
+            String header = String.format("== graph '%s' | exec #%d | %s=%s | thread %s", graphName, execution, deviceId, String.valueOf(device).trim(), threadName);
+            text.append(colour ? ColoursTerminal.BLUE + header + ColoursTerminal.RESET : header).append("\n");
+        }
+    }
+
+    private static String deviceIdFor(TornadoXPUDevice device) {
+        return DEVICE_IDS.computeIfAbsent(String.valueOf(device), key -> "D" + DEVICE_COUNTER.getAndIncrement());
+    }
+
+    void add(BytecodeLogEntry entry) {
+        count(entry);
+        if (entries != null) {
+            entries.add(entry);
+            return;
+        }
+        text.append(BytecodeRenderer.line(entry, mode, colour, sequence, indent)).append("\n");
+        sequence++;
+    }
+
+    /**
+     * Records a bytecode the interpreter deliberately did not perform. Only {@link BytecodeLogMode#TRACE}
+     * prints these, since on a steady-state loop they are the majority of the log.
+     */
+    void addSkipped(BytecodeLogEntry entry) {
+        skipped++;
+        if (mode == BytecodeLogMode.TRACE) {
+            text.append(BytecodeRenderer.line(entry.withStatus(false, entry.status()), mode, colour, sequence, indent)).append("\n");
+            sequence++;
+        }
+    }
+
+    private void count(BytecodeLogEntry entry) {
+        switch (entry.op()) {
+            case "ALLOC" -> allocations++;
+            case "DEALLOC" -> deallocations++;
+            case "LAUNCH" -> launches++;
+            case "PERSIST" -> persisted++;
+            default -> {
+                if (entry.op().startsWith("TRANSFER_HOST_TO_DEVICE")) {
+                    hostToDevice++;
+                    bytesToDevice += entry.executed() ? entry.size() : 0;
+                } else if (entry.op().startsWith("TRANSFER_DEVICE_TO_HOST")) {
+                    deviceToHost++;
+                    bytesToHost += entry.size();
+                }
+            }
+        }
+    }
+
+    void setIndent(String newIndent) {
+        this.indent = newIndent;
+    }
+
+    void end() {
+        if (!mode.isTextual()) {
+            return;
+        }
+        String summary = String.format("== END   graph '%s' | exec #%d | %d alloc | %d dealloc | %d launch | h2d %d (%s) | d2h %d (%s) | %d persist | %d skipped", //
+                graphName, execution, allocations, deallocations, launches, //
+                hostToDevice, RuntimeUtilities.humanReadableByteCount(bytesToDevice, false), //
+                deviceToHost, RuntimeUtilities.humanReadableByteCount(bytesToHost, false), //
+                persisted, skipped);
+        text.append(colour ? ColoursTerminal.BLUE + summary + ColoursTerminal.RESET : summary).append("\n");
+    }
+
+    /** Writes the log to the console and/or to the dump directory, honouring the selected mode. */
+    void flush() {
+        if (mode == BytecodeLogMode.DOT) {
+            BytecodeDotWriter.write(graphName, execution, entries);
+            return;
+        }
+        if (TornadoOptions.PRINT_BYTECODES) {
+            System.out.println(text);
+        }
+        if (!TornadoOptions.DUMP_BYTECODES.isBlank()) {
+            RuntimeUtilities.writeBytecodeToFile(text);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return text.toString();
+    }
+}

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeLog.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeLog.java
@@ -73,10 +73,6 @@ final class BytecodeLog {
     private long bytesToDevice;
     private long bytesToHost;
 
-    BytecodeLog(BytecodeLogMode mode, String graphName, long execution, TornadoXPUDevice device) {
-        this(mode, graphName, execution, device, false);
-    }
-
     /**
      * @param transfersOnly
      *     true when the interpreter is walking the bytecode for its data transfers only, as

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeLog.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeLog.java
@@ -58,6 +58,7 @@ final class BytecodeLog {
     private final String deviceId;
     private final StringBuilder text = new StringBuilder(4096);
     private final List<BytecodeLogEntry> entries;
+    private final boolean transfersOnly;
 
     private String indent = "";
     private int sequence;
@@ -73,6 +74,16 @@ final class BytecodeLog {
     private long bytesToHost;
 
     BytecodeLog(BytecodeLogMode mode, String graphName, long execution, TornadoXPUDevice device) {
+        this(mode, graphName, execution, device, false);
+    }
+
+    /**
+     * @param transfersOnly
+     *     true when the interpreter is walking the bytecode for its data transfers only, as
+     *     {@code TornadoExecutionPlan.transferToDevice()} does. Without saying so, such a pass reads
+     *     as an execution that mysteriously ran no kernels.
+     */
+    BytecodeLog(BytecodeLogMode mode, String graphName, long execution, TornadoXPUDevice device, boolean transfersOnly) {
         this.mode = mode;
         this.colour = InterpreterUtilities.isColourEnabled();
         this.graphName = graphName;
@@ -80,9 +91,11 @@ final class BytecodeLog {
         this.threadName = Thread.currentThread().getName();
         this.deviceId = deviceIdFor(device);
         this.entries = mode == BytecodeLogMode.DOT ? new ArrayList<>() : null;
+        this.transfersOnly = transfersOnly;
 
         if (mode.isTextual()) {
-            String header = String.format("== graph '%s' | exec #%d | %s=%s | thread %s", graphName, execution, deviceId, String.valueOf(device).trim(), threadName);
+            String header = String.format("== graph '%s' | exec #%d | %s=%s | thread %s%s", graphName, execution, deviceId, String.valueOf(device).trim(), threadName,
+                    transfersOnly ? " | transfers-only (no task runs)" : "");
             text.append(colour ? ColoursTerminal.BLUE + header + ColoursTerminal.RESET : header).append("\n");
         }
     }
@@ -144,11 +157,11 @@ final class BytecodeLog {
         }
         // h2d is reported as executed/total: a TRANSFER_HOST_TO_DEVICE_ONCE whose buffer is already on
         // the device is a no-op, and on a steady-state loop those are the majority.
-        String summary = String.format("== END   graph '%s' | exec #%d | %d alloc | %d dealloc | %d launch | h2d %d/%d (%s) | d2h %d (%s) | %d persist | %d skipped", //
+        String summary = String.format("== END   graph '%s' | exec #%d | %d alloc | %d dealloc | %d launch | h2d %d/%d (%s) | d2h %d (%s) | %d persist | %d skipped%s", //
                 graphName, execution, allocations, deallocations, launches, //
                 hostToDeviceExecuted, hostToDevice, RuntimeUtilities.humanReadableByteCount(bytesToDevice, false), //
                 deviceToHost, RuntimeUtilities.humanReadableByteCount(bytesToHost, false), //
-                persisted, skipped);
+                persisted, skipped, transfersOnly ? " | transfers-only" : "");
         text.append(colour ? ColoursTerminal.BLUE + summary + ColoursTerminal.RESET : summary).append("\n");
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeLog.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeLog.java
@@ -66,6 +66,7 @@ final class BytecodeLog {
     private int launches;
     private int skipped;
     private int hostToDevice;
+    private int hostToDeviceExecuted;
     private int deviceToHost;
     private int persisted;
     private long bytesToDevice;
@@ -121,7 +122,10 @@ final class BytecodeLog {
             default -> {
                 if (entry.op().startsWith("TRANSFER_HOST_TO_DEVICE")) {
                     hostToDevice++;
-                    bytesToDevice += entry.executed() ? entry.size() : 0;
+                    if (entry.executed()) {
+                        hostToDeviceExecuted++;
+                        bytesToDevice += entry.size();
+                    }
                 } else if (entry.op().startsWith("TRANSFER_DEVICE_TO_HOST")) {
                     deviceToHost++;
                     bytesToHost += entry.size();
@@ -138,9 +142,11 @@ final class BytecodeLog {
         if (!mode.isTextual()) {
             return;
         }
-        String summary = String.format("== END   graph '%s' | exec #%d | %d alloc | %d dealloc | %d launch | h2d %d (%s) | d2h %d (%s) | %d persist | %d skipped", //
+        // h2d is reported as executed/total: a TRANSFER_HOST_TO_DEVICE_ONCE whose buffer is already on
+        // the device is a no-op, and on a steady-state loop those are the majority.
+        String summary = String.format("== END   graph '%s' | exec #%d | %d alloc | %d dealloc | %d launch | h2d %d/%d (%s) | d2h %d (%s) | %d persist | %d skipped", //
                 graphName, execution, allocations, deallocations, launches, //
-                hostToDevice, RuntimeUtilities.humanReadableByteCount(bytesToDevice, false), //
+                hostToDeviceExecuted, hostToDevice, RuntimeUtilities.humanReadableByteCount(bytesToDevice, false), //
                 deviceToHost, RuntimeUtilities.humanReadableByteCount(bytesToHost, false), //
                 persisted, skipped);
         text.append(colour ? ColoursTerminal.BLUE + summary + ColoursTerminal.RESET : summary).append("\n");

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeLogEntry.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeLogEntry.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.runtime.interpreter;
+
+/**
+ * One entry of the TornadoVM bytecode log, holding the raw facts of a single interpreted bytecode.
+ *
+ * <p>
+ * Formatting is deliberately not done here: {@link BytecodeRenderer} turns an entry into text at the
+ * requested verbosity and {@link BytecodeDotWriter} turns the same entries into a dependency graph.
+ * Fields that do not apply to a given bytecode are left at their neutral value
+ * ({@code null}, {@code 0} or {@link #NO_EVENT}).
+ * </p>
+ *
+ * @param op
+ *     bytecode name, e.g. {@code ALLOC}, {@code LAUNCH}, {@code TRANSFER_HOST_TO_DEVICE_ONCE}
+ * @param executed
+ *     false when the interpreter logged the bytecode but did not perform the operation (buffer
+ *     already present, deallocation skipped because an execution graph is active, ...)
+ * @param object
+ *     the data object the bytecode operates on, or null for task/control bytecodes
+ * @param taskName
+ *     fully qualified task name for {@code LAUNCH}, otherwise null
+ * @param size
+ *     size in bytes of the object or transfer, 0 when not applicable
+ * @param batchSize
+ *     batch size in bytes, 0 when the object is not batched
+ * @param offset
+ *     offset in bytes into the object, 0 when not applicable
+ * @param eventList
+ *     index of the wait-event list this bytecode signals into, {@link #NO_EVENT} when none
+ * @param waitEvents
+ *     event identifiers this bytecode waits on, null when it waits on nothing
+ * @param status
+ *     short outcome word, e.g. {@code Transferred}, {@code Present}, {@code Freed}, {@code Persisted}
+ * @param note
+ *     free-form detail, e.g. {@code graphId=0} or the reason a bytecode was skipped
+ */
+record BytecodeLogEntry(String op, boolean executed, Object object, String taskName, long size, long batchSize, long offset, int eventList, int[] waitEvents, String status, String note) {
+
+    static final int NO_EVENT = Integer.MIN_VALUE;
+
+    static BytecodeLogEntry of(String op, Object object, long size, long batchSize) {
+        return new BytecodeLogEntry(op, true, object, null, size, batchSize, 0, NO_EVENT, null, null, null);
+    }
+
+    static BytecodeLogEntry control(String op, String note) {
+        return new BytecodeLogEntry(op, true, null, null, 0, 0, 0, NO_EVENT, null, null, note);
+    }
+
+    BytecodeLogEntry withStatus(boolean isExecuted, String newStatus) {
+        return new BytecodeLogEntry(op, isExecuted, object, taskName, size, batchSize, offset, eventList, waitEvents, newStatus, note);
+    }
+
+    BytecodeLogEntry withTransfer(long transferOffset, int list, int[] waits) {
+        return new BytecodeLogEntry(op, executed, object, taskName, size, batchSize, transferOffset, list, waits, status, note);
+    }
+
+    boolean hasEventList() {
+        return eventList != NO_EVENT;
+    }
+}

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeRenderer.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeRenderer.java
@@ -45,6 +45,8 @@ final class BytecodeRenderer {
     private static final int OP_WIDTH_FULL = 39;
     private static final int OP_WIDTH_COMPACT = 11;
     private static final int LABEL_WIDTH = 38;
+    /** Longest type label kept from a toString() before falling back to the simple class name. */
+    private static final int MAX_TYPE_LABEL = 30;
 
     private BytecodeRenderer() {
     }
@@ -79,8 +81,14 @@ final class BytecodeRenderer {
         if (asString.startsWith(object.getClass().getName() + "@")) {
             return simpleName + hash;
         }
-        // Types with a meaningful toString, e.g. "ImageFloat <320 x 240>" -> "ImageFloat<320x240>"
-        return asString.replace(" ", "") + hash;
+        // Types with a meaningful toString, e.g. "ImageFloat <320 x 240>" -> "ImageFloat<320x240>".
+        // Keep the first line only: MatrixFloat prints its whole contents, which would break the table.
+        int newLine = asString.indexOf('\n');
+        if (newLine >= 0) {
+            asString = asString.substring(0, newLine);
+        }
+        asString = asString.replace(" ", "").strip();
+        return (asString.length() > MAX_TYPE_LABEL || asString.isEmpty() ? simpleName : asString) + hash;
     }
 
     static String line(BytecodeLogEntry entry, BytecodeLogMode mode, boolean colour, int sequence, String indent) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeRenderer.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/BytecodeRenderer.java
@@ -1,0 +1,165 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.runtime.interpreter;
+
+import java.util.Arrays;
+
+import uk.ac.manchester.tornado.runtime.common.BytecodeLogMode;
+import uk.ac.manchester.tornado.runtime.common.ColoursTerminal;
+import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
+
+/**
+ * Turns a {@link BytecodeLogEntry} into one line of text.
+ *
+ * <p>
+ * {@link BytecodeLogMode#COMPACT} shortens the bytecode names, prints human-readable sizes and drops
+ * fields that carry no information. {@link BytecodeLogMode#FULL} keeps the full bytecode names and the
+ * raw byte counts of the historical format, so dumps stay comparable and greppable, but aligns the
+ * columns and prints the device once in the header instead of on every line.
+ * </p>
+ */
+final class BytecodeRenderer {
+
+    /** Width of the bytecode-name column, the longest name being TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING. */
+    private static final int OP_WIDTH_FULL = 39;
+    private static final int OP_WIDTH_COMPACT = 11;
+    private static final int LABEL_WIDTH = 38;
+
+    private BytecodeRenderer() {
+    }
+
+    static String shortOp(String op) {
+        return switch (op) {
+            case "TRANSFER_HOST_TO_DEVICE_ONCE" -> "H2D_ONCE";
+            case "TRANSFER_HOST_TO_DEVICE_ALWAYS" -> "H2D";
+            case "TRANSFER_DEVICE_TO_HOST_ALWAYS" -> "D2H";
+            case "TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING" -> "D2H_SYNC";
+            case "EXECUTION_GRAPH_BEGIN_CAPTURE" -> "GRAPH_CAP{";
+            case "EXECUTION_GRAPH_END_CAPTURE" -> "GRAPH_CAP}";
+            case "EXECUTION_GRAPH_LAUNCH" -> "GRAPH_RUN";
+            case "EXECUTION_GRAPH_DESTROY" -> "GRAPH_FREE";
+            case "ADD_DEPENDENCY" -> "ADD_DEP";
+            default -> op;
+        };
+    }
+
+    /**
+     * Uniform object label: simple type name, its dimensions when the type prints them, and always the
+     * identity hash. Replaces the historical mix of {@code ImageFloat <320 x 240>} and
+     * {@code uk.ac.manchester.tornado.api.types.arrays.FloatArray@3efe7086}.
+     */
+    static String objectLabel(Object object) {
+        if (object == null) {
+            return "-";
+        }
+        String hash = String.format("@%x", object.hashCode());
+        String simpleName = object.getClass().getSimpleName();
+        String asString = String.valueOf(object);
+        if (asString.startsWith(object.getClass().getName() + "@")) {
+            return simpleName + hash;
+        }
+        // Types with a meaningful toString, e.g. "ImageFloat <320 x 240>" -> "ImageFloat<320x240>"
+        return asString.replace(" ", "") + hash;
+    }
+
+    static String line(BytecodeLogEntry entry, BytecodeLogMode mode, boolean colour, int sequence, String indent) {
+        StringBuilder line = new StringBuilder(160);
+        line.append(indent);
+        line.append(String.format("%4d ", sequence));
+
+        boolean compact = mode.isTerse();
+        String name = compact ? shortOp(entry.op()) : entry.op();
+        String padded = String.format("%-" + (compact ? OP_WIDTH_COMPACT : OP_WIDTH_FULL) + "s", name);
+        line.append(colour ? colourFor(entry) + padded + ColoursTerminal.RESET : padded);
+        line.append(' ');
+
+        // Control bytecodes (barriers, execution-graph operations) have no object: their note is the label.
+        boolean noteIsLabel = entry.taskName() == null && entry.object() == null && entry.note() != null;
+        String label = entry.taskName() != null ? entry.taskName() : noteIsLabel ? entry.note() : objectLabel(entry.object());
+        line.append(String.format("%-" + LABEL_WIDTH + "s", label));
+
+        if (compact) {
+            appendCompactDetails(line, entry);
+        } else {
+            appendFullDetails(line, entry);
+        }
+
+        if (mode == BytecodeLogMode.TRACE && entry.waitEvents() != null) {
+            line.append(" waits=").append(Arrays.toString(entry.waitEvents()));
+        }
+        if (entry.note() != null && !noteIsLabel) {
+            line.append(' ').append(entry.note());
+        }
+        if (entry.status() != null) {
+            String status = "[" + entry.status() + "]";
+            line.append(' ').append(colour ? ColoursTerminal.YELLOW + status + ColoursTerminal.RESET : status);
+        }
+        return line.toString().stripTrailing();
+    }
+
+    private static void appendCompactDetails(StringBuilder line, BytecodeLogEntry entry) {
+        if (entry.size() > 0) {
+            line.append(String.format(" %10s", RuntimeUtilities.humanReadableByteCount(entry.size(), false)));
+        } else {
+            line.append(String.format(" %10s", ""));
+        }
+        if (entry.batchSize() > 0) {
+            line.append(" batch=").append(RuntimeUtilities.humanReadableByteCount(entry.batchSize(), false));
+        }
+        if (entry.offset() > 0) {
+            line.append(" offset=").append(RuntimeUtilities.humanReadableByteCount(entry.offset(), false));
+        }
+        if (entry.hasEventList() && entry.eventList() >= 0) {
+            line.append(" ev").append(entry.eventList());
+        }
+    }
+
+    private static void appendFullDetails(StringBuilder line, BytecodeLogEntry entry) {
+        StringBuilder details = new StringBuilder();
+        if (entry.size() > 0 || entry.batchSize() > 0) {
+            details.append(String.format("size=%d, batchSize=%d", entry.size(), entry.batchSize()));
+        }
+        if (entry.hasEventList()) {
+            if (!details.isEmpty()) {
+                details.append(", ");
+            }
+            details.append(String.format("offset=%d [event list=%d]", entry.offset(), entry.eventList()));
+        }
+        if (!details.isEmpty()) {
+            line.append(' ').append(details);
+        }
+    }
+
+    private static String colourFor(BytecodeLogEntry entry) {
+        if (!entry.executed()) {
+            return ColoursTerminal.YELLOW;
+        }
+        return switch (entry.op()) {
+            case "LAUNCH" -> ColoursTerminal.GREEN;
+            case "ALLOC", "DEALLOC" -> ColoursTerminal.PURPLE;
+            case "BARRIER", "ADD_DEPENDENCY", "END" -> ColoursTerminal.BLUE;
+            default -> entry.op().startsWith("TRANSFER") ? ColoursTerminal.CYAN : ColoursTerminal.RED;
+        };
+    }
+}

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
@@ -46,6 +46,15 @@ class DebugInterpreter {
         log.add(BytecodeLogEntry.of("DEALLOC", object, 0, 0).withStatus(materializeDealloc, materializeDealloc ? "Freed" : "Persisted"));
     }
 
+    /**
+     * An allocation the interpreter skipped because an execution (CUDA) graph already owns the
+     * buffers. Logged for the same reason the matching deallocation is: a bytecode that silently
+     * does nothing is what makes a log hard to trust.
+     */
+    static void logAllocSkipped(Object object, BytecodeLog log) {
+        log.addSkipped(BytecodeLogEntry.of("ALLOC", object, 0, 0).withStatus(false, "Skipped: execution graph active"));
+    }
+
     /** A deallocation the interpreter skipped because an execution (CUDA) graph still owns the buffer. */
     static void logDeallocSkipped(Object object, BytecodeLog log) {
         log.addSkipped(BytecodeLogEntry.of("DEALLOC", object, 0, 0).withStatus(false, "Skipped: execution graph active"));

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/DebugInterpreter.java
@@ -26,158 +26,78 @@ package uk.ac.manchester.tornado.runtime.interpreter;
 import java.util.List;
 
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
-import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
 
+/**
+ * Records what the interpreter did, one {@link BytecodeLogEntry} per bytecode.
+ *
+ * <p>
+ * These methods used to build finished, coloured strings. They now only collect facts: the device is
+ * named once in the {@link BytecodeLog} header rather than on every line, and {@link BytecodeRenderer}
+ * decides what to show at the requested verbosity.
+ * </p>
+ */
 class DebugInterpreter {
 
-    private static void appendLogBuilder(String logMessage, StringBuilder logBuilder) {
-        logBuilder.append(logMessage).append("\n");
+    static void logAllocObject(Object object, long size, long sizeBatch, BytecodeLog log) {
+        log.add(BytecodeLogEntry.of("ALLOC", object, size, sizeBatch));
     }
 
-    static void logAllocObject(Object object, TornadoXPUDevice interpreterDevice, long size, long sizeBatch, StringBuilder logBuilder) {
-        String verbose = String.format("bc: %s%s on %s, size=%d, batchSize=%d", //
-                InterpreterUtilities.debugHighLightBC("ALLOC"), //
-                object, //
-                InterpreterUtilities.debugDeviceBC(interpreterDevice), //
-                size, //
-                sizeBatch); //
-        appendLogBuilder(verbose, logBuilder);
+    static void logDeallocObject(Object object, BytecodeLog log, boolean materializeDealloc) {
+        log.add(BytecodeLogEntry.of("DEALLOC", object, 0, 0).withStatus(materializeDealloc, materializeDealloc ? "Freed" : "Persisted"));
     }
 
-    static void logDeallocObject(Object object, TornadoXPUDevice interpreterDevice, StringBuilder logBuilder, boolean materializeDealloc) {
-        String verbose = String.format("bc: %s[0x%x] %s [Status:%s] on %s", //
-                materializeDealloc ? InterpreterUtilities.debugHighLightBC("DEALLOC") : InterpreterUtilities.debugHighLightNonExecBC("DEALLOC"), //
-                object.hashCode(), //
-                object, //
-                InterpreterUtilities.debugHighLightNonExecBC(materializeDealloc ? "Freed" : "Persisted"), //
-                InterpreterUtilities.debugDeviceBC(interpreterDevice)); //
-        appendLogBuilder(verbose, logBuilder);
+    /** A deallocation the interpreter skipped because an execution (CUDA) graph still owns the buffer. */
+    static void logDeallocSkipped(Object object, BytecodeLog log) {
+        log.addSkipped(BytecodeLogEntry.of("DEALLOC", object, 0, 0).withStatus(false, "Skipped: execution graph active"));
     }
 
-    static void logOnDeviceObject(Object object, TornadoXPUDevice interpreterDevice, StringBuilder logBuilder) {
-        String verbose = String.format("bc: %s[0x%x] %s on %s", //
-                InterpreterUtilities.debugHighLightBC("ON_DEVICE"), //
-                object.hashCode(), //
-                object, //
-                InterpreterUtilities.debugDeviceBC(interpreterDevice));
-        appendLogBuilder(verbose, logBuilder);
+    static void logOnDeviceObject(Object object, BytecodeLog log) {
+        log.add(BytecodeLogEntry.of("ON_DEVICE", object, 0, 0));
     }
 
-    static void logPersistedObject(Object object, TornadoXPUDevice interpreterDevice, StringBuilder logBuilder) {
-        String verbose = String.format("bc: %s[0x%x] %s on %s", //
-                InterpreterUtilities.debugHighLightBC("PERSIST"), //
-                object.hashCode(), //
-                object, //
-                InterpreterUtilities.debugDeviceBC(interpreterDevice));
-        appendLogBuilder(verbose, logBuilder);
+    static void logPersistedObject(Object object, BytecodeLog log) {
+        log.add(BytecodeLogEntry.of("PERSIST", object, 0, 0));
     }
 
-    static void logTransferToDeviceOnce(List<Integer> allEvents, Object object, TornadoXPUDevice deviceForInterpreter, //
-            long sizeObject, long sizeBatch, long offset, final int eventList, StringBuilder logBuilder) {
-
+    static void logTransferToDeviceOnce(List<Integer> allEvents, Object object, long sizeObject, long sizeBatch, long offset, final int eventList, BytecodeLog log) {
+        // A null event list means the buffer was already on the device, so nothing was transferred.
         boolean executed = allEvents != null;
-
-        String transferStatus = executed ? "Transferred" : "Present";
-
-        String coloredText = executed //
-                ? InterpreterUtilities.debugHighLightBC("TRANSFER_HOST_TO_DEVICE_ONCE") //
-                : InterpreterUtilities.debugHighLightNonExecBC("TRANSFER_HOST_TO_DEVICE_ONCE"); //
-
-        String verbose = String.format("bc: %s [Object Hash Code=0x%x] %s on %s, size=%d, batchSize=%d, offset=%d [event list=%d], [Status:%s] ", //
-                coloredText, //
-                object.hashCode(), //
-                object, //
-                InterpreterUtilities.debugDeviceBC(deviceForInterpreter), //
-                sizeObject, // 
-                sizeBatch, //
-                offset, //
-                eventList, //
-                InterpreterUtilities.debugHighLightNonExecBC(transferStatus));
-
-        appendLogBuilder(verbose, logBuilder);
+        log.add(BytecodeLogEntry.of("TRANSFER_HOST_TO_DEVICE_ONCE", object, sizeObject, sizeBatch) //
+                .withTransfer(offset, eventList, null) //
+                .withStatus(executed, executed ? "Transferred" : "Present"));
     }
 
-    static void logTransferToDeviceAlways(Object object, TornadoXPUDevice deviceForInterpreter, long sizeObject, long sizeBatch, long offset, //
-            final int eventList, StringBuilder logBuilder) {
-        String verbose = String.format("bc: %s [0x%x] %s on %s, size=%d, batchSize=%d, offset=%d [event list=%d]", //
-                InterpreterUtilities.debugHighLightBC("TRANSFER_HOST_TO_DEVICE_ALWAYS"), //
-                object.hashCode(), //
-                object, //
-                InterpreterUtilities.debugDeviceBC(deviceForInterpreter), //
-                sizeObject, //
-                sizeBatch, //
-                offset, //
-                eventList); //
-        appendLogBuilder(verbose, logBuilder);
+    static void logTransferToDeviceAlways(Object object, long sizeObject, long sizeBatch, long offset, final int eventList, BytecodeLog log) {
+        log.add(BytecodeLogEntry.of("TRANSFER_HOST_TO_DEVICE_ALWAYS", object, sizeObject, sizeBatch).withTransfer(offset, eventList, null));
     }
 
-    static void logTransferToHostAlways(Object object, TornadoXPUDevice interpreterDevice, long sizeObject, long sizeBatch, //
-            long offset, final int eventList, StringBuilder logBuilder) {
-        String verbose = String.format("bc: " //
-                + InterpreterUtilities.debugHighLightBC("TRANSFER_DEVICE_TO_HOST_ALWAYS") //
-                + "[0x%x] %s on %s, size=%d, batchSize=%d, offset=%d [event list=%d]", //
-                object.hashCode(), //
-                object, //
-                InterpreterUtilities.debugDeviceBC(interpreterDevice), //
-                sizeObject, // 
-                sizeBatch, //
-                offset, //
-                eventList);
-        appendLogBuilder(verbose, logBuilder);
+    static void logTransferToHostAlways(Object object, long sizeObject, long sizeBatch, long offset, final int eventList, BytecodeLog log) {
+        log.add(BytecodeLogEntry.of("TRANSFER_DEVICE_TO_HOST_ALWAYS", object, sizeObject, sizeBatch).withTransfer(offset, eventList, null));
     }
 
-    static void logTransferToHostAlwaysBlocking(Object object, TornadoXPUDevice interpreterDevice, StringBuilder logBuilder, //
-            long sizeObject, long sizeBatch, long offset, int eventId) {
-        String verbose = String.format("bc: " //
-                + InterpreterUtilities.debugHighLightBC("TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING") //
-                + " [0x%x] %s on %s, size=%d, sizeBatch=%d, offset=%d [event list=%d]", //
-                object.hashCode(), //
-                object, //
-                InterpreterUtilities.debugDeviceBC(interpreterDevice), //
-                sizeObject, // 
-                sizeBatch, //
-                offset, //
-                eventId);
-        appendLogBuilder(verbose, logBuilder);
+    static void logTransferToHostAlwaysBlocking(Object object, BytecodeLog log, long sizeObject, long sizeBatch, long offset, int eventId) {
+        log.add(BytecodeLogEntry.of("TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING", object, sizeObject, sizeBatch).withTransfer(offset, eventId, null));
     }
 
-    public static void logLaunchTask(SchedulableTask task, TornadoXPUDevice interpreterDevice, long numBatchThreads, long offset, int eventId, StringBuilder logBuilder) {
-        String verbose = String.format("bc: " + InterpreterUtilities.debugHighLightBC("LAUNCH") //
-                + " %s on %s, numThreadBatch=%d, offset=%d [event list=%d]", //
-                task.getFullName(), //
-                interpreterDevice, //
-                numBatchThreads, //
-                offset, //
-                eventId);
-        appendLogBuilder(verbose, logBuilder);
+    static void logLaunchTask(SchedulableTask task, long numBatchThreads, long offset, int eventId, BytecodeLog log) {
+        String note = numBatchThreads > 0 ? "threads=" + numBatchThreads : null;
+        log.add(new BytecodeLogEntry("LAUNCH", true, null, task.getFullName(), 0, 0, offset, eventId, null, null, note));
     }
 
-    public static void logStreamInAtomic(Object bufferAtomics, TornadoXPUDevice interpreterDevice, int eventId, StringBuilder logBuilder) {
-        String verbose = String.format("bc: " //
-                + InterpreterUtilities.debugHighLightBC("STREAM_IN") //
-                + "  ATOMIC [0x%x] %s on %s, batchSize=%d, offset=%d [event list=%d]", //
-                bufferAtomics.hashCode(), //
-                bufferAtomics, //
-                interpreterDevice, //
-                0, //
-                0, //
-                eventId);
-        appendLogBuilder(verbose, logBuilder);
+    static void logStreamInAtomic(Object bufferAtomics, int eventId, BytecodeLog log) {
+        log.add(BytecodeLogEntry.of("STREAM_IN", bufferAtomics, 0, 0).withTransfer(0, eventId, null).withStatus(true, "Atomics"));
     }
 
-    public static void logAddDependency(int lastEvent, int eventId, StringBuilder logBuilder) {
-        String verbose = String.format("bc: " //
-                + InterpreterUtilities.debugHighLightBC("ADD_DEPENDENCY") //
-                + " %s to event list %d",  //
-                lastEvent,  //
-                eventId); //
-        appendLogBuilder(verbose, logBuilder);
+    /** Execution-graph (CUDA graph) capture, replay and teardown bytecodes. */
+    static void logExecutionGraph(BytecodeLog log, String op, int graphId) {
+        log.add(BytecodeLogEntry.control(op, "graphId=" + graphId));
     }
 
-    public static void logBarrier(int enventId, StringBuilder logBuilder) {
-        logBuilder.append(String.format("bc: " //
-                + InterpreterUtilities.debugHighLightBC("BARRIER") //
-                + " event-list %d%n",  //
-                enventId));
+    static void logAddDependency(int lastEvent, int eventId, BytecodeLog log) {
+        log.add(BytecodeLogEntry.control("ADD_DEPENDENCY", String.format("event %d to event list %d", lastEvent, eventId)));
+    }
+
+    static void logBarrier(int eventId, int[] waitList, BytecodeLog log) {
+        log.add(new BytecodeLogEntry("BARRIER", true, null, null, 0, 0, 0, eventId, waitList, null, null));
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/InterpreterUtilities.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/InterpreterUtilities.java
@@ -23,34 +23,31 @@
  */
 package uk.ac.manchester.tornado.runtime.interpreter;
 
-import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
-import uk.ac.manchester.tornado.runtime.common.ColoursTerminal;
-import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
+import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
 
 public class InterpreterUtilities {
+
+    private static final boolean COLOUR_ENABLED = resolveColourPolicy();
 
     public InterpreterUtilities() {
     }
 
-    static String debugHighLightBC(String bc) {
-        return ColoursTerminal.RED + " " + bc + " " + ColoursTerminal.RESET;
-    }
-
-    static String debugHighLightNonExecBC(String bc) {
-        return ColoursTerminal.YELLOW + " " + bc + " " + ColoursTerminal.RESET;
-    }
-
-    static String debugHighLightHelper(String info) {
-        return ColoursTerminal.BLUE + info + " " + ColoursTerminal.RESET;
-    }
-
-    static String debugDeviceBC(TornadoXPUDevice device) {
-        TornadoVMBackendType tornadoVMBackend = device.getTornadoVMBackend();
-        if (tornadoVMBackend == TornadoVMBackendType.OPENCL) {
-            return ColoursTerminal.CYAN + " " + device + " " + ColoursTerminal.RESET;
-        } else if (tornadoVMBackend == TornadoVMBackendType.CUDA) {
-            return ColoursTerminal.GREEN + " " + device + " " + ColoursTerminal.RESET;
+    /**
+     * Resolves {@code tornado.print.bytecodes.color}. The default (auto) keeps the escape codes out of
+     * redirected output, which is where the log usually ends up when it is being read carefully.
+     */
+    private static boolean resolveColourPolicy() {
+        String policy = TornadoOptions.BYTECODE_LOG_COLOUR;
+        if ("always".equalsIgnoreCase(policy)) {
+            return true;
         }
-        return ColoursTerminal.YELLOW + " " + device + " " + ColoursTerminal.RESET;
+        if ("never".equalsIgnoreCase(policy)) {
+            return false;
+        }
+        return System.console() != null && System.getenv("NO_COLOR") == null;
+    }
+
+    static boolean isColourEnabled() {
+        return COLOUR_ENABLED;
     }
 }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -58,7 +58,6 @@ import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
 import uk.ac.manchester.tornado.runtime.common.BatchConfiguration;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
-import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
@@ -139,6 +138,7 @@ public class TornadoVMInterpreter {
      * without running it.
      */
     private boolean transfersOnly = false;
+    private long logExecutionCounter;
     private boolean executionGraphEnabled = true;
 
     private TornadoLogger logger = new TornadoLogger(this.getClass());
@@ -359,11 +359,9 @@ public class TornadoVMInterpreter {
         int lastEvent = -1;
         initWaitEventList();
 
-        StringBuilder logBuilder = null;
+        BytecodeLog logBuilder = null;
         if (TornadoOptions.LOG_BYTECODES() && !isWarmup) {
-            logBuilder = new StringBuilder();
-            logBuilder.append(InterpreterUtilities.debugHighLightHelper("Interpreter instance running bytecodes for: ")).append(interpreterDevice).append(InterpreterUtilities.debugHighLightHelper(
-                    " Running in thread: ")).append(Thread.currentThread().getName()).append("\n");
+            logBuilder = new BytecodeLog(TornadoOptions.BYTECODE_LOG_MODE, graphExecutionContext.getId(), ++logExecutionCounter, interpreterDevice);
         }
 
         bytecodeLoop: while (bytecodeResult.hasRemaining()) {
@@ -394,7 +392,7 @@ public class TornadoVMInterpreter {
                 case CUDA_GRAPH_DESTROY -> lastEvent = handleCudaGraphDestroy(logBuilder, lastEvent, isWarmup);
                 case END -> {
                     if (!isWarmup && TornadoOptions.LOG_BYTECODES()) {
-                        logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC("END\n")).append("\n");
+                        logBuilder.end();
                     }
                     break bytecodeLoop;
                 }
@@ -431,12 +429,8 @@ public class TornadoVMInterpreter {
 
         bytecodeResult.reset();
 
-        if (TornadoOptions.PRINT_BYTECODES) {
-            System.out.println(logBuilder);
-        }
-
-        if (!TornadoOptions.DUMP_BYTECODES.isBlank()) {
-            RuntimeUtilities.writeBytecodeToFile(logBuilder);
+        if (logBuilder != null) {
+            logBuilder.flush();
         }
 
         return barrier;
@@ -545,33 +539,30 @@ public class TornadoVMInterpreter {
         }
     }
 
-    private void executeGraphBeginCapture(StringBuilder logBuilder, int graphId) {
+    private void executeGraphBeginCapture(BytecodeLog logBuilder, int graphId) {
         if (!interpreterDevice.supportsExecutionGraphs()) {
             throw new TornadoBailoutRuntimeException(
                     "EXECUTION_GRAPH_BEGIN_CAPTURE bytecode reached a device that does not support " +
                             "execution graphs: " + interpreterDevice.getDeviceName());
         }
         if (TornadoOptions.LOG_BYTECODES()) {
-            logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC(
-                    "EXECUTION_GRAPH_BEGIN_CAPTURE")).append(" graphId=").append(graphId).append("\n");
+            DebugInterpreter.logExecutionGraph(logBuilder, "EXECUTION_GRAPH_BEGIN_CAPTURE", graphId);
         }
         interpreterDevice.beginExecutionGraphCapture(graphExecutionContext.getExecutionPlanId());
     }
 
-    private void executeGraphEndCapture(StringBuilder logBuilder, int graphId) {
+    private void executeGraphEndCapture(BytecodeLog logBuilder, int graphId) {
         if (TornadoOptions.LOG_BYTECODES()) {
-            logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC(
-                    "EXECUTION_GRAPH_END_CAPTURE")).append(" graphId=").append(graphId).append("\n");
+            DebugInterpreter.logExecutionGraph(logBuilder, "EXECUTION_GRAPH_END_CAPTURE", graphId);
         }
         long handle = interpreterDevice.endExecutionGraphCaptureAndInstantiate(
                 graphExecutionContext.getExecutionPlanId());
         executionGraphHandles.put(graphId, handle);
     }
 
-    private int executeGraphLaunch(StringBuilder logBuilder, int graphId) {
+    private int executeGraphLaunch(BytecodeLog logBuilder, int graphId) {
         if (TornadoOptions.LOG_BYTECODES()) {
-            logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC(
-                    "EXECUTION_GRAPH_LAUNCH")).append(" graphId=").append(graphId).append("\n");
+            DebugInterpreter.logExecutionGraph(logBuilder, "EXECUTION_GRAPH_LAUNCH", graphId);
         }
         int event = interpreterDevice.launchExecutionGraph(
                 graphExecutionContext.getExecutionPlanId(),
@@ -586,7 +577,7 @@ public class TornadoVMInterpreter {
     // handler - it has to, the reads are positional - but the dispatch is now a switch over the
     // opcode enum and each behaviour is a named method.
 
-    private int handleAlloc(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleAlloc(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final long sizeBatch = bytecodeResult.getLong();
             final int argSize = bytecodeResult.getInt();
             final int[] args = new int[argSize];
@@ -602,24 +593,21 @@ public class TornadoVMInterpreter {
     // DEALLOC runs in a transfers-only pass too: it is a no-op for the locked buffers that hold the
     // uploaded data, and skipping it would let every task-graph of a plan hold its buffers at once -
     // enough to exhaust the device on a plan of many graphs.
-    private int handleDealloc(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleDealloc(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int objectIndex = bytecodeResult.getInt();
             if (isWarmup) {
                 return lastEvent;
             }
             if (!executionGraphHandles.isEmpty()) {
                 if (TornadoOptions.LOG_BYTECODES()) {
-                    Object object = objects.get(objectIndex);
-                    logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightNonExecBC(
-                                    "DEALLOC")).append(" [SKIPPED - execution graph active] ")
-                            .append(object).append("\n");
+                    DebugInterpreter.logDeallocSkipped(objects.get(objectIndex), logBuilder);
                 }
                 return lastEvent;
             }
             return executeDeAlloc(logBuilder, objectIndex);
     }
 
-    private int handleTransferHostToDeviceOnce(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleTransferHostToDeviceOnce(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int objectIndex = bytecodeResult.getInt();
             final int eventId = bytecodeResult.getInt();
             final long offset = bytecodeResult.getLong();
@@ -631,7 +619,7 @@ public class TornadoVMInterpreter {
             return transferHostToDeviceOnce(logBuilder, objectIndex, offset, eventId, sizeBatch, waitList);
     }
 
-    private int handleTransferHostToDeviceAlways(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleTransferHostToDeviceAlways(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int objectIndex = bytecodeResult.getInt();
             final int eventId = bytecodeResult.getInt();
             final long offset = bytecodeResult.getLong();
@@ -643,7 +631,7 @@ public class TornadoVMInterpreter {
             return transferHostToDeviceAlways(logBuilder, objectIndex, offset, eventId, sizeBatch, waitList);
     }
 
-    private int handleTransferDeviceToHostAlways(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleTransferDeviceToHostAlways(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int objectIndex = bytecodeResult.getInt();
             final int eventId = bytecodeResult.getInt();
             final long offset = bytecodeResult.getLong();
@@ -655,7 +643,7 @@ public class TornadoVMInterpreter {
             return transferDeviceToHost(logBuilder, objectIndex, offset, eventId, sizeBatch, waitList);
     }
 
-    private int handleTransferDeviceToHostAlwaysBlocking(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleTransferDeviceToHostAlwaysBlocking(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int objectIndex = bytecodeResult.getInt();
             final int eventId = bytecodeResult.getInt();
             final long offset = bytecodeResult.getLong();
@@ -668,7 +656,7 @@ public class TornadoVMInterpreter {
         return lastEvent;
     }
 
-    private int handleLaunch(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleLaunch(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int callWrapperIndex = bytecodeResult.getInt();
             final int taskIndex = bytecodeResult.getInt();
             final int numArgs = bytecodeResult.getInt();
@@ -683,7 +671,7 @@ public class TornadoVMInterpreter {
             return executeLaunch(logBuilder, numArgs, eventId, taskIndex, batchThreads, offset, executionFrame);
     }
 
-    private int handleAddDependency(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleAddDependency(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int eventList = bytecodeResult.getInt();
             if (isWarmup) {
                 return lastEvent;
@@ -692,7 +680,7 @@ public class TornadoVMInterpreter {
         return lastEvent;
     }
 
-    private int handleOnDevice(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleOnDevice(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int objectIndex = bytecodeResult.getInt();
             final int eventId = bytecodeResult.getInt();
             if (isWarmup) {
@@ -701,7 +689,7 @@ public class TornadoVMInterpreter {
             return executeOnDevice(logBuilder, objectIndex, eventId);
     }
 
-    private int handlePersist(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handlePersist(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int objectIndex = bytecodeResult.getInt();
             final int eventId = bytecodeResult.getInt();
             if (isWarmup) {
@@ -710,7 +698,7 @@ public class TornadoVMInterpreter {
             return executePersist(logBuilder, objectIndex, eventId);
     }
 
-    private int handleBarrier(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleBarrier(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int eventId = bytecodeResult.getInt();
             final int[] waitList = (useDependencies && eventId != -1) ? waitListFor(eventId) : null;
             if (isWarmup) {
@@ -719,7 +707,7 @@ public class TornadoVMInterpreter {
             return executeBarrier(logBuilder, eventId, waitList);
     }
 
-    private int handleCudaGraphLaunch(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleCudaGraphLaunch(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int graphId = bytecodeResult.getInt();
             if (isWarmup) {
                 return lastEvent;
@@ -730,7 +718,7 @@ public class TornadoVMInterpreter {
         return lastEvent;
     }
 
-    private int handleCudaGraphBeginCapture(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleCudaGraphBeginCapture(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int graphId = bytecodeResult.getInt();
             if (isWarmup) {
                 return lastEvent;
@@ -743,22 +731,28 @@ public class TornadoVMInterpreter {
                 preCompileLaunchesInCaptureRegion();
                 executeGraphBeginCapture(logBuilder, graphId);
                 insideCaptureRegion = true;
+                if (logBuilder != null) {
+                    logBuilder.setIndent("\t");
+                }
             }
 
         return lastEvent;
     }
 
-    private int handleCudaGraphEndCapture(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleCudaGraphEndCapture(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int graphId = bytecodeResult.getInt();
             if (isWarmup) {
                 return lastEvent;
             }
             insideCaptureRegion = false;
+            if (logBuilder != null) {
+                logBuilder.setIndent("");
+            }
             executeGraphEndCapture(logBuilder, graphId);
         return lastEvent;
     }
 
-    private int handleCudaGraphDestroy(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
+    private int handleCudaGraphDestroy(BytecodeLog logBuilder, int lastEvent, boolean isWarmup) {
             final int graphId = bytecodeResult.getInt();
             if (isWarmup) {
                 return lastEvent;
@@ -767,8 +761,7 @@ public class TornadoVMInterpreter {
             if (handle != null) {
                 interpreterDevice.destroyExecutionGraph(handle);
                 if (TornadoOptions.LOG_BYTECODES()) {
-                    logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC(
-                            "EXECUTION_GRAPH_DESTROY")).append(" graphId=").append(graphId).append("\n");
+                    DebugInterpreter.logExecutionGraph(logBuilder, "EXECUTION_GRAPH_DESTROY", graphId);
                 }
             }
         return lastEvent;
@@ -864,7 +857,7 @@ public class TornadoVMInterpreter {
         return new ObjectAllocationInfo(persistentObjectsInArgs, objectsToAlloc);
     }
 
-    private int executeAlloc(StringBuilder logBuilder, int[] args, long sizeBatch) {
+    private int executeAlloc(BytecodeLog logBuilder, int[] args, long sizeBatch) {
         // Extract the counting and classification of objects into a separate method
         ObjectAllocationInfo allocationInfo = countAndClassifyObjects(args);
 
@@ -912,8 +905,7 @@ public class TornadoVMInterpreter {
             for (XPUDeviceBufferState state : objectStates) {
                 long size = state.getXPUBuffer().size();
                 if (!state.isBufferReused()) {
-                    logBuilder.append(captureIndent());
-                    DebugInterpreter.logAllocObject(objects[objIndex], interpreterDevice, size, sizeBatch, logBuilder);
+                    DebugInterpreter.logAllocObject(objects[objIndex], size, sizeBatch, logBuilder);
                 }
                 objIndex++;
             }
@@ -939,7 +931,7 @@ public class TornadoVMInterpreter {
         }
     }
 
-    private int executeDeAlloc(StringBuilder tornadoVMBytecodeList, final int objectIndex) {
+    private int executeDeAlloc(BytecodeLog tornadoVMBytecodeList, final int objectIndex) {
         Object object = objects.get(objectIndex);
 
         // Fast path for buffer reuse (the default): a locked buffer is never freed, so there is nothing
@@ -947,7 +939,7 @@ public class TornadoVMInterpreter {
         // of which are paid once per object per execution - dominant for plans made of many small graphs.
         if (resolveObjectState(objectIndex).isLockedBuffer()) {
             if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
-                DebugInterpreter.logDeallocObject(object, interpreterDevice, tornadoVMBytecodeList, false);
+                DebugInterpreter.logDeallocObject(object, tornadoVMBytecodeList, false);
             }
             return -1;
         }
@@ -966,31 +958,31 @@ public class TornadoVMInterpreter {
         // Update current device area use
         if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
             boolean materializeDealloc = spaceDeallocated != 0;
-            DebugInterpreter.logDeallocObject(object, interpreterDevice, tornadoVMBytecodeList, materializeDealloc);
+            DebugInterpreter.logDeallocObject(object, tornadoVMBytecodeList, materializeDealloc);
         }
         graphExecutionContext.setCurrentDeviceMemoryUsage(graphExecutionContext.getCurrentDeviceMemoryUsage() - spaceDeallocated);
         return -1;
     }
 
-    private int executeOnDevice(StringBuilder logBuilder, final int objectIndex, final int eventId) {
+    private int executeOnDevice(BytecodeLog logBuilder, final int objectIndex, final int eventId) {
         Object object = objects.get(objectIndex);
         if (TornadoOptions.LOG_BYTECODES()) {
-            DebugInterpreter.logOnDeviceObject(object, interpreterDevice, logBuilder);
+            DebugInterpreter.logOnDeviceObject(object, logBuilder);
         }
         resetEventIndexes(eventId);
         return -1;
     }
 
-    private int executePersist(StringBuilder logBuilder, final int objectIndex, final int eventId) {
+    private int executePersist(BytecodeLog logBuilder, final int objectIndex, final int eventId) {
         Object object = objects.get(objectIndex);
         if (TornadoOptions.PRINT_BYTECODES) {
-            DebugInterpreter.logPersistedObject(object, interpreterDevice, logBuilder);
+            DebugInterpreter.logPersistedObject(object, logBuilder);
         }
         resetEventIndexes(eventId);
         return -1;
     }
 
-    private int transferHostToDeviceOnce(StringBuilder logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
+    private int transferHostToDeviceOnce(BytecodeLog logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
         Object object = objects.get(objectIndex);
 
         if (isObjectKernelContext(object)) {
@@ -1010,8 +1002,7 @@ public class TornadoVMInterpreter {
 
         if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
             long sizeObject = objectState.getXPUBuffer().size();
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logTransferToDeviceOnce(allEvents, object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
+            DebugInterpreter.logTransferToDeviceOnce(allEvents, object, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
 
         if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && allEvents != null) {
@@ -1035,7 +1026,7 @@ public class TornadoVMInterpreter {
         return -1;
     }
 
-    private int transferHostToDeviceAlways(StringBuilder logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
+    private int transferHostToDeviceAlways(BytecodeLog logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
         Object object = objects.get(objectIndex);
 
         if (isObjectKernelContext(object)) {
@@ -1049,8 +1040,7 @@ public class TornadoVMInterpreter {
 
         if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
             long sizeObject = objectState.getXPUBuffer().size();
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logTransferToDeviceAlways(object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
+            DebugInterpreter.logTransferToDeviceAlways(object, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
 
         if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && allEvents != null) {
@@ -1076,7 +1066,7 @@ public class TornadoVMInterpreter {
         return -1;
     }
 
-    private int transferDeviceToHost(StringBuilder logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
+    private int transferDeviceToHost(BytecodeLog logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
         Object object = objects.get(objectIndex);
 
         if (isObjectKernelContext(object)) {
@@ -1086,8 +1076,7 @@ public class TornadoVMInterpreter {
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
         if (TornadoOptions.LOG_BYTECODES()) {
             long sizeObject = objectState.getXPUBuffer().size();
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logTransferToHostAlways(object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
+            DebugInterpreter.logTransferToHostAlways(object, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
 
         // TRANSFER_DEVICE_TO_HOST_ALWAYS is the non-terminal copy-out: the graph compiler patches
@@ -1124,7 +1113,7 @@ public class TornadoVMInterpreter {
         return readEvent;
     }
 
-    private void transferDeviceToHostBlocking(StringBuilder logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
+    private void transferDeviceToHostBlocking(BytecodeLog logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
 
         Object object = objects.get(objectIndex);
 
@@ -1135,8 +1124,7 @@ public class TornadoVMInterpreter {
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
         if (TornadoOptions.LOG_BYTECODES()) {
             long sizeOfObject = objectState.getXPUBuffer().size();
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logTransferToHostAlwaysBlocking(object, interpreterDevice, logBuilder, sizeOfObject, sizeBatch, offset, eventId);
+            DebugInterpreter.logTransferToHostAlwaysBlocking(object, logBuilder, sizeOfObject, sizeBatch, offset, eventId);
         }
         final int readEvent = interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList);
 
@@ -1284,7 +1272,7 @@ public class TornadoVMInterpreter {
         }
     }
 
-    private int executeLaunch(StringBuilder logBuilder, final int numArgs, final int eventId, final int taskIndex, final long batchThreads, final long offset, XPUExecutionFrame executionFrame) {
+    private int executeLaunch(BytecodeLog logBuilder, final int numArgs, final int eventId, final int taskIndex, final long batchThreads, final long offset, XPUExecutionFrame executionFrame) {
 
         final SchedulableTask task = taskExecutionContexts.get(taskIndex);
 
@@ -1368,15 +1356,13 @@ public class TornadoVMInterpreter {
                 }
             }
             if (TornadoOptions.LOG_BYTECODES()) {
-                logBuilder.append(captureIndent());
-                DebugInterpreter.logStreamInAtomic(bufferAtomics, interpreterDevice, eventId, logBuilder);
+                DebugInterpreter.logStreamInAtomic(bufferAtomics, eventId, logBuilder);
 
             }
         }
 
         if (TornadoOptions.LOG_BYTECODES()) {
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logLaunchTask(task, interpreterDevice, batchThreads, offset, eventId, logBuilder);
+            DebugInterpreter.logLaunchTask(task, batchThreads, offset, eventId, logBuilder);
         }
 
         if (task.meta() instanceof TaskDataContext dataContext) {
@@ -1404,7 +1390,7 @@ public class TornadoVMInterpreter {
         }
     }
 
-    private int executeLibraryLaunch(StringBuilder logBuilder, LibraryTask task, final int numArgs, final int eventId, final long batchThreads, int[] waitList) {
+    private int executeLibraryLaunch(BytecodeLog logBuilder, LibraryTask task, final int numArgs, final int eventId, final long batchThreads, int[] waitList) {
 
         if (batchThreads != 0) {
             throw new TornadoRuntimeException("[ERROR] Batch processing is not supported for library tasks (task: " + task.getId() + ")");
@@ -1444,8 +1430,7 @@ public class TornadoVMInterpreter {
         final LibraryContext libraryContext = LibraryRegistry.getOrCreateContext(provider, interpreterDevice, graphExecutionContext.getExecutionPlanId());
 
         if (TornadoOptions.LOG_BYTECODES()) {
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logLaunchTask(task, interpreterDevice, batchThreads, 0, eventId, logBuilder);
+            DebugInterpreter.logLaunchTask(task, batchThreads, 0, eventId, logBuilder);
         }
 
         // The CUDA-C backend does not expose device-event timestamps yet, so the
@@ -1504,7 +1489,7 @@ public class TornadoVMInterpreter {
      * @param lastEvent event ID of the most recently executed bytecode operation
      * @param eventId   dependency slot index into the {@code events} array
      */
-    private void executeDependency(StringBuilder logBuilder, int lastEvent, int eventId) {
+    private void executeDependency(BytecodeLog logBuilder, int lastEvent, int eventId) {
         if (useDependencies && lastEvent != -1) {
             if (TornadoOptions.LOG_BYTECODES()) {
                 DebugInterpreter.logAddDependency(lastEvent, eventId, logBuilder);
@@ -1520,9 +1505,9 @@ public class TornadoVMInterpreter {
         }
     }
 
-    private int executeBarrier(StringBuilder logBuilder, int eventId, int[] waitList) {
+    private int executeBarrier(BytecodeLog logBuilder, int eventId, int[] waitList) {
         if (TornadoOptions.LOG_BYTECODES()) {
-            DebugInterpreter.logBarrier(eventId, logBuilder);
+            DebugInterpreter.logBarrier(eventId, waitList, logBuilder);
         }
 
         int lastEvent;
@@ -1622,10 +1607,6 @@ public class TornadoVMInterpreter {
         } finally {
             transfersOnly = false;
         }
-    }
-
-    private String captureIndent() {
-        return insideCaptureRegion ? "\t" : "";
     }
 
     public void clearInstalledCode() {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -361,7 +361,7 @@ public class TornadoVMInterpreter {
 
         BytecodeLog logBuilder = null;
         if (TornadoOptions.LOG_BYTECODES() && !isWarmup) {
-            logBuilder = new BytecodeLog(TornadoOptions.BYTECODE_LOG_MODE, graphExecutionContext.getId(), ++logExecutionCounter, interpreterDevice);
+            logBuilder = new BytecodeLog(TornadoOptions.BYTECODE_LOG_MODE, graphExecutionContext.getId(), ++logExecutionCounter, interpreterDevice, transfersOnly);
         }
 
         bytecodeLoop: while (bytecodeResult.hasRemaining()) {
@@ -371,6 +371,9 @@ public class TornadoVMInterpreter {
                 throwErrorInterpreter(op);
             }
             if (transfersOnly && SKIPPED_IN_TRANSFERS_ONLY.contains(bytecode)) {
+                if (logBuilder != null) {
+                    logBuilder.addSkipped(BytecodeLogEntry.control(bytecode.name(), "transfers-only pass"));
+                }
                 skipBytecodeOperands(op);
                 continue;
             }
@@ -584,7 +587,15 @@ public class TornadoVMInterpreter {
             for (int i = 0; i < argSize; i++) {
                 args[i] = bytecodeResult.getInt();
             }
-            if (isWarmup || !executionGraphHandles.isEmpty()) {
+            if (isWarmup) {
+                return lastEvent;
+            }
+            if (!executionGraphHandles.isEmpty()) {
+                if (TornadoOptions.LOG_BYTECODES()) {
+                    for (int arg : args) {
+                        DebugInterpreter.logAllocSkipped(objects.get(arg), logBuilder);
+                    }
+                }
                 return lastEvent;
             }
             return executeAlloc(logBuilder, args, sizeBatch);

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -57,7 +57,6 @@ import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.runtime.EmptyEvent;
 import uk.ac.manchester.tornado.runtime.common.BatchConfiguration;
 import uk.ac.manchester.tornado.runtime.common.KernelStackFrame;
-import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.TornadoInstalledCode;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
@@ -116,6 +115,7 @@ public class TornadoVMInterpreter {
     private HashMap<Object, Integer> totalEvenBatchesPerObject = new HashMap<>();
     private final HashMap<Integer, Long> executionGraphHandles = new HashMap<>();
     private boolean insideCaptureRegion = false;
+    private long logExecutionCounter;
     private boolean executionGraphEnabled = true;
 
     private TornadoLogger logger = new TornadoLogger(this.getClass());
@@ -335,11 +335,9 @@ public class TornadoVMInterpreter {
         int lastEvent = -1;
         initWaitEventList();
 
-        StringBuilder logBuilder = null;
+        BytecodeLog logBuilder = null;
         if (TornadoOptions.LOG_BYTECODES() && !isWarmup) {
-            logBuilder = new StringBuilder();
-            logBuilder.append(InterpreterUtilities.debugHighLightHelper("Interpreter instance running bytecodes for: ")).append(interpreterDevice).append(InterpreterUtilities.debugHighLightHelper(
-                    " Running in thread: ")).append(Thread.currentThread().getName()).append("\n");
+            logBuilder = new BytecodeLog(TornadoOptions.BYTECODE_LOG_MODE, graphExecutionContext.getId(), ++logExecutionCounter, interpreterDevice);
         }
 
         while (bytecodeResult.hasRemaining()) {
@@ -362,10 +360,7 @@ public class TornadoVMInterpreter {
                 }
                 if (!executionGraphHandles.isEmpty()) {
                     if (TornadoOptions.LOG_BYTECODES()) {
-                        Object object = objects.get(objectIndex);
-                        logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightNonExecBC(
-                                        "DEALLOC")).append(" [SKIPPED - execution graph active] ")
-                                .append(object).append("\n");
+                        DebugInterpreter.logDeallocSkipped(objects.get(objectIndex), logBuilder);
                     }
                     continue;
                 }
@@ -471,6 +466,9 @@ public class TornadoVMInterpreter {
                     preCompileLaunchesInCaptureRegion();
                     executeGraphBeginCapture(logBuilder, graphId);
                     insideCaptureRegion = true;
+                    if (logBuilder != null) {
+                        logBuilder.setIndent("\t");
+                    }
                 }
 
             } else if (op == TornadoVMBytecodes.CUDA_GRAPH_END_CAPTURE.value()) {
@@ -479,6 +477,9 @@ public class TornadoVMInterpreter {
                     continue;
                 }
                 insideCaptureRegion = false;
+                if (logBuilder != null) {
+                    logBuilder.setIndent("");
+                }
                 executeGraphEndCapture(logBuilder, graphId);
             } else if (op == TornadoVMBytecodes.CUDA_GRAPH_DESTROY.value()) {
                 final int graphId = bytecodeResult.getInt();
@@ -489,13 +490,12 @@ public class TornadoVMInterpreter {
                 if (handle != null) {
                     interpreterDevice.destroyExecutionGraph(handle);
                     if (TornadoOptions.LOG_BYTECODES()) {
-                        logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC(
-                                "EXECUTION_GRAPH_DESTROY")).append(" graphId=").append(graphId).append("\n");
+                        DebugInterpreter.logExecutionGraph(logBuilder, "EXECUTION_GRAPH_DESTROY", graphId);
                     }
                 }
             } else if (op == TornadoVMBytecodes.END.value()) {
                 if (!isWarmup && TornadoOptions.LOG_BYTECODES()) {
-                    logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC("END\n")).append("\n");
+                    logBuilder.end();
                 }
                 break;
             } else {
@@ -528,12 +528,8 @@ public class TornadoVMInterpreter {
 
         bytecodeResult.reset();
 
-        if (TornadoOptions.PRINT_BYTECODES) {
-            System.out.println(logBuilder);
-        }
-
-        if (!TornadoOptions.DUMP_BYTECODES.isBlank()) {
-            RuntimeUtilities.writeBytecodeToFile(logBuilder);
+        if (logBuilder != null) {
+            logBuilder.flush();
         }
 
         return barrier;
@@ -641,33 +637,30 @@ public class TornadoVMInterpreter {
         }
     }
 
-    private void executeGraphBeginCapture(StringBuilder logBuilder, int graphId) {
+    private void executeGraphBeginCapture(BytecodeLog logBuilder, int graphId) {
         if (!interpreterDevice.supportsExecutionGraphs()) {
             throw new TornadoBailoutRuntimeException(
                     "EXECUTION_GRAPH_BEGIN_CAPTURE bytecode reached a device that does not support " +
                             "execution graphs: " + interpreterDevice.getDeviceName());
         }
         if (TornadoOptions.LOG_BYTECODES()) {
-            logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC(
-                    "EXECUTION_GRAPH_BEGIN_CAPTURE")).append(" graphId=").append(graphId).append("\n");
+            DebugInterpreter.logExecutionGraph(logBuilder, "EXECUTION_GRAPH_BEGIN_CAPTURE", graphId);
         }
         interpreterDevice.beginExecutionGraphCapture(graphExecutionContext.getExecutionPlanId());
     }
 
-    private void executeGraphEndCapture(StringBuilder logBuilder, int graphId) {
+    private void executeGraphEndCapture(BytecodeLog logBuilder, int graphId) {
         if (TornadoOptions.LOG_BYTECODES()) {
-            logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC(
-                    "EXECUTION_GRAPH_END_CAPTURE")).append(" graphId=").append(graphId).append("\n");
+            DebugInterpreter.logExecutionGraph(logBuilder, "EXECUTION_GRAPH_END_CAPTURE", graphId);
         }
         long handle = interpreterDevice.endExecutionGraphCaptureAndInstantiate(
                 graphExecutionContext.getExecutionPlanId());
         executionGraphHandles.put(graphId, handle);
     }
 
-    private int executeGraphLaunch(StringBuilder logBuilder, int graphId) {
+    private int executeGraphLaunch(BytecodeLog logBuilder, int graphId) {
         if (TornadoOptions.LOG_BYTECODES()) {
-            logBuilder.append("bc: ").append(InterpreterUtilities.debugHighLightBC(
-                    "EXECUTION_GRAPH_LAUNCH")).append(" graphId=").append(graphId).append("\n");
+            DebugInterpreter.logExecutionGraph(logBuilder, "EXECUTION_GRAPH_LAUNCH", graphId);
         }
         int event = interpreterDevice.launchExecutionGraph(
                 graphExecutionContext.getExecutionPlanId(),
@@ -761,7 +754,7 @@ public class TornadoVMInterpreter {
         return new ObjectAllocationInfo(persistentObjectsInArgs, objectsToAlloc);
     }
 
-    private int executeAlloc(StringBuilder logBuilder, int[] args, long sizeBatch) {
+    private int executeAlloc(BytecodeLog logBuilder, int[] args, long sizeBatch) {
         // Extract the counting and classification of objects into a separate method
         ObjectAllocationInfo allocationInfo = countAndClassifyObjects(args);
 
@@ -809,8 +802,7 @@ public class TornadoVMInterpreter {
             for (XPUDeviceBufferState state : objectStates) {
                 long size = state.getXPUBuffer().size();
                 if (!state.isBufferReused()) {
-                    logBuilder.append(captureIndent());
-                    DebugInterpreter.logAllocObject(objects[objIndex], interpreterDevice, size, sizeBatch, logBuilder);
+                    DebugInterpreter.logAllocObject(objects[objIndex], size, sizeBatch, logBuilder);
                 }
                 objIndex++;
             }
@@ -836,7 +828,7 @@ public class TornadoVMInterpreter {
         }
     }
 
-    private int executeDeAlloc(StringBuilder tornadoVMBytecodeList, final int objectIndex) {
+    private int executeDeAlloc(BytecodeLog tornadoVMBytecodeList, final int objectIndex) {
         Object object = objects.get(objectIndex);
 
         // Fast path for buffer reuse (the default): a locked buffer is never freed, so there is nothing
@@ -844,7 +836,7 @@ public class TornadoVMInterpreter {
         // of which are paid once per object per execution - dominant for plans made of many small graphs.
         if (resolveObjectState(objectIndex).isLockedBuffer()) {
             if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
-                DebugInterpreter.logDeallocObject(object, interpreterDevice, tornadoVMBytecodeList, false);
+                DebugInterpreter.logDeallocObject(object, tornadoVMBytecodeList, false);
             }
             return -1;
         }
@@ -863,31 +855,31 @@ public class TornadoVMInterpreter {
         // Update current device area use
         if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
             boolean materializeDealloc = spaceDeallocated != 0;
-            DebugInterpreter.logDeallocObject(object, interpreterDevice, tornadoVMBytecodeList, materializeDealloc);
+            DebugInterpreter.logDeallocObject(object, tornadoVMBytecodeList, materializeDealloc);
         }
         graphExecutionContext.setCurrentDeviceMemoryUsage(graphExecutionContext.getCurrentDeviceMemoryUsage() - spaceDeallocated);
         return -1;
     }
 
-    private int executeOnDevice(StringBuilder logBuilder, final int objectIndex, final int eventId) {
+    private int executeOnDevice(BytecodeLog logBuilder, final int objectIndex, final int eventId) {
         Object object = objects.get(objectIndex);
         if (TornadoOptions.LOG_BYTECODES()) {
-            DebugInterpreter.logOnDeviceObject(object, interpreterDevice, logBuilder);
+            DebugInterpreter.logOnDeviceObject(object, logBuilder);
         }
         resetEventIndexes(eventId);
         return -1;
     }
 
-    private int executePersist(StringBuilder logBuilder, final int objectIndex, final int eventId) {
+    private int executePersist(BytecodeLog logBuilder, final int objectIndex, final int eventId) {
         Object object = objects.get(objectIndex);
         if (TornadoOptions.PRINT_BYTECODES) {
-            DebugInterpreter.logPersistedObject(object, interpreterDevice, logBuilder);
+            DebugInterpreter.logPersistedObject(object, logBuilder);
         }
         resetEventIndexes(eventId);
         return -1;
     }
 
-    private int transferHostToDeviceOnce(StringBuilder logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
+    private int transferHostToDeviceOnce(BytecodeLog logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
         Object object = objects.get(objectIndex);
 
         if (isObjectKernelContext(object)) {
@@ -907,8 +899,7 @@ public class TornadoVMInterpreter {
 
         if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
             long sizeObject = objectState.getXPUBuffer().size();
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logTransferToDeviceOnce(allEvents, object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
+            DebugInterpreter.logTransferToDeviceOnce(allEvents, object, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
 
         if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && allEvents != null) {
@@ -932,7 +923,7 @@ public class TornadoVMInterpreter {
         return -1;
     }
 
-    private int transferHostToDeviceAlways(StringBuilder logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
+    private int transferHostToDeviceAlways(BytecodeLog logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
         Object object = objects.get(objectIndex);
 
         if (isObjectKernelContext(object)) {
@@ -946,8 +937,7 @@ public class TornadoVMInterpreter {
 
         if (TornadoOptions.LOG_BYTECODES() && isNotObjectAtomic(object)) {
             long sizeObject = objectState.getXPUBuffer().size();
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logTransferToDeviceAlways(object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
+            DebugInterpreter.logTransferToDeviceAlways(object, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
 
         if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && allEvents != null) {
@@ -973,7 +963,7 @@ public class TornadoVMInterpreter {
         return -1;
     }
 
-    private int transferDeviceToHost(StringBuilder logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
+    private int transferDeviceToHost(BytecodeLog logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
         Object object = objects.get(objectIndex);
 
         if (isObjectKernelContext(object)) {
@@ -983,8 +973,7 @@ public class TornadoVMInterpreter {
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
         if (TornadoOptions.LOG_BYTECODES()) {
             long sizeObject = objectState.getXPUBuffer().size();
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logTransferToHostAlways(object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
+            DebugInterpreter.logTransferToHostAlways(object, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
 
         int readEvent = interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList);
@@ -1007,7 +996,7 @@ public class TornadoVMInterpreter {
         return readEvent;
     }
 
-    private void transferDeviceToHostBlocking(StringBuilder logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
+    private void transferDeviceToHostBlocking(BytecodeLog logBuilder, final int objectIndex, final long offset, final int eventId, final long sizeBatch, final int[] eventWaitList) {
 
         Object object = objects.get(objectIndex);
 
@@ -1018,8 +1007,7 @@ public class TornadoVMInterpreter {
         final XPUDeviceBufferState objectState = resolveObjectState(objectIndex);
         if (TornadoOptions.LOG_BYTECODES()) {
             long sizeOfObject = objectState.getXPUBuffer().size();
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logTransferToHostAlwaysBlocking(object, interpreterDevice, logBuilder, sizeOfObject, sizeBatch, offset, eventId);
+            DebugInterpreter.logTransferToHostAlwaysBlocking(object, logBuilder, sizeOfObject, sizeBatch, offset, eventId);
         }
         final int readEvent = interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList);
 
@@ -1167,7 +1155,7 @@ public class TornadoVMInterpreter {
         }
     }
 
-    private int executeLaunch(StringBuilder logBuilder, final int numArgs, final int eventId, final int taskIndex, final long batchThreads, final long offset, XPUExecutionFrame executionFrame) {
+    private int executeLaunch(BytecodeLog logBuilder, final int numArgs, final int eventId, final int taskIndex, final long batchThreads, final long offset, XPUExecutionFrame executionFrame) {
 
         final SchedulableTask task = taskExecutionContexts.get(taskIndex);
 
@@ -1251,15 +1239,13 @@ public class TornadoVMInterpreter {
                 }
             }
             if (TornadoOptions.LOG_BYTECODES()) {
-                logBuilder.append(captureIndent());
-                DebugInterpreter.logStreamInAtomic(bufferAtomics, interpreterDevice, eventId, logBuilder);
+                DebugInterpreter.logStreamInAtomic(bufferAtomics, eventId, logBuilder);
 
             }
         }
 
         if (TornadoOptions.LOG_BYTECODES()) {
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logLaunchTask(task, interpreterDevice, batchThreads, offset, eventId, logBuilder);
+            DebugInterpreter.logLaunchTask(task, batchThreads, offset, eventId, logBuilder);
         }
 
         if (task.meta() instanceof TaskDataContext dataContext) {
@@ -1287,7 +1273,7 @@ public class TornadoVMInterpreter {
         }
     }
 
-    private int executeLibraryLaunch(StringBuilder logBuilder, LibraryTask task, final int numArgs, final int eventId, final long batchThreads, int[] waitList) {
+    private int executeLibraryLaunch(BytecodeLog logBuilder, LibraryTask task, final int numArgs, final int eventId, final long batchThreads, int[] waitList) {
 
         if (batchThreads != 0) {
             throw new TornadoRuntimeException("[ERROR] Batch processing is not supported for library tasks (task: " + task.getId() + ")");
@@ -1327,8 +1313,7 @@ public class TornadoVMInterpreter {
         final LibraryContext libraryContext = LibraryRegistry.getOrCreateContext(provider, interpreterDevice, graphExecutionContext.getExecutionPlanId());
 
         if (TornadoOptions.LOG_BYTECODES()) {
-            logBuilder.append(captureIndent());
-            DebugInterpreter.logLaunchTask(task, interpreterDevice, batchThreads, 0, eventId, logBuilder);
+            DebugInterpreter.logLaunchTask(task, batchThreads, 0, eventId, logBuilder);
         }
 
         // The CUDA-C backend does not expose device-event timestamps yet, so the
@@ -1387,7 +1372,7 @@ public class TornadoVMInterpreter {
      * @param lastEvent event ID of the most recently executed bytecode operation
      * @param eventId   dependency slot index into the {@code events} array
      */
-    private void executeDependency(StringBuilder logBuilder, int lastEvent, int eventId) {
+    private void executeDependency(BytecodeLog logBuilder, int lastEvent, int eventId) {
         if (useDependencies && lastEvent != -1) {
             if (TornadoOptions.LOG_BYTECODES()) {
                 DebugInterpreter.logAddDependency(lastEvent, eventId, logBuilder);
@@ -1399,9 +1384,9 @@ public class TornadoVMInterpreter {
         }
     }
 
-    private int executeBarrier(StringBuilder logBuilder, int eventId, int[] waitList) {
+    private int executeBarrier(BytecodeLog logBuilder, int eventId, int[] waitList) {
         if (TornadoOptions.LOG_BYTECODES()) {
-            DebugInterpreter.logBarrier(eventId, logBuilder);
+            DebugInterpreter.logBarrier(eventId, waitList, logBuilder);
         }
 
         int lastEvent;
@@ -1488,10 +1473,6 @@ public class TornadoVMInterpreter {
 
     public Event execute() {
         return execute(false);
-    }
-
-    private String captureIndent() {
-        return insideCaptureRegion ? "\t" : "";
     }
 
     public void clearInstalledCode() {


### PR DESCRIPTION
## Problem

`--printBytecodes` is the only window into what the interpreter actually does, and it is the tool I
leaned on for the `persistOnDevice`/`consumeFromDevice` aliasing fix (#996), the silent bytecode-buffer
overflow (#1004) and the wait-event matrix rework (#1002). The format makes that work harder than it
needs to be. From a real 2-frame KFusion dump (288 `bc:` lines):

| Defect | Evidence |
|---|---|
| The device is repeated on **every** line, ~50 of ~130 characters, identical on all 288 | `on   [NVIDIA CUDA] -- NVIDIA GeForce RTX 4090 ,` |
| No graph name, execution index or bytecode index | nothing says which task-graph or which frame a line belongs to |
| Three different object identities | `[Object Hash Code=0x28276e50]`, `[0x55787112]`, and none at all on `ALLOC` |
| Two different type namings | `ImageFloat <320 x 240>` vs `uk.ac.manchester.tornado.api.types.arrays.FloatArray@3efe7086` |
| Raw bytes and raw event ids | `size=1228856`, `[event list=0]` |
| Console output always ANSI-coloured | every captured dump needs `sed 's/\x1b\[[0-9;]*m//g'` |
| No totals | no way to see "this execution moved 4.2 MiB and launched 10 kernels" |

The cause is structural: each of the 12 `DebugInterpreter` methods hand-builds a finished, coloured
`String.format`, so there is no representation of a bytecode event that can be aggregated, re-rendered
or exported.

## What this PR does

**1. The flag becomes a verbosity, not a boolean.** `-Dtornado.print.bytecodes` /
`--printBytecodes` now take `false | compact | full | trace | dot` (`true` keeps working and means
`full`). Plus `-Dtornado.print.bytecodes.color=auto|always|never`, defaulting to `auto`, so redirected
output is clean without `sed`.

**2. Data separated from presentation.** `BytecodeLogEntry` records the facts of one bytecode;
`BytecodeRenderer` formats it at the requested verbosity; `BytecodeLog` owns the per-execution header,
device registry and summary. `DebugInterpreter` now only collects facts. The device is declared once in
the header as `D0` instead of being repeated per line, which is where most of the width went.

**3. A Graphviz export** (`=dot`) writes `tornado-bytecodes.dot` into `tornado.dump.bytecodes.dir`.
Tasks are clustered per task-graph and buffers are global nodes, so a buffer that two task-graphs share
— the persist/consume relationship the text log cannot show — appears as one node with edges crossing
the cluster boundary.

`compact`, KFusion:

```
== graph 'preproc' | exec #1 | D0=[NVIDIA CUDA] -- NVIDIA GeForce RTX 4090 | thread main
   0 ALLOC       ImageFloat<320x240>@545de5a4            300.1 KiB
   2 H2D_ONCE    ImageFloat<320x240>@545de5a4            300.1 KiB [Transferred]
  12 ALLOC       MatrixFloat<4x4>@30ea8c23                    96 B
  20 LAUNCH      task preproc.mm2meters - mm2metersKernel           ev0
== END   graph 'preproc' | exec #1 | 15 alloc | 0 dealloc | 10 launch | h2d 15/15 (4.2 MiB) | d2h 0 (0 B) | 7 persist | 8 skipped
```

The summary is the part I did not expect to matter most. On KFusion frame 2 it reads
`h2d 0/14 (0 B)`: fourteen `TRANSFER_HOST_TO_DEVICE_ONCE` bytecodes, none of which transfer anything —
steady state confirmed in one line instead of by reading 40.

## Verification

- `make BACKEND=opencl,cuda` green; `./mvnw checkstyle:check` clean.
- **Opcode stream unchanged.** `TestBatches` with `=True`: 764 bytecodes before, 734 after, and
  `diff` of the opcode streams is empty once the 30 `END` lines (now the summary line) are excluded.
- **`tornado-test --quickPass`: 1033 run / 236 failed on this branch vs 1033 / 237 on `develop`**,
  measured back to back on the same machine. The one difference is the known-flaky
  `branching.TestLoopConditions`.
- CUDA-priority sweep (`-Dtornado.cuda.priority=10 -Dtornado.opencl.priority=1`) on
  `TestCUDAStreams`, `TestStreamsPerformance`, `TestConcurrentBackends`,
  `TestMultipleTasksMultipleDevices`: all pass. This is the multi-stream path where
  `useDependencies == true`, i.e. the one my #1002 regression hid in.
- **Overhead when disabled:** every log call site is still behind the existing
  `TornadoOptions.LOG_BYTECODES()` guard and `logBuilder` stays `null`, so no entry is allocated.
  GPULlama3 (3B-Q8, RTX 4090) with the log off: 100.2 and 93.5 tok/s, the same range as `develop`.
  With `=compact` it drops to 85.9 tok/s, as expected for a debug path.
- Dumps collected from the complex cases and posted as separate comments below: KFusion
  (persist/consume + CUDA-graph capture), GPULlama3 (743 graph executions), a cuBLAS hybrid
  `libraryTask`, `withIntraPlanConcurrency` multi-stream at `trace`, batched execution, and the DOT
  graph.

## Known follow-up, deliberately not in this PR

[TornadoViz](https://github.com/beehive-lab/tornadoviz) parses the log textually
(`bc:\s+(\w+)`, `size=(\d+), batchSize=(\d+)`, `[Status: ...]`, `event-list (\d+)`, and the
`Interpreter instance running bytecodes for:` section header). The new formats break those regexes, so
TornadoViz needs a matching update — or, if you prefer, I can add a `legacy` mode that reproduces the
old text byte-for-byte and map `true` to it, leaving the readable formats fully opt-in. I built that
variant and dropped it; say which way you want it and I will land it.


---

## Rebased onto `develop` (2026-08-27)

Rebased from `b65c2053f` onto `abf2b53ad`. Two things had landed in exactly the code this PR rewrites:

- **The interpreter dispatch refactor.** `execute()`'s 24-arm `if`/`else` chain became a `switch` over
  the opcode enum with one handler method per bytecode. This PR's logging changes were spread across
  those arms, so they were re-applied onto the new handlers rather than re-scattered: `StringBuilder`
  becomes `BytecodeLog` throughout, the inline `append` chains become `DebugInterpreter` calls, and
  `captureIndent()` is gone in favour of `BytecodeLog.setIndent` around the capture region.
- **#1036 (`TornadoExecutionPlan.transferToDevice()`).** A plan can now walk its bytecode for the data
  transfers only, which the log had no vocabulary for. See below.

All five original commits are preserved; the four changes below are new on top.

### 1. A transfers-only pass is now legible

`transferToDevice()` walks the bytecode performing only the copy-ins. Before, that rendered as an
execution that mysteriously ran no kernels and skipped nothing:

```
== END   graph 'copyInThenRun' | exec #1 | 3 alloc | 3 dealloc | 0 launch | h2d 2/2 (64.0 KiB) | d2h 0 (0 B) | 0 persist | 0 skipped
```

The LAUNCH and copy-out bytecodes *were* skipped, but they are bypassed before reaching a handler, so
nothing counted them. Now the pass says what it is, and the count is honest:

```
== graph 'copyInThenRun' | exec #1 | D0=... | thread main | transfers-only (no task runs)
...
== END   graph 'copyInThenRun' | exec #1 | 3 alloc | 3 dealloc | 0 launch | h2d 2/2 (64.0 KiB) | d2h 0 (0 B) | 0 persist | 2 skipped | transfers-only
```

`trace` lists the bypassed bytecodes in place:

```
   5 LAUNCH                                  transfers-only pass
   6 TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING transfers-only pass
```

This also makes the log a direct check on #1036: `h2d 2/2` on the upload pass and `h2d 1/2` on the
execution after it is the `FIRST_EXECUTION` object being placed by the call and not re-sent.

### 2. Skipped allocations were invisible

A `DEALLOC` skipped because an execution graph still owns the buffer was logged. The matching `ALLOC`
was not — it returned early with no entry and no count. On a replayed CUDA graph the summary claimed
`3 skipped` when six bytecodes had been skipped. `DebugInterpreter.logAllocSkipped` makes the pair
symmetric, and the replay now reports `6 skipped`. A bytecode that silently does nothing is precisely
what this PR exists to stop.

### 3. `tornado-test` gained the verbosity argument — and both CLIs had a live bug

`tornado-test` still hardcoded `-Dtornado.print.bytecodes=True`, so the modes were unreachable without
`-J`. Giving it the same optional argument as `tornado` surfaced a real defect in **both** scripts:
argparse's `nargs='?'` consumes whatever follows the flag, so

```
tornado-test --printBytecodes uk.ac.manchester.tornado.unittests.arrays.TestArrays#testAdd
```

read the test class as the verbosity and ran **the entire suite** instead of one class. The value is
now made explicit before argparse sees it, so the bare flag, `-pbc compact`, `--printBytecodes=trace`
and a following positional all behave. Every previously valid invocation keeps working.

### 4. Dead constructor removed

The `BytecodeLog` constructor overload left behind by change 1 had no callers and is gone.

### Verification after the rebase

- `make BACKEND=cuda` and `make BACKEND=opencl` green; `./mvnw checkstyle:check` clean.
- All four modes exercised end to end on CUDA: `compact`, `full`, `trace` render, and `dot` writes
  valid Graphviz (it writes `tornado-bytecodes.dot` rather than printing, which is easy to mistake for
  "no output").
- Capture/replay logging still nests correctly under CUDA graphs — `GRAPH_CAP{ … }` indented, then
  `GRAPH_RUN` per replay.
- All four CLI forms verified, including the one that previously ran the whole suite.
- **Full suite (`tornado-test`, all 170 classes) on CUDA: 11 failures across 6 classes**, identical to
  the `develop` baseline measured on this machine — `TestReductionsFloats` (1), 
  `TestMatrixMultiplicationKernelContext` (2), `TestProfiler` (3), `ComputeTests` (2),
  `TransformerKernelsTest` (1), `TestDevices` (2). None are in the logging path.
- One caveat recorded honestly: a first full run also showed `api.TestIO` failing 1/4. It passes 5/5
  standalone and 4/4 in a second full run at the same position in the same build, so it is flaky here
  (`TestMemoryLimit` stresses device memory immediately before it), not a regression from this PR. I
  have not fixed it and am not claiming otherwise.
