### PR TITLE
Add CUDA-samples-derived compute examples with measured results (GEMM, N-body, binomial options, FDTD stencil)

### DIFF
--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/BinomialOptions.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/BinomialOptions.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2026 APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.examples.kernelcontext.compute;
+
+import java.util.Random;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+
+/**
+ * European call pricing with a Cox-Ross-Rubinstein binomial tree -- a
+ * <b>block-per-work-item wavefront</b>, which is a parallel decomposition nothing else in the
+ * TornadoVM examples uses.
+ *
+ * <p>
+ * Every other {@code KernelContext} example here maps one thread to one output element and uses
+ * the block purely as a staging area (tiled GEMM, tiled N-body, reductions). This one inverts
+ * that: <b>one block prices one option</b>, and the threads inside the block cooperate on that
+ * single option's tree. Each thread owns one tree node; the whole block then walks the tree
+ * backwards from expiry to the present, collapsing one level per iteration:
+ *
+ * <pre>
+ * leaf:  every thread computes its own terminal payoff
+ * for level = STEPS down to 1:
+ *     tree[tid] = myValue          // publish
+ *     localBarrier()               // everyone's value is visible
+ *     if (tid &lt; level)
+ *         myValue = pu*tree[tid+1] + pd*tree[tid]   // collapse one level
+ *     localBarrier()               // nobody overwrites before all reads land
+ * thread 0 holds the option price
+ * </pre>
+ *
+ * <p>
+ * Note the loop runs {@code STEPS} iterations with <b>two barriers each</b> -- 510 barriers per
+ * block, versus the single barrier per K-tile in the GEMM kernels. The active thread count shrinks
+ * by one every level, so the block finishes almost entirely idle. That is inherent to the
+ * algorithm, and it is exactly why this shape is interesting to have as an example: it stresses
+ * barrier throughput and divergence rather than memory bandwidth or FLOPs.
+ *
+ * <p>
+ * <b>Why both barriers are load-bearing.</b> The update reads {@code tree[tid]} and
+ * {@code tree[tid+1]} and writes {@code tree[tid]}. Drop the second barrier and thread
+ * {@code tid} can overwrite {@code tree[tid]} while thread {@code tid-1} is still reading it as
+ * its {@code tid+1} neighbour -- a classic in-place-sweep race. Keeping the new value in a
+ * register ({@code myValue}) and only publishing it at the top of the next iteration is what makes
+ * the two-barrier form correct.
+ *
+ * <p>
+ * A {@code @Parallel} one-option-per-thread version is included as a baseline. It needs no shared
+ * memory and no barriers at all, but each thread must hold the whole tree -- and on a GPU that is
+ * fatal: see its javadoc, the launch is rejected outright.
+ *
+ * <h2>Measured result</h2>
+ *
+ * <p>
+ * RTX 3070 (sm_86), CUDA 13.0, 2048 options, 255 tree steps, mean of 10 steady-state iterations:
+ *
+ * <pre>
+ *   block-per-option (GPU, kernel-only)   35265 us
+ *   sequential Java (1 CPU core)          44561 us
+ *   -> 1.25x
+ * </pre>
+ *
+ * <p>
+ * 1.25x over a single CPU core is a poor return for 524288 GPU threads, and the reason is
+ * structural rather than fixable by tuning. The kernel is <b>barrier- and divergence-bound</b>,
+ * not compute- or bandwidth-bound:
+ *
+ * <ul>
+ * <li>2048 blocks x 510 barriers is over a million block-wide synchronisations, and there is no
+ * arithmetic to hide them behind -- each level does two multiplies and an add per node.</li>
+ * <li>The active thread count falls by one per level, from 255 down to 1. Averaged over the
+ * sweep only half the block is ever doing useful work, and the final levels run a 256-thread
+ * block to compute a handful of values.</li>
+ * <li>Kernel-only time (35.3 ms) is essentially the whole end-to-end time (35.6 ms), so data
+ * movement is not the issue either.</li>
+ * </ul>
+ *
+ * <p>
+ * The honest summary: a binomial tree of this depth is a bad fit for one-block-per-option on this
+ * hardware. The real CUDA sample amortises the cost differently -- far more options in flight and
+ * a cache-blocked sweep so the tree does not have to be walked level-by-level in lockstep. This
+ * example is kept for the pattern, not the throughput: it is the only place in the TornadoVM
+ * examples where a block cooperates on a single work item, and it shows what that costs.
+ *
+ * <p>
+ * How to run:
+ * </p>
+ *
+ * <pre>
+ * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.BinomialOptions
+ * </pre>
+ *
+ * <p>
+ * Kernel-only timing:
+ * </p>
+ *
+ * <pre>
+ * tornado --enableProfiler console -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.BinomialOptions
+ * </pre>
+ */
+public class BinomialOptions {
+
+    /** Threads per block == tree leaves. STEPS is one less, so leaf index tid maps 1:1. */
+    private static final int BLOCK = 256;
+    private static final int STEPS = BLOCK - 1;
+
+    private static final int NUM_OPTIONS = 2048;
+    private static final int ITERATIONS = 10;
+
+    private static final float RISK_FREE = 0.02f;
+    private static final float VOLATILITY = 0.30f;
+
+    /**
+     * One block per option, one thread per tree node.
+     */
+    public static void binomialKernelContext(KernelContext ctx, FloatArray spot, FloatArray strike, FloatArray years, FloatArray callResult) {
+        int option = ctx.groupIdx;
+        int tid = ctx.localIdx;
+
+        float s = spot.get(option);
+        float k = strike.get(option);
+        float t = years.get(option);
+
+        float dt = t / STEPS;
+        float vDt = VOLATILITY * (float) Math.sqrt(dt);
+        float rDt = RISK_FREE * dt;
+        float ifX = (float) Math.exp(rDt);
+        float discount = (float) Math.exp(-rDt);
+        float u = (float) Math.exp(vDt);
+        float d = (float) Math.exp(-vDt);
+        float pu = (ifX - d) / (u - d);
+        float pd = 1.0f - pu;
+        float puByDf = pu * discount;
+        float pdByDf = pd * discount;
+
+        // Terminal payoff for this thread's leaf: tid up-moves, (STEPS - tid) down-moves.
+        float terminalPrice = s * (float) Math.exp(vDt * (2.0f * tid - STEPS));
+        float payoff = terminalPrice - k;
+        float myValue = payoff > 0.0f ? payoff : 0.0f;
+
+        float[] tree = ctx.allocateFloatLocalArray(BLOCK);
+
+        for (int level = STEPS; level > 0; level--) {
+            tree[tid] = myValue;
+            ctx.localBarrier();
+            if (tid < level) {
+                myValue = puByDf * tree[tid + 1] + pdByDf * tree[tid];
+            }
+            ctx.localBarrier();
+        }
+
+        if (tid == 0) {
+            callResult.set(option, myValue);
+        }
+    }
+
+    /**
+     * Baseline: one thread prices a whole option, walking the tree in a private array. No shared
+     * memory and no barriers -- but every thread must carry the entire tree.
+     *
+     * <p>
+     * <b>This does not run on the GPU, and that is the point.</b> The private {@code float[256]}
+     * is 1 KB per thread; multiplied by a full block's worth of resident threads it blows past the
+     * per-thread local-memory budget and the launch is rejected with
+     * {@code CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES}. The kernel then produces no output at all, so
+     * {@link #main} checks the result before reporting any timing -- a failed launch otherwise
+     * looks like a spectacularly fast kernel.
+     *
+     * <p>
+     * This is precisely the constraint that makes the block-cooperative version worth writing:
+     * the tree is too big to be private per thread, but it fits comfortably in shared memory when
+     * a whole block shares one copy.
+     */
+    public static void binomialParallel(FloatArray spot, FloatArray strike, FloatArray years, FloatArray callResult) {
+        for (@Parallel int option = 0; option < NUM_OPTIONS; option++) {
+            float s = spot.get(option);
+            float k = strike.get(option);
+            float t = years.get(option);
+
+            float dt = t / STEPS;
+            float vDt = VOLATILITY * (float) Math.sqrt(dt);
+            float rDt = RISK_FREE * dt;
+            float ifX = (float) Math.exp(rDt);
+            float discount = (float) Math.exp(-rDt);
+            float u = (float) Math.exp(vDt);
+            float d = (float) Math.exp(-vDt);
+            float pu = (ifX - d) / (u - d);
+            float pd = 1.0f - pu;
+            float puByDf = pu * discount;
+            float pdByDf = pd * discount;
+
+            float[] tree = new float[BLOCK];
+            for (int i = 0; i <= STEPS; i++) {
+                float terminalPrice = s * (float) Math.exp(vDt * (2.0f * i - STEPS));
+                float payoff = terminalPrice - k;
+                tree[i] = payoff > 0.0f ? payoff : 0.0f;
+            }
+
+            for (int level = STEPS; level > 0; level--) {
+                for (int i = 0; i < level; i++) {
+                    tree[i] = puByDf * tree[i + 1] + pdByDf * tree[i];
+                }
+            }
+
+            callResult.set(option, tree[0]);
+        }
+    }
+
+    /** Sequential Java reference. */
+    private static void binomialSequential(FloatArray spot, FloatArray strike, FloatArray years, FloatArray callResult) {
+        for (int option = 0; option < NUM_OPTIONS; option++) {
+            float s = spot.get(option);
+            float k = strike.get(option);
+            float t = years.get(option);
+
+            float dt = t / STEPS;
+            float vDt = VOLATILITY * (float) Math.sqrt(dt);
+            float rDt = RISK_FREE * dt;
+            float ifX = (float) Math.exp(rDt);
+            float discount = (float) Math.exp(-rDt);
+            float u = (float) Math.exp(vDt);
+            float d = (float) Math.exp(-vDt);
+            float pu = (ifX - d) / (u - d);
+            float pd = 1.0f - pu;
+            float puByDf = pu * discount;
+            float pdByDf = pd * discount;
+
+            float[] tree = new float[BLOCK];
+            for (int i = 0; i <= STEPS; i++) {
+                float terminalPrice = s * (float) Math.exp(vDt * (2.0f * i - STEPS));
+                float payoff = terminalPrice - k;
+                tree[i] = payoff > 0.0f ? payoff : 0.0f;
+            }
+
+            for (int level = STEPS; level > 0; level--) {
+                for (int i = 0; i < level; i++) {
+                    tree[i] = puByDf * tree[i + 1] + pdByDf * tree[i];
+                }
+            }
+
+            callResult.set(option, tree[0]);
+        }
+    }
+
+    private static float maxRelativeError(FloatArray got, FloatArray expected) {
+        float worst = 0.0f;
+        for (int i = 0; i < got.getSize(); i++) {
+            float e = expected.get(i);
+            float denom = Math.abs(e) > 1e-3f ? Math.abs(e) : 1.0f;
+            worst = Math.max(worst, Math.abs(got.get(i) - e) / denom);
+        }
+        return worst;
+    }
+
+    private static long[] timePlan(TornadoExecutionPlan plan, GridScheduler grid) throws TornadoExecutionPlanException {
+        long start = System.nanoTime();
+        if (grid != null) {
+            plan.withGridScheduler(grid).execute();
+        } else {
+            plan.execute();
+        }
+        long firstRunNs = System.nanoTime() - start;
+
+        long steadyStart = System.nanoTime();
+        for (int i = 0; i < ITERATIONS; i++) {
+            if (grid != null) {
+                plan.withGridScheduler(grid).execute();
+            } else {
+                plan.execute();
+            }
+        }
+        return new long[] { firstRunNs, (System.nanoTime() - steadyStart) / ITERATIONS };
+    }
+
+    public static void main(String[] args) throws TornadoExecutionPlanException {
+        System.out.printf("Binomial option pricing -- %d options, %d tree steps, block-per-option%n", NUM_OPTIONS, STEPS);
+        System.out.printf("(%d barriers per block: two per tree level)%n", 2 * STEPS);
+        System.out.println();
+
+        Random rng = new Random(5);
+        FloatArray spot = new FloatArray(NUM_OPTIONS);
+        FloatArray strike = new FloatArray(NUM_OPTIONS);
+        FloatArray years = new FloatArray(NUM_OPTIONS);
+        for (int i = 0; i < NUM_OPTIONS; i++) {
+            spot.set(i, 5.0f + rng.nextFloat() * 25.0f);
+            strike.set(i, 5.0f + rng.nextFloat() * 25.0f);
+            years.set(i, 0.25f + rng.nextFloat() * 9.75f);
+        }
+
+        FloatArray refResult = new FloatArray(NUM_OPTIONS);
+        long seqStart = System.nanoTime();
+        binomialSequential(spot, strike, years, refResult);
+        long seqNs = System.nanoTime() - seqStart;
+
+        // ---- block-per-option, KernelContext ----
+        FloatArray ctxResult = new FloatArray(NUM_OPTIONS);
+        KernelContext context = new KernelContext();
+        WorkerGrid1D worker = new WorkerGrid1D(NUM_OPTIONS * BLOCK);
+        worker.setLocalWork(BLOCK, 1, 1);
+        GridScheduler grid = new GridScheduler("blockPerOption.price", worker);
+        TaskGraph ctxGraph = new TaskGraph("blockPerOption") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, spot, strike, years) //
+                .task("price", BinomialOptions::binomialKernelContext, context, spot, strike, years, ctxResult) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, ctxResult);
+
+        long[] ctxTimes;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(ctxGraph.snapshot())) {
+            ctxTimes = timePlan(plan, grid);
+        }
+
+        // ---- one option per thread, @Parallel ----
+        FloatArray parResult = new FloatArray(NUM_OPTIONS);
+        TaskGraph parGraph = new TaskGraph("threadPerOption") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, spot, strike, years) //
+                .task("price", BinomialOptions::binomialParallel, spot, strike, years, parResult) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, parResult);
+
+        long[] parTimes;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(parGraph.snapshot())) {
+            parTimes = timePlan(plan, null);
+        }
+
+        float ctxErr = maxRelativeError(ctxResult, refResult);
+        float parErr = maxRelativeError(parResult, refResult);
+        // A rejected launch leaves the output untouched, which reads as ~100% relative error.
+        // Reporting its "time" would advertise a kernel that never ran as the fastest one.
+        boolean parRan = parErr < 0.01f;
+
+        System.out.println("Results:");
+        System.out.printf("  %-30s steady=%8.3f ms  first-run=%8.1f ms  maxRelErr=%.6f%n", "block-per-option (barriers)", ctxTimes[1] / 1e6, ctxTimes[0] / 1e6, ctxErr);
+        if (parRan) {
+            System.out.printf("  %-30s steady=%8.3f ms  first-run=%8.1f ms  maxRelErr=%.6f%n", "thread-per-option (@Parallel)", parTimes[1] / 1e6, parTimes[0] / 1e6, parErr);
+        } else {
+            System.out.printf("  %-30s LAUNCH FAILED -- a %d-float private tree per thread (%d KB) exceeds%n", "thread-per-option (@Parallel)", BLOCK, BLOCK * 4 / 1024);
+            System.out.printf("  %-30s the per-thread local-memory budget (CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES).%n", "");
+            System.out.printf("  %-30s This is why the tree has to live in shared memory, shared by a block.%n", "");
+        }
+        System.out.printf("  %-30s        %8.3f ms%n", "sequential Java (1 core)", seqNs / 1e6);
+        System.out.println();
+        if (parRan) {
+            System.out.printf("block-per-option vs thread-per-option: %.2fx%n", (double) parTimes[1] / ctxTimes[1]);
+        }
+        System.out.printf("block-per-option vs sequential Java:   %.2fx%n", (double) seqNs / ctxTimes[1]);
+        System.out.println();
+        System.out.println("End-to-end times include the result copy-back; for kernel-only timing use:");
+        System.out.println("  tornado --enableProfiler console -m ...BinomialOptions");
+    }
+
+}

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Fdtd3dStencil.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Fdtd3dStencil.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2026 APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.examples.kernelcontext.compute;
+
+import java.util.Random;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid2D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+
+/**
+ * 3D finite-difference wave stencil (FDTD-style), naive vs XY shared-memory tiled.
+ *
+ * <p>
+ * A symmetric star stencil of radius {@value #RADIUS}: each interior point reads
+ * {@code 6 * RADIUS + 1} neighbours -- itself plus {@code RADIUS} points in each of the six axial
+ * directions -- weighted by a coefficient that depends only on distance. Unlike the other examples
+ * in this directory, this one is genuinely <b>memory-bound</b>: 25 loads feed about 25 FLOPs, so
+ * the arithmetic cannot hide the traffic. That makes it the case where shared-memory tiling is
+ * actually expected to pay, which is why it is worth having alongside the tiled N-body (where it
+ * demonstrably does not).
+ *
+ * <p>
+ * The naive kernel reads every neighbour straight from global memory. Adjacent threads re-read the
+ * same points -- with radius 4 in X and Y, each value is loaded up to 9 times across the block.
+ * The tiled kernel loads one XY slab (plus a {@value #RADIUS}-wide halo on each side) into shared
+ * memory per Z step, so the X and Y neighbours are read once per block instead of once per thread:
+ *
+ * <pre>
+ * for each z in the interior:
+ *     tile[ty+R][tx+R] = in[x, y, z]        // interior point
+ *     threads with tx &lt; R also fetch the left/right halo columns
+ *     threads with ty &lt; R also fetch the top/bottom halo rows
+ *     localBarrier()
+ *     out[x,y,z] = c0*tile[centre]
+ *                + sum over r of c[r] * (X and Y neighbours from the tile
+ *                                        + Z neighbours from global memory)
+ *     localBarrier()
+ * </pre>
+ *
+ * <p>
+ * Z neighbours still come from global memory here. The full CUDA sample additionally keeps a
+ * rolling window of {@code 2*RADIUS+1} Z values in registers as it sweeps, so the Z direction is
+ * reused too; that refinement is deliberately not implemented, to keep the shared-memory effect
+ * isolated and measurable on its own.
+ *
+ * <p>
+ * The second {@code localBarrier} matters: without it a thread can start overwriting the tile for
+ * the next Z step while its neighbours are still reading the current one.
+ *
+ * <h2>Measured result: the tiling makes it slower, and the bandwidth figure explains why</h2>
+ *
+ * <p>
+ * RTX 3070 (sm_86), CUDA 13.0, 256x256x64, radius 4, mean of 10 steady-state iterations,
+ * kernel-only via {@code --enableProfiler console}:
+ *
+ * <pre>
+ *   fdtdNaive     155.3 us    2148 GiB/s effective
+ *   fdtdTiled     183.2 us    1821 GiB/s effective     0.85x
+ * </pre>
+ *
+ * <p>
+ * The decisive number is the effective bandwidth. Counting {@code 6*RADIUS+2} accesses per
+ * interior point, the naive kernel is moving the equivalent of <b>2148 GiB/s</b> -- roughly five
+ * times an RTX 3070's ~448 GB/s of DRAM bandwidth. A kernel cannot exceed DRAM bandwidth, so most
+ * of those accesses are never reaching DRAM: the L1/L2 hierarchy is already absorbing the
+ * stencil's reuse. Staging the same values manually in shared memory therefore buys no traffic
+ * reduction and adds real cost -- two barriers per Z step, halo-index arithmetic, and a
+ * conditional halo fetch that makes the first {@value #RADIUS} threads of each row and column do
+ * extra work.
+ *
+ * <p>
+ * This matches what the tiled N-body example in this directory found, and the two together make
+ * the general point: on Ampere-class hardware the cache hierarchy has largely absorbed the reuse
+ * that manual shared-memory tiling was invented to provide. The optimisation was formulated for
+ * GPUs whose caches were far weaker relative to their arithmetic. Tiling still matters when a
+ * working set genuinely does not fit, or when the access pattern defeats the cache -- but it is
+ * no longer a reflexive win, and it needs measuring rather than assuming.
+ *
+ * <h2>Beware the end-to-end number here</h2>
+ *
+ * <p>
+ * Wall-clock per execution is ~11 ms, but the kernel is only ~0.16 ms of that: the rest is copying
+ * the 16 MB result volume back to the host. This example is an extreme case of something worth
+ * internalising -- for a short kernel over a large array, end-to-end timing measures PCIe, not the
+ * GPU. Against the sequential Java reference the end-to-end figure suggests ~7x, while the kernels
+ * themselves are closer to 500x.
+ *
+ * <p>
+ * How to run:
+ * </p>
+ *
+ * <pre>
+ * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.Fdtd3dStencil
+ * </pre>
+ *
+ * <p>
+ * Kernel-only timing:
+ * </p>
+ *
+ * <pre>
+ * tornado --enableProfiler console -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.Fdtd3dStencil
+ * </pre>
+ */
+public class Fdtd3dStencil {
+
+    private static final int RADIUS = 4;
+
+    private static final int TILE_X = 32;
+    private static final int TILE_Y = 8;
+
+    private static final int DIM_X = 256;
+    private static final int DIM_Y = 256;
+    private static final int DIM_Z = 64;
+
+    private static final int SHARED_X = TILE_X + 2 * RADIUS;
+    private static final int SHARED_Y = TILE_Y + 2 * RADIUS;
+
+    private static final int ITERATIONS = 10;
+
+    /** Naive: every neighbour comes straight from global memory. */
+    public static void fdtdNaive(KernelContext ctx, FloatArray in, FloatArray out, FloatArray coeff) {
+        int x = ctx.globalIdx;
+        int y = ctx.globalIdy;
+
+        if (x < RADIUS || x >= DIM_X - RADIUS || y < RADIUS || y >= DIM_Y - RADIUS) {
+            return;
+        }
+
+        for (int z = RADIUS; z < DIM_Z - RADIUS; z++) {
+            int centre = (z * DIM_Y + y) * DIM_X + x;
+            float value = coeff.get(0) * in.get(centre);
+            for (int r = 1; r <= RADIUS; r++) {
+                float c = coeff.get(r);
+                value += c * (in.get(centre + r) + in.get(centre - r));
+                value += c * (in.get(centre + r * DIM_X) + in.get(centre - r * DIM_X));
+                value += c * (in.get(centre + r * DIM_X * DIM_Y) + in.get(centre - r * DIM_X * DIM_Y));
+            }
+            out.set(centre, value);
+        }
+    }
+
+    /** Tiled: X and Y neighbours are staged in shared memory once per block per Z step. */
+    public static void fdtdTiled(KernelContext ctx, FloatArray in, FloatArray out, FloatArray coeff) {
+        int x = ctx.globalIdx;
+        int y = ctx.globalIdy;
+        int tx = ctx.localIdx;
+        int ty = ctx.localIdy;
+
+        float[] tile = ctx.allocateFloatLocalArray(SHARED_X * SHARED_Y);
+
+        boolean interior = x >= RADIUS && x < DIM_X - RADIUS && y >= RADIUS && y < DIM_Y - RADIUS;
+
+        for (int z = RADIUS; z < DIM_Z - RADIUS; z++) {
+            int slice = z * DIM_Y * DIM_X;
+
+            // Interior point for this thread.
+            tile[(ty + RADIUS) * SHARED_X + tx + RADIUS] = in.get(slice + y * DIM_X + x);
+
+            // Halo columns: the first RADIUS threads of each row fetch both sides.
+            if (tx < RADIUS) {
+                int leftX = x - RADIUS;
+                int rightX = x + TILE_X;
+                if (leftX >= 0) {
+                    tile[(ty + RADIUS) * SHARED_X + tx] = in.get(slice + y * DIM_X + leftX);
+                }
+                if (rightX < DIM_X) {
+                    tile[(ty + RADIUS) * SHARED_X + tx + RADIUS + TILE_X] = in.get(slice + y * DIM_X + rightX);
+                }
+            }
+            // Halo rows: the first RADIUS threads of each column fetch top and bottom.
+            if (ty < RADIUS) {
+                int topY = y - RADIUS;
+                int bottomY = y + TILE_Y;
+                if (topY >= 0) {
+                    tile[ty * SHARED_X + tx + RADIUS] = in.get(slice + topY * DIM_X + x);
+                }
+                if (bottomY < DIM_Y) {
+                    tile[(ty + RADIUS + TILE_Y) * SHARED_X + tx + RADIUS] = in.get(slice + bottomY * DIM_X + x);
+                }
+            }
+            ctx.localBarrier();
+
+            if (interior) {
+                int centre = slice + y * DIM_X + x;
+                int localCentre = (ty + RADIUS) * SHARED_X + tx + RADIUS;
+                float value = coeff.get(0) * tile[localCentre];
+                for (int r = 1; r <= RADIUS; r++) {
+                    float c = coeff.get(r);
+                    value += c * (tile[localCentre + r] + tile[localCentre - r]);
+                    value += c * (tile[localCentre + r * SHARED_X] + tile[localCentre - r * SHARED_X]);
+                    // Z stays in global memory -- see the class javadoc.
+                    value += c * (in.get(centre + r * DIM_X * DIM_Y) + in.get(centre - r * DIM_X * DIM_Y));
+                }
+                out.set(centre, value);
+            }
+            // Nobody may overwrite the tile until every thread has finished reading it.
+            ctx.localBarrier();
+        }
+    }
+
+    /** Sequential Java reference. */
+    private static void fdtdSequential(FloatArray in, FloatArray out, FloatArray coeff) {
+        for (int z = RADIUS; z < DIM_Z - RADIUS; z++) {
+            for (int y = RADIUS; y < DIM_Y - RADIUS; y++) {
+                for (int x = RADIUS; x < DIM_X - RADIUS; x++) {
+                    int centre = (z * DIM_Y + y) * DIM_X + x;
+                    float value = coeff.get(0) * in.get(centre);
+                    for (int r = 1; r <= RADIUS; r++) {
+                        float c = coeff.get(r);
+                        value += c * (in.get(centre + r) + in.get(centre - r));
+                        value += c * (in.get(centre + r * DIM_X) + in.get(centre - r * DIM_X));
+                        value += c * (in.get(centre + r * DIM_X * DIM_Y) + in.get(centre - r * DIM_X * DIM_Y));
+                    }
+                    out.set(centre, value);
+                }
+            }
+        }
+    }
+
+    private static float maxDeviation(FloatArray got, FloatArray expected) {
+        float worst = 0.0f;
+        for (int z = RADIUS; z < DIM_Z - RADIUS; z++) {
+            for (int y = RADIUS; y < DIM_Y - RADIUS; y++) {
+                for (int x = RADIUS; x < DIM_X - RADIUS; x++) {
+                    int i = (z * DIM_Y + y) * DIM_X + x;
+                    worst = Math.max(worst, Math.abs(got.get(i) - expected.get(i)));
+                }
+            }
+        }
+        return worst;
+    }
+
+    private static long[] timePlan(TornadoExecutionPlan plan, GridScheduler grid) throws TornadoExecutionPlanException {
+        long start = System.nanoTime();
+        plan.withGridScheduler(grid).execute();
+        long firstRunNs = System.nanoTime() - start;
+
+        long steadyStart = System.nanoTime();
+        for (int i = 0; i < ITERATIONS; i++) {
+            plan.withGridScheduler(grid).execute();
+        }
+        return new long[] { firstRunNs, (System.nanoTime() - steadyStart) / ITERATIONS };
+    }
+
+    /** Effective bandwidth: each interior point does 6*RADIUS+1 reads and one write. */
+    private static double effectiveGiBs(long nanos) {
+        long interior = (long) (DIM_X - 2 * RADIUS) * (DIM_Y - 2 * RADIUS) * (DIM_Z - 2 * RADIUS);
+        double bytes = (double) interior * (6 * RADIUS + 2) * 4.0;
+        return (bytes / (nanos / 1e9)) / (1024.0 * 1024.0 * 1024.0);
+    }
+
+    public static void main(String[] args) throws TornadoExecutionPlanException {
+        System.out.printf("FDTD 3D stencil -- %dx%dx%d, radius %d (%d-point star), tile %dx%d%n", DIM_X, DIM_Y, DIM_Z, RADIUS, 6 * RADIUS + 1, TILE_X, TILE_Y);
+        System.out.println("Memory-bound: ~25 loads per ~25 FLOPs, so tiling is expected to matter here.");
+        System.out.println();
+
+        int volume = DIM_X * DIM_Y * DIM_Z;
+        Random rng = new Random(19);
+        FloatArray in = new FloatArray(volume);
+        for (int i = 0; i < volume; i++) {
+            in.set(i, rng.nextFloat());
+        }
+        FloatArray coeff = new FloatArray(RADIUS + 1);
+        coeff.set(0, -6.0f);
+        for (int r = 1; r <= RADIUS; r++) {
+            coeff.set(r, 1.0f / (r * r));
+        }
+
+        FloatArray refOut = new FloatArray(volume);
+        long seqStart = System.nanoTime();
+        fdtdSequential(in, refOut, coeff);
+        long seqNs = System.nanoTime() - seqStart;
+
+        KernelContext context = new KernelContext();
+
+        // ---- naive ----
+        FloatArray naiveOut = new FloatArray(volume);
+        WorkerGrid2D naiveWorker = new WorkerGrid2D(DIM_X, DIM_Y);
+        naiveWorker.setLocalWork(TILE_X, TILE_Y, 1);
+        GridScheduler naiveGrid = new GridScheduler("naive.stencil", naiveWorker);
+        TaskGraph naiveGraph = new TaskGraph("naive") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, in, coeff) //
+                .task("stencil", Fdtd3dStencil::fdtdNaive, context, in, naiveOut, coeff) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, naiveOut);
+
+        long[] naiveTimes;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(naiveGraph.snapshot())) {
+            naiveTimes = timePlan(plan, naiveGrid);
+        }
+
+        // ---- tiled ----
+        FloatArray tiledOut = new FloatArray(volume);
+        WorkerGrid2D tiledWorker = new WorkerGrid2D(DIM_X, DIM_Y);
+        tiledWorker.setLocalWork(TILE_X, TILE_Y, 1);
+        GridScheduler tiledGrid = new GridScheduler("tiled.stencil", tiledWorker);
+        TaskGraph tiledGraph = new TaskGraph("tiled") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, in, coeff) //
+                .task("stencil", Fdtd3dStencil::fdtdTiled, context, in, tiledOut, coeff) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, tiledOut);
+
+        long[] tiledTimes;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tiledGraph.snapshot())) {
+            tiledTimes = timePlan(plan, tiledGrid);
+        }
+
+        System.out.println("Results:");
+        System.out.printf("  %-24s steady=%8.3f ms  %7.1f GiB/s  first-run=%8.1f ms  maxDev=%.6f%n", "naive (all global)", naiveTimes[1] / 1e6, effectiveGiBs(naiveTimes[1]), naiveTimes[0] / 1e6, maxDeviation(naiveOut, refOut));
+        System.out.printf("  %-24s steady=%8.3f ms  %7.1f GiB/s  first-run=%8.1f ms  maxDev=%.6f%n", "tiled (XY in shared)", tiledTimes[1] / 1e6, effectiveGiBs(tiledTimes[1]), tiledTimes[0] / 1e6, maxDeviation(tiledOut, refOut));
+        System.out.printf("  %-24s       %8.3f ms%n", "sequential Java (1 core)", seqNs / 1e6);
+        System.out.println();
+        System.out.printf("tiled vs naive:              %.2fx%n", (double) naiveTimes[1] / tiledTimes[1]);
+        System.out.printf("tiled vs sequential Java:    %.2fx%n", (double) seqNs / tiledTimes[1]);
+        System.out.println();
+        System.out.println("End-to-end includes the volume copy-back; for kernel-only timing use:");
+        System.out.println("  tornado --enableProfiler console -m ...Fdtd3dStencil");
+    }
+
+}

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/NBodyTiled.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/NBodyTiled.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2026 APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.examples.kernelcontext.compute;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+
+/**
+ * All-pairs N-body, naive vs shared-memory tiled, timed against each other.
+ *
+ * <p>
+ * The existing {@code kernelcontext.compute.NBody} example is the naive form: every thread re-reads
+ * all N bodies straight from global memory, so the whole grid pulls N x N body records across the
+ * memory system. This adds the classic CUDA optimisation that sample omits -- stage a tile of
+ * bodies in shared memory once per block, have every thread in the block consume it, then advance
+ * to the next tile:
+ *
+ * <pre>
+ * for each tile:
+ *     shared[localIdx] = body[tile * TILE + localIdx]   // one cooperative load
+ *     localBarrier()
+ *     for j in 0..TILE:  accumulate force from shared[j] // TILE reuses per load
+ *     localBarrier()
+ * </pre>
+ *
+ * Global loads per thread drop from N to N/TILE; the arithmetic is unchanged.
+ *
+ * <h2>Measured result: the tiling does not help on Ampere</h2>
+ *
+ * <p>
+ * RTX 3070 (sm_86), CUDA 13.0, 16384 bodies, TILE=256, mean of 10 steady-state iterations,
+ * kernel-only via {@code --enableProfiler console}:
+ *
+ * <pre>
+ *   nBodyNaive     25648 us
+ *   nBodyTiled     25411 us     1.01x
+ * </pre>
+ *
+ * <p>
+ * A 1% difference is noise -- the shared-memory staging buys nothing here, and that is worth
+ * knowing rather than hiding. Two reasons:
+ *
+ * <ul>
+ * <li>The kernel is not memory-bound. Both variants sustain only ~210 GFLOP/s against an RTX
+ * 3070's multi-TFLOP fp32 peak, which points at the special-function unit: every pair interaction
+ * costs one {@code sqrt}, and 268M of them at ~25 ms works out near the SFU's throughput ceiling.
+ * Relieving memory pressure cannot speed up a kernel that is waiting on the transcendental
+ * pipeline.</li>
+ * <li>What tiling provides -- reuse of each body record across a block -- an Ampere L1/L2 already
+ * provides for a working set this small. The classic textbook win for this optimisation was
+ * measured on GPUs whose caches were far weaker than their arithmetic.</li>
+ * </ul>
+ *
+ * <p>
+ * The tiled kernel is kept because it is still the correct way to write this when N or the body
+ * record grows past what the cache can hold, and because the naive/tiled pair is a clean
+ * demonstration of {@code allocateFloatLocalArray} + double {@code localBarrier} outside a GEMM.
+ * Just do not assume the speedup is there without measuring it.
+ *
+ * <h2>Both kernels are double-buffered, deliberately</h2>
+ *
+ * <p>
+ * They read {@code posIn}/{@code velIn} and write {@code posOut}/{@code velOut}, never both. An
+ * in-place version -- which is what the older {@code NBody} example does -- is a data race: there
+ * is no grid-wide barrier between the force loop and the integration step, so a thread can
+ * overwrite a body's position while other threads are still reading it for their own force sums.
+ * It is easy to mistake the resulting error for floating-point drift; it is not, and with
+ * double-buffering both kernels here reproduce the sequential reference exactly
+ * ({@code maxDev = 0.00000}, since the summation order is identical).
+ *
+ * <p>
+ * Both kernels are validated against the same sequential Java reference before any timing is
+ * reported, and timing separates the first (JIT/NVRTC-compiling) run from the steady-state mean.
+ *
+ * <p>
+ * Note both kernels accumulate into plain {@code float} scalars rather than a small
+ * {@code float[3]}. The naive example uses {@code new float[]{...}} inside the kernel, which
+ * TornadoVM does handle for small fixed-size private arrays, but scalars keep the accumulator
+ * unambiguously in registers and sidestep the in-kernel-allocation restriction entirely.
+ *
+ * <p>
+ * How to run:
+ * </p>
+ *
+ * <pre>
+ * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.NBodyTiled
+ * </pre>
+ *
+ * <p>
+ * Kernel-only timing (recommended -- the wall-clock figure includes the position/velocity
+ * copy-back, which is identical work for both kernels and dilutes the ratio):
+ * </p>
+ *
+ * <pre>
+ * tornado --enableProfiler console -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.NBodyTiled
+ *
+ * nsys profile --trace=cuda,nvtx -o nbody-tiled \
+ *   tornado -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.NBodyTiled
+ * nsys stats --report cuda_gpu_kern_sum nbody-tiled.nsys-rep
+ * </pre>
+ */
+public class NBodyTiled {
+
+    private static final float DELT = 0.005f;
+    private static final float ESP_SQR = 500.0f;
+
+    private static final int TILE = 256;
+    private static final int NUM_BODIES = 16384;
+    private static final int ITERATIONS = 10;
+
+    /** Naive: every thread streams all N bodies from global memory. */
+    private static void nBodyNaive(KernelContext context, int numBodies, FloatArray posIn, FloatArray velIn, FloatArray posOut, FloatArray velOut) {
+        int i = context.globalIdx;
+        int body = 4 * i;
+
+        float myX = posIn.get(body);
+        float myY = posIn.get(body + 1);
+        float myZ = posIn.get(body + 2);
+
+        float accX = 0.0f;
+        float accY = 0.0f;
+        float accZ = 0.0f;
+
+        for (int j = 0; j < numBodies; j++) {
+            int index = 4 * j;
+            float rx = posIn.get(index) - myX;
+            float ry = posIn.get(index + 1) - myY;
+            float rz = posIn.get(index + 2) - myZ;
+
+            float distSqr = rx * rx + ry * ry + rz * rz;
+            float invDist = 1.0f / sqrtF(distSqr + ESP_SQR);
+            float s = posIn.get(index + 3) * invDist * invDist * invDist;
+
+            accX += s * rx;
+            accY += s * ry;
+            accZ += s * rz;
+        }
+
+        integrate(posIn, velIn, posOut, velOut, body, accX, accY, accZ);
+    }
+
+    /** Tiled: each block stages TILE bodies in shared memory and reuses them TILE times. */
+    private static void nBodyTiled(KernelContext context, int numBodies, FloatArray posIn, FloatArray velIn, FloatArray posOut, FloatArray velOut) {
+        int i = context.globalIdx;
+        int local = context.localIdx;
+        int body = 4 * i;
+
+        // One tile of bodies: x, y, z, mass interleaved, same layout as the global array.
+        float[] tile = context.allocateFloatLocalArray(TILE * 4);
+
+        float myX = posIn.get(body);
+        float myY = posIn.get(body + 1);
+        float myZ = posIn.get(body + 2);
+
+        float accX = 0.0f;
+        float accY = 0.0f;
+        float accZ = 0.0f;
+
+        for (int tileStart = 0; tileStart < numBodies; tileStart += TILE) {
+            // Cooperative load: one body per thread, so the block pulls TILE bodies per round.
+            int src = 4 * (tileStart + local);
+            int dst = 4 * local;
+            tile[dst] = posIn.get(src);
+            tile[dst + 1] = posIn.get(src + 1);
+            tile[dst + 2] = posIn.get(src + 2);
+            tile[dst + 3] = posIn.get(src + 3);
+            context.localBarrier();
+
+            for (int j = 0; j < TILE; j++) {
+                int index = 4 * j;
+                float rx = tile[index] - myX;
+                float ry = tile[index + 1] - myY;
+                float rz = tile[index + 2] - myZ;
+
+                float distSqr = rx * rx + ry * ry + rz * rz;
+                float invDist = 1.0f / sqrtF(distSqr + ESP_SQR);
+                float s = tile[index + 3] * invDist * invDist * invDist;
+
+                accX += s * rx;
+                accY += s * ry;
+                accZ += s * rz;
+            }
+            // Second barrier: nobody may overwrite the tile until every thread has consumed it.
+            context.localBarrier();
+        }
+
+        integrate(posIn, velIn, posOut, velOut, body, accX, accY, accZ);
+    }
+
+    private static float sqrtF(float value) {
+        return (float) Math.sqrt(value);
+    }
+
+    private static void integrate(FloatArray posIn, FloatArray velIn, FloatArray posOut, FloatArray velOut, int body, float accX, float accY, float accZ) {
+        posOut.set(body, posIn.get(body) + velIn.get(body) * DELT + 0.5f * accX * DELT * DELT);
+        posOut.set(body + 1, posIn.get(body + 1) + velIn.get(body + 1) * DELT + 0.5f * accY * DELT * DELT);
+        posOut.set(body + 2, posIn.get(body + 2) + velIn.get(body + 2) * DELT + 0.5f * accZ * DELT * DELT);
+        posOut.set(body + 3, posIn.get(body + 3)); // carry mass through untouched
+        velOut.set(body, velIn.get(body) + accX * DELT);
+        velOut.set(body + 1, velIn.get(body + 1) + accY * DELT);
+        velOut.set(body + 2, velIn.get(body + 2) + accZ * DELT);
+        velOut.set(body + 3, velIn.get(body + 3));
+    }
+
+    /**
+     * Sequential Java reference, used to validate both GPU kernels.
+     *
+     * <p>
+     * Forces are computed against a SNAPSHOT of the input positions. Reading {@code pos} directly
+     * while the same loop writes to it would let body i+1 see body i's already-integrated
+     * position, which is a different (and wrong) algorithm -- every thread on the GPU sees the
+     * original positions, since the integration happens after all forces are accumulated. Getting
+     * this wrong shows up as a small but stubborn deviation that looks like float drift and is
+     * not.
+     */
+    private static void nBodySequential(int numBodies, FloatArray pos, FloatArray vel, FloatArray posOut, FloatArray velOut) {
+        float[] snapshot = new float[numBodies * 4];
+        for (int i = 0; i < snapshot.length; i++) {
+            snapshot[i] = pos.get(i);
+        }
+
+        for (int i = 0; i < numBodies; i++) {
+            int body = 4 * i;
+            float myX = snapshot[body];
+            float myY = snapshot[body + 1];
+            float myZ = snapshot[body + 2];
+
+            float accX = 0.0f;
+            float accY = 0.0f;
+            float accZ = 0.0f;
+
+            for (int j = 0; j < numBodies; j++) {
+                int index = 4 * j;
+                float rx = snapshot[index] - myX;
+                float ry = snapshot[index + 1] - myY;
+                float rz = snapshot[index + 2] - myZ;
+
+                float distSqr = rx * rx + ry * ry + rz * rz;
+                float invDist = (float) (1.0f / Math.sqrt(distSqr + ESP_SQR));
+                float s = snapshot[index + 3] * invDist * invDist * invDist;
+
+                accX += s * rx;
+                accY += s * ry;
+                accZ += s * rz;
+            }
+
+            posOut.set(body, pos.get(body) + vel.get(body) * DELT + 0.5f * accX * DELT * DELT);
+            posOut.set(body + 1, pos.get(body + 1) + vel.get(body + 1) * DELT + 0.5f * accY * DELT * DELT);
+            posOut.set(body + 2, pos.get(body + 2) + vel.get(body + 2) * DELT + 0.5f * accZ * DELT * DELT);
+            posOut.set(body + 3, pos.get(body + 3));
+            velOut.set(body, vel.get(body) + accX * DELT);
+            velOut.set(body + 1, vel.get(body + 1) + accY * DELT);
+            velOut.set(body + 2, vel.get(body + 2) + accZ * DELT);
+            velOut.set(body + 3, vel.get(body + 3));
+        }
+    }
+
+    private static FloatArray seedPositions(long seed) {
+        java.util.Random rng = new java.util.Random(seed);
+        FloatArray pos = new FloatArray(NUM_BODIES * 4);
+        for (int i = 0; i < NUM_BODIES; i++) {
+            pos.set(i * 4, rng.nextFloat() * 100.0f);
+            pos.set(i * 4 + 1, rng.nextFloat() * 100.0f);
+            pos.set(i * 4 + 2, rng.nextFloat() * 100.0f);
+            pos.set(i * 4 + 3, 1.0f + rng.nextFloat()); // mass
+        }
+        return pos;
+    }
+
+    private static FloatArray seedVelocities(long seed) {
+        java.util.Random rng = new java.util.Random(seed);
+        FloatArray vel = new FloatArray(NUM_BODIES * 4);
+        for (int i = 0; i < NUM_BODIES * 4; i++) {
+            vel.set(i, rng.nextFloat() - 0.5f);
+        }
+        return vel;
+    }
+
+    private static float maxDeviation(FloatArray got, FloatArray expected) {
+        float worst = 0.0f;
+        for (int i = 0; i < got.getSize(); i++) {
+            worst = Math.max(worst, Math.abs(got.get(i) - expected.get(i)));
+        }
+        return worst;
+    }
+
+    /** Runs once to pay JIT, then {@code ITERATIONS} more; returns {firstRunNs, meanSteadyNs}. */
+    private static long[] timePlan(TornadoExecutionPlan plan, GridScheduler grid) throws TornadoExecutionPlanException {
+        long start = System.nanoTime();
+        plan.withGridScheduler(grid).execute();
+        long firstRunNs = System.nanoTime() - start;
+
+        long steadyStart = System.nanoTime();
+        for (int i = 0; i < ITERATIONS; i++) {
+            plan.withGridScheduler(grid).execute();
+        }
+        return new long[] { firstRunNs, (System.nanoTime() - steadyStart) / ITERATIONS };
+    }
+
+    private static double gflops(long nanos) {
+        // ~20 flops per pair interaction (3 subs, 3 mults + 2 adds for distSqr, rsqrt, 3 mults
+        // for the cube, 1 mult for mass, 3 fma for the accumulate). Approximate but consistent
+        // across both kernels, which is what matters for the comparison.
+        double pairs = (double) NUM_BODIES * NUM_BODIES;
+        return ((pairs * 20.0) / (nanos / 1e9)) / 1e9;
+    }
+
+    public static void main(String[] args) throws TornadoExecutionPlanException {
+        System.out.printf("N-body all-pairs -- %d bodies, TILE=%d, %d timed iterations%n", NUM_BODIES, TILE, ITERATIONS);
+        System.out.println("Steady-state times only; first-run includes JIT/NVRTC compilation.");
+        System.out.println();
+
+        // Sequential reference over a single step, from the same seed as the GPU runs.
+        FloatArray seedPos = seedPositions(7);
+        FloatArray seedVel = seedVelocities(13);
+        FloatArray refPos = new FloatArray(NUM_BODIES * 4);
+        FloatArray refVel = new FloatArray(NUM_BODIES * 4);
+        nBodySequential(NUM_BODIES, seedPos, seedVel, refPos, refVel);
+
+        KernelContext context = new KernelContext();
+
+        // Double-buffered: the kernels read posIn/velIn and write posOut/velOut, never both.
+        // Writing into the same array a neighbouring thread is still reading is a data race --
+        // there is no grid-wide barrier between the force loop and the integration step.
+        // ---- naive ----
+        FloatArray naiveIn = seedPositions(7);
+        FloatArray naiveVelIn = seedVelocities(13);
+        FloatArray naiveOut = new FloatArray(NUM_BODIES * 4);
+        FloatArray naiveVelOut = new FloatArray(NUM_BODIES * 4);
+        WorkerGrid1D naiveWorker = new WorkerGrid1D(NUM_BODIES);
+        naiveWorker.setLocalWork(TILE, 1, 1);
+        GridScheduler naiveGrid = new GridScheduler("naive.compute", naiveWorker);
+        TaskGraph naiveGraph = new TaskGraph("naive") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, naiveIn, naiveVelIn) //
+                .task("compute", NBodyTiled::nBodyNaive, context, NUM_BODIES, naiveIn, naiveVelIn, naiveOut, naiveVelOut) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, naiveOut, naiveVelOut);
+
+        long[] naiveTimes;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(naiveGraph.snapshot())) {
+            naiveTimes = timePlan(plan, naiveGrid);
+        }
+
+        // ---- tiled ----
+        FloatArray tiledIn = seedPositions(7);
+        FloatArray tiledVelIn = seedVelocities(13);
+        FloatArray tiledOut = new FloatArray(NUM_BODIES * 4);
+        FloatArray tiledVelOut = new FloatArray(NUM_BODIES * 4);
+        WorkerGrid1D tiledWorker = new WorkerGrid1D(NUM_BODIES);
+        tiledWorker.setLocalWork(TILE, 1, 1);
+        GridScheduler tiledGrid = new GridScheduler("tiled.compute", tiledWorker);
+        TaskGraph tiledGraph = new TaskGraph("tiled") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, tiledIn, tiledVelIn) //
+                .task("compute", NBodyTiled::nBodyTiled, context, NUM_BODIES, tiledIn, tiledVelIn, tiledOut, tiledVelOut) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, tiledOut, tiledVelOut);
+
+        long[] tiledTimes;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(tiledGraph.snapshot())) {
+            tiledTimes = timePlan(plan, tiledGrid);
+        }
+
+        // Inputs are never mutated, so every execution recomputes the same single step and the
+        // final output must match the one-step sequential reference.
+        float naiveErr = Math.max(maxDeviation(naiveOut, refPos), maxDeviation(naiveVelOut, refVel));
+        float tiledErr = Math.max(maxDeviation(tiledOut, refPos), maxDeviation(tiledVelOut, refVel));
+
+        System.out.println("Results:");
+        System.out.printf("  %-22s steady=%8.3f ms  %8.1f GFLOP/s  first-run=%8.1f ms  maxDev=%.5f%n", "naive (global reads)", naiveTimes[1] / 1e6, gflops(naiveTimes[1]), naiveTimes[0] / 1e6, naiveErr);
+        System.out.printf("  %-22s steady=%8.3f ms  %8.1f GFLOP/s  first-run=%8.1f ms  maxDev=%.5f%n", "tiled (shared memory)", tiledTimes[1] / 1e6, gflops(tiledTimes[1]), tiledTimes[0] / 1e6, tiledErr);
+        System.out.println();
+        System.out.printf("Tiled vs naive (end-to-end): %.2fx%n", (double) naiveTimes[1] / tiledTimes[1]);
+        System.out.println();
+        System.out.println("End-to-end includes the position/velocity copy-back, identical for both kernels.");
+        System.out.println("For kernel-only time:  tornado --enableProfiler console -m ...NBodyTiled");
+    }
+
+}

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/FP8GemmStage.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/FP8GemmStage.java
@@ -65,8 +65,8 @@ public final class FP8GemmStage {
         int tileCol = (warpId % numTilesN) * WMMA_N;
 
         int[] aTile = ctx.allocateIntLocalArray(WMMA_M * WMMA_K / 4);
-        int[] bTile0 = ctx.allocateIntLocalArray(WMMA_K * 8 / 4);
-        int[] bTile1 = ctx.allocateIntLocalArray(WMMA_K * 8 / 4);
+        int[] bTile0 = ctx.allocateIntLocalArray(64);
+        int[] bTile1 = ctx.allocateIntLocalArray(64);
 
         float[] fragC0 = ctx.mmaFragment(0.0f);
         float[] fragC1 = ctx.mmaFragment(0.0f);
@@ -84,24 +84,28 @@ public final class FP8GemmStage {
                 aTile[r * (WMMA_K / 4) + kk / 4] = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
             }
 
-            for (int idx = lane; idx < (WMMA_K * 8) / 4; idx += WARP_SIZE) {
-                int kRow = idx / 2;
-                int jQuad = idx % 2;
-                int jBase = jQuad * 4;
+            // B panels: an int packs 2 K-values x 2 J-values (NOT 4 consecutive J-values). This
+            // is the layout the validated int8 M16N8K32 path uses -- FP8 shares the shape and the
+            // 8-bit fragment tiling, so it shares the layout. Worth stating explicitly because
+            // this stage cannot be validated on pre-Ada hardware, so it is derived from the
+            // proven int8 kernel rather than from a passing FP8 run.
+            for (int idx = lane; idx < 64; idx += WARP_SIZE) {
+                int kRow = idx / 4;
+                int jPair = idx % 4;
+                int jBase = jPair * 2;
+                int kPair = 2 * kRow;
 
-                int gL = (kBase + kRow) * dimN + tileCol + jBase;
-                int l0 = b.get(gL) & 0xFF;
-                int l1 = b.get(gL + 1) & 0xFF;
-                int l2 = b.get(gL + 2) & 0xFF;
-                int l3 = b.get(gL + 3) & 0xFF;
-                bTile0[kRow * 2 + jQuad] = l0 | (l1 << 8) | (l2 << 16) | (l3 << 24);
+                int bL0 = b.get((kBase + kPair) * dimN + tileCol + jBase) & 0xFF;
+                int bL1 = b.get((kBase + kPair + 1) * dimN + tileCol + jBase) & 0xFF;
+                int bL2 = b.get((kBase + kPair) * dimN + tileCol + jBase + 1) & 0xFF;
+                int bL3 = b.get((kBase + kPair + 1) * dimN + tileCol + jBase + 1) & 0xFF;
+                bTile0[kRow * 4 + jPair] = bL0 | (bL1 << 8) | (bL2 << 16) | (bL3 << 24);
 
-                int gR = (kBase + kRow) * dimN + tileCol + 8 + jBase;
-                int r0 = b.get(gR) & 0xFF;
-                int r1 = b.get(gR + 1) & 0xFF;
-                int r2 = b.get(gR + 2) & 0xFF;
-                int r3 = b.get(gR + 3) & 0xFF;
-                bTile1[kRow * 2 + jQuad] = r0 | (r1 << 8) | (r2 << 16) | (r3 << 24);
+                int bR0 = b.get((kBase + kPair) * dimN + tileCol + 8 + jBase) & 0xFF;
+                int bR1 = b.get((kBase + kPair + 1) * dimN + tileCol + 8 + jBase) & 0xFF;
+                int bR2 = b.get((kBase + kPair) * dimN + tileCol + 8 + jBase + 1) & 0xFF;
+                int bR3 = b.get((kBase + kPair + 1) * dimN + tileCol + 8 + jBase + 1) & 0xFF;
+                bTile1[kRow * 4 + jPair] = bR0 | (bR1 << 8) | (bR2 << 16) | (bR3 << 24);
             }
             ctx.localBarrier();
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/FP8GemmStage.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/FP8GemmStage.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026 APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.examples.kernelcontext.matrices;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.MMAShape;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FP8Array;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+
+/**
+ * The FP8 (E4M3) stage of {@link LowPrecisionGemmBenchmark}, kept in its own class so that the
+ * hardware-gated failure on pre-Ada GPUs stays isolated from the rest of the benchmark.
+ *
+ * <p>
+ * FP8 tensor-core MMA needs compute capability &gt;= 8.9 (Ada/Hopper) AND PTX ISA &gt;= 8.4
+ * (CUDA 12.4+). TornadoVM enforces both in {@code CUDATensorCoreSupportPhase} and raises
+ * {@code TornadoDeviceFP8NotSupported} otherwise -- so on, say, an Ampere RTX 3070 (sm_86) this
+ * whole stage is reported as skipped rather than failing the run.
+ *
+ * <p>
+ * Note the K-step is 32 here, not 16: FP8 MMA uses {@link MMAShape#M16N8K32}, twice the depth per
+ * instruction, since twice as many 8-bit operands fit in the same fragment registers.
+ */
+public final class FP8GemmStage {
+
+    private static final int WMMA_M = 16;
+    private static final int WMMA_N = 16;
+    private static final int WMMA_K = 32;
+    private static final int WARP_SIZE = 32;
+
+    private FP8GemmStage() {
+    }
+
+    /**
+     * GEMM over E4M3 FP8 operands with fp32 accumulation. Four FP8 bytes are packed per shared
+     * int, so the tile arithmetic divides by 4 where the fp16 path divides by 2.
+     */
+    public static void gemmFP8(KernelContext ctx, FP8Array a, FP8Array b, FloatArray c, int dimN, int dimK) {
+        int warpId = ctx.groupIdx;
+        int lane = ctx.localIdx;
+
+        int numTilesN = dimN / WMMA_N;
+        int tileRow = (warpId / numTilesN) * WMMA_M;
+        int tileCol = (warpId % numTilesN) * WMMA_N;
+
+        int[] aTile = ctx.allocateIntLocalArray(WMMA_M * WMMA_K / 4);
+        int[] bTile0 = ctx.allocateIntLocalArray(WMMA_K * 8 / 4);
+        int[] bTile1 = ctx.allocateIntLocalArray(WMMA_K * 8 / 4);
+
+        float[] fragC0 = ctx.mmaFragment(0.0f);
+        float[] fragC1 = ctx.mmaFragment(0.0f);
+
+        for (int kBase = 0; kBase < dimK; kBase += WMMA_K) {
+            for (int idx = lane; idx < (WMMA_M * WMMA_K) / 4; idx += WARP_SIZE) {
+                int elemBase = idx * 4;
+                int r = elemBase / WMMA_K;
+                int kk = elemBase % WMMA_K;
+                int globalBase = (tileRow + r) * dimK + kBase + kk;
+                int b0 = a.get(globalBase) & 0xFF;
+                int b1 = a.get(globalBase + 1) & 0xFF;
+                int b2 = a.get(globalBase + 2) & 0xFF;
+                int b3 = a.get(globalBase + 3) & 0xFF;
+                aTile[r * (WMMA_K / 4) + kk / 4] = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24);
+            }
+
+            for (int idx = lane; idx < (WMMA_K * 8) / 4; idx += WARP_SIZE) {
+                int kRow = idx / 2;
+                int jQuad = idx % 2;
+                int jBase = jQuad * 4;
+
+                int gL = (kBase + kRow) * dimN + tileCol + jBase;
+                int l0 = b.get(gL) & 0xFF;
+                int l1 = b.get(gL + 1) & 0xFF;
+                int l2 = b.get(gL + 2) & 0xFF;
+                int l3 = b.get(gL + 3) & 0xFF;
+                bTile0[kRow * 2 + jQuad] = l0 | (l1 << 8) | (l2 << 16) | (l3 << 24);
+
+                int gR = (kBase + kRow) * dimN + tileCol + 8 + jBase;
+                int r0 = b.get(gR) & 0xFF;
+                int r1 = b.get(gR + 1) & 0xFF;
+                int r2 = b.get(gR + 2) & 0xFF;
+                int r3 = b.get(gR + 3) & 0xFF;
+                bTile1[kRow * 2 + jQuad] = r0 | (r1 << 8) | (r2 << 16) | (r3 << 24);
+            }
+            ctx.localBarrier();
+
+            byte[] fragA = ctx.mmaLoadAFP8(aTile, WMMA_K);
+            byte[] fragB0 = ctx.mmaLoadBFP8(bTile0, WMMA_K);
+            fragC0 = ctx.mmaFP8E4M3(fragA, fragB0, fragC0, MMAShape.M16N8K32);
+            byte[] fragB1 = ctx.mmaLoadBFP8(bTile1, WMMA_K);
+            fragC1 = ctx.mmaFP8E4M3(fragA, fragB1, fragC1, MMAShape.M16N8K32);
+
+            ctx.localBarrier();
+        }
+
+        ctx.mmaStore(fragC0, c, tileRow, tileCol, dimN);
+        ctx.mmaStore(fragC1, c, tileRow, tileCol + 8, dimN);
+    }
+
+    /**
+     * Builds, runs and times the FP8 stage.
+     *
+     * <p>
+     * Two different failure modes have to be handled, because they depend on a JVM flag the
+     * caller may not control. With {@code -Dtornado.recover.bailout=False} (what {@code
+     * tornado-test} sets) an unsupported-hardware FP8 kernel raises
+     * {@code TornadoDeviceFP8NotSupported}, which propagates out of here. With the default
+     * bailout behaviour (what a plain {@code tornado} example run uses) TornadoVM instead prints
+     * a {@code [Bailout]} warning and silently re-runs the method as sequential host Java -- where
+     * {@link KernelContext} indices are all zero, so nothing meaningful is computed and the
+     * "kernel" appears absurdly fast. Timing that would report a fictional five-digit GFLOP/s
+     * figure, so the result is validated before any number is printed: an untouched (all-zero)
+     * output means the device kernel never ran.
+     *
+     * @return {@code true} if the FP8 kernel genuinely executed on the device, {@code false} if it
+     *     silently bailed out to the sequential host path.
+     */
+    public static boolean run(KernelContext context, float[] refA, float[] refB, int m, int n, int k, int iterations) throws TornadoExecutionPlanException {
+        FP8Array a = new FP8Array(m * k);
+        FP8Array b = new FP8Array(k * n);
+        FloatArray c = new FloatArray(m * n);
+
+        for (int i = 0; i < m * k; i++) {
+            a.setE4M3(i, refA[i]);
+        }
+        for (int i = 0; i < k * n; i++) {
+            b.setE4M3(i, refB[i]);
+        }
+
+        int warpTiles = (m / WMMA_M) * (n / WMMA_N);
+        WorkerGrid1D worker = new WorkerGrid1D(warpTiles * WARP_SIZE);
+        worker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler grid = new GridScheduler("fp8.gemm", worker);
+
+        TaskGraph graph = new TaskGraph("fp8") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a, b) //
+                .task("gemm", FP8GemmStage::gemmFP8, context, a, b, c, n, k) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        long firstRunNs;
+        long steadyNs;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(graph.snapshot())) {
+            long start = System.nanoTime();
+            plan.withGridScheduler(grid).execute();
+            firstRunNs = System.nanoTime() - start;
+
+            long steadyStart = System.nanoTime();
+            for (int i = 0; i < iterations; i++) {
+                plan.withGridScheduler(grid).execute();
+            }
+            steadyNs = (System.nanoTime() - steadyStart) / iterations;
+        }
+
+        // A silent bailout to sequential host Java leaves C untouched: KernelContext indices are
+        // all zero there, so only element (0,0) is ever a candidate to be written and the rest
+        // stay at their initial 0.0f. Sample a few genuinely-should-be-nonzero outputs.
+        boolean ranOnDevice = false;
+        for (int i = 1; i < 4 && !ranOnDevice; i++) {
+            for (int j = 1; j < 4; j++) {
+                if (c.get(i * n + j) != 0.0f) {
+                    ranOnDevice = true;
+                    break;
+                }
+            }
+        }
+        if (!ranOnDevice) {
+            return false;
+        }
+
+        double ops = 2.0 * m * n * k;
+        double gflops = (ops / (steadyNs / 1e9)) / 1e9;
+        System.out.printf("  %-26s  steady=%8.3f ms   %8.1f GFLOP/s   first-run=%8.1f ms%n", "FP8 E4M3 MMA", steadyNs / 1e6, gflops, firstRunNs / 1e6);
+        return true;
+    }
+
+}

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/LowPrecisionGemmBenchmark.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/LowPrecisionGemmBenchmark.java
@@ -1,0 +1,545 @@
+/*
+ * Copyright (c) 2026 APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.examples.kernelcontext.matrices;
+
+import java.util.Random;
+
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.KernelContext;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.WorkerGrid2D;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.MMAShape;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.BFloat16;
+import uk.ac.manchester.tornado.api.types.HalfFloat;
+import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+
+/**
+ * Low-precision GEMM benchmark: the same {@code C[M,N] = A[M,K] * B[K,N]} computed six ways, all
+ * through {@link KernelContext}, timed back-to-back so the tensor-core and launch-overhead
+ * effects are directly comparable.
+ *
+ * <ol>
+ * <li><b>fp32 shared-memory tiled</b> -- classic tiled GEMM, no tensor cores. The baseline.</li>
+ * <li><b>fp16 MMA</b> -- {@code mmaLoadA}/{@code mmaLoadB}/{@code mma} on {@code M16N8K16}
+ * tensor-core fragments, fp32 accumulate.</li>
+ * <li><b>bf16 MMA</b> -- identical fragment plumbing, {@code mmaBF16} reinterprets the same
+ * register tuples as bf16. Wider exponent, fewer mantissa bits than fp16.</li>
+ * <li><b>fp16 MMA + cp.async</b> -- {@code asyncCopyToLocal}/{@code asyncCopyCommit}/
+ * {@code asyncCopyWaitGroup}: global-to-shared staging bypassing registers (Ampere
+ * {@code cp.async}).</li>
+ * <li><b>fp16 MMA + CUDA Graphs</b> -- same kernel, executed under {@code withCUDAGraph()} so the
+ * launch sequence is captured once and replayed. Isolates per-launch CPU overhead from kernel
+ * time; the win grows as kernels get shorter and more numerous.</li>
+ * <li><b>FP8 E4M3 MMA</b> -- {@code M16N8K32}. Requires compute capability &gt;= 8.9 (Ada/Hopper);
+ * on older hardware TornadoVM raises {@code TornadoDeviceFP8NotSupported} and this stage reports
+ * as skipped rather than failing.</li>
+ * </ol>
+ *
+ * <p>
+ * Every stage runs a warm-up execution first and reports STEADY-STATE time separately from the
+ * first (JIT/NVRTC-compiling) run. Comparing first-run numbers is meaningless -- compilation
+ * dominates by an order of magnitude and produces impressive-looking but entirely fictional
+ * speedups.
+ *
+ * <h2>Reading the numbers: wall-clock understates the kernel speedup</h2>
+ *
+ * <p>
+ * The times printed below are END-TO-END per execution, and each execution copies the 4 MB fp32
+ * result back to the host ({@code transferToHost(EVERY_EXECUTION, ...)}). That transfer is the
+ * same cost for every stage, so it compresses the ratios badly: the tensor-core stages look ~1.1x
+ * to ~1.3x faster than the fp32 baseline, while the KERNELS themselves are 1.7x to 4.1x faster.
+ * Always confirm a GEMM speedup claim against kernel-only timing.
+ *
+ * <p>
+ * Measured on an RTX 3070 (sm_86, Ampere), CUDA 13.0, M=N=K=1024, mean of 20 steady-state
+ * iterations, via {@code --enableProfiler console} ({@code TASK_KERNEL_TIME}):
+ *
+ * <pre>
+ *   kernel                 device time    vs fp32
+ *   gemmFp32Tiled            1336 us       1.00x
+ *   gemmFp16MMA               773 us       1.73x
+ *   gemmBf16MMA               767 us       1.74x
+ *   gemmFp16MMACpAsync        327 us       4.08x
+ * </pre>
+ *
+ * <p>
+ * {@code nsys stats --report cuda_gpu_kern_sum} independently agrees on the three kernels it
+ * records (1197 / 715 / 292 us). Note one profiler quirk worth knowing: in these runs nsys did
+ * NOT record the {@code gemmBf16MMA} launches at all, even though the kernel demonstrably runs
+ * (its cubin is emitted, its results carry bf16 rounding error, and TornadoVM's own profiler
+ * times it). If a kernel goes missing from an nsys report, cross-check with
+ * {@code --enableProfiler console} before concluding it never ran.
+ *
+ * <p>
+ * On accuracy: {@code maxErr} is the largest deviation from an fp32 CPU reference. fp16 lands near
+ * 0.006 and bf16 near 0.07 for these inputs -- roughly an order of magnitude worse, which is the
+ * expected trade: bf16 keeps fp32's exponent range but has only 8 mantissa bits to fp16's 11.
+ *
+ * <p>
+ * How to run:
+ * </p>
+ *
+ * <pre>
+ * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.matrices.LowPrecisionGemmBenchmark
+ * </pre>
+ *
+ * <p>
+ * Cross-check the wall-clock numbers against real GPU kernel time with Nsight Systems:
+ * </p>
+ *
+ * <pre>
+ * source setvars.sh
+ * nsys profile --trace=cuda,nvtx -o lowprec-gemm \
+ *   tornado -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.matrices.LowPrecisionGemmBenchmark
+ * nsys stats --report cuda_gpu_kern_sum lowprec-gemm.nsys-rep
+ * </pre>
+ *
+ * <p>
+ * Or for per-kernel timing straight from TornadoVM, without an nsys capture:
+ * </p>
+ *
+ * <pre>
+ * tornado --enableProfiler console -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.matrices.LowPrecisionGemmBenchmark
+ * </pre>
+ */
+public class LowPrecisionGemmBenchmark {
+
+    private static final int WMMA_M = 16;
+    private static final int WMMA_N = 16;
+    private static final int WMMA_K = 16;
+    private static final int WMMA_K_FP8 = 32;
+    private static final int WARP_SIZE = 32;
+
+    private static final int M = 1024;
+    private static final int N = 1024;
+    private static final int K = 1024;
+
+    private static final int FP32_TILE = 16;
+    private static final int ITERATIONS = 20;
+
+    // ------------------------------------------------------------------
+    // 1. fp32 shared-memory tiled GEMM (baseline -- no tensor cores)
+    // ------------------------------------------------------------------
+    public static void gemmFp32Tiled(KernelContext ctx, FloatArray a, FloatArray b, FloatArray c, int dimN, int dimK) {
+        // Launched on a 2D worker grid: X spans N (columns), Y spans M (rows).
+        int col = ctx.globalIdx;
+        int row = ctx.globalIdy;
+        int tx = ctx.localIdx;
+        int ty = ctx.localIdy;
+
+        float[] aTile = ctx.allocateFloatLocalArray(FP32_TILE * FP32_TILE);
+        float[] bTile = ctx.allocateFloatLocalArray(FP32_TILE * FP32_TILE);
+
+        float sum = 0.0f;
+        for (int kBase = 0; kBase < dimK; kBase += FP32_TILE) {
+            aTile[ty * FP32_TILE + tx] = a.get(row * dimK + kBase + tx);
+            bTile[ty * FP32_TILE + tx] = b.get((kBase + ty) * dimN + col);
+            ctx.localBarrier();
+
+            for (int kk = 0; kk < FP32_TILE; kk++) {
+                sum += aTile[ty * FP32_TILE + kk] * bTile[kk * FP32_TILE + tx];
+            }
+            ctx.localBarrier();
+        }
+        c.set(row * dimN + col, sum);
+    }
+
+    // ------------------------------------------------------------------
+    // 2. fp16 MMA (tensor cores), fp32 accumulate
+    // ------------------------------------------------------------------
+    public static void gemmFp16MMA(KernelContext ctx, HalfFloatArray a, HalfFloatArray b, FloatArray c, int dimN, int dimK) {
+        int warpId = ctx.groupIdx;
+        int lane = ctx.localIdx;
+
+        int numTilesN = dimN / WMMA_N;
+        int tileRow = (warpId / numTilesN) * WMMA_M;
+        int tileCol = (warpId % numTilesN) * WMMA_N;
+
+        int[] aTile = ctx.allocateIntLocalArray(WMMA_M * WMMA_K / 2);
+        int[] bTile0 = ctx.allocateIntLocalArray(WMMA_K * WMMA_N / 2);
+        int[] bTile1 = ctx.allocateIntLocalArray(WMMA_K * WMMA_N / 2);
+
+        float[] fragC0 = ctx.mmaFragment(0.0f);
+        float[] fragC1 = ctx.mmaFragment(0.0f);
+
+        for (int kBase = 0; kBase < dimK; kBase += WMMA_K) {
+            for (int idx = lane; idx < (WMMA_M * WMMA_K) / 2; idx += WARP_SIZE) {
+                int elemBase = idx * 2;
+                int r = elemBase / WMMA_K;
+                int kk = elemBase % WMMA_K;
+                int globalBase = (tileRow + r) * dimK + kBase + kk;
+                int lo = a.get(globalBase).getHalfFloatValue() & 0xFFFF;
+                int hi = a.get(globalBase + 1).getHalfFloatValue() & 0xFFFF;
+                aTile[r * (WMMA_K / 2) + kk / 2] = lo | (hi << 16);
+            }
+
+            for (int idx = lane; idx < 64; idx += WARP_SIZE) {
+                int kRow = idx / 4;
+                int jPair = idx % 4;
+                int jBase = jPair * 2;
+
+                int gL0 = (kBase + kRow) * dimN + tileCol + jBase;
+                int loLeft = b.get(gL0).getHalfFloatValue() & 0xFFFF;
+                int hiLeft = b.get(gL0 + 1).getHalfFloatValue() & 0xFFFF;
+                bTile0[kRow * 4 + jPair] = loLeft | (hiLeft << 16);
+
+                int gR0 = (kBase + kRow) * dimN + tileCol + 8 + jBase;
+                int loRight = b.get(gR0).getHalfFloatValue() & 0xFFFF;
+                int hiRight = b.get(gR0 + 1).getHalfFloatValue() & 0xFFFF;
+                bTile1[kRow * 4 + jPair] = loRight | (hiRight << 16);
+            }
+            ctx.localBarrier();
+
+            HalfFloat[] fragA = ctx.mmaLoadA(aTile, WMMA_K);
+            HalfFloat[] fragB0 = ctx.mmaLoadB(bTile0, WMMA_K);
+            fragC0 = ctx.mma(fragA, fragB0, fragC0, MMAShape.M16N8K16);
+            HalfFloat[] fragB1 = ctx.mmaLoadB(bTile1, WMMA_K);
+            fragC1 = ctx.mma(fragA, fragB1, fragC1, MMAShape.M16N8K16);
+
+            ctx.localBarrier();
+        }
+
+        ctx.mmaStore(fragC0, c, tileRow, tileCol, dimN);
+        ctx.mmaStore(fragC1, c, tileRow, tileCol + 8, dimN);
+    }
+
+    // ------------------------------------------------------------------
+    // 3. bf16 MMA -- same fragment plumbing, mmaBF16 reinterprets the bits
+    // ------------------------------------------------------------------
+    public static void gemmBf16MMA(KernelContext ctx, BFloat16Array a, BFloat16Array b, FloatArray c, int dimN, int dimK) {
+        int warpId = ctx.groupIdx;
+        int lane = ctx.localIdx;
+
+        int numTilesN = dimN / WMMA_N;
+        int tileRow = (warpId / numTilesN) * WMMA_M;
+        int tileCol = (warpId % numTilesN) * WMMA_N;
+
+        int[] aTile = ctx.allocateIntLocalArray(WMMA_M * WMMA_K / 2);
+        int[] bTile0 = ctx.allocateIntLocalArray(WMMA_K * WMMA_N / 2);
+        int[] bTile1 = ctx.allocateIntLocalArray(WMMA_K * WMMA_N / 2);
+
+        float[] fragC0 = ctx.mmaFragment(0.0f);
+        float[] fragC1 = ctx.mmaFragment(0.0f);
+
+        for (int kBase = 0; kBase < dimK; kBase += WMMA_K) {
+            for (int idx = lane; idx < (WMMA_M * WMMA_K) / 2; idx += WARP_SIZE) {
+                int elemBase = idx * 2;
+                int r = elemBase / WMMA_K;
+                int kk = elemBase % WMMA_K;
+                int globalBase = (tileRow + r) * dimK + kBase + kk;
+                int lo = a.get(globalBase) & 0xFFFF;
+                int hi = a.get(globalBase + 1) & 0xFFFF;
+                aTile[r * (WMMA_K / 2) + kk / 2] = lo | (hi << 16);
+            }
+
+            for (int idx = lane; idx < 64; idx += WARP_SIZE) {
+                int kRow = idx / 4;
+                int jPair = idx % 4;
+                int jBase = jPair * 2;
+
+                int gL0 = (kBase + kRow) * dimN + tileCol + jBase;
+                int loLeft = b.get(gL0) & 0xFFFF;
+                int hiLeft = b.get(gL0 + 1) & 0xFFFF;
+                bTile0[kRow * 4 + jPair] = loLeft | (hiLeft << 16);
+
+                int gR0 = (kBase + kRow) * dimN + tileCol + 8 + jBase;
+                int loRight = b.get(gR0) & 0xFFFF;
+                int hiRight = b.get(gR0 + 1) & 0xFFFF;
+                bTile1[kRow * 4 + jPair] = loRight | (hiRight << 16);
+            }
+            ctx.localBarrier();
+
+            HalfFloat[] fragA = ctx.mmaLoadA(aTile, WMMA_K);
+            HalfFloat[] fragB0 = ctx.mmaLoadB(bTile0, WMMA_K);
+            fragC0 = ctx.mmaBF16(fragA, fragB0, fragC0, MMAShape.M16N8K16);
+            HalfFloat[] fragB1 = ctx.mmaLoadB(bTile1, WMMA_K);
+            fragC1 = ctx.mmaBF16(fragA, fragB1, fragC1, MMAShape.M16N8K16);
+
+            ctx.localBarrier();
+        }
+
+        ctx.mmaStore(fragC0, c, tileRow, tileCol, dimN);
+        ctx.mmaStore(fragC1, c, tileRow, tileCol + 8, dimN);
+    }
+
+    // ------------------------------------------------------------------
+    // 4. fp16 MMA staged through cp.async instead of register round-trips
+    // ------------------------------------------------------------------
+    public static void gemmFp16MMACpAsync(KernelContext ctx, HalfFloatArray a, HalfFloatArray b, FloatArray c, int dimN, int dimK) {
+        int warpId = ctx.groupIdx;
+        int lane = ctx.localIdx;
+
+        int numTilesN = dimN / WMMA_N;
+        int tileRow = (warpId / numTilesN) * WMMA_M;
+        int tileCol = (warpId % numTilesN) * WMMA_N;
+
+        int[] aTile = ctx.allocateIntLocalArray(WMMA_M * WMMA_K / 2);
+        int[] bTile0 = ctx.allocateIntLocalArray(WMMA_K * WMMA_N / 2);
+        int[] bTile1 = ctx.allocateIntLocalArray(WMMA_K * WMMA_N / 2);
+
+        float[] fragC0 = ctx.mmaFragment(0.0f);
+        float[] fragC1 = ctx.mmaFragment(0.0f);
+
+        for (int kBase = 0; kBase < dimK; kBase += WMMA_K) {
+            for (int idx = lane; idx < (WMMA_M * WMMA_K) / 2; idx += WARP_SIZE) {
+                int elemBase = idx * 2;
+                int r = elemBase / WMMA_K;
+                int kk = elemBase % WMMA_K;
+                int globalBase = (tileRow + r) * dimK + kBase + kk;
+                ctx.asyncCopyToLocal(aTile, r * (WMMA_K / 2) + kk / 2, a, globalBase);
+            }
+
+            for (int idx = lane; idx < 64; idx += WARP_SIZE) {
+                int kRow = idx / 4;
+                int jPair = idx % 4;
+                int jBase = jPair * 2;
+                int gLeft = (kBase + kRow) * dimN + tileCol + jBase;
+                ctx.asyncCopyToLocal(bTile0, kRow * 4 + jPair, b, gLeft);
+                int gRight = (kBase + kRow) * dimN + tileCol + 8 + jBase;
+                ctx.asyncCopyToLocal(bTile1, kRow * 4 + jPair, b, gRight);
+            }
+            ctx.asyncCopyCommit();
+            ctx.asyncCopyWaitGroup(0);
+            ctx.localBarrier();
+
+            HalfFloat[] fragA = ctx.mmaLoadA(aTile, WMMA_K);
+            HalfFloat[] fragB0 = ctx.mmaLoadB(bTile0, WMMA_K);
+            fragC0 = ctx.mma(fragA, fragB0, fragC0, MMAShape.M16N8K16);
+            HalfFloat[] fragB1 = ctx.mmaLoadB(bTile1, WMMA_K);
+            fragC1 = ctx.mma(fragA, fragB1, fragC1, MMAShape.M16N8K16);
+
+            ctx.localBarrier();
+        }
+
+        ctx.mmaStore(fragC0, c, tileRow, tileCol, dimN);
+        ctx.mmaStore(fragC1, c, tileRow, tileCol + 8, dimN);
+    }
+
+    // ------------------------------------------------------------------
+    // Host-side helpers
+    // ------------------------------------------------------------------
+
+    private static float[] randomMatrix(int elements, long seed) {
+        Random rng = new Random(seed);
+        float[] data = new float[elements];
+        for (int i = 0; i < elements; i++) {
+            data[i] = rng.nextFloat() * 2.0f - 1.0f;
+        }
+        return data;
+    }
+
+    /** Max |difference| against an fp32 CPU reference, sampled over the first few rows. */
+    private static float maxError(FloatArray got, float[] refA, float[] refB, int sampleRows) {
+        float worst = 0.0f;
+        for (int i = 0; i < sampleRows; i++) {
+            for (int j = 0; j < N; j += 97) { // stride to keep the check cheap
+                float expected = 0.0f;
+                for (int k = 0; k < K; k++) {
+                    expected += refA[i * K + k] * refB[k * N + j];
+                }
+                worst = Math.max(worst, Math.abs(expected - got.get(i * N + j)));
+            }
+        }
+        return worst;
+    }
+
+    private static double gflops(long nanos) {
+        double seconds = nanos / 1e9;
+        double ops = 2.0 * M * N * K; // one multiply + one add per element
+        return (ops / seconds) / 1e9;
+    }
+
+    private static void report(String label, long steadyNs, long firstRunNs, float error) {
+        System.out.printf("  %-26s  steady=%8.3f ms   %8.1f GFLOP/s   first-run=%8.1f ms   maxErr=%.4f%n", label, steadyNs / 1e6, gflops(steadyNs), firstRunNs / 1e6, error);
+    }
+
+    private static void reportSkipped(String label, String why) {
+        System.out.printf("  %-26s  SKIPPED (%s)%n", label, why);
+    }
+
+    /** Runs the plan once (warm-up, pays JIT) then {@code ITERATIONS} more; returns {first, mean-steady}. */
+    private static long[] timePlan(TornadoExecutionPlan plan, GridScheduler grid) throws TornadoExecutionPlanException {
+        long start = System.nanoTime();
+        plan.withGridScheduler(grid).execute();
+        long firstRunNs = System.nanoTime() - start;
+
+        long steadyStart = System.nanoTime();
+        for (int i = 0; i < ITERATIONS; i++) {
+            plan.withGridScheduler(grid).execute();
+        }
+        long steadyNs = (System.nanoTime() - steadyStart) / ITERATIONS;
+
+        return new long[] { firstRunNs, steadyNs };
+    }
+
+    public static void main(String[] args) throws TornadoExecutionPlanException {
+        System.out.printf("Low-precision GEMM benchmark -- %dx%d x %dx%d, %d timed iterations per stage%n", M, K, K, N, ITERATIONS);
+        System.out.println("Comparing steady-state times only; first-run includes JIT/NVRTC compilation.");
+        System.out.println();
+
+        float[] refA = randomMatrix(M * K, 11);
+        float[] refB = randomMatrix(K * N, 23);
+
+        KernelContext context = new KernelContext();
+        int warpTiles = (M / WMMA_M) * (N / WMMA_N);
+        int mmaGlobalSize = warpTiles * WARP_SIZE;
+
+        // ---- 1. fp32 tiled baseline -------------------------------------------------
+        FloatArray a32 = new FloatArray(M * K);
+        FloatArray b32 = new FloatArray(K * N);
+        FloatArray c32 = new FloatArray(M * N);
+        for (int i = 0; i < M * K; i++) {
+            a32.set(i, refA[i]);
+        }
+        for (int i = 0; i < K * N; i++) {
+            b32.set(i, refB[i]);
+        }
+
+        WorkerGrid2D fp32Worker = new WorkerGrid2D(N, M);
+        fp32Worker.setLocalWork(FP32_TILE, FP32_TILE, 1);
+        GridScheduler fp32Grid = new GridScheduler("fp32.gemm", fp32Worker);
+        TaskGraph fp32Graph = new TaskGraph("fp32") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a32, b32) //
+                .task("gemm", LowPrecisionGemmBenchmark::gemmFp32Tiled, context, a32, b32, c32, N, K) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c32);
+
+        System.out.println("Results:");
+        long[] fp32Times;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(fp32Graph.snapshot())) {
+            fp32Times = timePlan(plan, fp32Grid);
+        }
+        report("fp32 tiled (baseline)", fp32Times[1], fp32Times[0], maxError(c32, refA, refB, 2));
+
+        // ---- 2. fp16 MMA ------------------------------------------------------------
+        HalfFloatArray a16 = new HalfFloatArray(M * K);
+        HalfFloatArray b16 = new HalfFloatArray(K * N);
+        FloatArray c16 = new FloatArray(M * N);
+        for (int i = 0; i < M * K; i++) {
+            a16.set(i, new HalfFloat(refA[i]));
+        }
+        for (int i = 0; i < K * N; i++) {
+            b16.set(i, new HalfFloat(refB[i]));
+        }
+
+        WorkerGrid1D mmaWorker = new WorkerGrid1D(mmaGlobalSize);
+        mmaWorker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler fp16Grid = new GridScheduler("fp16.gemm", mmaWorker);
+        TaskGraph fp16Graph = new TaskGraph("fp16") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a16, b16) //
+                .task("gemm", LowPrecisionGemmBenchmark::gemmFp16MMA, context, a16, b16, c16, N, K) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c16);
+
+        long[] fp16Times;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(fp16Graph.snapshot())) {
+            fp16Times = timePlan(plan, fp16Grid);
+        }
+        report("fp16 MMA (tensor core)", fp16Times[1], fp16Times[0], maxError(c16, refA, refB, 2));
+
+        // ---- 3. bf16 MMA ------------------------------------------------------------
+        BFloat16Array aBf = new BFloat16Array(M * K);
+        BFloat16Array bBf = new BFloat16Array(K * N);
+        FloatArray cBf = new FloatArray(M * N);
+        for (int i = 0; i < M * K; i++) {
+            aBf.set(i, BFloat16.bf16FromFloat(refA[i]));
+        }
+        for (int i = 0; i < K * N; i++) {
+            bBf.set(i, BFloat16.bf16FromFloat(refB[i]));
+        }
+
+        WorkerGrid1D bf16Worker = new WorkerGrid1D(mmaGlobalSize);
+        bf16Worker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler bf16Grid = new GridScheduler("bf16.gemm", bf16Worker);
+        TaskGraph bf16Graph = new TaskGraph("bf16") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, aBf, bBf) //
+                .task("gemm", LowPrecisionGemmBenchmark::gemmBf16MMA, context, aBf, bBf, cBf, N, K) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, cBf);
+
+        long[] bf16Times;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(bf16Graph.snapshot())) {
+            bf16Times = timePlan(plan, bf16Grid);
+        }
+        report("bf16 MMA (tensor core)", bf16Times[1], bf16Times[0], maxError(cBf, refA, refB, 2));
+
+        // ---- 4. fp16 MMA + cp.async -------------------------------------------------
+        FloatArray cAsync = new FloatArray(M * N);
+        WorkerGrid1D asyncWorker = new WorkerGrid1D(mmaGlobalSize);
+        asyncWorker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler asyncGrid = new GridScheduler("cpasync.gemm", asyncWorker);
+        TaskGraph asyncGraph = new TaskGraph("cpasync") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a16, b16) //
+                .task("gemm", LowPrecisionGemmBenchmark::gemmFp16MMACpAsync, context, a16, b16, cAsync, N, K) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, cAsync);
+
+        long[] asyncTimes;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(asyncGraph.snapshot())) {
+            asyncTimes = timePlan(plan, asyncGrid);
+        }
+        report("fp16 MMA + cp.async", asyncTimes[1], asyncTimes[0], maxError(cAsync, refA, refB, 2));
+
+        // ---- 5. fp16 MMA under a captured CUDA Graph --------------------------------
+        FloatArray cGraph = new FloatArray(M * N);
+        WorkerGrid1D graphWorker = new WorkerGrid1D(mmaGlobalSize);
+        graphWorker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler cudaGraphGrid = new GridScheduler("cudagraph.gemm", graphWorker);
+        TaskGraph cudaGraphTaskGraph = new TaskGraph("cudagraph") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a16, b16) //
+                .task("gemm", LowPrecisionGemmBenchmark::gemmFp16MMA, context, a16, b16, cGraph, N, K) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, cGraph);
+
+        long[] graphTimes;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(cudaGraphTaskGraph.snapshot())) {
+            plan.withCUDAGraph();
+            graphTimes = timePlan(plan, cudaGraphGrid);
+        }
+        report("fp16 MMA + CUDA Graph", graphTimes[1], graphTimes[0], maxError(cGraph, refA, refB, 2));
+
+        // ---- 6. FP8 E4M3 MMA (needs compute capability >= 8.9) ----------------------
+        // Two failure modes depending on the bailout flag -- see FP8GemmStage#run. With
+        // -Dtornado.recover.bailout=False an exception propagates; with the default (what a
+        // plain `tornado` run uses) it silently falls back to sequential host Java, which
+        // FP8GemmStage detects and reports by returning false.
+        try {
+            if (!FP8GemmStage.run(context, refA, refB, M, N, K, ITERATIONS)) {
+                reportSkipped("FP8 E4M3 MMA", "needs compute capability >= 8.9; bailed out to sequential");
+            }
+        } catch (Throwable t) {
+            reportSkipped("FP8 E4M3 MMA", t.getClass().getSimpleName());
+        }
+
+        System.out.println();
+        System.out.println("NOTE: these are END-TO-END times -- each execution copies the 4MB result back to");
+        System.out.println("      the host, which is identical work for every stage and compresses the ratios.");
+        System.out.println("      For kernel-only time, re-run with:  tornado --enableProfiler console ...");
+        System.out.println("      (on an RTX 3070 the kernels are 1.73x/1.74x/4.08x vs fp32, not the numbers below)");
+        System.out.println();
+        System.out.println("Speedups vs fp32 tiled baseline (end-to-end, transfer-dominated):");
+        System.out.printf("  fp16 MMA              %.2fx%n", (double) fp32Times[1] / fp16Times[1]);
+        System.out.printf("  bf16 MMA              %.2fx%n", (double) fp32Times[1] / bf16Times[1]);
+        System.out.printf("  fp16 MMA + cp.async   %.2fx%n", (double) fp32Times[1] / asyncTimes[1]);
+        System.out.printf("  fp16 MMA + CUDA Graph %.2fx%n", (double) fp32Times[1] / graphTimes[1]);
+        System.out.println();
+        System.out.printf("CUDA Graph vs plain fp16 MMA (launch-overhead effect): %.2fx%n", (double) fp16Times[1] / graphTimes[1]);
+    }
+
+}

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/LowPrecisionGemmBenchmark.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/LowPrecisionGemmBenchmark.java
@@ -33,6 +33,8 @@ import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.Int8Array;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 
 /**
  * Low-precision GEMM benchmark: the same {@code C[M,N] = A[M,K] * B[K,N]} computed six ways, all
@@ -51,10 +53,23 @@ import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
  * <li><b>fp16 MMA + CUDA Graphs</b> -- same kernel, executed under {@code withCUDAGraph()} so the
  * launch sequence is captured once and replayed. Isolates per-launch CPU overhead from kernel
  * time; the win grows as kernels get shorter and more numerous.</li>
+ * <li><b>int8 MMA</b> -- {@code mmaLoadAInt8}/{@code mmaLoadBInt8}/{@code mmaInt8} on
+ * {@code M16N8K32}, s32 accumulate. Twice the K-depth per instruction of the fp16 shape, since
+ * twice as many 8-bit operands fit the same fragment registers. Integer GEMM is exact, so its
+ * reported error is a true correctness check, not a rounding measurement.</li>
  * <li><b>FP8 E4M3 MMA</b> -- {@code M16N8K32}. Requires compute capability &gt;= 8.9 (Ada/Hopper);
  * on older hardware TornadoVM raises {@code TornadoDeviceFP8NotSupported} and this stage reports
  * as skipped rather than failing.</li>
  * </ol>
+ *
+ * <p>
+ * On multi-streaming: TornadoVM's CUDA backend already runs transfers and compute on separate,
+ * NVTX-labelled CUDA streams (DEFAULT / H2D / COMPUTE / D2H, see {@code CUDACommandQueue}), but
+ * that pipeline is managed internally -- there is no user-facing stream API on
+ * {@code TornadoExecutionPlan} to schedule work onto explicit streams. {@code withConcurrentDevices()}
+ * is about multi-DEVICE execution, not multi-stream within one GPU. The closest user-visible
+ * control over that pipeline is the {@link DataTransferMode} on each argument, whose cost this
+ * benchmark quantifies below.
  *
  * <p>
  * Every stage runs a warm-up execution first and reports STEADY-STATE time separately from the
@@ -77,11 +92,18 @@ import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
  *
  * <pre>
  *   kernel                 device time    vs fp32
- *   gemmFp32Tiled            1336 us       1.00x
- *   gemmFp16MMA               773 us       1.73x
- *   gemmBf16MMA               767 us       1.74x
- *   gemmFp16MMACpAsync        327 us       4.08x
+ *   gemmFp32Tiled            1334 us       1.00x
+ *   gemmBf16MMA               771 us       1.73x
+ *   gemmFp16MMA               757 us       1.76x
+ *   gemmInt8MMA               446 us       2.99x
+ *   gemmFp16MMACpAsync        327 us       4.09x
  * </pre>
+ *
+ * <p>
+ * int8 lands between the 16-bit formats and the cp.async-pipelined fp16 kernel, which is the
+ * expected shape: it halves the operand bytes AND doubles the K-depth per instruction
+ * ({@code M16N8K32} vs {@code M16N8K16}), but still stages its tiles through the same
+ * synchronous global-to-shared path that {@code cp.async} avoids.
  *
  * <p>
  * {@code nsys stats --report cuda_gpu_kern_sum} independently agrees on the three kernels it
@@ -128,7 +150,7 @@ public class LowPrecisionGemmBenchmark {
     private static final int WMMA_M = 16;
     private static final int WMMA_N = 16;
     private static final int WMMA_K = 16;
-    private static final int WMMA_K_FP8 = 32;
+    private static final int WMMA_K_INT8 = 32;
     private static final int WARP_SIZE = 32;
 
     private static final int M = 1024;
@@ -337,6 +359,71 @@ public class LowPrecisionGemmBenchmark {
     }
 
     // ------------------------------------------------------------------
+    // 6. int8 MMA -- s8 operands, s32 accumulate (M16N8K32)
+    // ------------------------------------------------------------------
+    public static void gemmInt8MMA(KernelContext ctx, Int8Array a, Int8Array b, IntArray c, int dimN, int dimK) {
+        int warpId = ctx.groupIdx;
+        int lane = ctx.localIdx;
+
+        int numTilesN = dimN / WMMA_N;
+        int tileRow = (warpId / numTilesN) * WMMA_M;
+        int tileCol = (warpId % numTilesN) * WMMA_N;
+
+        int[] aTile = ctx.allocateIntLocalArray(WMMA_M * WMMA_K_INT8 / 4);
+        int[] bTile0 = ctx.allocateIntLocalArray(64);
+        int[] bTile1 = ctx.allocateIntLocalArray(64);
+
+        int[] fragC0 = ctx.mmaFragmentInt(0);
+        int[] fragC1 = ctx.mmaFragmentInt(0);
+
+        for (int kBase = 0; kBase < dimK; kBase += WMMA_K_INT8) {
+            for (int idx = lane; idx < (WMMA_M * WMMA_K_INT8) / 4; idx += WARP_SIZE) {
+                int elemBase = idx * 4;
+                int r = elemBase / WMMA_K_INT8;
+                int kk = elemBase % WMMA_K_INT8;
+                int base = (tileRow + r) * dimK + kBase + kk;
+                int packed = (a.get(base) & 0xFF) //
+                        | ((a.get(base + 1) & 0xFF) << 8) //
+                        | ((a.get(base + 2) & 0xFF) << 16) //
+                        | ((a.get(base + 3) & 0xFF) << 24);
+                aTile[r * (WMMA_K_INT8 / 4) + kk / 4] = packed;
+            }
+
+            // Each int packs 2 K-values x 2 J-values for the 8-bit fragment layout.
+            for (int idx = lane; idx < 64; idx += WARP_SIZE) {
+                int kRow = idx / 4;
+                int jPair = idx % 4;
+                int jBase = jPair * 2;
+                int kPair = 2 * kRow;
+
+                int bL0 = b.get((kBase + kPair) * dimN + tileCol + jBase) & 0xFF;
+                int bL1 = b.get((kBase + kPair + 1) * dimN + tileCol + jBase) & 0xFF;
+                int bL2 = b.get((kBase + kPair) * dimN + tileCol + jBase + 1) & 0xFF;
+                int bL3 = b.get((kBase + kPair + 1) * dimN + tileCol + jBase + 1) & 0xFF;
+                bTile0[kRow * 4 + jPair] = bL0 | (bL1 << 8) | (bL2 << 16) | (bL3 << 24);
+
+                int bR0 = b.get((kBase + kPair) * dimN + tileCol + 8 + jBase) & 0xFF;
+                int bR1 = b.get((kBase + kPair + 1) * dimN + tileCol + 8 + jBase) & 0xFF;
+                int bR2 = b.get((kBase + kPair) * dimN + tileCol + 8 + jBase + 1) & 0xFF;
+                int bR3 = b.get((kBase + kPair + 1) * dimN + tileCol + 8 + jBase + 1) & 0xFF;
+                bTile1[kRow * 4 + jPair] = bR0 | (bR1 << 8) | (bR2 << 16) | (bR3 << 24);
+            }
+            ctx.localBarrier();
+
+            byte[] fragA = ctx.mmaLoadAInt8(aTile, WMMA_K_INT8);
+            byte[] fragB0 = ctx.mmaLoadBInt8(bTile0, WMMA_K_INT8);
+            fragC0 = ctx.mmaInt8(fragA, fragB0, fragC0, MMAShape.M16N8K32);
+            byte[] fragB1 = ctx.mmaLoadBInt8(bTile1, WMMA_K_INT8);
+            fragC1 = ctx.mmaInt8(fragA, fragB1, fragC1, MMAShape.M16N8K32);
+
+            ctx.localBarrier();
+        }
+
+        ctx.mmaStoreInt(fragC0, c, tileRow, tileCol, dimN);
+        ctx.mmaStoreInt(fragC1, c, tileRow, tileCol + 8, dimN);
+    }
+
+    // ------------------------------------------------------------------
     // Host-side helpers
     // ------------------------------------------------------------------
 
@@ -355,6 +442,21 @@ public class LowPrecisionGemmBenchmark {
         for (int i = 0; i < sampleRows; i++) {
             for (int j = 0; j < N; j += 97) { // stride to keep the check cheap
                 float expected = 0.0f;
+                for (int k = 0; k < K; k++) {
+                    expected += refA[i * K + k] * refB[k * N + j];
+                }
+                worst = Math.max(worst, Math.abs(expected - got.get(i * N + j)));
+            }
+        }
+        return worst;
+    }
+
+    /** Exact integer reference for the int8 stage -- any nonzero result is a genuine bug. */
+    private static float maxErrorInt(IntArray got, byte[] refA, byte[] refB) {
+        int worst = 0;
+        for (int i = 0; i < 2; i++) {
+            for (int j = 0; j < N; j += 97) {
+                int expected = 0;
                 for (int k = 0; k < K; k++) {
                     expected += refA[i * K + k] * refB[k * N + j];
                 }
@@ -514,7 +616,40 @@ public class LowPrecisionGemmBenchmark {
         }
         report("fp16 MMA + CUDA Graph", graphTimes[1], graphTimes[0], maxError(cGraph, refA, refB, 2));
 
-        // ---- 6. FP8 E4M3 MMA (needs compute capability >= 8.9) ----------------------
+        // ---- 6. int8 MMA (s8 in, s32 accumulate) ------------------------------------
+        // Small integer operands so the s32 accumulator cannot overflow: worst case is
+        // K * 7 * 7 = 1024 * 49, far inside int range. Integer GEMM is EXACT, so any nonzero
+        // error here is a real bug, not a rounding artifact.
+        Random intRng = new Random(37);
+        byte[] refA8 = new byte[M * K];
+        byte[] refB8 = new byte[K * N];
+        Int8Array a8 = new Int8Array(M * K);
+        Int8Array b8 = new Int8Array(K * N);
+        IntArray c8 = new IntArray(M * N);
+        for (int i = 0; i < M * K; i++) {
+            refA8[i] = (byte) (intRng.nextInt(15) - 7);
+            a8.set(i, refA8[i]);
+        }
+        for (int i = 0; i < K * N; i++) {
+            refB8[i] = (byte) (intRng.nextInt(15) - 7);
+            b8.set(i, refB8[i]);
+        }
+
+        WorkerGrid1D int8Worker = new WorkerGrid1D(mmaGlobalSize);
+        int8Worker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler int8Grid = new GridScheduler("int8.gemm", int8Worker);
+        TaskGraph int8Graph = new TaskGraph("int8") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a8, b8) //
+                .task("gemm", LowPrecisionGemmBenchmark::gemmInt8MMA, context, a8, b8, c8, N, K) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c8);
+
+        long[] int8Times;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(int8Graph.snapshot())) {
+            int8Times = timePlan(plan, int8Grid);
+        }
+        report("int8 MMA (tensor core)", int8Times[1], int8Times[0], maxErrorInt(c8, refA8, refB8));
+
+        // ---- 7. FP8 E4M3 MMA (needs compute capability >= 8.9) ----------------------
         // Two failure modes depending on the bailout flag -- see FP8GemmStage#run. With
         // -Dtornado.recover.bailout=False an exception propagates; with the default (what a
         // plain `tornado` run uses) it silently falls back to sequential host Java, which
@@ -531,13 +666,15 @@ public class LowPrecisionGemmBenchmark {
         System.out.println("NOTE: these are END-TO-END times -- each execution copies the 4MB result back to");
         System.out.println("      the host, which is identical work for every stage and compresses the ratios.");
         System.out.println("      For kernel-only time, re-run with:  tornado --enableProfiler console ...");
-        System.out.println("      (on an RTX 3070 the kernels are 1.73x/1.74x/4.08x vs fp32, not the numbers below)");
+        System.out.println("      (on an RTX 3070 the kernels are 1.76x fp16 / 1.73x bf16 / 2.99x int8 / 4.09x");
+        System.out.println("       cp.async vs fp32 -- not the compressed numbers below)");
         System.out.println();
         System.out.println("Speedups vs fp32 tiled baseline (end-to-end, transfer-dominated):");
         System.out.printf("  fp16 MMA              %.2fx%n", (double) fp32Times[1] / fp16Times[1]);
         System.out.printf("  bf16 MMA              %.2fx%n", (double) fp32Times[1] / bf16Times[1]);
         System.out.printf("  fp16 MMA + cp.async   %.2fx%n", (double) fp32Times[1] / asyncTimes[1]);
         System.out.printf("  fp16 MMA + CUDA Graph %.2fx%n", (double) fp32Times[1] / graphTimes[1]);
+        System.out.printf("  int8 MMA              %.2fx%n", (double) fp32Times[1] / int8Times[1]);
         System.out.println();
         System.out.printf("CUDA Graph vs plain fp16 MMA (launch-overhead effect): %.2fx%n", (double) fp16Times[1] / graphTimes[1]);
     }

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/LowPrecisionGemmBenchmark.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/matrices/LowPrecisionGemmBenchmark.java
@@ -53,6 +53,9 @@ import uk.ac.manchester.tornado.api.types.arrays.IntArray;
  * <li><b>fp16 MMA + CUDA Graphs</b> -- same kernel, executed under {@code withCUDAGraph()} so the
  * launch sequence is captured once and replayed. Isolates per-launch CPU overhead from kernel
  * time; the win grows as kernels get shorter and more numerous.</li>
+ * <li><b>fp16 MMA + XOR swizzle</b> -- {@code swizzleStoreFp16Stride32} + {@code mmaLoadBSwizzled},
+ * scattering B across shared-memory banks. See the measured results: on this layout it is a
+ * wash, and the reason is worth knowing.</li>
  * <li><b>int8 MMA</b> -- {@code mmaLoadAInt8}/{@code mmaLoadBInt8}/{@code mmaInt8} on
  * {@code M16N8K32}, s32 accumulate. Twice the K-depth per instruction of the fp16 shape, since
  * twice as many 8-bit operands fit the same fragment registers. Integer GEMM is exact, so its
@@ -92,11 +95,12 @@ import uk.ac.manchester.tornado.api.types.arrays.IntArray;
  *
  * <pre>
  *   kernel                 device time    vs fp32
- *   gemmFp32Tiled            1334 us       1.00x
- *   gemmBf16MMA               771 us       1.73x
- *   gemmFp16MMA               757 us       1.76x
- *   gemmInt8MMA               446 us       2.99x
- *   gemmFp16MMACpAsync        327 us       4.09x
+ *   gemmFp32Tiled            1336 us       1.00x
+ *   gemmBf16MMA               772 us       1.73x
+ *   gemmFp16MMASwizzled       764 us       1.75x
+ *   gemmFp16MMA               761 us       1.76x
+ *   gemmInt8MMA               449 us       2.98x
+ *   gemmFp16MMACpAsync        329 us       4.06x
  * </pre>
  *
  * <p>
@@ -104,6 +108,16 @@ import uk.ac.manchester.tornado.api.types.arrays.IntArray;
  * expected shape: it halves the operand bytes AND doubles the K-depth per instruction
  * ({@code M16N8K32} vs {@code M16N8K16}), but still stages its tiles through the same
  * synchronous global-to-shared path that {@code cp.async} avoids.
+ *
+ * <p>
+ * The XOR-swizzled stage is a deliberate NEGATIVE result, kept because it is informative: it is
+ * indistinguishable from plain fp16 MMA here (764 vs 761 us, inside run-to-run noise). Swizzling
+ * pays off when the shared-memory layout would otherwise make a warp's {@code ldmatrix} reads
+ * collide on the same bank -- but this benchmark's plain path already stores B int-packed (two
+ * fp16 per 32-bit word), which sidesteps most of that conflict on its own. The swizzled variant
+ * instead keeps B as native fp16 elements and uses the XOR swizzle to undo the conflicts that
+ * layout would reintroduce, so the two roughly cancel. Reach for {@code swizzleStoreFp16Stride32}
+ * when your tile layout actually conflicts, not as a reflexive optimisation.
  *
  * <p>
  * {@code nsys stats --report cuda_gpu_kern_sum} independently agrees on the three kernels it
@@ -424,6 +438,62 @@ public class LowPrecisionGemmBenchmark {
     }
 
     // ------------------------------------------------------------------
+    // 7. fp16 MMA with XOR-swizzled shared tiles (bank-conflict avoidance)
+    // ------------------------------------------------------------------
+    public static void gemmFp16MMASwizzled(KernelContext ctx, HalfFloatArray a, HalfFloatArray b, FloatArray c, int dimN, int dimK) {
+        int warpId = ctx.groupIdx;
+        int lane = ctx.localIdx;
+
+        int numTilesN = dimN / WMMA_N;
+        int tileRow = (warpId / numTilesN) * WMMA_M;
+        int tileCol = (warpId % numTilesN) * WMMA_N;
+
+        int[] aTile = ctx.allocateIntLocalArray(WMMA_M * WMMA_K / 2);
+        // B tiles stay NATIVE fp16 here (not int-packed) so the swizzle helpers can address
+        // individual elements: 8 rows x 16 cols per panel.
+        HalfFloat[] bTile0 = ctx.allocateHalfFloatLocalArray(8 * 16);
+        HalfFloat[] bTile1 = ctx.allocateHalfFloatLocalArray(8 * 16);
+
+        float[] fragC0 = ctx.mmaFragment(0.0f);
+        float[] fragC1 = ctx.mmaFragment(0.0f);
+
+        for (int kBase = 0; kBase < dimK; kBase += WMMA_K) {
+            for (int idx = lane; idx < (WMMA_M * WMMA_K) / 2; idx += WARP_SIZE) {
+                int elemBase = idx * 2;
+                int r = elemBase / WMMA_K;
+                int kk = elemBase % WMMA_K;
+                int globalBase = (tileRow + r) * dimK + kBase + kk;
+                int lo = a.get(globalBase).getHalfFloatValue() & 0xFFFF;
+                int hi = a.get(globalBase + 1).getHalfFloatValue() & 0xFFFF;
+                aTile[r * (WMMA_K / 2) + kk / 2] = lo | (hi << 16);
+            }
+
+            // Scatter B through the XOR swizzle so that the subsequent ldmatrix reads hit
+            // distinct shared-memory banks instead of serialising on the same bank.
+            for (int idx = lane; idx < 128; idx += WARP_SIZE) {
+                int kRow = idx / 8;
+                int j = idx % 8;
+                HalfFloat valL = b.get((kBase + kRow) * dimN + tileCol + j);
+                HalfFloat valR = b.get((kBase + kRow) * dimN + tileCol + 8 + j);
+                ctx.swizzleStoreFp16Stride32(bTile0, kRow, j, 8, valL);
+                ctx.swizzleStoreFp16Stride32(bTile1, kRow, j, 8, valR);
+            }
+            ctx.localBarrier();
+
+            HalfFloat[] fragA = ctx.mmaLoadA(aTile, WMMA_K);
+            HalfFloat[] fragB0 = ctx.mmaLoadBSwizzled(bTile0, WMMA_K);
+            fragC0 = ctx.mma(fragA, fragB0, fragC0, MMAShape.M16N8K16);
+            HalfFloat[] fragB1 = ctx.mmaLoadBSwizzled(bTile1, WMMA_K);
+            fragC1 = ctx.mma(fragA, fragB1, fragC1, MMAShape.M16N8K16);
+
+            ctx.localBarrier();
+        }
+
+        ctx.mmaStore(fragC0, c, tileRow, tileCol, dimN);
+        ctx.mmaStore(fragC1, c, tileRow, tileCol + 8, dimN);
+    }
+
+    // ------------------------------------------------------------------
     // Host-side helpers
     // ------------------------------------------------------------------
 
@@ -649,7 +719,23 @@ public class LowPrecisionGemmBenchmark {
         }
         report("int8 MMA (tensor core)", int8Times[1], int8Times[0], maxErrorInt(c8, refA8, refB8));
 
-        // ---- 7. FP8 E4M3 MMA (needs compute capability >= 8.9) ----------------------
+        // ---- 7. fp16 MMA with XOR-swizzled shared tiles ------------------------------
+        FloatArray cSwizzled = new FloatArray(M * N);
+        WorkerGrid1D swizzleWorker = new WorkerGrid1D(mmaGlobalSize);
+        swizzleWorker.setLocalWork(WARP_SIZE, 1, 1);
+        GridScheduler swizzleGrid = new GridScheduler("swizzle.gemm", swizzleWorker);
+        TaskGraph swizzleGraph = new TaskGraph("swizzle") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a16, b16) //
+                .task("gemm", LowPrecisionGemmBenchmark::gemmFp16MMASwizzled, context, a16, b16, cSwizzled, N, K) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, cSwizzled);
+
+        long[] swizzleTimes;
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(swizzleGraph.snapshot())) {
+            swizzleTimes = timePlan(plan, swizzleGrid);
+        }
+        report("fp16 MMA + swizzle", swizzleTimes[1], swizzleTimes[0], maxError(cSwizzled, refA, refB, 2));
+
+        // ---- 8. FP8 E4M3 MMA (needs compute capability >= 8.9) ----------------------
         // Two failure modes depending on the bailout flag -- see FP8GemmStage#run. With
         // -Dtornado.recover.bailout=False an exception propagates; with the default (what a
         // plain `tornado` run uses) it silently falls back to sequential host Java, which
@@ -675,6 +761,7 @@ public class LowPrecisionGemmBenchmark {
         System.out.printf("  fp16 MMA + cp.async   %.2fx%n", (double) fp32Times[1] / asyncTimes[1]);
         System.out.printf("  fp16 MMA + CUDA Graph %.2fx%n", (double) fp32Times[1] / graphTimes[1]);
         System.out.printf("  int8 MMA              %.2fx%n", (double) fp32Times[1] / int8Times[1]);
+        System.out.printf("  fp16 MMA + swizzle    %.2fx%n", (double) fp32Times[1] / swizzleTimes[1]);
         System.out.println();
         System.out.printf("CUDA Graph vs plain fp16 MMA (launch-overhead effect): %.2fx%n", (double) fp16Times[1] / graphTimes[1]);
     }


### PR DESCRIPTION
## Summary

A runnable benchmark example that exercises the low-precision / tensor-core surface of `KernelContext` end to end, and measures it honestly. Six implementations of the same `C[1024,1024] = A[1024,1024] * B[1024,1024]`, run back-to-back on identical data so the tensor-core and launch-overhead effects are directly comparable:

| # | Stage | KernelContext API exercised |
|---|---|---|
| 1 | fp32 shared-memory tiled (baseline) | `allocateFloatLocalArray`, `localBarrier`, 2D worker grid |
| 2 | fp16 MMA | `mmaFragment`, `mmaLoadA`, `mmaLoadB`, `mma`, `mmaStore` (`M16N8K16`, fp32 accumulate) |
| 3 | bf16 MMA | same fragment plumbing, `mmaBF16` reinterprets the register tuples as bf16 |
| 4 | fp16 MMA + `cp.async` | `asyncCopyToLocal`, `asyncCopyCommit`, `asyncCopyWaitGroup` |
| 5 | fp16 MMA + CUDA Graphs | `withCUDAGraph()` — captures the launch sequence and replays it |
| 6 | FP8 E4M3 MMA | `mmaLoadAFP8`, `mmaLoadBFP8`, `mmaFP8E4M3` (`M16N8K32`) |

Correctness is checked for every stage against an fp32 CPU reference. fp16 lands at `maxErr ≈ 0.006`, bf16 at `≈ 0.07` — the expected trade, since bf16 keeps fp32's exponent range but has only 8 mantissa bits to fp16's 11.

## Measured results

RTX 3070 (sm_86, Ampere), CUDA 13.0, M=N=K=1024, mean of 20 steady-state iterations (warm-up excluded), kernel-only time from `--enableProfiler console` (`TASK_KERNEL_TIME`):

```
kernel                 device time    vs fp32
gemmFp32Tiled            1336 us       1.00x
gemmFp16MMA               773 us       1.73x
gemmBf16MMA               767 us       1.74x
gemmFp16MMACpAsync        327 us       4.08x
```

`nsys stats --report cuda_gpu_kern_sum` independently agrees on the three kernels it recorded (1197 / 715 / 292 µs).

FP8 reports as **skipped** on this hardware: FP8 tensor-core MMA needs compute capability ≥ 8.9 (Ada/Hopper), and sm_86 is Ampere.

## Two measurement findings, documented rather than papered over

**1. End-to-end wall-clock badly understates the kernel speedup.** The naive numbers show only ~1.2–1.6x, versus the real 1.7–4.1x. Each execution copies the 4 MB fp32 result back to the host, which is identical work for every stage and compresses all the ratios toward 1. The example prints both figures and says explicitly which one to trust, with the command to reproduce the kernel-only measurement.

**2. `nsys` silently omitted a kernel that definitely ran.** `gemmBf16MMA` appears nowhere in the nsys kernel summary across repeated runs, despite the kernel demonstrably executing — its cubin is emitted to the code cache, its results carry bf16-specific rounding error (0.0699, distinct from fp16's 0.0060), and TornadoVM's own profiler times it at 767 µs. Worth knowing as a profiler caveat: if a kernel goes missing from an nsys report, cross-check with `--enableProfiler console` before concluding it never ran. This is called out in the example's javadoc.

## A trap the FP8 stage has to defend against

Without `-Dtornado.recover.bailout=False` (which `tornado-test` sets but a plain `tornado` example run does not), an unsupported FP8 kernel does **not** throw. TornadoVM prints a `[Bailout]` warning and silently re-runs the method as sequential host Java — where `KernelContext` indices are all zero, so nothing meaningful is computed and the "kernel" appears absurdly fast. Timed naively this reports a fictional **33 TFLOP/s** on hardware that cannot do FP8 at all.

`FP8GemmStage` therefore validates the output before printing any number, and reports the stage as skipped if the device kernel never ran. Both failure modes (exception vs. silent bailout) are handled, since which one occurs depends on a JVM flag the example cannot assume.

## How to run

```bash
tornado -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.matrices.LowPrecisionGemmBenchmark

# kernel-only timing
tornado --enableProfiler console -m tornado.examples/...LowPrecisionGemmBenchmark

# full timeline
nsys profile --trace=cuda,nvtx -o lowprec-gemm tornado -m tornado.examples/...LowPrecisionGemmBenchmark
nsys stats --report cuda_gpu_kern_sum lowprec-gemm.nsys-rep
```

## Test plan

- [x] `make BACKEND=cuda` builds clean
- [x] All six stages run; five execute on device and validate against the fp32 reference, FP8 correctly reports skipped on sm_86
- [x] Kernel times cross-validated with two independent tools (TornadoVM profiler + nsys)
- [x] `./mvnw checkstyle:check` clean
- [x] Examples-only change — no runtime, driver, or API code touched, so no test-suite impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)