### PR TITLE
[bugfix] cuSPARSE native library is never packaged, so the provider is dead on Linux/macOS

### DIFF
--- a/tornado-drivers/cusparse-jni/pom.xml
+++ b/tornado-drivers/cusparse-jni/pom.xml
@@ -89,6 +89,14 @@
                                     </includes>
                                 </resource>
                                 <resource>
+                                    <!-- linux/mac: the Makefile generator places the library directly in cmake/ -->
+                                    <directory>${project.build.directory}/cmake</directory>
+                                    <includes>
+                                        <include>*.so</include>
+                                        <include>*.dylib</include>
+                                    </includes>
+                                </resource>
+                                <resource>
                                     <directory>${project.build.directory}/cmake/Release</directory>
                                     <includes>
                                         <!-- windows -->


### PR DESCRIPTION
## Problem

`libtornado-cusparse.so` is built, but it never reaches the SDK, so every cuSPARSE library task fails at `System.loadLibrary` and the provider reports `UNSUPPORTED`. The whole `nvidia/cusparse` provider shipped in a state where it cannot run.

`tornado-drivers/cusparse-jni/pom.xml` copies the built binary from `target/cmake/build` and `target/cmake/Release` only. With the Makefile generator used on Linux and macOS, CMake places the library directly in `target/cmake`, which is why `cublas-jni`, `cufft-jni`, `cudnn-jni` and `cutlass-jni` all list that third directory. `cusparse-jni` is the only one that does not.

Evidence, on `develop` @ b65c2053f (RTX 4090, CUDA 12.6, `make BACKEND=cuda`):

```
$ ls tornado-drivers/cusparse-jni/target/linux-amd64-release/cmake/libtornado-cusparse.so
tornado-drivers/cusparse-jni/target/linux-amd64-release/cmake/libtornado-cusparse.so   # built

$ ls dist/tornadovm-*/tornadovm-*/lib/ | grep -i cusparse
                                                                                        # not shipped

$ tornado-test -V uk.ac.manchester.tornado.unittests.cusparse.TestCusparse
Test ran: 11, Failed: 0, Unsupported: 11
```

## Fix

Add the missing `${project.build.directory}/cmake` resource entry, matching `cublas-jni/pom.xml` exactly.

## Result

Same machine, after the fix:

```
$ ls dist/tornadovm-*/tornadovm-*/lib/ | grep -i cusparse
libtornado-cusparse.so

$ tornado-test -V uk.ac.manchester.tornado.unittests.cusparse.TestCusparse
Test ran: 11, Failed: 0, Unsupported: 0
```

All 11 tests pass, including `testSpMVWithCudaGraph` and `testSpMVWithJitPreAndPost`. No source change; packaging only.

## Verification

- `make BACKEND=cuda` clean
- `tornado-test --quickPass`: 1030 run / 92 failed-or-unsupported before, 1030 / 81 after — the 11 cuSPARSE tests move from UNSUPPORTED to PASS, nothing else changes
- `./mvnw checkstyle:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)