### PR TITLE
[cuda] Skip the per-launch kernel stack-frame upload when the device copy is unchanged (~2x on short task graphs)

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContext.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContext.java
@@ -386,7 +386,7 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
      * Multi-queue issue is disabled while the plan's stream is capturing into a CUDA graph:
      * capture records a single stream, and touching other streams would invalidate it.
      */
-    private boolean isMultiStreamEnabled(long executionPlanId) {
+    public boolean isMultiStreamEnabled(long executionPlanId) {
         return intraPlanConcurrencyPlans.contains(executionPlanId) && !isStreamCapturing(executionPlanId);
     }
 

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/CUDAInstalledCode.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/CUDAInstalledCode.java
@@ -226,9 +226,16 @@ public class CUDAInstalledCode extends InstalledCode implements TornadoInstalled
         if (deviceContext.deferKernelContextWriteIfCapturing(executionPlanId, kernelArgs)) {
             waitEvents = events;
         } else {
-            internalEvents[0] = kernelArgs.enqueueWrite(executionPlanId, events);
-            waitEvents = internalEvents;
-            updateProfilerKernelContextWrite(executionPlanId, internalEvents[0], meta, kernelArgs);
+            int kernelContextWriteEventId = kernelArgs.enqueueWrite(executionPlanId, events);
+            if (kernelContextWriteEventId == -1) {
+                // The frame was already on the device unchanged, so there is no write event to
+                // chain the launch onto: keep the caller's dependencies instead of dropping them.
+                waitEvents = events;
+            } else {
+                internalEvents[0] = kernelContextWriteEventId;
+                waitEvents = internalEvents;
+                updateProfilerKernelContextWrite(executionPlanId, kernelContextWriteEventId, meta, kernelArgs);
+            }
         }
 
         int task;
@@ -314,7 +321,9 @@ public class CUDAInstalledCode extends InstalledCode implements TornadoInstalled
         setKernelArgs(oclKernelStackFrame, atomicSpace, meta);
         if (!deviceContext.deferKernelContextWriteIfCapturing(executionPlanId, oclKernelStackFrame)) {
             int kernelContextWriteEventId = oclKernelStackFrame.enqueueWrite(executionPlanId);
-            updateProfilerKernelContextWrite(executionPlanId, kernelContextWriteEventId, meta, oclKernelStackFrame);
+            if (kernelContextWriteEventId != -1) {
+                updateProfilerKernelContextWrite(executionPlanId, kernelContextWriteEventId, meta, oclKernelStackFrame);
+            }
         }
 
         if (meta == null) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAKernelStackFrame.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAKernelStackFrame.java
@@ -57,6 +57,19 @@ public class CUDAKernelStackFrame extends CUDAByteBuffer implements KernelStackF
     /** Off-heap host buffer backing {@code buffer}, or 0 when allocation fell back to heap. */
     private long hostPointer;
 
+    /**
+     * Snapshot of the frame slots as they currently sit in device memory, and the execution plan
+     * that put them there. The frame is re-uploaded on every launch even though its contents are
+     * identical across iterations for the common case (no {@code KernelContext}, so all slots are
+     * zero), which costs a {@code cuMemcpyHtoDAsync} plus an event pair per launch. Comparing the
+     * host slots against this snapshot lets an unchanged frame skip the transfer entirely.
+     */
+    private final long[] deviceSlots = new long[RESERVED_SLOTS];
+
+    private boolean deviceSlotsValid;
+
+    private long deviceSlotsPlanId;
+
     CUDAKernelStackFrame(long bufferId, int numArgs, CUDADeviceContext device) {
         super(device, bufferId, 0, FRAME_BYTES);
         this.callArguments = new ArrayList<>(numArgs);
@@ -90,6 +103,7 @@ public class CUDAKernelStackFrame extends CUDAByteBuffer implements KernelStackF
     @Override
     public void invalidate() {
         isValid = false;
+        deviceSlotsValid = false;
         if (hostPointer != 0) {
             // Unregister (native side synchronises the context first) BEFORE freeing, so
             // no stale pin can survive the host buffer.
@@ -100,13 +114,22 @@ public class CUDAKernelStackFrame extends CUDAByteBuffer implements KernelStackF
         deviceContext.getPlatformContext().releaseBuffer(toBuffer());
     }
 
-    /** Async device write from the off-heap (pinned) host frame: no per-launch stream sync. */
+    /**
+     * Async device write from the off-heap (pinned) host frame: no per-launch stream sync.
+     * Returns {@code -1} when the device copy already holds these slots and the transfer was
+     * skipped; that value is the established "no event" marker in dependency lists.
+     */
     @Override
     public int enqueueWrite(long executionPlanId, final int[] events) {
         if (hostPointer == 0) {
             return super.enqueueWrite(executionPlanId, events);
         }
-        return deviceContext.enqueueWriteBuffer(executionPlanId, toBuffer(), getOffset(), FRAME_BYTES, hostPointer, 0, events);
+        if (deviceCopyIsUpToDate(executionPlanId)) {
+            return -1;
+        }
+        int event = deviceContext.enqueueWriteBuffer(executionPlanId, toBuffer(), getOffset(), FRAME_BYTES, hostPointer, 0, events);
+        snapshotDeviceCopy(executionPlanId);
+        return event;
     }
 
     /** Blocking device write from the off-heap host frame (used by the CUDA-graph capture flush). */
@@ -117,6 +140,32 @@ public class CUDAKernelStackFrame extends CUDAByteBuffer implements KernelStackF
             return;
         }
         deviceContext.writeBuffer(executionPlanId, toBuffer(), getOffset(), FRAME_BYTES, hostPointer, 0, events);
+        snapshotDeviceCopy(executionPlanId);
+    }
+
+    /**
+     * Whether the device copy already matches the host frame. Only claimed for a plan that issues
+     * on a single stream: under intra-plan concurrency the launch may run on a different queue from
+     * the one that carried the write, and skipping would drop the ordering the write event provides.
+     */
+    private boolean deviceCopyIsUpToDate(long executionPlanId) {
+        if (!deviceSlotsValid || deviceSlotsPlanId != executionPlanId || deviceContext.isMultiStreamEnabled(executionPlanId)) {
+            return false;
+        }
+        for (int i = 0; i < RESERVED_SLOTS; i++) {
+            if (buffer.getLong(i << 3) != deviceSlots[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void snapshotDeviceCopy(long executionPlanId) {
+        for (int i = 0; i < RESERVED_SLOTS; i++) {
+            deviceSlots[i] = buffer.getLong(i << 3);
+        }
+        deviceSlotsValid = true;
+        deviceSlotsPlanId = executionPlanId;
     }
 
     @Override


### PR DESCRIPTION
Two changes to the same thing: the fixed cost the host pays per operation, independent of how many bytes move. They were #1022 and #1023; #1023 is folded in here because its value is only measurable on top of this one, and reviewing them apart means reading the same profile twice.

## How this was found

JFR (1 ms sampling, `stackdepth=192`, `DebugNonSafepoints`) plus Nsight Systems on `develop` @`ba28f1526`. A `saxpy` task graph over 512 floats — one kernel, one H2D, one blocking D2H — spent **17.46 µs per `execute()` while the GPU did 3.31 µs of work**. Per iteration the runtime issued **4 stream operations, 12 event calls and 3 `cuStreamSynchronize`** to move 2 KB and run a 1.1 µs kernel.

Worth recording from the same profile: the Java bytecode interpreter and its data structures account for **~0.9% of wall time** (118 `jdk.ExecutionSample` vs 13,545 `jdk.NativeMethodSample`, and most of the Java samples are the benchmark harness's own `Arrays.sort`). The cost is in the per-operation CUDA dispatch sequence, not in interpreting bytecodes.

## Commit 1 — skip the per-launch kernel stack-frame upload

The 24-byte kernel-argument stack frame is re-uploaded on **every** kernel launch, even though its contents are identical across iterations in the common case (no `KernelContext`, so all three slots are zero). Nsight Systems puts that copy at **2.00 µs per launch on an RTX 4090 — the same cost as the 2 KB user-data copy in the same graph**, because the price is the JNI round trip, the `cuMemcpyHtoDAsync` and an event pair, not the bytes.

`CUDAKernelStackFrame` now keeps a snapshot of the slots it last placed on the device, together with the execution-plan id that put them there. `enqueueWrite` compares the host frame against that snapshot and returns `-1` — the established "no event" marker in dependency lists, already skipped by `CUDAEventPool.serialiseEvents` — instead of issuing the transfer when they match.

`CUDAInstalledCode` falls back to the caller's dependency list when there is no write event, so dependencies are never dropped: previously the launch chained onto the write event, which transitively carried the caller's dependencies.

The skip is refused when the plan runs with intra-plan concurrency (`isMultiStreamEnabled`), where the launch may issue on a different queue from the one that carried the write and the write event is load-bearing for ordering.

## Commit 2 — skip stream synchronisation when nothing has been enqueued

A task-graph execution ends with a blocking device-to-host read-back, then `flush()`, then `waitOn()` — **three `cuStreamSynchronize` per execution, two of them issued against a stream that is already empty**.

`cuda_queue_t` gains a `pending` flag, set by every stream enqueue (both transfer helpers, `cuLaunchKernel`, every `cuEventRecord`, `cuStreamWaitEvent`, `cuGraphLaunch`) and cleared on drain. `clFlush`, `clFinish` and the blocking-transfer sync all route through a single `sync_stream()` helper that returns immediately when nothing has been enqueued since the last drain — in which case the stream is empty by construction and the driver round trip buys nothing.

The second half of that commit matters as much as the flag: the transfer helpers now record their completion event **before** draining rather than after. Recording afterwards re-armed `pending`, so the following `flush()` still synchronised an otherwise idle stream. With the reorder the sync covers the event record too, and `pending` is genuinely clear afterwards. The semantics are unchanged — the event still marks the end of the copy.

`sync_stream()` only ever skips when the flag says nothing has been enqueued since the previous successful drain. Every path that puts work on the stream sets it, including `cuStreamWaitEvent` (a wait node is stream work) and `cuGraphLaunch` (a replayed graph is stream work like any other). `cuMemcpyDtoD` in `CUDANativeCommandQueue.cpp` is the synchronous variant and leaves nothing outstanding. Capture is unaffected: the helpers already refuse to synchronise a capturing stream.

## Numbers

RTX 4090, JDK 21.0.2, base `develop` @`ba28f1526`. Per-`execute()` median reported by `BenchmarkDriver` (which already discards the first 30 iterations), `saxpy 100000 512`:

| build | median |
|---|---|
| `develop` | 17.46 µs |
| commit 1 only | 8.75 µs |
| commit 2 only | 17.44 µs |
| **both (this PR)** | **8.35 / 8.36 / 8.60 µs** |

**2.09x.** The second commit is worth nothing on its own on this workload and **4.2% once the first lands** — which is the argument for shipping them together: the removed syncs only surface as time when the dominant per-launch cost is gone.

nsys, 20,000 iterations, per iteration:

| | `develop` | this PR |
|---|---|---|
| NVTX `H2D 24 B` instances | 20,000 (2.00 µs avg) | **1** |
| `cuStreamSynchronize` calls | 60,000 (3/iter) | **20,000 (1/iter)** |
| `cuEventCreate` / `Record` / `Destroy` | 4 each | 3 each |
| NVTX `D2H 2.0 KB` avg | 7.81 µs | 5.63 µs |

The saving is larger than the 2.00 µs the copy itself cost: removing it also removes an event pair and shortens the queue that the blocking read-back waits behind.

Across the small-size benchmarks the win tracks how dispatch-dominated the graph is, and nothing regresses:

| benchmark (size 512) | `develop` | this PR | speed-up |
|---|---|---|---|
| `saxpy` | 18.33 µs | 9.38 µs | 1.95x |
| `stencil` | 17.24 µs | 13.24 µs | 1.30x |
| `blackscholes` | 22.56 µs | 20.39 µs | 1.11x |
| `nbody` | 40.22 µs | 39.22 µs | 1.03x |
| `dft` | 95.83 µs | 94.18 µs | 1.02x |
| `blurFilter 3000 256` (3 tasks) | 266.59 µs | 262.56 µs | 1.015x |

**Controls — GPU-bound work unaffected:**

| workload | `develop` | this PR |
|---|---|---|
| `saxpy 2000 16777216` | 7.542 / 7.530 / 7.518 ms | 7.456 / 7.392 / 7.425 ms |
| `nbody 500 16384` | 1.7222 / 1.7239 / 1.7260 ms | 1.7261 / 1.7252 / 1.7270 ms |

## Testing

- `tornado-test --quickPass`, CUDA backend: same failures as the `develop` baseline on this machine (86 vs 85, the difference being the known-flaky `MMwithBytes`, 4/4 in isolated re-runs).
- CUDA-graph capture exercised specifically, since both changes touch state that must survive stream capture (`cuGraphLaunch` sets `pending`; the deferred frame write must still see a valid frame): `TestCuBlas` 12/12, `TestCuFft` 8/8, `TestExecutor` 7/7.
- `./mvnw checkstyle:check` clean.

## Known limitation

A generated kernel with a non-void return writes `frame[0]` through `CUDAReturnSlot`, so its device copy could drift from the host snapshot. This is only reachable via the internal JIT test path — the `TaskGraph.task(...)` functional interfaces are all `void` — and nothing on the CUDA path reads the frame back.

## Reproduction

```bash
tornado --jvm="-Dtornado.benchmarks.skipserial=True" \
  -m tornado.benchmarks/uk.ac.manchester.tornado.benchmarks.BenchmarkRunner \
  --params="saxpy 100000 512"

nsys profile -t cuda --sample=none --cpuctxsw=none -o saxpy512 \
  tornado --jvm="-Dtornado.benchmarks.skipserial=True" \
  -m tornado.benchmarks/uk.ac.manchester.tornado.benchmarks.BenchmarkRunner \
  --params="saxpy 20000 512"
nsys stats --report cuda_api_sum saxpy512.nsys-rep
```

Part of #1028. Supersedes #1023.
