### PR TITLE
Correct the hybrid-API documentation against the code on develop

### DIFF
--- a/HYBRID_API_GUIDE.md
+++ b/HYBRID_API_GUIDE.md
@@ -2,7 +2,7 @@
 
 The **hybrid API** lets a single TornadoVM `TaskGraph` mix JIT-compiled Java
 tasks (`@Parallel` / `KernelContext`) with calls into vendor-optimized native
-GPU libraries — **cuBLAS, cuBLASLt, cuFFT, cuDNN, CUTLASS, and cuTENSOR**.
+GPU libraries — **cuBLAS, cuBLASLt, cuFFT, cuDNN, cuSPARSE, and CUTLASS**.
 A native call becomes a **library task**: it shares TornadoVM-managed device
 buffers with the surrounding kernels, runs on the same CUDA stream, and is
 captured into CUDA Graphs — so data produced by a JIT kernel feeds a library
@@ -17,7 +17,7 @@ call (and vice-versa) with **no extra copies and no manual memory management**.
 
 1. [Quick start](#1-quick-start)
 2. [Core concepts](#2-core-concepts)
-3. [Provider catalog](#3-provider-catalog) — cuBLAS · cuBLASLt · cuFFT · cuDNN · CUTLASS · cuTENSOR
+3. [Provider catalog](#3-provider-catalog) — cuBLAS · cuBLASLt · cuFFT · cuDNN · cuSPARSE · CUTLASS
 4. [Composition patterns](#4-composition-patterns)
 5. [CUDA Graphs](#5-cuda-graphs)
 6. [Profiling](#6-profiling)
@@ -63,7 +63,7 @@ tornado -m tornado.cublas/uk.ac.manchester.tornado.cublas.tests.TestCuBlasSgemvW
 
 The only new API surface is **`.libraryTask(id, factory, args...)`** — a sibling
 of `.task(...)` that takes a provider factory method reference plus its
-arguments. There are 18 overloads (`libraryTask` with 1–18 typed arguments).
+arguments. There are 20 overloads (`libraryTask` with 1–20 typed arguments).
 
 ---
 
@@ -91,14 +91,15 @@ computed on the GPU stays on the GPU across the JIT ↔ native boundary. You onl
 ### 2.3 Same stream, automatic ordering
 
 The provider binds its native handle to the backend's CUDA stream (e.g.
-`cublasSetStream`, `cudnnSetStream`; cuTENSOR/CUTLASS take the stream per call).
+`cublasSetStream`, `cudnnSetStream`, `cusparseSetStream`; CUTLASS takes the
+stream per call).
 Everything — JIT kernels, transfers, library calls — runs **in order on one
 stream**, with no host synchronization.
 
 ### 2.4 The `prepare()` hook (capture safety)
 
-Libraries that create per-shape plans or workspaces (cuDNN, cuTENSOR, CUTLASS,
-cuFFT) do that allocation in a `prepare()` hook that the interpreter calls in
+Libraries that create per-shape plans or workspaces (cuDNN, CUTLASS, cuFFT,
+cuSPARSE, cuBLAS) do that allocation in a `prepare()` hook that the interpreter calls in
 the **pre-compilation pass, before CUDA-Graph capture starts** (allocation is
 illegal mid-capture). `prepare()` is idempotent (plan-cache lookup), so the
 per-`libraryTask` `dispatch()` allocates nothing and is capture-safe.
@@ -113,8 +114,8 @@ Each provider registers a unique id, matched by the factory:
 | `nvidia/cublaslt` | `tornado-cublas` |
 | `nvidia/cufft` | `tornado-cufft` |
 | `nvidia/cudnn` | `tornado-cudnn` |
+| `nvidia/cusparse` | `tornado-cusparse` |
 | `nvidia/cutlass` | `tornado-cutlass` |
-| `nvidia/cutensor` | `tornado-cutensor` |
 
 ---
 
@@ -153,11 +154,19 @@ Reference (RTX 4090, FP32, CUDA 12.6): cuBLAS SGEMM 24 / 46 / 51 TFLOP/s at
 ### 3.2 cuBLASLt — fused-epilogue GEMM (`nvidia/cublaslt`)
 
 FP16 GEMM with a **fused bias + activation epilogue** (BIAS, GELU_BIAS) — one
-kernel instead of GEMM + separate bias/activation passes. Tuned via an opaque
-`withTuning` descriptor and a cached plan + 32 MiB workspace.
+kernel instead of GEMM + separate bias/activation passes. FP32 and FP8 (E4M3 in,
+FP16 out) matmuls use the same plan cache and 32 MiB workspace.
+
+| Factory | Epilogue |
+|---|---|
+| `ltMatmulFP32` / `ltMatmulFP16` | none |
+| `ltMatmulFP8` | none (E4M3 operands, FP16 output, TN form, `ld` multiple of 16 B) |
+| `ltMatmulBiasFP16` | `BIAS` |
+| `ltMatmulGeluBiasFP16` | `GELU_BIAS` (tanh approximation) |
 
 ```java
-taskGraph.libraryTask("mlp", CuBlasLt::matmulBiasGelu, m, n, k, aFP16, bFP16, bias, dFP16);
+taskGraph.libraryTask("mlp", CuBlasLt::ltMatmulGeluBiasFP16,
+        transa, transb, m, n, k, alpha, aFP16, lda, bFP16, ldb, beta, dFP16, ldd, bias);
 ```
 
 `BenchmarkLtFusedMlp`: fusion is **1.1–1.7×** the unfused path (biggest win in
@@ -169,18 +178,18 @@ Complex and real transforms with a per-`(n, batch)` cached plan.
 
 | Factory | Transform |
 |---|---|
-| `cufftC2C(input, output, n, batch, direction)` | 1D complex→complex fwd/inv |
-| `cufftR2C` / `cufftC2R` | real↔complex (Hermitian, `n ↔ n/2+1`) |
-| `cufftZ2Z` | FP64 complex→complex |
-| `cufft2D_C2C` | 2D complex→complex |
+| `cufftForwardC2C` / `cufftInverseC2C(input, output, n, batch)` | 1D complex→complex |
+| `cufftForwardR2C` / `cufftInverseC2R(input, output, n, batch)` | real↔complex (Hermitian, `n ↔ n/2+1`) |
+| `cufftForwardZ2Z` / `cufftInverseZ2Z(input, output, n, batch)` | FP64 complex→complex, 1D |
+| `cufftForward2dC2C` / `cufftInverse2dC2C(input, output, nx, ny)` | 2D complex→complex |
 
 ```java
 // fft → JIT low-pass filter → ifft → JIT normalize, all on-device
 new TaskGraph("filter")
     .transferToDevice(DataTransferMode.EVERY_EXECUTION, signal)
-    .libraryTask("fwd",  CuFft::cufftC2C, signal, freq, n, 1, CuFft.FORWARD)
+    .libraryTask("fwd",  CuFft::cufftForwardC2C, signal, freq, n, 1)
     .task("lowpass",     Filters::lowPass, freq, cutoff)
-    .libraryTask("inv",  CuFft::cufftC2C, freq, out, n, 1, CuFft.INVERSE)
+    .libraryTask("inv",  CuFft::cufftInverseC2C, freq, out, n, 1)
     .task("normalize",   Filters::scale, out, 1.0f / n)
     .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
 ```
@@ -242,22 +251,30 @@ clear message. FP32 SIMT has no constraint.
 `BenchmarkCutlassGemm` (RTX 4090, 1024): FP16 tensor-core **39 TFLOP/s = 7.7×**
 the tiled `KernelContext` kernel; fused epilogue **1.28×** the unfused path.
 
-### 3.6 cuTENSOR — tensor contractions / einsum (`nvidia/cutensor`)
+### 3.6 cuSPARSE — sparse linear algebra (`nvidia/cusparse`)
 
-FP32 **tensor contractions** — the einsum generalization of matmul. Row-major.
+FP32 sparse matrix products over **CSR** (32-bit, zero-based indices), with
+`alpha = 1.0` and `beta = 0.0`.
 
-| Factory | Contraction |
+| Factory | Operation |
 |---|---|
-| `cutensorContraction(m, n, k, A, B, C)` | `C[m,n] = Σ_k A[m,k]·B[k,n]` (matmul) |
-| `cutensorContraction2(i, j, k, l, A, B, C)` | `C[i,j] = Σ_{k,l} A[i,k,l]·B[k,l,j]` |
+| `cusparseSpMV(rows, cols, nnz, csrRowOffsets, csrColInd, csrValues, x, y)` | `y = A·x` |
+| `cusparseSpMM(rows, k, n, nnz, csrRowOffsets, csrColInd, csrValues, b, c)` | `C = A·B`, dense `B`/`C` row-major |
 
 ```java
-// Two-mode contraction — the thing cuBLAS cannot express in one call
-taskGraph.libraryTask("contract", Cutensor::cutensorContraction2, i, j, k, l, a, b, c);
+new TaskGraph("spmv")
+    .transferToDevice(DataTransferMode.EVERY_EXECUTION, rowOffsets, colIndices, values, x)
+    .libraryTask("spmv", Cusparse::cusparseSpMV, rows, cols, nnz, rowOffsets, colIndices, values, x, y)
+    .transferToHost(DataTransferMode.EVERY_EXECUTION, y);
 ```
 
-`BenchmarkCutensor` (RTX 4090, 1024): matmul **21 TFLOP/s = 5.4×** the JIT
-kernel; two-mode contraction **2.3×**.
+The provider pre-allocates an 8 MiB workspace in `prepare()`. A matrix needing
+more than that is rejected while capturing a CUDA graph, because the workspace
+cannot grow inside a capture region — run the graph once without CUDA graphs
+first, or reduce the problem size.
+
+> **cuTENSOR** (`nvidia/cutensor`, tensor contractions / einsum) is implemented
+> on branch `hybrid-cutensor` but is **not part of this build**.
 
 ---
 
@@ -348,7 +365,7 @@ To confirm native and JIT kernels share one stream, profile with **nsys**:
 
 ```bash
 nsys profile --trace=cuda -o run tornado -m <module>/<MainClass>
-nsys stats --report cuda_gpu_trace run.nsys-rep   # cutlass/cutensor kernels + JIT kernels, same Strm
+nsys stats --report cuda_gpu_trace run.nsys-rep   # library kernels + JIT kernels, same Strm
 ```
 
 ---
@@ -362,14 +379,14 @@ make BACKEND=cuda        # activates the cuda-backend Maven profile
 ```
 
 The Java modules (`tornado-cublas`, `tornado-cufft`, `tornado-cudnn`,
-`tornado-cutlass`, `tornado-cutensor`) always compile. Their native `*-jni`
+`tornado-cusparse`, `tornado-cutlass`) always compile. Their native `*-jni`
 counterparts build only under the `cuda-backend` profile, and each is
 **self-guarding**: if its library/toolkit is missing the native `.so` is skipped
 (the build still succeeds) and that provider reports `UNSUPPORTED` at runtime.
 
 The launcher adds the provider modules to `--add-modules` automatically when the
 CUDA backend is present:
-`tornado.cublas, tornado.cufft, tornado.cudnn, tornado.cutlass, tornado.cutensor`.
+`tornado.cublas, tornado.cufft, tornado.cudnn, tornado.cusparse, tornado.cutlass`.
 
 ### 7.2 Per-library install requirements
 
@@ -379,10 +396,9 @@ CUDA backend is present:
 | cuBLASLt | in the CUDA toolkit | nothing |
 | cuDNN | libcudnn 9 | `apt install libcudnn9-cuda-12 libcudnn9-dev-cuda-12` |
 | CUTLASS | header-only, **CUDA 12+** | fetched by CMake `FetchContent` (v3.5.1); no install |
-| cuTENSOR | libcutensor, **CUDA 12+** | `pip install cutensor-cu12` (or NVIDIA download), then `export CUTENSOR_ROOT=<dir>` |
+| cuSPARSE | in the CUDA toolkit | nothing |
 
-`CUTENSOR_ROOT` (or `~/.local/cutensor`, `/usr/local/cutensor`) points at a
-directory with `include/` and `lib/`. The CUTLASS kernel arch defaults to
+The CUTLASS kernel arch defaults to
 `sm_80` SASS + `compute_80` PTX (runs on all Ampere/Ada, JITs for Hopper);
 override with `CUDA_ARCH=<cc>` (e.g. `CUDA_ARCH=89`).
 
@@ -493,7 +509,7 @@ Key SPI types (in `tornado-runtime/.../runtime/library/spi/`):
 
 ## 9. Reference: layout, data types, alignment
 
-- **Layout.** CUTLASS and cuTENSOR are **row-major** (match TornadoVM arrays
+- **Layout.** CUTLASS and cuSPARSE are **row-major** (match TornadoVM arrays
   directly). **cuBLAS is column-major** — pass the transpose op or swap operands.
 - **Data types.** `FloatArray` (FP32), `HalfFloatArray` (FP16, via
   `new HalfFloat(float)` / `.get(i).getFloat32()`), `DoubleArray` (FP64, cuFFT
@@ -513,7 +529,6 @@ Key SPI types (in `tornado-runtime/.../runtime/library/spi/`):
 |---|---|
 | Test reports `UNSUPPORTED` | Default device is not CUDA, or the native `.so` / vendor library is missing. Build `make BACKEND=cuda`; install the library (§7.2). |
 | `UnsatisfiedLinkError: libtornado-<x>` | Native module was skipped at build time (library not found). Set the corresponding `*_ROOT` and rebuild. |
-| cuTENSOR `SIGSEGV` in `cutensorCreatePlan` | Native stack overflow — plan selection needs a large stack. The JNI already runs it on a 64 MB pthread; if you hit it elsewhere, raise `ulimit -s`. |
 | CUTLASS FP16 rejects a shape | `k` or `n` not a multiple of 4 (8-byte alignment). Pad, or use `cutlassSgemm` (FP32, unconstrained). |
 | Wrong result from cuBLAS | Column-major mismatch — transpose (SGEMV) or swap operands (SGEMM). |
 | `CUDA_ERROR_LAUNCH_FAILED` after a tensor-core call | The kernel was built for the wrong SM. Rebuild with `CUDA_ARCH=<your cc>`. |
@@ -523,8 +538,7 @@ Key SPI types (in `tornado-runtime/.../runtime/library/spi/`):
 ## See also
 
 - `docs/source/hybrid-api.rst` — architecture reference (SPI internals).
-- `HYBRID_API_BRANCHES.md` — which branch contains which provider.
 - Per-provider READMEs: `tornado-cublas/`, `tornado-cudnn/`, `tornado-cutlass/`,
-  `tornado-cutensor/`.
+  `tornado-cusparse/`.
 - Unit tests double as worked examples:
-  `tornado-unittests/.../unittests/{cublas,cufft,cudnn,cutlass,cutensor}/`.
+  `tornado-unittests/.../unittests/{cublas,cufft,cudnn,cusparse,cutlass}/`.

--- a/docs/source/hybrid-api.rst
+++ b/docs/source/hybrid-api.rst
@@ -158,9 +158,9 @@ Scope and roadmap
 
 Implemented today, via the same provider SPI: **cuBLAS** and **cuBLASLt**
 (dense linear algebra, fused-epilogue GEMM), **cuFFT** (FFTs), **cuDNN**
-(deep-learning primitives, including fused FP16 flash attention), **CUTLASS**
-(open-template FP32/FP16 GEMM with fused epilogues), and **cuTENSOR** (tensor
-contractions / einsum). Each is a Java module pair (a ``tornado-<lib>`` API
+(deep-learning primitives, including fused FP16 flash attention), **cuSPARSE**
+(CSR SpMV/SpMM), and **CUTLASS** (open-template FP32/FP16/BF16 GEMM with fused
+epilogues). Each is a Java module pair (a ``tornado-<lib>`` API
 module plus a native ``*-jni`` module) with per-(plan, device) contexts for
 cached descriptors and plans. The native ``*-jni`` module for each library
 builds only under the ``cuda-backend`` Maven profile, and is
@@ -175,8 +175,12 @@ read; the binding marks it ``READ_WRITE`` automatically (include it in
 :code:`transferToDevice` if its initial values come from the host). Batch
 processing (:code:`withBatch`) is not supported for library tasks.
 
-Header-only device libraries (CUB, CUTLASS/CuTe) plug into the CUDA-C
-backend's NVRTC compilation rather than the library-task path.
+A cuTENSOR provider (tensor contractions / einsum) exists on branch
+``hybrid-cutensor`` but is not part of this build.
+
+Header-only device libraries (CUB, CUTLASS/CuTe) would plug into the CUDA-C
+backend's NVRTC compilation rather than the library-task path. No CUB
+integration ships today.
 
 Note that cuBLAS assumes column-major storage: for row-major TornadoVM arrays
 pass the transpose operation (SGEMV) or swap operands (SGEMM), as in the
@@ -187,7 +191,7 @@ See also
 
 `HYBRID_API_GUIDE.md <https://github.com/beehive-lab/TornadoVM/blob/master/HYBRID_API_GUIDE.md>`__
 (repository root) is a complete, example-driven guide to every provider
-(cuBLAS, cuBLASLt, cuFFT, cuDNN, CUTLASS, cuTENSOR): factory tables, code
+(cuBLAS, cuBLASLt, cuFFT, cuDNN, cuSPARSE, CUTLASS): factory tables, code
 snippets, composition patterns, CUDA-Graph usage, build/install
 requirements, CLI flags, a "write your own provider" walkthrough, and a
 troubleshooting table.

--- a/docs/source/programming.rst
+++ b/docs/source/programming.rst
@@ -175,18 +175,58 @@ The following table presents the available features that TornadoVM exposes in Ja
 +----------------------------------------------------+-------------------------------+------------------------------------+
 | kc.getLocalGroupSize()                             | get_local_size()              | blockDim                           |
 +----------------------------------------------------+-------------------------------+------------------------------------+
-| kc.localBarrier()                                  | barrier(CLK_LOCAL_MEM_FENCE)  | barrier.sync                       |
+| kc.localBarrier()                                  | barrier(CLK_LOCAL_MEM_FENCE)  | \__syncthreads()                   |
 +----------------------------------------------------+-------------------------------+------------------------------------+
-| kc.globalBarrier()                                 | barrier(CLK_GLOBAL_MEM_FENCE) | barrier.sync                       |
+| kc.globalBarrier()                                 | barrier(CLK_GLOBAL_MEM_FENCE) | \__syncthreads()                   |
 +----------------------------------------------------+-------------------------------+------------------------------------+
-| int[] array = kc.allocateIntLocalArray(size)       | \__local int array[size]      | .shared .s32 array[size]           |
+| int[] array = kc.allocateIntLocalArray(size)       | \__local int array[size]      | \__shared__ int array[size]        |
 +----------------------------------------------------+-------------------------------+------------------------------------+
-| float[] array = kc.allocateFloatLocalArray(size)   | \__local float array[size]    | .shared .s32 array[size]           |
+| float[] array = kc.allocateFloatLocalArray(size)   | \__local float array[size]    | \__shared__ float array[size]      |
 +----------------------------------------------------+-------------------------------+------------------------------------+
-| long[] array = kc.allocateLongLocalArray(size)     | \__local long array[size]     | .shared .s64 array[size]           |
+| long[] array = kc.allocateLongLocalArray(size)     | \__local long array[size]     | \__shared__ long array[size]       |
 +----------------------------------------------------+-------------------------------+------------------------------------+
-| double[] array = kc.allocateDoubleLocalArray(size) | \__local double array[size]   | .shared .s64 array[size]           |
+| double[] array = kc.allocateDoubleLocalArray(size) | \__local double array[size]   | \__shared__ double array[size]     |
 +----------------------------------------------------+-------------------------------+------------------------------------+
+
+Both barriers synchronise a work-group (a CUDA block), not the whole grid.
+``__syncthreads()`` already makes a block's prior global and shared memory
+accesses visible to the rest of the block, so it is the correct mapping for
+``globalBarrier()`` as well.
+
+Backend support for the advanced operations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Not every ``KernelContext`` operation exists on every backend. An operation a
+backend cannot honour is rejected while the task graph is compiled, with a
+message naming the operation — it is never silently replaced by its Java
+fallback, which would run without complaint and produce a wrong result.
+
++-----------------------------------------------------------------+------------+--------+-------+
+| Operation                                                       | CUDA       | OpenCL | Metal |
++=================================================================+============+========+=======+
+| ``atomicAdd`` (IntArray, int[], LongArray)                      | yes        | yes    | yes   |
++-----------------------------------------------------------------+------------+--------+-------+
+| ``atomicAdd`` (FloatArray, DoubleArray)                         | yes        | no     | yes   |
++-----------------------------------------------------------------+------------+--------+-------+
+| ``atomicCAS``, ``atomicExchange``, ``atomicMin``, ``atomicMax`` | local only | no     | no    |
++-----------------------------------------------------------------+------------+--------+-------+
+| ``simdSum``, ``simdShuffleDown``, ``simdBroadcastFirst``        | yes        | no     | yes   |
++-----------------------------------------------------------------+------------+--------+-------+
+| ``allocateHalf2LocalArray``                                     | yes        | no     | no    |
++-----------------------------------------------------------------+------------+--------+-------+
+| ``mma*`` Tensor Core ops (FP16/BF16/INT8/FP8)                   | yes        | no     | no    |
++-----------------------------------------------------------------+------------+--------+-------+
+| ``asyncCopyToLocal`` and friends (``cp.async``, Ampere+)        | yes        | no     | no    |
++-----------------------------------------------------------------+------------+--------+-------+
+| ``swizzleLoadFp16Stride32``, ``swizzleStoreFp16Stride32``       | yes        | no     | no    |
++-----------------------------------------------------------------+------------+--------+-------+
+| ``swizzle*Fp16Stride16``, ``swizzle*Int8``                      | no         | no     | no    |
++-----------------------------------------------------------------+------------+--------+-------+
+| ``simdgroupMatrix*``, ``matrixMultiply8x8``                     | no         | no     | yes   |
++-----------------------------------------------------------------+------------+--------+-------+
+
+``local only`` means the operation is supported when the array was allocated
+with ``KernelContext.allocateIntLocalArray(int)``; a global array is rejected.
 
 Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/KernelContext.java
@@ -126,7 +126,7 @@ public class KernelContext implements ExecutionContext {
      * <p>
      * OpenCL equivalent: barrier(CLK_LOCAL_MEM_FENCE);
      * <p>
-     * CUDA equivalent: barrier.sync;
+     * CUDA equivalent: __syncthreads();
      */
     @Override
     public void localBarrier() {
@@ -136,9 +136,12 @@ public class KernelContext implements ExecutionContext {
      * Method used as a barrier to synchronize the order of memory operations to the
      * global memory.
      * <p>
+     * The scope is the work-group (a CUDA block), not the whole grid.
+     * <p>
      * OpenCL equivalent: barrier(CLK_GLOBAL_MEM_FENCE);
      * <p>
-     * CUDA equivalent: barrier.sync;
+     * CUDA equivalent: __syncthreads(), which already makes the block's prior global and shared
+     * accesses visible to the rest of the block.
      */
     @Override
     public void globalBarrier() {


### PR DESCRIPTION
## Why

The hybrid-API documentation describes a tree that does not exist. It promises a provider that was never merged, omits one that ships, and names factory methods that are not in the code. Every claim below was checked against `develop` @ b65c2053f.

## What was wrong

| Claim | Reality |
|---|---|
| `HYBRID_API_GUIDE.md`, `docs/source/hybrid-api.rst`: cuTENSOR (`nvidia/cutensor`) is a shipping provider, with a factory table, a troubleshooting row and an install row | No `tornado-cutensor` module on develop. It exists on branch `hybrid-cutensor`, unmerged |
| Both documents list the providers and omit cuSPARSE | `tornado-cusparse` ships (CSR SpMV/SpMM) |
| `HYBRID_API_GUIDE.md`: "18 overloads (`libraryTask` with 1-18 typed arguments)" | 20, since the task-arity work |
| `HYBRID_API_GUIDE.md`: `CuBlasLt::matmulBiasGelu` | Actual name is `ltMatmulGeluBiasFP16`, with a different parameter list |
| `HYBRID_API_GUIDE.md`: `CuFft::cufftC2C` with `CuFft.FORWARD` / `CuFft.INVERSE` | Direction constants do not exist; the factories are `cufftForwardC2C` / `cufftInverseC2C` |
| `HYBRID_API_GUIDE.md` links `HYBRID_API_BRANCHES.md` | Not on develop |
| `docs/source/hybrid-api.rst`: header-only device libraries "plug into" the CUDA-C backend's NVRTC compilation | No CUB integration ships; that is a design note, not a feature |
| `docs/source/programming.rst`: CUDA column says `barrier.sync`, `.shared .s32 array[size]` | PTX-era text; the CUDA-C backend emits `__syncthreads()` and `__shared__ int` |

## What this changes

- **`HYBRID_API_GUIDE.md`**: cuTENSOR section replaced by cuSPARSE, with cuTENSOR called out as living on a branch; arity corrected; cuBLASLt and cuFFT factory names, tables and examples corrected against the source; module lists, install table and the `--add-modules` line corrected; dead link removed.
- **`docs/source/hybrid-api.rst`**: same provider-list correction, plus a note that no CUB integration ships.
- **`docs/source/programming.rst`**: CUDA column fixed, and a new table of which `KernelContext` operations each backend supports, so the limits are discoverable before you hit them.
- **`KernelContext` javadoc**: both barriers say `__syncthreads()` for CUDA rather than `barrier.sync`, and `globalBarrier` states that its scope is the work-group - `__syncthreads()` already makes a block's prior global and shared accesses visible to the block, which is why both fence flags map to it.

Documentation and javadoc only; no behaviour change. `./mvnw checkstyle:check` clean, `make BACKEND=cuda` clean.

The support table in `programming.rst` says an unsupported operation is rejected rather than silently wrong, which is the behaviour after #1013. If that PR is rejected or changed, the wording here should follow it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
