### PR TITLE
[profiler] Harvest device timestamps after the stream drains instead of blocking on every operation (profiler-on cost -34%)

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContext.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContext.java
@@ -203,6 +203,7 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
         // host against up to 7 queues per execution.
         joinRoleQueues(executionPlanId, commandQueue);
         commandQueue.finish();
+        harvestDeferredProfilerReads();
     }
 
     @Override
@@ -941,6 +942,39 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
     public void flush(long executionPlanId) {
         CUDACommandQueue commandQueue = getCommandQueue(executionPlanId);
         commandQueue.flush();
+        harvestDeferredProfilerReads();
+    }
+
+    /**
+     * Profiler read-outs postponed until the stream has been drained. Reading a device
+     * timestamp waits for its event, so doing it inline after each launch pins the host to
+     * the device for the whole run; the reads are batched here and run once the work is
+     * known complete, where they cost nothing.
+     */
+    private final List<Runnable> deferredProfilerReads = Collections.synchronizedList(new ArrayList<>());
+
+    /** Bound on outstanding reads, so a long run cannot outlive the backing event slots. */
+    private static final int MAX_DEFERRED_PROFILER_READS = 256;
+
+    public void deferProfilerRead(Runnable read) {
+        deferredProfilerReads.add(read);
+        if (deferredProfilerReads.size() >= MAX_DEFERRED_PROFILER_READS) {
+            harvestDeferredProfilerReads();
+        }
+    }
+
+    public void harvestDeferredProfilerReads() {
+        if (deferredProfilerReads.isEmpty()) {
+            return;
+        }
+        List<Runnable> pending;
+        synchronized (deferredProfilerReads) {
+            pending = new ArrayList<>(deferredProfilerReads);
+            deferredProfilerReads.clear();
+        }
+        for (Runnable read : pending) {
+            read.run();
+        }
     }
 
     @Override

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/CUDAInstalledCode.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/CUDAInstalledCode.java
@@ -272,17 +272,20 @@ public class CUDAInstalledCode extends InstalledCode implements TornadoInstalled
         // Skipped while capturing into a CUDA graph: waiting on a capture-recorded event is
         // illegal and invalidates the capture.
         if (TornadoOptions.isProfilerEnabled() && !deviceContext.isStreamCapturing(executionPlanId)) {
-            Event tornadoKernelEvent = deviceContext.resolveEvent(executionPlanId, task);
-            tornadoKernelEvent.waitForEvents(executionPlanId);
-            long timer = meta.getProfiler().getTimer(ProfilerType.TOTAL_KERNEL_TIME);
-            // Register globalTime
-            meta.getProfiler().setTimer(ProfilerType.TOTAL_KERNEL_TIME, timer + tornadoKernelEvent.getElapsedTime());
-            // Register the time for the task
-            meta.getProfiler().setTaskTimer(ProfilerType.TASK_KERNEL_TIME, meta.getId(), tornadoKernelEvent.getElapsedTime());
-            // Register the dispatch time of the kernel
-            long dispatchValue = meta.getProfiler().getTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME);
-            dispatchValue += tornadoKernelEvent.getDriverDispatchTime();
-            meta.getProfiler().setTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME, dispatchValue);
+            final int kernelEvent = task;
+            deviceContext.deferProfilerRead(() -> {
+                Event tornadoKernelEvent = deviceContext.resolveEvent(executionPlanId, kernelEvent);
+                tornadoKernelEvent.waitForEvents(executionPlanId);
+                long timer = meta.getProfiler().getTimer(ProfilerType.TOTAL_KERNEL_TIME);
+                // Register globalTime
+                meta.getProfiler().setTimer(ProfilerType.TOTAL_KERNEL_TIME, timer + tornadoKernelEvent.getElapsedTime());
+                // Register the time for the task
+                meta.getProfiler().setTaskTimer(ProfilerType.TASK_KERNEL_TIME, meta.getId(), tornadoKernelEvent.getElapsedTime());
+                // Register the dispatch time of the kernel
+                long dispatchValue = meta.getProfiler().getTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME);
+                dispatchValue += tornadoKernelEvent.getDriverDispatchTime();
+                meta.getProfiler().setTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME, dispatchValue);
+            });
         }
         return task;
     }
@@ -327,16 +330,19 @@ public class CUDAInstalledCode extends InstalledCode implements TornadoInstalled
     private void updateProfilerKernelContextWrite(long executionPlanId, int kernelContextWriteEventId, TaskDataContext meta, CUDAKernelStackFrame callWrapper) {
         if (TornadoOptions.isProfilerEnabled()) {
             TornadoProfiler profiler = meta.getProfiler();
-            Event event = deviceContext.resolveEvent(executionPlanId, kernelContextWriteEventId);
-            event.waitForEvents(executionPlanId);
-            long copyInTimer = meta.getProfiler().getTimer(ProfilerType.COPY_IN_TIME);
-            copyInTimer += event.getElapsedTime();
-            profiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
-            profiler.addValueToMetric(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES, meta.getId(), callWrapper.getSize());
+            final long frameBytes = callWrapper.getSize();
+            deviceContext.deferProfilerRead(() -> {
+                Event event = deviceContext.resolveEvent(executionPlanId, kernelContextWriteEventId);
+                event.waitForEvents(executionPlanId);
+                long copyInTimer = profiler.getTimer(ProfilerType.COPY_IN_TIME);
+                copyInTimer += event.getElapsedTime();
+                profiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
+                profiler.addValueToMetric(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES, meta.getId(), frameBytes);
 
-            long dispatchValue = profiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
-            dispatchValue += event.getDriverDispatchTime();
-            profiler.setTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME, dispatchValue);
+                long dispatchValue = profiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
+                dispatchValue += event.getDriverDispatchTime();
+                profiler.setTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME, dispatchValue);
+            });
         }
     }
 

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/scheduler/CUDAKernelScheduler.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/scheduler/CUDAKernelScheduler.java
@@ -76,17 +76,22 @@ public abstract class CUDAKernelScheduler {
                         : -1);
             }
 
-            Event tornadoKernelEvent = deviceContext.resolveEvent(executionPlanId, taskEvent);
-            tornadoKernelEvent.waitForEvents(executionPlanId);
-            long timer = meta.getProfiler().getTimer(ProfilerType.TOTAL_KERNEL_TIME);
-            // Register globalTime
-            meta.getProfiler().setTimer(ProfilerType.TOTAL_KERNEL_TIME, timer + tornadoKernelEvent.getElapsedTime());
-            // Register the time for the task
-            meta.getProfiler().setTaskTimer(ProfilerType.TASK_KERNEL_TIME, meta.getId(), tornadoKernelEvent.getElapsedTime());
-            // Register the dispatch time of the kernel
-            long dispatchValue = meta.getProfiler().getTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME);
-            dispatchValue += tornadoKernelEvent.getDriverDispatchTime();
-            meta.getProfiler().setTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME, dispatchValue);
+            // Read the kernel timestamps once the stream has been drained: waiting on the event
+            // here would block the host until this kernel finished, before the next one is even
+            // enqueued.
+            deviceContext.deferProfilerRead(() -> {
+                Event tornadoKernelEvent = deviceContext.resolveEvent(executionPlanId, taskEvent);
+                tornadoKernelEvent.waitForEvents(executionPlanId);
+                long timer = meta.getProfiler().getTimer(ProfilerType.TOTAL_KERNEL_TIME);
+                // Register globalTime
+                meta.getProfiler().setTimer(ProfilerType.TOTAL_KERNEL_TIME, timer + tornadoKernelEvent.getElapsedTime());
+                // Register the time for the task
+                meta.getProfiler().setTaskTimer(ProfilerType.TASK_KERNEL_TIME, meta.getId(), tornadoKernelEvent.getElapsedTime());
+                // Register the dispatch time of the kernel
+                long dispatchValue = meta.getProfiler().getTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME);
+                dispatchValue += tornadoKernelEvent.getDriverDispatchTime();
+                meta.getProfiler().setTimer(ProfilerType.TOTAL_DISPATCH_KERNEL_TIME, dispatchValue);
+            });
         }
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -27,12 +27,14 @@ import static uk.ac.manchester.tornado.api.enums.TornadoExecutionStatus.COMPLETE
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VIRTUAL_DEVICE_ENABLED;
 import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VM_USE_DEPS;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.KernelContext;
@@ -105,6 +107,26 @@ public class TornadoVMInterpreter {
     private final List<SchedulableTask> localTaskList;
     private final TornadoExecutionContext graphExecutionContext;
     private final TornadoVMBytecodeResult bytecodeResult;
+
+    /**
+     * Device timings the profiler still has to read out of their events. Reading a timestamp
+     * means waiting for the event, so doing it inline after each transfer serialises the host
+     * against the device for the whole run - with the profiler on, a short task graph slows
+     * down several times over. The samples are instead harvested once the run has drained its
+     * stream, where every event is already complete and the read costs nothing.
+     */
+    private record DeferredProfilerSample(int eventIndex, Consumer<Event> harvest) {
+    }
+
+    private final List<DeferredProfilerSample> deferredProfilerSamples = new ArrayList<>();
+
+    /**
+     * Harvest early once this many samples are outstanding: event slots are recycled by the
+     * backend event pool, so a very long run must not hold references to slots that have since
+     * been reused.
+     */
+    private static final int MAX_DEFERRED_PROFILER_SAMPLES = 256;
+
     private TornadoProfiler timeProfiler;
     private double totalTime;
     private long invocations;
@@ -513,6 +535,7 @@ public class TornadoVMInterpreter {
             if (TornadoOptions.USE_VM_FLUSH) {
                 interpreterDevice.flush(graphExecutionContext.getExecutionPlanId());
             }
+            harvestProfilerSamples();
         }
 
         final long t1 = System.nanoTime();
@@ -912,16 +935,17 @@ public class TornadoVMInterpreter {
         }
 
         if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && allEvents != null) {
+            final long transferredBytes = objectState.getXPUBuffer().size();
             for (Integer e : allEvents) {
-                Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), e);
-                event.waitForEvents(graphExecutionContext.getExecutionPlanId());
-                long copyInTimer = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
-                copyInTimer += event.getElapsedTime();
-                timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
-                timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
-                long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
-                dispatchValue += event.getDriverDispatchTime();
-                timeProfiler.setTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME, dispatchValue);
+                deferProfilerSample(e, event -> {
+                    long copyInTimer = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
+                    copyInTimer += event.getElapsedTime();
+                    timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
+                    timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, transferredBytes);
+                    long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
+                    dispatchValue += event.getDriverDispatchTime();
+                    timeProfiler.setTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME, dispatchValue);
+                });
             }
         }
 
@@ -951,18 +975,19 @@ public class TornadoVMInterpreter {
         }
 
         if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && allEvents != null) {
+            final long transferredBytes = objectState.getXPUBuffer().size();
             for (Integer e : allEvents) {
-                Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), e);
-                event.waitForEvents(graphExecutionContext.getExecutionPlanId());
-                long copyInTimer = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
-                copyInTimer += event.getElapsedTime();
-                timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
+                deferProfilerSample(e, event -> {
+                    long copyInTimer = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
+                    copyInTimer += event.getElapsedTime();
+                    timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, copyInTimer);
 
-                timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
+                    timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_IN_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, transferredBytes);
 
-                long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
-                dispatchValue += event.getDriverDispatchTime();
-                timeProfiler.setTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME, dispatchValue);
+                    long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
+                    dispatchValue += event.getDriverDispatchTime();
+                    timeProfiler.setTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME, dispatchValue);
+                });
             }
         }
 
@@ -992,17 +1017,18 @@ public class TornadoVMInterpreter {
         resetEventIndexes(eventId);
 
         if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && readEvent != -1) {
-            Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), readEvent);
-            event.waitForEvents(graphExecutionContext.getExecutionPlanId());
-            long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
-            value += event.getElapsedTime();
-            timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
+            final long transferredBytes = objectState.getXPUBuffer().size();
+            deferProfilerSample(readEvent, event -> {
+                long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
+                value += event.getElapsedTime();
+                timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
 
-            timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
+                timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, transferredBytes);
 
-            long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
-            dispatchValue += event.getDriverDispatchTime();
-            timeProfiler.setTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME, dispatchValue);
+                long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
+                dispatchValue += event.getDriverDispatchTime();
+                timeProfiler.setTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME, dispatchValue);
+            });
         }
         return readEvent;
     }
@@ -1024,17 +1050,18 @@ public class TornadoVMInterpreter {
         final int readEvent = interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList);
 
         if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && readEvent != -1) {
-            Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), readEvent);
-            event.waitForEvents(graphExecutionContext.getExecutionPlanId());
-            long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
-            value += event.getElapsedTime();
-            timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
+            final long transferredBytes = objectState.getXPUBuffer().size();
+            deferProfilerSample(readEvent, event -> {
+                long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
+                value += event.getElapsedTime();
+                timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
 
-            timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
+                timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, transferredBytes);
 
-            long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
-            dispatchValue += event.getDriverDispatchTime();
-            timeProfiler.setTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME, dispatchValue);
+                long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
+                dispatchValue += event.getDriverDispatchTime();
+                timeProfiler.setTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME, dispatchValue);
+            });
         }
         resetEventIndexes(eventId);
     }
@@ -1243,11 +1270,11 @@ public class TornadoVMInterpreter {
             List<Integer> allEvents = bufferAtomics.enqueueWrite(graphExecutionContext.getExecutionPlanId(), null, 0, 0, null, false);
             if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion) {
                 for (Integer e : allEvents) {
-                    Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), e);
-                    event.waitForEvents(graphExecutionContext.getExecutionPlanId());
-                    long value = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
-                    value += event.getElapsedTime();
-                    timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, value);
+                    deferProfilerSample(e, event -> {
+                        long value = timeProfiler.getTimer(ProfilerType.COPY_IN_TIME);
+                        value += event.getElapsedTime();
+                        timeProfiler.setTimer(ProfilerType.COPY_IN_TIME, value);
+                    });
                 }
             }
             if (TornadoOptions.LOG_BYTECODES()) {
@@ -1434,6 +1461,26 @@ public class TornadoVMInterpreter {
 
     private boolean isNotObjectAtomic(Object object) {
         return !(object instanceof AtomicInteger);
+    }
+
+    private void deferProfilerSample(int eventIndex, Consumer<Event> harvest) {
+        deferredProfilerSamples.add(new DeferredProfilerSample(eventIndex, harvest));
+        if (deferredProfilerSamples.size() >= MAX_DEFERRED_PROFILER_SAMPLES) {
+            harvestProfilerSamples();
+        }
+    }
+
+    private void harvestProfilerSamples() {
+        if (deferredProfilerSamples.isEmpty()) {
+            return;
+        }
+        final long executionPlanId = graphExecutionContext.getExecutionPlanId();
+        for (DeferredProfilerSample sample : deferredProfilerSamples) {
+            Event event = interpreterDevice.resolveEvent(executionPlanId, sample.eventIndex());
+            event.waitForEvents(executionPlanId);
+            sample.harvest().accept(event);
+        }
+        deferredProfilerSamples.clear();
     }
 
     private void resetEventIndexes(int eventList) {


### PR DESCRIPTION
## Summary

With `-Dtornado.profiler=True` (`--enableProfiler`), every transfer and every kernel launch did `resolveEvent → waitForEvents → getElapsedTime` **inline**, so the host waited for each operation to complete before it enqueued the next one. JFR on a profiler-on run put **51.9 % of wall time inside `CUDAEvent.clWaitForEvents`** (`cuEventSynchronize`).

Two consequences, both bad:

1. **Turning the profiler on made a short task graph 3.3× slower** — 17.46 µs → 57.32 µs per `execute()` for `saxpy` over 512 floats.
2. **The numbers it reported were wrong.** It gave `copyInAvg = 12.9 µs` for a 2 KB host-to-device copy that Nsight Systems measures at **0.65 µs** — the reported span was mostly the serialisation the profiler itself introduced.

A profiler that changes the thing it measures by that much is not usable for the workloads people most want to profile.

## Change

The reads are deferred to a point where the stream has already been drained and every event is complete, so reading a timestamp costs nothing. Two queues, one per layer:

- **`TornadoVMInterpreter`** (backend-neutral): `deferProfilerSample(eventIndex, Consumer<Event>)` replaces the five inline read sites — copy-in ×2, copy-out ×2, atomics copy-in. Harvested in the run epilogue, immediately after `flush()`.
- **`CUDADeviceContext`** (CUDA-only): `deferProfilerRead(Runnable)` for the three driver sites — `CUDAKernelScheduler.updateProfiler`, `CUDAInstalledCode.submitSequential`, `CUDAInstalledCode.updateProfilerKernelContextWrite`. Harvested in `flush()` and `sync()`.

Both queues harvest early once 256 samples are outstanding, so a long run cannot hold references to event slots that the backend event pool has since recycled.

Library-task timing is deliberately left inline: it measures host wall time bounded by stream markers, so it genuinely needs the synchronisation.

Nothing about what is recorded changes — the same metrics are accumulated into the same `ProfilerType` slots, just read later. Profiler results are consumed after execution, so the deferral is not observable.

## Numbers

RTX 4090, JDK 21.0.2, base `develop` @`ba28f1526`. `saxpy 100000 512`, per-`execute()` median, 5 runs.

| build | profiler OFF | profiler ON | ratio |
|---|---|---|---|
| `develop` | 17.46 µs | **57.32 µs** | 3.28× |
| this PR | 17.47 µs | **37.77 µs** (37.62, 37.72, 37.77, 37.83, 37.85) | 2.16× |

**Profiler-on cost down 34 %.** The default path is untouched, as expected — this PR only changes code behind `TornadoOptions.isProfilerEnabled()`.

JFR on the profiler-on run after the change: `clWaitForEvents` drops from **51.9 % → 1.1 %** of wall.

Stacked with the two dispatch-overhead PRs in this series the profiler-on figure reaches 32.61 µs.

## The reported metrics get closer to the truth

`saxpy 20000 512`, `-Dtornado.profiler=True -Dtornado.log.profiler=True`, against Nsight Systems as ground truth:

| metric | `develop` | this PR | nsys |
|---|---|---|---|
| `kernelMin` | 2336 ns | 2368 ns | kernel 1141 ns |
| `kernelAvg` | 10 663 ns | 9097 ns | — |
| `copyInAvg` | 12 899 ns | 4624 ns | H2D 646 ns |

`copyInAvg` moves about 3× closer to the real copy time. The residual inflation is queue wait inside the start→end event span, not host blocking.

## Remaining profiler overhead, for the record

Still ~2.2× versus profiler-off, and it is not the deferral. With timing enabled each operation needs `CU_EVENT_DEFAULT` events rather than `CU_EVENT_DISABLE_TIMING`: nsys measures `cuEventRecord` at **615 ns** with timing against **137 ns** without, six of them per iteration, and the timing events also stretch the terminal `cuStreamSynchronize` from 3.0 µs to 14.0 µs.

Halving that by reusing operation *N−1*'s end event as operation *N*'s start is **incompatible with deferred harvesting** — shared boundary events get re-recorded before anyone reads them. Cutting it further would mean an opt-in timing granularity (for example kernels only, leaving `copyIn`/`copyOut` untimed), which is a behavioural change and out of scope here.

## Testing

- `tornado-test -V --quickPass`: **1031 PASS / 9 FAILED**, identical to `develop` on the same machine. All failures whitelisted.
- Profiler-on runs to exercise the deferred harvest specifically: `TestArrays` 23/23, `TestReductionsIntegersKernelContext` 12/12.
- `./mvnw checkstyle:check` clean.

Note that the `TornadoVMInterpreter` half is backend-neutral and therefore also affects OpenCL and Metal; the deferral is mechanical there (same reads, later), and the CUDA-specific queue is confined to `CUDADeviceContext`.

## Reproduction

```bash
# profiler on / off
tornado --jvm="-Dtornado.benchmarks.skipserial=True -Dtornado.profiler=True" \
  -m tornado.benchmarks/uk.ac.manchester.tornado.benchmarks.BenchmarkRunner \
  --params="saxpy 100000 512"

# JFR attribution
tornado --jvm="-XX:StartFlightRecording=filename=prof.jfr,dumponexit=true \
  -XX:FlightRecorderOptions=stackdepth=192 -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints \
  -Dtornado.benchmarks.skipserial=True -Dtornado.profiler=True" \
  -m tornado.benchmarks/uk.ac.manchester.tornado.benchmarks.BenchmarkRunner \
  --params="saxpy 300000 512"
jfr print --events jdk.NativeMethodSample prof.jfr
```
