### PR TITLE
[bugfix] CUDA: getFloat32() on a swizzle-loaded half float fails to compile

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/phases/TornadoHalfFloatReplacement.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/phases/TornadoHalfFloatReplacement.java
@@ -56,6 +56,7 @@ import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.LocalArrayNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.MultHalfNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAConvertFloatToHalf;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDAConvertHalfToFloat;
+import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.CUDASwizzledLoadFP16Stride32Node;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.ReadHalfFloatNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.SubHalfNode;
 import uk.ac.manchester.tornado.drivers.cuda.graal.nodes.WriteHalfFloatNode;
@@ -113,6 +114,12 @@ public class TornadoHalfFloatReplacement extends BasePhase<TornadoHighTierContex
         if (input instanceof LoadIndexedNode loadIndexed //
                 && loadIndexed.array() instanceof LocalArrayNode localArray //
                 && localArray.getCUDAKind() == CUDAKind.HALF) {
+            return input;
+        }
+        // A swizzled fp16 load produces a HALF-kind value directly, so it is a half-source in the
+        // same way a ReadHalfFloatNode is. Without this case, calling getFloat32() on a value read
+        // through swizzleLoadFp16Stride32 nulls out the convert node's input.
+        if (input instanceof CUDASwizzledLoadFP16Stride32Node) {
             return input;
         }
         if (input instanceof PiNode || input instanceof IsNullNode) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/local/memory/TestSwizzledLocalArrays.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/kernelcontext/local/memory/TestSwizzledLocalArrays.java
@@ -175,7 +175,6 @@ public class TestSwizzledLocalArrays extends TornadoTestBase {
     public void testSwizzleLoadStoreFp16Stride32() throws TornadoExecutionPlanException {
         assertNotBackend(TornadoVMBackendType.OPENCL);
         assertNotBackend(TornadoVMBackendType.METAL);
-        assertNotBackend(TornadoVMBackendType.CUDA);
         // Tile geometry: 16 rows × 16 fp16 cols = 256 elements per work-group.
         // Stride 32 bytes = 16 fp16 cols, which matches FP16_STRIDE_32 policy.
         final int rowsPerTile = 16;
@@ -296,7 +295,6 @@ public class TestSwizzledLocalArrays extends TornadoTestBase {
     public void testSwizzleLoadConvertToFloat() throws TornadoExecutionPlanException {
         assertNotBackend(TornadoVMBackendType.OPENCL);
         assertNotBackend(TornadoVMBackendType.METAL);
-        assertNotBackend(TornadoVMBackendType.CUDA);
 
         final int rowsPerTile = 16;
         final int colsPerTile = 16;


### PR DESCRIPTION
## Problem

Reading a value with `KernelContext.swizzleLoadFp16Stride32(...)` and converting it in-kernel with `HalfFloat.getFloat32()` aborts compilation:

```
uk.ac.manchester.tornado.api.exceptions.TornadoInternalError: CUDAConvertHalfToFloat: input was cleared
by a preceding graph rewrite; an unrecognised half-source pattern reached LIR.
Check TornadoHalfFloatReplacement#identifyFieldReplacement.
```

`TornadoHalfFloatReplacement#identifyFieldReplacement` walks the inputs of a `LoadFieldNode` looking for a node that produces a half value. It recognises `ReadHalfFloatNode`, `ValuePhiNode`, and a `LoadIndexedNode` on a `CUDAKind.HALF` local array. It does not recognise `CUDASwizzledLoadFP16Stride32Node`, which also produces a `CUDAKind.HALF` variable directly (`CUDASwizzledLoadFP16Stride32Node#generate`). The walk returns `null`, the convert node loses its input, and compilation dies at LIR.

This was invisible because the test that covers it, `TestSwizzledLocalArrays#testSwizzleLoadConvertToFloat`, excludes every backend — CUDA included — even though CUDA is the only backend that implements the stride-32 swizzle intrinsics.

## Fix

One case in `identifyFieldReplacement`: a `CUDASwizzledLoadFP16Stride32Node` is a half source, exactly like a `ReadHalfFloatNode`.

## Test

Removed `assertNotBackend(TornadoVMBackendType.CUDA)` from the two stride-32 tests in `TestSwizzledLocalArrays`, which were disabled on a backend that supports them. The stride-16 and int8 tests stay excluded everywhere — no backend implements `swizzle*Fp16Stride16` or `swizzle*Int8`.

Before this change, on `develop` @ b65c2053f (RTX 4090, CUDA 12.6), with only the guards removed:

```
	testSwizzleLoadStoreFp16Stride32  ....  [PASS]         # worked all along, just disabled
	testSwizzleLoadConvertToFloat     ....  [FAILED]
		\_[REASON] CUDAConvertHalfToFloat: input was cleared by a preceding graph rewrite ...
Test ran: 6, Failed: 1, Unsupported: 4
```

After:

```
	testSwizzleLoadStoreFp16Stride32  ....  [PASS]
	testSwizzleLoadConvertToFloat     ....  [PASS]
Test ran: 6, Failed: 0, Unsupported: 4
```

## Verification

- `make BACKEND=cuda` clean
- `tornado-test --quickPass`: two tests move from UNSUPPORTED to PASS, nothing else changes
- `./mvnw checkstyle:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)