### PR TITLE
[bugfix] Library tasks can allocate device memory inside a CUDA-graph capture region

### DIFF
--- a/tornado-cublas/ROADMAP.md
+++ b/tornado-cublas/ROADMAP.md
@@ -171,7 +171,7 @@ transitively loads `libcublasLt`). Exercises everything the SPI reserved:
 | # | Item | Notes | Status |
 |---|---|---|---|
 | G1 | 64-bit interface (`cublas*_64`) | TornadoVM segments can exceed INT_MAX elements; switch to `_64` entry points wholesale (int64 dims) rather than dual-binding | [ ] |
-| G2 | Graph-capture guard surfaced to providers | `LibraryInvocation.isCapturing()` so providers can reject capture-unsafe options (C6 AUTOTUNE, E-b host pointer mode) with a clear error instead of a corrupted capture | [ ] |
+| G2 | Graph-capture guard surfaced to providers | `LibraryInvocation.isCapturing()` ships; cuSPARSE uses it to refuse a workspace growth during capture, and the cuBLAS workspace is now pre-allocated in `prepare()`. Remaining users: C6 AUTOTUNE, E-b host pointer mode | [x] |
 | G3 | Multi-device | One context per device already; needs TornadoVM-level multi-device task graphs. `cublasXt` is **not** the path (host-pointer API conflicts with device-buffer model) | [-] |
 | G4 | Legacy cuBLAS API / emulation modes (`CUBLAS_EMULATE_*`) | Env-var driven, work without binding changes; document only | [-] |
 | G5 | tornado-test harness integration | `uk.ac.manchester.tornado.unittests.cublas.TestCuBlas` (10 JUnit tests, registered in `tornado-test`); skips via JUnit assumption when the default device is not CUDA or libtornado-cublas is missing. main()-runners kept as documented examples | [x] |

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLibraryProvider.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLibraryProvider.java
@@ -19,6 +19,7 @@ package uk.ac.manchester.tornado.cublas.provider;
 
 import java.util.Map;
 
+import uk.ac.manchester.tornado.api.common.LibraryTaskDescriptor;
 import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.cublas.CuBlas;
 import uk.ac.manchester.tornado.cublas.CuBlasOptions;
@@ -98,6 +99,18 @@ public final class CuBlasLibraryProvider implements TornadoLibraryProvider {
         return new CuBlasContext(handle);
     }
 
+    /**
+     * Pre-allocates the workspace requested through the descriptor's tuning options.
+     * cudaMalloc is not legal inside a CUDA-graph capture region, so the allocation
+     * has to happen here rather than on the first {@link #dispatch}.
+     */
+    @Override
+    public void prepare(LibraryTaskDescriptor descriptor, LibraryContext context) {
+        if (descriptor.getTuning() instanceof CuBlasOptions options && options.getWorkspaceBytes() > 0) {
+            ensureWorkspace((CuBlasContext) context, options.getWorkspaceBytes());
+        }
+    }
+
     @Override
     public void dispatch(String functionName, LibraryInvocation invocation) {
         CuBlasCall call = FUNCTIONS.get(functionName);
@@ -125,23 +138,33 @@ public final class CuBlasLibraryProvider implements TornadoLibraryProvider {
         if (options == null) {
             return;
         }
-        if (options.getWorkspaceBytes() > context.workspaceBytes) {
-            if (context.workspacePtr != 0) {
-                CuBlasNativeLib.freeDeviceMemory(context.workspacePtr);
-                context.workspacePtr = 0;
-                context.workspaceBytes = 0;
-            }
-            long ptr = CuBlasNativeLib.allocateDeviceMemory(options.getWorkspaceBytes());
-            if (ptr == 0) {
-                throw new TornadoRuntimeException("[ERROR] Unable to allocate cuBLAS workspace of " + options.getWorkspaceBytes() + " bytes");
-            }
-            context.workspacePtr = ptr;
-            context.workspaceBytes = options.getWorkspaceBytes();
-            CuBlasNativeLib.checkStatus(CuBlasNativeLib.cublasSetWorkspace(context.handle, context.workspacePtr, context.workspaceBytes), "cublasSetWorkspace");
-        }
+        ensureWorkspace(context, options.getWorkspaceBytes());
         if (options.getMathMode() != CuBlasMathMode.CUBLAS_DEFAULT_MATH) {
             CuBlasNativeLib.checkStatus(CuBlasNativeLib.cublasSetMathMode(context.handle, options.getMathMode().value()), "cublasSetMathMode");
         }
+    }
+
+    /**
+     * Grow-only device workspace bound to the handle. A no-op once the context
+     * already holds at least {@code bytes}, which is what keeps {@link #dispatch}
+     * allocation-free after {@link #prepare} has run.
+     */
+    private void ensureWorkspace(CuBlasContext context, long bytes) {
+        if (bytes <= context.workspaceBytes) {
+            return;
+        }
+        if (context.workspacePtr != 0) {
+            CuBlasNativeLib.freeDeviceMemory(context.workspacePtr);
+            context.workspacePtr = 0;
+            context.workspaceBytes = 0;
+        }
+        long ptr = CuBlasNativeLib.allocateDeviceMemory(bytes);
+        if (ptr == 0) {
+            throw new TornadoRuntimeException("[ERROR] Unable to allocate cuBLAS workspace of " + bytes + " bytes");
+        }
+        context.workspacePtr = ptr;
+        context.workspaceBytes = bytes;
+        CuBlasNativeLib.checkStatus(CuBlasNativeLib.cublasSetWorkspace(context.handle, context.workspacePtr, context.workspaceBytes), "cublasSetWorkspace");
     }
 
     private void resetOptions(CuBlasContext context, CuBlasOptions options) {

--- a/tornado-cusparse/src/main/java/uk/ac/manchester/tornado/cusparse/provider/CusparseLibraryProvider.java
+++ b/tornado-cusparse/src/main/java/uk/ac/manchester/tornado/cusparse/provider/CusparseLibraryProvider.java
@@ -33,7 +33,8 @@ import uk.ac.manchester.tornado.runtime.library.spi.TornadoNativeStreamSupport;
  * buffer size depends on the sparse structure (only known once the operand
  * device pointers are resolved at dispatch), {@link #prepare} pre-allocates a
  * default workspace so the small SpMV/SpMM buffers do not trigger an allocation
- * inside a CUDA-graph capture region.
+ * inside a CUDA-graph capture region. A shape that needs more than that is
+ * rejected while capturing rather than allocated, which the driver would refuse.
  */
 public final class CusparseLibraryProvider implements TornadoLibraryProvider {
 
@@ -49,8 +50,15 @@ public final class CusparseLibraryProvider implements TornadoLibraryProvider {
             this.handle = handle;
         }
 
-        private void growWorkspace(long required) {
+        private void growWorkspace(long required, boolean capturing) {
             if (required > workspaceBytes) {
+                if (capturing) {
+                    // cudaMalloc is not legal inside a stream capture region: it would
+                    // abort the capture with a cryptic driver error. Fail here instead,
+                    // naming the size the workspace would have to be pre-sized to.
+                    throw new TornadoRuntimeException("[ERROR] cuSPARSE needs a " + required + " byte workspace but only " + workspaceBytes
+                            + " bytes were pre-allocated, and the workspace cannot grow while capturing a CUDA graph. Run this task graph once without CUDA graphs, or reduce the problem size.");
+                }
                 if (workspacePtr != 0) {
                     CusparseNativeLib.freeDeviceMemory(workspacePtr);
                     workspacePtr = 0;
@@ -93,7 +101,7 @@ public final class CusparseLibraryProvider implements TornadoLibraryProvider {
         // The exact buffer size needs the operand device pointers (resolved only
         // at dispatch), so pre-allocate a default workspace here to keep dispatch
         // allocation-free and CUDA-graph-capture-safe for the common small cases.
-        ((CusparseContext) context).growWorkspace(DEFAULT_WORKSPACE_BYTES);
+        ((CusparseContext) context).growWorkspace(DEFAULT_WORKSPACE_BYTES, false);
     }
 
     @Override
@@ -121,7 +129,7 @@ public final class CusparseLibraryProvider implements TornadoLibraryProvider {
         if (needed < 0) {
             throw new TornadoRuntimeException("[ERROR] cusparseSpMV_bufferSize failed");
         }
-        context.growWorkspace(needed);
+        context.growWorkspace(needed, invocation.isCapturing());
         return CusparseNativeLib.spmv(context.handle, rows, cols, nnz, dRow, dCol, dVal, dX, dY, 1.0f, 0.0f, context.workspacePtr);
     }
 
@@ -140,7 +148,7 @@ public final class CusparseLibraryProvider implements TornadoLibraryProvider {
         if (needed < 0) {
             throw new TornadoRuntimeException("[ERROR] cusparseSpMM_bufferSize failed");
         }
-        context.growWorkspace(needed);
+        context.growWorkspace(needed, invocation.isCapturing());
         return CusparseNativeLib.spmm(context.handle, rows, k, n, nnz, dRow, dCol, dVal, dB, dC, 1.0f, 0.0f, context.workspacePtr);
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -1352,7 +1352,7 @@ public class TornadoVMInterpreter {
         }
         try {
             provider.dispatch(descriptor.getFunctionName(), new LibraryInvocation(callArgs, devicePointers, isReference, interpreterDevice, graphExecutionContext.getExecutionPlanId(), libraryContext,
-                    descriptor.getTuning()));
+                    descriptor.getTuning(), insideCaptureRegion));
         } finally {
             if (nvtxDevice != null) {
                 nvtxDevice.nvtxRangePop();

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/library/spi/LibraryInvocation.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/library/spi/LibraryInvocation.java
@@ -40,8 +40,9 @@ public final class LibraryInvocation {
     private final long executionPlanId;
     private final LibraryContext context;
     private final Object tuning;
+    private final boolean capturing;
 
-    public LibraryInvocation(Object[] javaArgs, long[] devicePointers, boolean[] isReference, TornadoXPUDevice device, long executionPlanId, LibraryContext context, Object tuning) {
+    public LibraryInvocation(Object[] javaArgs, long[] devicePointers, boolean[] isReference, TornadoXPUDevice device, long executionPlanId, LibraryContext context, Object tuning, boolean capturing) {
         this.javaArgs = javaArgs;
         this.devicePointers = devicePointers;
         this.isReference = isReference;
@@ -49,6 +50,7 @@ public final class LibraryInvocation {
         this.executionPlanId = executionPlanId;
         this.context = context;
         this.tuning = tuning;
+        this.capturing = capturing;
     }
 
     public int getNumArgs() {
@@ -94,5 +96,16 @@ public final class LibraryInvocation {
      */
     public Object getTuning() {
         return tuning;
+    }
+
+    /**
+     * Whether this call is being recorded into a CUDA graph rather than executed
+     * immediately. Device allocations, host synchronisation and stream queries are
+     * not capture-safe, so a provider that would need one must reject the call
+     * instead of performing it. Sizing work of that kind belongs in
+     * {@link TornadoLibraryProvider#prepare}, which runs before the capture starts.
+     */
+    public boolean isCapturing() {
+        return capturing;
     }
 }


### PR DESCRIPTION
## Problem

`TornadoLibraryProvider#prepare` exists so that plan and workspace allocation happens **before** capture starts, because `cudaMalloc` inside a stream capture region is not legal and aborts the capture. Two providers can still allocate from `dispatch`:

- **cuSPARSE.** The external buffer size depends on the sparse structure and is only known once the operand device pointers are resolved, so `prepare()` pre-allocates a fixed 8 MiB and `dispatch()` calls `growWorkspace(needed)`. Any matrix whose `cusparseSpMV_bufferSize`/`SpMM_bufferSize` exceeds 8 MiB therefore calls `cudaMalloc` mid-capture.
- **cuBLAS.** A workspace requested through `withTuning(CuBlasOptions.withWorkspace(...))` is allocated lazily on the first `dispatch`, which is inside the capture region when the plan uses CUDA graphs. `CuBlasLibraryProvider` has no `prepare()` at all.

A provider also has no way to know it is being captured, so it cannot reject an unsafe option even when it wants to. This is tracked as G2 in `tornado-cublas/ROADMAP.md`.

## Fix

1. `LibraryInvocation.isCapturing()` — the interpreter already tracks `insideCaptureRegion` (it uses it to skip markers and host-side profiling around library launches); it is now passed to the invocation. Device allocation, host synchronisation and stream queries are all capture-unsafe, so a provider that needs one can refuse instead.
2. cuSPARSE refuses to grow its workspace while capturing, naming the size it would have needed and what to do:
   `"cuSPARSE needs a N byte workspace but only M bytes were pre-allocated, and the workspace cannot grow while capturing a CUDA graph. Run this task graph once without CUDA graphs, or reduce the problem size."`
   Outside capture the behaviour is unchanged: it grows.
3. cuBLAS gains a `prepare()` that pre-allocates the tuning workspace, and the grow logic moves into a shared `ensureWorkspace(...)` used by both `prepare()` and `applyOptions(...)`, so `dispatch` no longer allocates for an already-sized context.
4. `tornado-cublas/ROADMAP.md`: G2 marked done.

`LibraryInvocation`'s constructor takes one more argument. The interpreter is its only caller in the tree.

## Verification

RTX 4090, CUDA 12.6, `make BACKEND=cuda`:

```
$ tornado-test -V uk.ac.manchester.tornado.unittests.cublas.TestCuBlas
Test ran: 12, Failed: 0, Unsupported: 0        # includes testWorkspace and the CUDA-graph test

$ tornado-test -V uk.ac.manchester.tornado.unittests.cusparse.TestCusparse
Test ran: 11, Failed: 0, Unsupported: 0        # includes testSpMVWithCudaGraph
```

`TestCusparse` only runs with #1012 (cuSPARSE native packaging) applied; without it every cuSPARSE test reports `UNSUPPORTED`. The two PRs are otherwise independent — this one touches no build file.

- `tornado-test --quickPass` unchanged
- `./mvnw checkstyle:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)