### PR TITLE
Feat/cuda vector8

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/asm/CUDAAssembler.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/asm/CUDAAssembler.java
@@ -1275,13 +1275,16 @@ public final class CUDAAssembler extends Assembler {
     public static class CUDAOp8 extends CUDAOp4 {
         // @formatter:off
 
-        public static final CUDAOp8 VMOV_SHORT8 = new CUDAOp8("(short8)");
-        public static final CUDAOp8 VMOV_INT8 = new CUDAOp8("(int8)");
-        public static final CUDAOp8 VMOV_FLOAT8 = new CUDAOp8("(float8)");
-        public static final CUDAOp8 VMOV_BYTE8 = new CUDAOp8("(char8)");
-        public static final CUDAOp8 VMOV_DOUBLE8 = new CUDAOp8("(double8)");
+        // CUDA has no built-in width-8 vector type; these name the make_<type>8(...)
+        // constructor functions CUDAPreamble defines for the custom struct types
+        // (mirroring the real CUDA-provided make_<type>N for widths 2/3/4).
+        public static final CUDAOp8 VMOV_SHORT8 = new CUDAOp8("make_short8");
+        public static final CUDAOp8 VMOV_INT8 = new CUDAOp8("make_int8");
+        public static final CUDAOp8 VMOV_FLOAT8 = new CUDAOp8("make_float8");
+        public static final CUDAOp8 VMOV_BYTE8 = new CUDAOp8("make_char8");
+        public static final CUDAOp8 VMOV_DOUBLE8 = new CUDAOp8("make_double8");
 
-        public static final CUDAOp8 VMOV_HALF8 = new CUDAOp8("(half8)");
+        public static final CUDAOp8 VMOV_HALF8 = new CUDAOp8("make_half8");
 
         // @formatter:on
 
@@ -1290,7 +1293,25 @@ public final class CUDAAssembler extends Assembler {
         }
 
         public void emit(CUDACompilationResultBuilder crb, Value s0, Value s1, Value s2, Value s3, Value s4, Value s5, Value s6, Value s7) {
-            throw new uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException("CUDA backend does not support width-8 vector types.");
+            final CUDAAssembler asm = crb.getAssembler();
+            emitOpcode(asm);
+            asm.emit("(");
+            asm.emitValue(crb, s0);
+            asm.emit(", ");
+            asm.emitValue(crb, s1);
+            asm.emit(", ");
+            asm.emitValue(crb, s2);
+            asm.emit(", ");
+            asm.emitValue(crb, s3);
+            asm.emit(", ");
+            asm.emitValue(crb, s4);
+            asm.emit(", ");
+            asm.emitValue(crb, s5);
+            asm.emit(", ");
+            asm.emitValue(crb, s6);
+            asm.emit(", ");
+            asm.emitValue(crb, s7);
+            asm.emit(")");
         }
     }
 

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDAPreamble.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/backend/CUDAPreamble.java
@@ -23,6 +23,9 @@
  */
 package uk.ac.manchester.tornado.drivers.cuda.graal.backend;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * CUDA C preamble prepended to compiled kernels that need it.
  *
@@ -60,5 +63,59 @@ public final class CUDAPreamble {
      */
     public static final String FP8_PREAMBLE =
         "#include <cuda_fp8.h>\n";
+    // @formatter:on
+
+    /**
+     * Struct + {@code make_<type>8(...)} constructor definitions for the width-8
+     * vector kinds. CUDA has no built-in vector type wider than 4 lanes (unlike
+     * OpenCL, which natively supports width 8/16), so {@link
+     * uk.ac.manchester.tornado.drivers.cuda.graal.lir.CUDAKind#getCUDATypeName()}
+     * maps width-8 kinds to one of these instead. Fields are named {@code s0..s7}
+     * to match the lane names TornadoVM's CUDA codegen already emits for width-8
+     * component access/store (mirroring OpenCL's {@code .sN} swizzle and the
+     * {@code getS0()..getS7()} accessors on the Java-side vector types).
+     *
+     * <p>Each entry is only prepended when the generated kernel source actually
+     * references that struct name, with the same source-scan gating as PREAMBLE /
+     * FP8_PREAMBLE (see {@code CUDACompilationResultBuilder#finish}). The struct
+     * itself never needs a specific memory alignment: TornadoVM's CUDA backend
+     * never reinterpret-casts a pointer to a vector struct type (that would fault
+     * on element-aligned buffers - see the alignment comments on
+     * {@code CUDALIRStmt.VectorLoadStmt}/{@code VectorStoreStmt}); it only ever
+     * appears as a register-resident value built and torn down componentwise.
+     */
+    // @formatter:off
+    public static final Map<String, String> WIDTH8_PREAMBLES = buildWidth8Preambles();
+
+    private static Map<String, String> buildWidth8Preambles() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("short8", struct8("short8", "short", "make_short8"));
+        map.put("int8", struct8("int8", "int", "make_int8"));
+        map.put("float8", struct8("float8", "float", "make_float8"));
+        map.put("char8", struct8("char8", "char", "make_char8"));
+        map.put("double8", struct8("double8", "double", "make_double8"));
+        // __half8 depends on the __half type from cuda_fp16.h (PREAMBLE), which
+        // CUDACompilationResultBuilder#finish is ordered to inject first. Constructor
+        // is "make_half8" (not "make___half8") to match the existing make_half2/
+        // make_half4 naming convention used for the other half-vector widths.
+        map.put("__half8", struct8("__half8", "__half", "make_half8"));
+        return map;
+    }
+
+    private static String struct8(String structName, String elementType, String ctorName) {
+        StringBuilder params = new StringBuilder();
+        StringBuilder assigns = new StringBuilder();
+        for (int i = 0; i < 8; i++) {
+            if (i > 0) {
+                params.append(", ");
+            }
+            params.append(elementType).append(" s").append(i);
+            assigns.append("r.s").append(i).append("=s").append(i).append(";");
+        }
+        return "struct " + structName + " { " + elementType + " s0,s1,s2,s3,s4,s5,s6,s7; };\n"
+                + "static __device__ __forceinline__ " + structName + " " + ctorName + "(" + params + ") {\n"
+                + "    " + structName + " r; " + assigns + " return r;\n"
+                + "}\n";
+    }
     // @formatter:on
 }

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/CUDACompilationResultBuilder.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/CUDACompilationResultBuilder.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.graalvm.collections.EconomicMap;
@@ -250,6 +251,18 @@ public class CUDACompilationResultBuilder extends CompilationResultBuilder {
         // every spelling (__half, half2 vectors, __float2half / __half2float). See
         // CUDAPreamble for why the header is not emitted unconditionally.
         String source = new String(code);
+        // Width-8 vector structs (float8, int8, ...): CUDA has no built-in vector type
+        // wider than 4 lanes, so CUDAKind#getCUDATypeName() maps these to a custom
+        // struct + make_<type>8(...) constructor that must be declared before first
+        // use. Prepended first (before the fp8/fp16 checks below) so that, in the
+        // final source, it lands AFTER the fp16 include - __half8 depends on the
+        // __half type cuda_fp16.h defines.
+        for (Map.Entry<String, String> entry : CUDAPreamble.WIDTH8_PREAMBLES.entrySet()) {
+            String structName = entry.getKey();
+            if (containsIdentifier(source, structName) && !source.contains("struct " + structName)) {
+                source = entry.getValue() + source;
+            }
+        }
         // cuda_fp8.h before the fp16 check: the fp8 include is emitted together with the
         // fp16 one (its conversions produce __half values), and both prepends keep the
         // fp16 include first because cuda_fp8.h builds on cuda_fp16.h types.
@@ -262,6 +275,32 @@ public class CUDACompilationResultBuilder extends CompilationResultBuilder {
         code = source.getBytes();
 
         compilationResult.setTargetCode(code, code.length);
+    }
+
+    /**
+     * Whether {@code source} references {@code identifier} as a whole word, not as
+     * a substring of a longer identifier (e.g. {@code "int8"} must not match inside
+     * {@code "uint8"} or {@code "point8"}).
+     */
+    private static boolean containsIdentifier(String source, String identifier) {
+        int from = 0;
+        while (true) {
+            int idx = source.indexOf(identifier, from);
+            if (idx < 0) {
+                return false;
+            }
+            boolean boundaryBefore = idx == 0 || !isIdentifierChar(source.charAt(idx - 1));
+            int afterIdx = idx + identifier.length();
+            boolean boundaryAfter = afterIdx >= source.length() || !isIdentifierChar(source.charAt(afterIdx));
+            if (boundaryBefore && boundaryAfter) {
+                return true;
+            }
+            from = idx + 1;
+        }
+    }
+
+    private static boolean isIdentifierChar(char c) {
+        return Character.isLetterOrDigit(c) || c == '_';
     }
 
     void emitLoopBlock(HIRBlock block) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDABinary.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDABinary.java
@@ -79,8 +79,9 @@ public class CUDABinary {
 
         // CUDA built-in vector types (float2/3/4, int2/3/4, ...) have NO overloaded
         // arithmetic operators, so vector add/sub/mul/div must be emitted
-        // componentwise via the make_<type>N(...) constructor.
-        private static final String[] COMPONENTS = { "x", "y", "z", "w" };
+        // componentwise via the make_<type>N(...) constructor. Width 8 uses the
+        // custom struct types from CUDAPreamble the same way - see
+        // CUDAKind#vectorComponentName for the .x/.y/.z/.w vs .s0..s7 naming split.
 
         public Expr(CUDABinaryOp opcode, LIRKind lirKind, Value x, Value y) {
             super(opcode, lirKind, x, y);
@@ -97,7 +98,7 @@ public class CUDABinary {
             }
 
             int length = resultKind.getVectorLength();
-            if (length < 2 || length > 4) {
+            if (length < 2 || (length > 4 && length != 8)) {
                 throw new uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException(
                         "CUDA backend does not support arithmetic on vector width " + length + ".");
             }
@@ -133,12 +134,12 @@ public class CUDABinary {
             }
 
             StringBuilder sb = new StringBuilder();
-            sb.append("make_").append(resultKind.getElementKind().toString()).append(length).append("(");
+            sb.append(CUDAKind.makeConstructorName(resultKind.getElementKind(), length)).append("(");
             for (int i = 0; i < length; i++) {
                 if (i > 0) {
                     sb.append(", ");
                 }
-                String c = COMPONENTS[i];
+                String c = CUDAKind.vectorComponentName(i, length);
                 String xc = xIsVector ? ("(" + xs + ")." + c) : ("(" + xs + ")");
                 String yc = yIsVector ? ("(" + ys + ")." + c) : ("(" + ys + ")");
                 sb.append(xc).append(" ").append(op).append(" ").append(yc);

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAKind.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAKind.java
@@ -526,9 +526,12 @@ public enum CUDAKind implements PlatformKind {
      *
      * <p>Scalars map to the native unsigned/signed types. Vectors of width 2/3/4
      * map to the CUDA built-in vector types ({@code float4}, {@code int2}, ...).
-     * Vector widths 8 and 16 have no CUDA built-in equivalent and are rejected
-     * with a bailout, so unsupported kernels fail honestly rather than emitting
-     * invalid code.
+     * CUDA has no built-in vector type wider than 4 lanes, so width 8 maps to a
+     * custom struct ({@code float8}, {@code __half8}, ...) defined by
+     * {@link uk.ac.manchester.tornado.drivers.cuda.graal.backend.CUDAPreamble}
+     * and conditionally injected by {@code CUDACompilationResultBuilder#finish}.
+     * Width 16 has no such struct yet and is rejected with a bailout, so
+     * unsupported kernels fail honestly rather than emitting invalid code.
      */
     public String getCUDATypeName() {
         if (!isVector()) {
@@ -537,17 +540,18 @@ public enum CUDAKind implements PlatformKind {
         int len = getVectorLength();
         CUDAKind element = getElementKind();
         if (element == HALF) {
-            // cuda_fp16.h provides only __half2; report wider half vectors as an FP16
-            // device limitation (unsupported) rather than a hard compiler bailout.
-            if (len == 2) {
-                return "__half2";
+            // cuda_fp16.h provides only __half2 as a built-in; __half8 is the custom
+            // struct + make_half8(...) constructor defined in CUDAPreamble.
+            if (len != 2 && len != 8) {
+                throw new uk.ac.manchester.tornado.api.exceptions.TornadoDeviceFP16NotSupported(
+                        "CUDA backend does not support half-precision vector type " + name() + "; only __half2 and __half8 are available.");
             }
-            throw new uk.ac.manchester.tornado.api.exceptions.TornadoDeviceFP16NotSupported(
-                    "CUDA backend does not support half-precision vector type " + name() + "; only __half2 is available.");
+            return (len == 2) ? "__half2" : "__half8";
         }
-        if (len != 2 && len != 3 && len != 4) {
+        boolean width8Supported = len == 8 && (element == SHORT || element == INT || element == FLOAT || element == CHAR || element == DOUBLE);
+        if (len != 2 && len != 3 && len != 4 && !width8Supported) {
             throw new uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException(
-                    "CUDA backend does not support vector width " + len + " (kind " + name() + "); only widths 2, 3 and 4 are supported.");
+                    "CUDA backend does not support vector width " + len + " (kind " + name() + "); only widths 2, 3, 4 and 8 (short/int/float/char/double/half element) are supported.");
         }
         return element.toString() + len;
     }
@@ -602,6 +606,39 @@ public enum CUDAKind implements PlatformKind {
 
     public boolean isVector() {
         return vectorLength > 1;
+    }
+
+    private static final String[] NATIVE_COMPONENTS = { "x", "y", "z", "w" };
+
+    /**
+     * Name of lane {@code lane} of a {@code vectorLength}-wide vector in generated
+     * CUDA C. Widths 2-4 use CUDA's built-in {@code .x/.y/.z/.w} vector fields;
+     * width 8 uses the {@code .s0..s7} fields of the custom struct types defined by
+     * {@link uk.ac.manchester.tornado.drivers.cuda.graal.backend.CUDAPreamble}
+     * (mirroring OpenCL's {@code .sN} swizzle, since CUDA has no built-in vector
+     * type wider than 4 lanes). Shared by every width-8-aware emission site
+     * (component load/store, componentwise arithmetic) so they agree on naming.
+     */
+    public static String vectorComponentName(int lane, int vectorLength) {
+        if (vectorLength <= 4) {
+            return NATIVE_COMPONENTS[lane];
+        }
+        return "s" + lane;
+    }
+
+    /**
+     * Name of the {@code make_<elementName><length>(...)} constructor function for
+     * a vector of this element kind and length (e.g. {@code make_float8},
+     * {@code make_half2}). {@link CUDAKind#toString()} renders the HALF element
+     * kind as {@code "__half"} (the real CUDA scalar type name), but the
+     * constructor naming convention already established for width 2-4
+     * ({@code make_half2}, {@code make_half4} in {@link CUDAAssembler.CUDAOp2}) -
+     * and matched by width 8's {@code make_half8} in {@link CUDAAssembler.CUDAOp8}
+     * - uses the single-underscore "half", so that substitution is applied here too.
+     */
+    public static String makeConstructorName(CUDAKind elementKind, int length) {
+        String elementName = (elementKind == HALF) ? "half" : elementKind.toString();
+        return "make_" + elementName + length;
     }
 
     public boolean isPrimitive() {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDALIRStmt.java
@@ -1195,7 +1195,7 @@ public class CUDALIRStmt {
                 return;
             }
             StringBuilder sb = new StringBuilder();
-            sb.append("make_").append(elem).append(n).append("(");
+            sb.append(CUDAKind.makeConstructorName(vectorKind.getElementKind(), n)).append("(");
             for (int i = 0; i < n; i++) {
                 if (i > 0) {
                     sb.append(", ");
@@ -1790,8 +1790,6 @@ public class CUDALIRStmt {
             this.index = index;
         }
 
-        private static final String[] COMPONENTS = { "x", "y", "z", "w" };
-
         @Override
         public void emitCode(CUDACompilationResultBuilder crb, CUDAAssembler asm) {
             // OpenCL vstoreN(v, i, p) stores N (unaligned) elements at p[i*N]. As with
@@ -1836,7 +1834,7 @@ public class CUDALIRStmt {
                 asm.space();
                 asm.assign();
                 asm.space();
-                asm.emit(String.format("(%s).%s", v, COMPONENTS[i]));
+                asm.emit(String.format("(%s).%s", v, CUDAKind.vectorComponentName(i, n)));
                 asm.delimiter();
                 asm.eol();
             }

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAVectorElementSelect.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/lir/CUDAVectorElementSelect.java
@@ -68,18 +68,20 @@ public class CUDAVectorElementSelect extends CUDALIROp {
         }
     }
 
-    // CUDA built-in vector types expose components as .x/.y/.z/.w (width <= 4).
-    private static final String[] CUDA_COMPONENTS = { "x", "y", "z", "w" };
-
     @Override
     public void emit(CUDACompilationResultBuilder crb, CUDAAssembler asm) {
         asm.emitValueOrOp(crb, vector);
         int idx = Integer.parseInt(CUDAAssembler.getAbsoluteIndexFromValue(selection));
-        if (idx < 0 || idx > 3) {
+        // The lane index alone doesn't say whether this vector uses CUDA's built-in
+        // .x/.y/.z/.w fields (width <= 4) or the custom struct's .s0..s7 fields
+        // (width 8, from CUDAPreamble) - both are indexed 0-3 for their first four
+        // lanes, so the vector's own width decides which naming applies.
+        int vectorLength = (vector.getPlatformKind() instanceof CUDAKind) ? ((CUDAKind) vector.getPlatformKind()).getVectorLength() : -1;
+        if (vectorLength <= 0 || (vectorLength > 4 && vectorLength != 8) || idx < 0 || idx >= vectorLength) {
             throw new uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException(
-                    "CUDA backend supports vector component access only for widths 2-4 (index " + idx + ").");
+                    "CUDA backend supports vector component access only for widths 2-4 and 8 (index " + idx + ", vector width " + vectorLength + ").");
         }
-        asm.emitSymbol("." + CUDA_COMPONENTS[idx]);
+        asm.emitSymbol("." + CUDAKind.vectorComponentName(idx, vectorLength));
     }
 
     @Override

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestDoubles.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestDoubles.java
@@ -291,7 +291,6 @@ public class TestDoubles extends TornadoTestBase {
 
     @Test
     public void testDoubleAdd8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 1;
         Double8 a = new Double8(1., 2., 3., 4., 5., 6., 7., 8.);
         Double8 b = new Double8(8., 7., 6., 5., 4., 3., 2., 1.);
@@ -471,7 +470,6 @@ public class TestDoubles extends TornadoTestBase {
 
     @Test
     public void testVectorDouble8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 64;
 
         VectorDouble8 a = new VectorDouble8(size);
@@ -586,7 +584,6 @@ public class TestDoubles extends TornadoTestBase {
 
     @Test
     public void privateVectorDouble8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 16;
         VectorDouble8 sequentialOutput = new VectorDouble8(16);
         VectorDouble8 tornadoOutput = new VectorDouble8(16);
@@ -717,7 +714,6 @@ public class TestDoubles extends TornadoTestBase {
 
     @Test
     public void testInternalSetMethod04() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         final int size = 16;
         VectorDouble8 tornadoInput = new VectorDouble8(size);
         VectorDouble8 sequentialInput = new VectorDouble8(size);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestFloats.java
@@ -395,7 +395,6 @@ public class TestFloats extends TornadoTestBase {
 
     @Test
     public void testSimpleDotProductFloat8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         Float8 a = new Float8(1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f);
         Float8 b = new Float8(8f, 7f, 6f, 5f, 4f, 3f, 2f, 1f);
         VectorFloat output = new VectorFloat(1);
@@ -681,7 +680,6 @@ public class TestFloats extends TornadoTestBase {
 
     @Test
     public void testVectorFloat8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 8;
 
         VectorFloat8 a = new VectorFloat8(size);
@@ -718,7 +716,6 @@ public class TestFloats extends TornadoTestBase {
 
     @Test
     public void testVectorFloat8_Storage() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 8;
 
         VectorFloat8 a = new VectorFloat8(size);
@@ -862,7 +859,6 @@ public class TestFloats extends TornadoTestBase {
 
     @Test
     public void privateVectorFloat8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 16;
         VectorFloat8 sequentialOutput = new VectorFloat8(16);
         VectorFloat8 tornadoOutput = new VectorFloat8(16);
@@ -1018,7 +1014,6 @@ public class TestFloats extends TornadoTestBase {
 
     @Test
     public void testInternalSetMethod04() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         final int size = 16;
         VectorFloat8 tornadoInput = new VectorFloat8(size);
         VectorFloat8 sequentialInput = new VectorFloat8(size);
@@ -1161,7 +1156,6 @@ public class TestFloats extends TornadoTestBase {
 
     @Test
     public void testVectorFloat8Int8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 8192;
         VectorFloat8 a = new VectorFloat8(size);
         VectorInt8 b = new VectorInt8(size);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestInts.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/vectortypes/TestInts.java
@@ -316,7 +316,6 @@ public class TestInts extends TornadoTestBase {
 
     @Test
     public void testAddInt8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 1;
         Int8 a = new Int8(1, 2, 3, 4, 1, 2, 3, 4);
         Int8 b = new Int8(4, 3, 2, 1, 1, 2, 3, 4);
@@ -706,7 +705,6 @@ public class TestInts extends TornadoTestBase {
 
     @Test
     public void testVectorAddInt8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 256;
 
         VectorInt8 a = new VectorInt8(size);
@@ -790,7 +788,6 @@ public class TestInts extends TornadoTestBase {
 
     @Test
     public void testVectorSubInt8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 256;
 
         VectorInt8 a = new VectorInt8(size);
@@ -827,7 +824,6 @@ public class TestInts extends TornadoTestBase {
 
     @Test
     public void testVectorDivInt8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 256;
 
         VectorInt8 a = new VectorInt8(size);
@@ -912,7 +908,6 @@ public class TestInts extends TornadoTestBase {
 
     @Test
     public void privateVectorInt8() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         int size = 16;
         VectorInt8 sequentialOutput = new VectorInt8(16);
         VectorInt8 tornadoOutput = new VectorInt8(16);
@@ -1046,7 +1041,6 @@ public class TestInts extends TornadoTestBase {
 
     @Test
     public void testInternalSetMethod04() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.CUDA);
         final int size = 16;
         VectorInt8 tornadoInput = new VectorInt8(size);
         VectorInt8 sequentialInput = new VectorInt8(size);


### PR DESCRIPTION
# Add CUDA backend support for width-8 vector types

#### Description

Adds CUDA backend support for width-8 vector types (`Float8`, `Int8`, `Double8`, `Half8`, `Short8`, `Char8`, and the `Image`/`Vector` collection kinds built on them).

CUDA has no built-in vector type wider than 4 lanes (unlike OpenCL, which natively supports width 8/16), so `CUDAKind#getCUDATypeName()` bailed out for width 8 with `TornadoBailoutRuntimeException: CUDA backend does not support vector width 8`, and four other codegen sites made the same width <= 4 assumption. This PR:

- Defines a custom `struct <type>8 { <type> s0..s7; }` + `make_<type>8(...)` constructor per element kind (short/int/float/char/double/half), injected into the kernel preamble the same way the existing fp16/fp8 headers are gated (source-text scan in `CUDACompilationResultBuilder#finish`).
- Fixes `CUDAAssembler.CUDAOp8`'s `VMOV_*` opcode strings, which held leftover OpenCL-cast-syntax (`"(float8)"`) from an incomplete port instead of the real `make_float8` constructor name, and implements its previously-throwing `emit(...)` override.
- Extends the remaining width <= 4 assumptions to width 8: type declarations (`CUDAKind#getCUDATypeName`), componentwise load/store (`CUDALIRStmt.VectorLoadStmt`/`VectorStoreStmt`), componentwise arithmetic (`CUDABinary.Expr`), and scalar lane access (`CUDAVectorElementSelect`, which now checks the vector's actual width to choose `.x/.y/.z/.w` vs `.s0-.s7` rather than assuming from the lane index alone).
- Adds a shared `CUDAKind.vectorComponentName(lane, width)` / `CUDAKind.makeConstructorName(elementKind, width)` helper pair so all of the above agree on naming (notably handling the `HALF` element kind, whose scalar type name `__half` doesn't match its constructor name `make_half8`).
- Un-skips the width-8 vector unit tests in `TestFloats`, `TestInts`, and `TestDoubles` (previously guarded with `assertNotBackend(CUDA)` since CUDA didn't support width 8 yet). Width-16 guards are left in place - that width is still unsupported (no struct defined for it).

This is a codegen-only change: width-8 vectors are always loaded/stored componentwise through the element pointer (never a raw struct reinterpret-cast), so no changes were needed to memory layout, buffer allocation, or host<->device marshalling.

#### Problem description

[kfusion-tornadovm](https://github.com/beehive-lab/kfusion-tornadovm)'s ICP tracking kernel packs 8 floats per pixel into an `ImageFloat8`/`Float8` (correspondence normal + residual + error + result code), used purely for scalar `getS0()..getS7()` access - no actual 8-wide vector math. On the CUDA backend this failed outright:

```
Exception in thread "main" uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException:
Unable to compile task icp0.track0 - trackPose
The internal error is: [Error during the Task Compilation]: CUDA backend does not support
vector width 8 (kind FLOAT8); only widths 2, 3 and 4 are supported.
```

To reproduce (pre-fix), on any CUDA device:

```bash
cd kfusion-tornadovm
source source.env
source <tornadovm-cuda-sdk>/setvars.sh
./scripts/run.sh cuda
```

#### Backend/s tested

- [ ] OpenCL
- [x] CUDA
- [ ] Metal

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?

1. Build the CUDA backend:
   ```bash
   make BACKEND=cuda
   ```
2. Run the width-8 vector unit tests (previously `[CUDA CONFIGURATION UNSUPPORTED]`, now `[PASS]`):
   ```bash
   source setvars.sh
   tornado-test --ea -V uk.ac.manchester.tornado.unittests.vectortypes.TestFloats
   tornado-test --ea -V uk.ac.manchester.tornado.unittests.vectortypes.TestInts
   tornado-test --ea -V uk.ac.manchester.tornado.unittests.vectortypes.TestDoubles
   tornado-test --ea -V uk.ac.manchester.tornado.unittests.vectortypes.TestHalfFloats
   ```
   All four suites pass with 0 failures (width-16 tests remain correctly reported as `CUDA CONFIGURATION UNSUPPORTED`; a handful of pre-existing, unrelated `Half3`/`Half4`/`Half16` FP16 gaps are unaffected by this change).
3. End-to-end: run [kfusion-tornadovm](https://github.com/beehive-lab/kfusion-tornadovm)'s benchmark against this SDK - `icp0.track0 - trackPose` now compiles and the pipeline runs to completion instead of bailing out.