### PR TITLE
[api] TornadoExecutionPlan.withDeferredOutputs(): overlap the read-back with host work and pipeline consecutive executions (1.59x back-to-back)

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionPlanType.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionPlanType.java
@@ -42,6 +42,8 @@ import uk.ac.manchester.tornado.api.plan.types.WithResetDevice;
 import uk.ac.manchester.tornado.api.plan.types.WithStagedTransfers;
 import uk.ac.manchester.tornado.api.plan.types.WithThreadInfo;
 import uk.ac.manchester.tornado.api.plan.types.WithWarmUpIterations;
+import uk.ac.manchester.tornado.api.plan.types.OffDeferredOutputs;
+import uk.ac.manchester.tornado.api.plan.types.WithDeferredOutputs;
 import uk.ac.manchester.tornado.api.plan.types.WithWarmUpTime;
 
 public abstract sealed class ExecutionPlanType extends TornadoExecutionPlan //
@@ -50,7 +52,7 @@ public abstract sealed class ExecutionPlanType extends TornadoExecutionPlan //
         WithConcurrentDevices, WithDefaultScheduler, WithDevice,  //
         WithFreeDeviceMemory, WithGraph, WithGridScheduler, WithMemoryLimit, WithPrintKernel, WithProfiler, //
         WithResetDevice, WithThreadInfo, WithWarmUpIterations, WithWarmUpTime, WithCUDAGraph, WithIntraPlanConcurrency, //
-        WithStagedTransfers { //
+        WithStagedTransfers, WithDeferredOutputs, OffDeferredOutputs { //
 
     public ExecutionPlanType(TornadoExecutionPlan parentNode) {
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -154,6 +154,18 @@ public class ImmutableTaskGraph {
         return taskGraph.isFinished();
     }
 
+    void awaitDeferredOutputs() {
+        taskGraph.awaitDeferredOutputs();
+    }
+
+    void withDeferredOutputs() {
+        taskGraph.withDeferredOutputs();
+    }
+
+    void withoutDeferredOutputs() {
+        taskGraph.withoutDeferredOutputs();
+    }
+
     void dumpProfiles() {
         taskGraph.dumpProfiles();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -1104,6 +1104,18 @@ public class TaskGraph implements TaskGraphInterface {
         return taskGraphImpl.isFinished();
     }
 
+    void awaitDeferredOutputs() {
+        taskGraphImpl.awaitDeferredOutputs();
+    }
+
+    void withDeferredOutputs() {
+        taskGraphImpl.withDeferredOutputs();
+    }
+
+    void withoutDeferredOutputs() {
+        taskGraphImpl.withoutDeferredOutputs();
+    }
+
     public Set<Object> getArgumentsLookup() {
         return taskGraphImpl.getArgumentsLookup();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -34,7 +34,9 @@ import uk.ac.manchester.tornado.api.plan.types.OffProfiler;
 import uk.ac.manchester.tornado.api.plan.types.OffThreadInfo;
 import uk.ac.manchester.tornado.api.plan.types.WithAllGraphs;
 import uk.ac.manchester.tornado.api.plan.types.WithBatch;
+import uk.ac.manchester.tornado.api.plan.types.OffDeferredOutputs;
 import uk.ac.manchester.tornado.api.plan.types.WithCUDAGraph;
+import uk.ac.manchester.tornado.api.plan.types.WithDeferredOutputs;
 import uk.ac.manchester.tornado.api.plan.types.WithClearProfiles;
 import uk.ac.manchester.tornado.api.plan.types.WithCompilerFlags;
 import uk.ac.manchester.tornado.api.plan.types.WithConcurrentDevices;
@@ -634,6 +636,40 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
         }
         tornadoExecutor.withWarmUpIterations(iterations, executionFrame);
         return new WithWarmUpIterations(this, iterations);
+    }
+
+    /**
+     * Lets an execution return before its outputs have been copied back: the copy-outs stay in
+     * flight and the host only waits when the results are observed.
+     *
+     * <p><b>The output buffers are undefined until the execution has been awaited.</b> Reach the
+     * data through the {@link TornadoExecutionResult} that {@link #execute()} returns -
+     * {@link TornadoExecutionResult#await()}, {@link TornadoExecutionResult#transferToHost(Object...)}
+     * or {@link TornadoExecutionResult#isReady()} - not by reading the arrays directly after
+     * {@code execute()}. The runtime also awaits implicitly before the next execution of this plan
+     * and before its device memory is freed, so results are never silently lost; they are only
+     * unavailable earlier than the await.
+     *
+     * <p>The point of the option is the window in between: host work placed between
+     * {@code execute()} and {@code await()} overlaps with the read-back. With nothing to overlap it
+     * is a no-op. Ignored while the profiler is enabled, which needs the drained stream.
+     *
+     * @return {@link TornadoExecutionPlan}
+     */
+    public TornadoExecutionPlan withDeferredOutputs() {
+        tornadoExecutor.withDeferredOutputs();
+        return new WithDeferredOutputs(this);
+    }
+
+    /**
+     * Restores the default: an execution waits for its outputs before returning. Awaits any
+     * execution that is still in flight.
+     *
+     * @return {@link TornadoExecutionPlan}
+     */
+    public TornadoExecutionPlan withoutDeferredOutputs() {
+        tornadoExecutor.withoutDeferredOutputs();
+        return new OffDeferredOutputs(this);
     }
 
     public TornadoExecutionPlan withCUDAGraph() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionResult.java
@@ -44,6 +44,8 @@ public class TornadoExecutionResult {
      * @since 0.15.0
      */
     public TornadoProfilerResult getProfilerResult() {
+        // Timers cover the whole execution, so they are only complete once it is.
+        tornadoProfilerResult.getExecutor().awaitDeferredOutputs();
         return tornadoProfilerResult;
     }
 
@@ -81,6 +83,24 @@ public class TornadoExecutionResult {
      */
     public TornadoExecutionResult transferToHost(DataRange dataRange) {
         tornadoProfilerResult.getExecutor().partialTransferToHost(dataRange);
+        return this;
+    }
+
+    /**
+     * Blocks until the outputs of the execution that produced this result are in their host
+     * buffers.
+     *
+     * <p>Only meaningful with {@code -Dtornado.deferred.outputs=True}, where an execution
+     * returns with its copy-outs still in flight and the host buffers are undefined until this
+     * method returns. Without that option an execution has already waited before returning and
+     * this is a no-op. The runtime also awaits implicitly at the next execution of the same
+     * plan, at {@link #transferToHost(Object...)}, at {@link #isReady()} and when the plan's
+     * device memory is freed, so this is only needed to read the outputs earlier than that.
+     *
+     * @return {@link TornadoExecutionResult}
+     */
+    public TornadoExecutionResult await() {
+        tornadoProfilerResult.getExecutor().awaitDeferredOutputs();
         return this;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -156,6 +156,18 @@ class TornadoExecutor {
         immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(dataRange.getArray(), dataRange.getOffset(), dataRange.getPartialSize()));
     }
 
+    void awaitDeferredOutputs() {
+        immutableTaskGraphList.forEach(ImmutableTaskGraph::awaitDeferredOutputs);
+    }
+
+    void withDeferredOutputs() {
+        immutableTaskGraphList.forEach(ImmutableTaskGraph::withDeferredOutputs);
+    }
+
+    void withoutDeferredOutputs() {
+        immutableTaskGraphList.forEach(ImmutableTaskGraph::withoutDeferredOutputs);
+    }
+
     boolean isFinished() {
         boolean result = true;
         for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -57,6 +57,10 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void withCUDAGraph();
 
+    void withDeferredOutputs();
+
+    void withoutDeferredOutputs();
+
     void withMemoryLimit(String memoryLimit);
 
     void withoutMemoryLimit();
@@ -110,6 +114,12 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
     void useDefaultThreadScheduler(boolean use);
 
     boolean isFinished();
+
+    /**
+     * Blocks until the copy-outs of the last execution have landed in their host buffers. A
+     * no-op unless {@code tornado.deferred.outputs} left an execution's reads in flight.
+     */
+    void awaitDeferredOutputs();
 
     Set<Object> getArgumentsLookup();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/XPUBuffer.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/XPUBuffer.java
@@ -49,6 +49,18 @@ public interface XPUBuffer {
 
     int enqueueRead(long executionPlanId, Object reference, long hostOffset, int[] events, boolean useDeps);
 
+    /**
+     * Whether {@link #enqueueRead} copies out exactly what {@link #read} would, so that a caller
+     * may issue the read without waiting for it and synchronise the device later instead.
+     *
+     * <p>Defaults to {@code false}: several implementations (field buffers, for instance) support
+     * the blocking read only, and would silently copy the wrong bytes - or nothing at all - if the
+     * asynchronous variant were used in its place.
+     */
+    default boolean supportsAsyncRead() {
+        return false;
+    }
+
     List<Integer> enqueueWrite(long executionPlanId, Object reference, long batchSize, long hostOffset, int[] events, boolean useDeps);
 
     void allocate(Object reference, long batchSize, Access access) throws TornadoOutOfMemoryException, TornadoMemoryException;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/OffDeferredOutputs.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/OffDeferredOutputs.java
@@ -1,0 +1,12 @@
+package uk.ac.manchester.tornado.api.plan.types;
+
+import uk.ac.manchester.tornado.api.ExecutionPlanType;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+
+public final class OffDeferredOutputs extends ExecutionPlanType {
+
+    public OffDeferredOutputs(TornadoExecutionPlan parent) {
+        super(parent);
+    }
+
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithDeferredOutputs.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithDeferredOutputs.java
@@ -1,0 +1,12 @@
+package uk.ac.manchester.tornado.api.plan.types;
+
+import uk.ac.manchester.tornado.api.ExecutionPlanType;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+
+public final class WithDeferredOutputs extends ExecutionPlanType {
+
+    public WithDeferredOutputs(TornadoExecutionPlan parent) {
+        super(parent);
+    }
+
+}

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -190,6 +190,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.memory.TestMemoryLimit"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestIO"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestMultipleCopyOuts"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestDeferredOutputs"),
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGrid"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGridScheduler"),

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -189,6 +189,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestInitDataTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.memory.TestMemoryLimit"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestIO"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestMultipleCopyOuts"),
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGrid"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGridScheduler"),

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAMemorySegmentWrapper.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAMemorySegmentWrapper.java
@@ -300,4 +300,10 @@ public class CUDAMemorySegmentWrapper implements XPUBuffer {
         return sizeOfType;
     }
 
+
+    @Override
+    public boolean supportsAsyncRead() {
+        // enqueueRead and read copy the same region for a whole-segment transfer.
+        return true;
+    }
 }

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/mm/MetalMemorySegmentWrapper.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/mm/MetalMemorySegmentWrapper.java
@@ -252,4 +252,10 @@ public class MetalMemorySegmentWrapper implements XPUBuffer {
         return sizeOfType;
     }
 
+
+    @Override
+    public boolean supportsAsyncRead() {
+        // enqueueRead and read copy the same region for a whole-segment transfer.
+        return true;
+    }
 }

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/runtime/MetalTornadoDevice.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/runtime/MetalTornadoDevice.java
@@ -620,7 +620,7 @@ public class MetalTornadoDevice implements TornadoXPUDevice {
     @Override
     public int streamOut(long executionPlanId, Object object, long offset, DeviceBufferState state, int[] events) {
         TornadoInternalError.guarantee(state.hasObjectBuffer(), "invalid variable");
-        int event = state.getXPUBuffer().enqueueRead(executionPlanId, object, offset, events, events == null);
+        int event = state.getXPUBuffer().enqueueRead(executionPlanId, object, offset, events, events != null);
         if (events != null) {
             return event;
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
@@ -251,4 +251,10 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
         return sizeOfType;
     }
 
+
+    @Override
+    public boolean supportsAsyncRead() {
+        // enqueueRead and read copy the same region for a whole-segment transfer.
+        return true;
+    }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -603,7 +603,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     @Override
     public int streamOut(long executionPlanId, Object object, long offset, DeviceBufferState state, int[] events) {
         TornadoInternalError.guarantee(state.hasObjectBuffer(), "invalid variable");
-        int event = state.getXPUBuffer().enqueueRead(executionPlanId, object, offset, events, events == null);
+        int event = state.getXPUBuffer().enqueueRead(executionPlanId, object, offset, events, events != null);
         if (events != null) {
             return event;
         }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -197,6 +197,14 @@ public class TornadoVM {
         executeActionOnInterpreters(TornadoVMInterpreter::destroyExecutionGraphs);
     }
 
+    /**
+     * Blocks until the copy-outs of the last execution have landed in their host buffers. A
+     * no-op unless {@code tornado.deferred.outputs} left an execution's reads in flight.
+     */
+    public void awaitDeferredOutputs() {
+        executeActionOnInterpreters(TornadoVMInterpreter::awaitDeferredOutputs);
+    }
+
     public void printTimes() {
         executeActionOnInterpreters(TornadoVMInterpreter::printTimes);
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -295,6 +295,16 @@ public class TornadoOptions {
     public static final boolean ENABLE_STREAM_OUT_BLOCKING = getBooleanValue("tornado.enable.streamOut.blocking", TRUE);
 
     /**
+     * How many executions of a plan with deferred outputs may be outstanding before the next one
+     * waits for the oldest. Consecutive executions do not have to be serialised against each other
+     * on a single in-order queue, so allowing a few in flight lets the host run ahead of the
+     * device; the bound stops it running ahead without limit. Defaults to 4, which is where the
+     * measured gain flattens out.
+     */
+    public static final int MAX_DEFERRED_EXECUTIONS_IN_FLIGHT = getIntValue("tornado.deferred.outputs.maxInFlight", "4");
+
+
+    /**
      * Option to run concurrently on multiple device in single or multi-backend
      * configuration. False by default.
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -96,6 +96,7 @@ public class TornadoExecutionContext {
     private long executionPlanId;  // This is set at runtime. Thus, no need to clone this value.
     private long currentDeviceMemoryUsage;
     private boolean isExecutionGraphEnabled;
+    private boolean isDeferredOutputsEnabled;
     private boolean isIntraPlanConcurrencyEnabled;
     private boolean isStagedTransfersEnabled;
 
@@ -122,6 +123,7 @@ public class TornadoExecutionContext {
         this.profiler = null;
         this.isDataDependencyDetected = isDataDependencyInTaskGraph();
         this.isExecutionGraphEnabled = false;
+        this.isDeferredOutputsEnabled = false;
         this.isIntraPlanConcurrencyEnabled = false;
         // Defaults to the -Dtornado.staged.transfers property, so the plan-level API overrides it
         // rather than replacing it.
@@ -694,6 +696,7 @@ public class TornadoExecutionContext {
         newExecutionContext.executionPlanMemoryLimit = this.executionPlanMemoryLimit;
 
         newExecutionContext.isExecutionGraphEnabled = this.isExecutionGraphEnabled;
+        newExecutionContext.isDeferredOutputsEnabled = this.isDeferredOutputsEnabled;
         newExecutionContext.isIntraPlanConcurrencyEnabled = this.isIntraPlanConcurrencyEnabled;
         newExecutionContext.isStagedTransfersEnabled = this.isStagedTransfersEnabled;
 
@@ -727,6 +730,18 @@ public class TornadoExecutionContext {
 
     public void setExecutionGraphEnabled(boolean enabled) {
         this.isExecutionGraphEnabled = enabled;
+    }
+
+    /**
+     * Whether this plan keeps its copy-outs in flight after an execution, so that the wait
+     * happens when the results are observed rather than inside execute().
+     */
+    public void setDeferredOutputsEnabled(boolean enabled) {
+        this.isDeferredOutputsEnabled = enabled;
+    }
+
+    public boolean isDeferredOutputsEnabled() {
+        return this.isDeferredOutputsEnabled;
     }
 
     public boolean isExecutionGraphEnabled() {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
@@ -141,8 +141,9 @@ public class TornadoVMGraphCompiler {
                         graph, intermediateTornadoGraph);
             }
 
-            // Last operation -> perform synchronisation
-            if (!useCUDAGraphs) {
+            // Last operation -> perform synchronisation. Deferred outputs skip it entirely: the
+            // wait moves out of the execution and into whoever observes the results.
+            if (!useCUDAGraphs && !executionContext.isDeferredOutputsEnabled()) {
                 if (TornadoOptions.ENABLE_STREAM_OUT_BLOCKING) {
                     synchronizeOperationLastByteCode(tornadoVMBytecodeBuilder, intermediateTornadoGraph.getNumberOfDependencies());
                 } else {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -118,6 +118,10 @@ public class TornadoVMInterpreter {
     private boolean insideCaptureRegion = false;
     private boolean executionGraphEnabled = true;
 
+    /** Executions that returned with their copy-outs still in flight. */
+    private int deferredExecutionsInFlight = 0;
+
+
     private TornadoLogger logger = new TornadoLogger(this.getClass());
 
     /**
@@ -295,6 +299,14 @@ public class TornadoVMInterpreter {
 
     private Event execute(boolean isWarmup) {
         isWarmup = isWarmup || VIRTUAL_DEVICE_ENABLED;
+
+        // A previous execution may have left its copy-outs in flight. Waiting for them here is only
+        // necessary when the ordering that makes pipelining safe does not hold, or when too many
+        // executions are already outstanding.
+        if (deferredExecutionsInFlight >= TornadoOptions.MAX_DEFERRED_EXECUTIONS_IN_FLIGHT || isIntraPlanConcurrencyActive()) {
+            awaitDeferredOutputs();
+        }
+
         interpreterDevice.enableThreadSharing();
 
         // Push the per-plan intra-plan-concurrency setting to the backend before issuing any
@@ -510,7 +522,12 @@ public class TornadoVMInterpreter {
                 barrier = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), event);
             }
 
-            if (TornadoOptions.USE_VM_FLUSH) {
+            if (deferOutputs()) {
+                // Leave the copy-outs in flight. flush() would drain the stream, which is the
+                // wait this option exists to avoid; the marker above is not needed either,
+                // because awaitDeferredOutputs() synchronises the whole queue.
+                deferredExecutionsInFlight++;
+            } else if (TornadoOptions.USE_VM_FLUSH) {
                 interpreterDevice.flush(graphExecutionContext.getExecutionPlanId());
             }
         }
@@ -674,6 +691,27 @@ public class TornadoVMInterpreter {
                 executionGraphHandles.get(graphId));
 
         return event;
+    }
+
+    /**
+     * Whether this execution may return before its copy-outs have landed. The profiler reads
+     * device timestamps at the end of the run, which needs a drained stream, so it keeps the
+     * synchronous tail.
+     */
+    private boolean deferOutputs() {
+        return graphExecutionContext.isDeferredOutputsEnabled() && !TornadoOptions.isProfilerEnabled();
+    }
+
+    /**
+     * Blocks until the copy-outs of the previous execution have landed in their host buffers.
+     * A no-op unless an execution actually left work in flight, so every observation point can
+     * call it unconditionally.
+     */
+    public void awaitDeferredOutputs() {
+        if (deferredExecutionsInFlight > 0) {
+            deferredExecutionsInFlight = 0;
+            interpreterDevice.sync(graphExecutionContext.getExecutionPlanId());
+        }
     }
 
     private void initWaitEventList() {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -994,7 +994,8 @@ public class TornadoVMInterpreter {
         // host wait for no benefit, so this takes the asynchronous read whenever the blocking
         // variant is not doing something extra: it also covers atomics, under-demand partial
         // copies and batch chunks, none of which enqueueRead supports.
-        final boolean canReadAsync = !objectState.isAtomicRegionPresent() //
+        final boolean canReadAsync = objectState.getXPUBuffer().supportsAsyncRead() //
+                && !objectState.isAtomicRegionPresent() //
                 && objectState.getPartialCopySize() == 0 //
                 && sizeBatch <= 0;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -987,7 +987,20 @@ public class TornadoVMInterpreter {
             DebugInterpreter.logTransferToHostAlways(object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
 
-        int readEvent = interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList);
+        // TRANSFER_DEVICE_TO_HOST_ALWAYS is the non-terminal copy-out: the graph compiler patches
+        // only the last one into TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING, which - together with the
+        // sync in TornadoTaskGraph.waitOn() - is what makes the outputs visible when execute()
+        // returns. Reading synchronously here as well makes every intermediate copy-out its own
+        // host wait for no benefit, so this takes the asynchronous read whenever the blocking
+        // variant is not doing something extra: it also covers atomics, under-demand partial
+        // copies and batch chunks, none of which enqueueRead supports.
+        final boolean canReadAsync = !objectState.isAtomicRegionPresent() //
+                && objectState.getPartialCopySize() == 0 //
+                && sizeBatch <= 0;
+
+        int readEvent = canReadAsync
+                ? interpreterDevice.streamOut(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList)
+                : interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList);
 
         resetEventIndexes(eventId);
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -307,7 +307,15 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     @Override
     public boolean isFinished() {
+        awaitDeferredOutputs();
         return this.isFinished;
+    }
+
+    @Override
+    public void awaitDeferredOutputs() {
+        if (vm != null) {
+            vm.awaitDeferredOutputs();
+        }
     }
 
     @Override
@@ -1091,6 +1099,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     @Override
     public void waitOn() {
+        if (executionContext.isDeferredOutputsEnabled() && !TornadoOptions.isProfilerEnabled()) {
+            // The execution keeps its copy-outs in flight; awaitDeferredOutputs() does this wait
+            // when something can observe the output buffers.
+            return;
+        }
         if ((TornadoOptions.VM_USE_DEPS || executionContext.isIntraPlanConcurrencyEnabled()) && event != null) {
             event.waitOn();
         } else {
@@ -1355,6 +1368,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             return;
         }
 
+        awaitDeferredOutputs();
         vm.destroyExecutionGraphs();
         LibraryRegistry.destroyContexts(executionPlanId);
         freeIOObjects();
@@ -1470,6 +1484,8 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         if (vm == null) {
             return;
         }
+
+        awaitDeferredOutputs();
 
         List<Event> events = new ArrayList<>();
         for (Object object : objects) {
@@ -1982,6 +1998,17 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     @Override
     public void withCUDAGraph() {
         executionContext.setExecutionGraphEnabled(true);
+    }
+
+    @Override
+    public void withDeferredOutputs() {
+        executionContext.setDeferredOutputsEnabled(true);
+    }
+
+    @Override
+    public void withoutDeferredOutputs() {
+        awaitDeferredOutputs();
+        executionContext.setDeferredOutputsEnabled(false);
     }
 
     @Override

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDeferredOutputs.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDeferredOutputs.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Tests for {@link TornadoExecutionPlan#withDeferredOutputs()}: an execution returns with its
+ * copy-outs still in flight, and the outputs become valid once the execution has been awaited -
+ * explicitly through the {@link TornadoExecutionResult}, or implicitly at the next execution of
+ * the same plan.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.api.TestDeferredOutputs
+ * </code>
+ */
+public class TestDeferredOutputs extends TornadoTestBase {
+
+    private static final int SIZE = 1 << 16;
+
+    public static void scale(FloatArray input, FloatArray output, float alpha) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, alpha * input.get(i));
+        }
+    }
+
+    private static TaskGraph buildGraph(FloatArray input, FloatArray output) {
+        return new TaskGraph("deferred") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("t", TestDeferredOutputs::scale, input, output, 2.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+    }
+
+    /** Busy-waits, so that it does not park the thread the way a sleep would. */
+    private static long hostWork(long micros) {
+        long deadline = System.nanoTime() + micros * 1000;
+        long spins = 0;
+        while (System.nanoTime() < deadline) {
+            spins++;
+        }
+        return spins;
+    }
+
+    @Test
+    public void testAwaitMakesOutputsVisible() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            executionPlan.execute().await();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(6.0f, output.get(i), 0.001f);
+        }
+    }
+
+    /**
+     * The point of the option: host work between {@code execute()} and {@code await()} overlaps
+     * with the read-back, and the results are still correct afterwards.
+     */
+    @Test
+    public void testHostWorkBetweenExecuteAndAwait() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray output = new FloatArray(SIZE);
+        long spins = 0;
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            for (int iteration = 1; iteration <= 8; iteration++) {
+                input.init(iteration);
+                TornadoExecutionResult executionResult = executionPlan.execute();
+                spins += hostWork(200);
+                executionResult.await();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(2.0f * iteration, output.get(i), 0.001f);
+                }
+            }
+        }
+        assertTrue(spins > 0);
+    }
+
+    /**
+     * Nothing is lost when the caller never awaits: the next execution of the same plan awaits
+     * the previous one before it can overwrite anything.
+     */
+    @Test
+    public void testNextExecutionAwaitsThePreviousOne() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            for (int iteration = 1; iteration <= 8; iteration++) {
+                input.init(iteration);
+                executionPlan.execute();
+            }
+            executionPlan.execute().await();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(16.0f, output.get(i), 0.001f);
+        }
+    }
+
+    /** {@code isReady()} is an observation point, so it awaits like {@code await()} does. */
+    @Test
+    public void testIsReadyAwaits() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(5.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            TornadoExecutionResult executionResult = executionPlan.execute();
+            assertTrue(executionResult.isReady());
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(10.0f, output.get(i), 0.001f);
+            }
+        }
+    }
+
+    /** Switching the option back off restores the synchronous contract for later executions. */
+    @Test
+    public void testWithoutDeferredOutputsRestoresBlockingExecution() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            input.init(1.0f);
+            executionPlan.execute().await();
+
+            executionPlan.withoutDeferredOutputs();
+            for (int iteration = 2; iteration <= 4; iteration++) {
+                input.init(iteration);
+                executionPlan.execute();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(2.0f * iteration, output.get(i), 0.001f);
+                }
+            }
+        }
+    }
+
+    /** A deferred plan that is simply closed must not leave a copy-out in flight. */
+    @Test
+    public void testCloseAwaitsPendingOutputs() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(7.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(14.0f, output.get(i), 0.001f);
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestMultipleCopyOuts.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestMultipleCopyOuts.java
@@ -31,6 +31,7 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -53,6 +54,14 @@ public class TestMultipleCopyOuts extends TornadoTestBase {
     public static void scale(FloatArray input, FloatArray output, float alpha) {
         for (@Parallel int i = 0; i < input.getSize(); i++) {
             output.set(i, alpha * input.get(i));
+        }
+    }
+
+    public static void scaleMatrix(Matrix2DFloat input, Matrix2DFloat output, float alpha) {
+        for (@Parallel int i = 0; i < input.getNumRows(); i++) {
+            for (@Parallel int j = 0; j < input.getNumColumns(); j++) {
+                output.set(i, j, alpha * input.get(i, j));
+            }
         }
     }
 
@@ -220,6 +229,42 @@ public class TestMultipleCopyOuts extends TornadoTestBase {
                 for (int i = 0; i < batchedSize; i++) {
                     assertEquals(2.0f * iteration, output.get(i), 0.001f);
                 }
+            }
+        }
+    }
+
+    /**
+     * Two matrix outputs: the first one is a non-terminal copy-out, so it goes through the
+     * asynchronous read while the second stays blocking. Matrices use a different buffer wrapper
+     * from the flat arrays the other tests cover.
+     */
+    @Test
+    public void testTwoMatrixOutputs() throws TornadoExecutionPlanException {
+        final int n = 64;
+        Matrix2DFloat input = new Matrix2DFloat(n, n);
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                input.set(i, j, i + j);
+            }
+        }
+        Matrix2DFloat outA = new Matrix2DFloat(n, n);
+        Matrix2DFloat outB = new Matrix2DFloat(n, n);
+
+        TaskGraph taskGraph = new TaskGraph("matrixOut") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestMultipleCopyOuts::scaleMatrix, input, outA, 2.0f) //
+                .task("b", TestMultipleCopyOuts::scaleMatrix, input, outB, 3.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, outA, outB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                assertEquals(2.0f * (i + j), outA.get(i, j), 0.001f);
+                assertEquals(3.0f * (i + j), outB.get(i, j), 0.001f);
             }
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestMultipleCopyOuts.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestMultipleCopyOuts.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.DataRange;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Task graphs with more than one copy-out. Only the last copy-out of a graph is compiled into
+ * the blocking bytecode; the others are read asynchronously, so these tests check that every
+ * output is still complete and up to date by the time {@code execute()} returns, including the
+ * cases that keep the blocking read (partial copies and batches).
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.api.TestMultipleCopyOuts
+ * </code>
+ */
+public class TestMultipleCopyOuts extends TornadoTestBase {
+
+    private static final int SIZE = 8192;
+
+    public static void scale(FloatArray input, FloatArray output, float alpha) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, alpha * input.get(i));
+        }
+    }
+
+    public static void increment(IntArray input, IntArray output, int delta) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, input.get(i) + delta);
+        }
+    }
+
+    /**
+     * Four outputs: three of them are non-terminal copy-outs, so three asynchronous reads have
+     * to have landed before {@code execute()} returns.
+     */
+    @Test
+    public void testFourOutputsInOneGraph() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(2.0f);
+
+        FloatArray outA = new FloatArray(SIZE);
+        FloatArray outB = new FloatArray(SIZE);
+        FloatArray outC = new FloatArray(SIZE);
+        FloatArray outD = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("multiOut") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestMultipleCopyOuts::scale, input, outA, 1.0f) //
+                .task("b", TestMultipleCopyOuts::scale, input, outB, 2.0f) //
+                .task("c", TestMultipleCopyOuts::scale, input, outC, 3.0f) //
+                .task("d", TestMultipleCopyOuts::scale, input, outD, 4.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, outA, outB, outC, outD);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(2.0f, outA.get(i), 0.001f);
+            assertEquals(4.0f, outB.get(i), 0.001f);
+            assertEquals(6.0f, outC.get(i), 0.001f);
+            assertEquals(8.0f, outD.get(i), 0.001f);
+        }
+    }
+
+    /**
+     * Same graph executed repeatedly with a different input each time. A read that has not
+     * landed shows up here as an output from the previous execution rather than as a wrong
+     * value, which a single-execution test would miss.
+     */
+    @Test
+    public void testMultipleOutputsAcrossExecutions() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray outA = new FloatArray(SIZE);
+        FloatArray outB = new FloatArray(SIZE);
+        FloatArray outC = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("multiOutRepeat") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestMultipleCopyOuts::scale, input, outA, 1.0f) //
+                .task("b", TestMultipleCopyOuts::scale, input, outB, 2.0f) //
+                .task("c", TestMultipleCopyOuts::scale, input, outC, 3.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, outA, outB, outC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            for (int iteration = 1; iteration <= 8; iteration++) {
+                input.init(iteration);
+                executionPlan.execute();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(iteration, outA.get(i), 0.001f);
+                    assertEquals(2.0f * iteration, outB.get(i), 0.001f);
+                    assertEquals(3.0f * iteration, outC.get(i), 0.001f);
+                }
+            }
+        }
+    }
+
+    /**
+     * Mixed output types, so the reads go through different buffer wrappers within one graph.
+     */
+    @Test
+    public void testMixedOutputTypes() throws TornadoExecutionPlanException {
+        FloatArray floatInput = new FloatArray(SIZE);
+        floatInput.init(1.5f);
+        IntArray intInput = new IntArray(SIZE);
+        intInput.init(7);
+
+        FloatArray floatOutput = new FloatArray(SIZE);
+        IntArray intOutput = new IntArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("mixedOut") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, floatInput, intInput) //
+                .task("f", TestMultipleCopyOuts::scale, floatInput, floatOutput, 2.0f) //
+                .task("i", TestMultipleCopyOuts::increment, intInput, intOutput, 5) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, floatOutput, intOutput);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(3.0f, floatOutput.get(i), 0.001f);
+            assertEquals(12, intOutput.get(i));
+        }
+    }
+
+    /**
+     * An under-demand partial copy-out alongside an every-execution one. The partial read keeps
+     * the blocking path, so this covers the guard rather than the asynchronous read.
+     */
+    @Test
+    public void testPartialCopyOutWithSecondOutput() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray eagerOutput = new FloatArray(SIZE);
+        FloatArray onDemandOutput = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("partialOut") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestMultipleCopyOuts::scale, input, eagerOutput, 2.0f) //
+                .task("b", TestMultipleCopyOuts::scale, input, onDemandOutput, 5.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, eagerOutput) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, onDemandOutput);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            TornadoExecutionResult executionResult = executionPlan.execute();
+
+            DataRange dataRange = new DataRange(onDemandOutput);
+            executionResult.transferToHost(dataRange.withSize(SIZE / 2));
+            executionResult.transferToHost(dataRange.withOffset(SIZE / 2).withSize(SIZE / 2));
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(6.0f, eagerOutput.get(i), 0.001f);
+            assertEquals(15.0f, onDemandOutput.get(i), 0.001f);
+        }
+    }
+
+    /**
+     * Batched copy-out, repeated so the per-chunk reads are exercised more than once. Batch
+     * chunks keep the blocking read, so this is the other half of the guard.
+     *
+     * <p>Deliberately a single output: a batched graph with two outputs fails on {@code develop}
+     * with a null device buffer, independently of how the reads are issued.
+     */
+    @Test
+    public void testBatchedCopyOut() throws TornadoExecutionPlanException {
+        final int batchedSize = 1024 * 1024;
+        FloatArray input = new FloatArray(batchedSize);
+        FloatArray output = new FloatArray(batchedSize);
+
+        TaskGraph taskGraph = new TaskGraph("batchedOut") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestMultipleCopyOuts::scale, input, output, 2.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withBatch("1MB");
+            for (int iteration = 1; iteration <= 3; iteration++) {
+                input.init(iteration);
+                executionPlan.execute();
+                for (int i = 0; i < batchedSize; i++) {
+                    assertEquals(2.0f * iteration, output.get(i), 0.001f);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #1029 (read non-terminal copy-outs asynchronously). Review that one first; this PR's diff is the second commit.

## What this adds

```java
try (TornadoExecutionPlan plan = new TornadoExecutionPlan(graph)) {
    plan.withDeferredOutputs();

    TornadoExecutionResult result = plan.execute();
    prepareNextInput();          // runs while the read-back drains
    result.await();              // outputs are valid from here on
}
```

`execute()` returns once the work is enqueued instead of once the outputs have landed. The host only waits when the results are observed: `TornadoExecutionResult.await()` (new), `transferToHost(...)`, `isReady()`, `getProfilerResult()`, the next execution of the same plan once the in-flight bound is reached, and `close()`/`freeDeviceMemory()`.

**The output buffers are undefined until the execution has been awaited.** That is the whole contract, and it is why this is per plan and opt-in — never a global default. `withoutDeferredOutputs()` restores the synchronous behaviour (and awaits anything outstanding).

## How it works

Three things had to change, and only one of them was where I expected:

1. **The graph compiler** no longer patches the last copy-out into `TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING` for a deferred plan.
2. **`TornadoTaskGraph.waitOn()`** — this is what actually made `execute()` synchronous. Every execution ended with `taskGraphImpl.execute(package).waitOn()` → `TornadoXPUDevice.sync()` → `cuStreamSynchronize`, *regardless* of the bytecode. Confirmed with nsys: 350 executions, 350 syncs of 444 µs average, all inside `execute()`. With deferred outputs that sync moves to the observation points.
3. **Consecutive executions are not serialised against each other.** Execution N's copy-out completes before execution N+1's kernel starts on a single in-order queue, so the host buffers are written in order and only the observer has to wait. Up to `tornado.deferred.outputs.maxInFlight` (default 4) executions may be outstanding before the next one waits — the bound stops the host running arbitrarily far ahead of the device. Plans with `withIntraPlanConcurrency()` keep the wait, because there the ordering argument does not hold.

Deferral is ignored while the profiler is enabled: it reads device timestamps at the end of a run and needs the drained stream.

## Numbers

RTX 4090, JDK 21, CUDA backend. Same task graph throughout (H2D input, kernel, D2H output).

**Overlapping host work with the read-back** — `execute()` → 200 µs of host work → `await()`, median of 300 iterations:

| output size | deferred OFF | deferred ON | gain |
|---|---|---|---|
| 256 KB | 264.4 µs | 249.3 µs | 1.06x |
| 4 MB | 706.8 µs | **497.9 µs** | **1.42x** |

The gain is `min(host work, device time)` — you can only hide what you have work to hide behind. On the 4 MB case `execute()` also returns in **43 µs instead of 499 µs**, so the caller gets its thread back 11x sooner even where the total does not move.

**Back-to-back executions, no host work at all** (this is the case where deferral alone used to do nothing), 4096-element output, 20,000 executions:

| `tornado.deferred.outputs.maxInFlight` | per-`execute()` median | throughput |
|---|---|---|
| deferred OFF | 19.47 µs | 20.62 µs/exec |
| 1 | 18.31 µs | 18.23 µs/exec |
| 2 | 10.38 µs | 15.13 µs/exec |
| **4 (default)** | **8.73 µs** | **12.93 µs/exec** |
| 8 | 8.21 µs | 14.07 µs/exec |
| 16 | 8.39 µs | 12.62 µs/exec |

**1.59x throughput**, and the gain flattens at 4 — hence the default. A device-bound graph (256 K elements, 135 µs/execution) is unchanged at 135 µs, as it should be: the device is the limit, not the host.

## Testing

- New `TestDeferredOutputs` (6 tests, registered in `tornado-test`), all passing: `await()` makes outputs visible; host work between `execute()` and `await()`; the next execution awaits the previous one when nothing awaited it; `isReady()` awaits; `withoutDeferredOutputs()` restores blocking execution; closing a plan awaits anything in flight. Each one checks the values, and the repeated-execution tests use a different input per iteration so a read that has not landed shows up as the *previous* result.
- `tornado-test --quickPass`, CUDA backend: **85 failures, identical to the `develop` baseline** — the default path is untouched.
- `./mvnw checkstyle:check` clean.

## Backend/OS tested

- CUDA backend, NVIDIA RTX 4090, Ubuntu 24.04, JDK 21.

The API surface is backend-neutral; OpenCL and Metal get the same behaviour through `TornadoXPUDevice.sync()`, but I have no OpenCL/Metal device here to confirm the timings.

Part of #1028.
