### PR TITLE
[runtime] Issue on-demand copy-outs together and wait once instead of once per object (2.6x for 8 objects)

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionPlanType.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ExecutionPlanType.java
@@ -42,6 +42,8 @@ import uk.ac.manchester.tornado.api.plan.types.WithResetDevice;
 import uk.ac.manchester.tornado.api.plan.types.WithStagedTransfers;
 import uk.ac.manchester.tornado.api.plan.types.WithThreadInfo;
 import uk.ac.manchester.tornado.api.plan.types.WithWarmUpIterations;
+import uk.ac.manchester.tornado.api.plan.types.OffDeferredOutputs;
+import uk.ac.manchester.tornado.api.plan.types.WithDeferredOutputs;
 import uk.ac.manchester.tornado.api.plan.types.WithWarmUpTime;
 
 public abstract sealed class ExecutionPlanType extends TornadoExecutionPlan //
@@ -50,7 +52,7 @@ public abstract sealed class ExecutionPlanType extends TornadoExecutionPlan //
         WithConcurrentDevices, WithDefaultScheduler, WithDevice,  //
         WithFreeDeviceMemory, WithGraph, WithGridScheduler, WithMemoryLimit, WithPrintKernel, WithProfiler, //
         WithResetDevice, WithThreadInfo, WithWarmUpIterations, WithWarmUpTime, WithCUDAGraph, WithIntraPlanConcurrency, //
-        WithStagedTransfers { //
+        WithStagedTransfers, WithDeferredOutputs, OffDeferredOutputs { //
 
     public ExecutionPlanType(TornadoExecutionPlan parentNode) {
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -154,6 +154,18 @@ public class ImmutableTaskGraph {
         return taskGraph.isFinished();
     }
 
+    void awaitDeferredOutputs() {
+        taskGraph.awaitDeferredOutputs();
+    }
+
+    void withDeferredOutputs() {
+        taskGraph.withDeferredOutputs();
+    }
+
+    void withoutDeferredOutputs() {
+        taskGraph.withoutDeferredOutputs();
+    }
+
     void dumpProfiles() {
         taskGraph.dumpProfiles();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -1104,6 +1104,18 @@ public class TaskGraph implements TaskGraphInterface {
         return taskGraphImpl.isFinished();
     }
 
+    void awaitDeferredOutputs() {
+        taskGraphImpl.awaitDeferredOutputs();
+    }
+
+    void withDeferredOutputs() {
+        taskGraphImpl.withDeferredOutputs();
+    }
+
+    void withoutDeferredOutputs() {
+        taskGraphImpl.withoutDeferredOutputs();
+    }
+
     public Set<Object> getArgumentsLookup() {
         return taskGraphImpl.getArgumentsLookup();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -34,7 +34,9 @@ import uk.ac.manchester.tornado.api.plan.types.OffProfiler;
 import uk.ac.manchester.tornado.api.plan.types.OffThreadInfo;
 import uk.ac.manchester.tornado.api.plan.types.WithAllGraphs;
 import uk.ac.manchester.tornado.api.plan.types.WithBatch;
+import uk.ac.manchester.tornado.api.plan.types.OffDeferredOutputs;
 import uk.ac.manchester.tornado.api.plan.types.WithCUDAGraph;
+import uk.ac.manchester.tornado.api.plan.types.WithDeferredOutputs;
 import uk.ac.manchester.tornado.api.plan.types.WithClearProfiles;
 import uk.ac.manchester.tornado.api.plan.types.WithCompilerFlags;
 import uk.ac.manchester.tornado.api.plan.types.WithConcurrentDevices;
@@ -634,6 +636,40 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
         }
         tornadoExecutor.withWarmUpIterations(iterations, executionFrame);
         return new WithWarmUpIterations(this, iterations);
+    }
+
+    /**
+     * Lets an execution return before its outputs have been copied back: the copy-outs stay in
+     * flight and the host only waits when the results are observed.
+     *
+     * <p><b>The output buffers are undefined until the execution has been awaited.</b> Reach the
+     * data through the {@link TornadoExecutionResult} that {@link #execute()} returns -
+     * {@link TornadoExecutionResult#await()}, {@link TornadoExecutionResult#transferToHost(Object...)}
+     * or {@link TornadoExecutionResult#isReady()} - not by reading the arrays directly after
+     * {@code execute()}. The runtime also awaits implicitly before the next execution of this plan
+     * and before its device memory is freed, so results are never silently lost; they are only
+     * unavailable earlier than the await.
+     *
+     * <p>The point of the option is the window in between: host work placed between
+     * {@code execute()} and {@code await()} overlaps with the read-back. With nothing to overlap it
+     * is a no-op. Ignored while the profiler is enabled, which needs the drained stream.
+     *
+     * @return {@link TornadoExecutionPlan}
+     */
+    public TornadoExecutionPlan withDeferredOutputs() {
+        tornadoExecutor.withDeferredOutputs();
+        return new WithDeferredOutputs(this);
+    }
+
+    /**
+     * Restores the default: an execution waits for its outputs before returning. Awaits any
+     * execution that is still in flight.
+     *
+     * @return {@link TornadoExecutionPlan}
+     */
+    public TornadoExecutionPlan withoutDeferredOutputs() {
+        tornadoExecutor.withoutDeferredOutputs();
+        return new OffDeferredOutputs(this);
     }
 
     public TornadoExecutionPlan withCUDAGraph() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionResult.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionResult.java
@@ -44,6 +44,8 @@ public class TornadoExecutionResult {
      * @since 0.15.0
      */
     public TornadoProfilerResult getProfilerResult() {
+        // Timers cover the whole execution, so they are only complete once it is.
+        tornadoProfilerResult.getExecutor().awaitDeferredOutputs();
         return tornadoProfilerResult;
     }
 
@@ -81,6 +83,24 @@ public class TornadoExecutionResult {
      */
     public TornadoExecutionResult transferToHost(DataRange dataRange) {
         tornadoProfilerResult.getExecutor().partialTransferToHost(dataRange);
+        return this;
+    }
+
+    /**
+     * Blocks until the outputs of the execution that produced this result are in their host
+     * buffers.
+     *
+     * <p>Only meaningful with {@code -Dtornado.deferred.outputs=True}, where an execution
+     * returns with its copy-outs still in flight and the host buffers are undefined until this
+     * method returns. Without that option an execution has already waited before returning and
+     * this is a no-op. The runtime also awaits implicitly at the next execution of the same
+     * plan, at {@link #transferToHost(Object...)}, at {@link #isReady()} and when the plan's
+     * device memory is freed, so this is only needed to read the outputs earlier than that.
+     *
+     * @return {@link TornadoExecutionResult}
+     */
+    public TornadoExecutionResult await() {
+        tornadoProfilerResult.getExecutor().awaitDeferredOutputs();
         return this;
     }
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -156,6 +156,18 @@ class TornadoExecutor {
         immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(dataRange.getArray(), dataRange.getOffset(), dataRange.getPartialSize()));
     }
 
+    void awaitDeferredOutputs() {
+        immutableTaskGraphList.forEach(ImmutableTaskGraph::awaitDeferredOutputs);
+    }
+
+    void withDeferredOutputs() {
+        immutableTaskGraphList.forEach(ImmutableTaskGraph::withDeferredOutputs);
+    }
+
+    void withoutDeferredOutputs() {
+        immutableTaskGraphList.forEach(ImmutableTaskGraph::withoutDeferredOutputs);
+    }
+
     boolean isFinished() {
         boolean result = true;
         for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -57,6 +57,10 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void withCUDAGraph();
 
+    void withDeferredOutputs();
+
+    void withoutDeferredOutputs();
+
     void withMemoryLimit(String memoryLimit);
 
     void withoutMemoryLimit();
@@ -110,6 +114,12 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
     void useDefaultThreadScheduler(boolean use);
 
     boolean isFinished();
+
+    /**
+     * Blocks until the copy-outs of the last execution have landed in their host buffers. A
+     * no-op unless {@code tornado.deferred.outputs} left an execution's reads in flight.
+     */
+    void awaitDeferredOutputs();
 
     Set<Object> getArgumentsLookup();
 

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/XPUBuffer.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/memory/XPUBuffer.java
@@ -49,6 +49,18 @@ public interface XPUBuffer {
 
     int enqueueRead(long executionPlanId, Object reference, long hostOffset, int[] events, boolean useDeps);
 
+    /**
+     * Whether {@link #enqueueRead} copies out exactly what {@link #read} would, so that a caller
+     * may issue the read without waiting for it and synchronise the device later instead.
+     *
+     * <p>Defaults to {@code false}: several implementations (field buffers, for instance) support
+     * the blocking read only, and would silently copy the wrong bytes - or nothing at all - if the
+     * asynchronous variant were used in its place.
+     */
+    default boolean supportsAsyncRead() {
+        return false;
+    }
+
     List<Integer> enqueueWrite(long executionPlanId, Object reference, long batchSize, long hostOffset, int[] events, boolean useDeps);
 
     void allocate(Object reference, long batchSize, Access access) throws TornadoOutOfMemoryException, TornadoMemoryException;

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/OffDeferredOutputs.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/OffDeferredOutputs.java
@@ -1,0 +1,12 @@
+package uk.ac.manchester.tornado.api.plan.types;
+
+import uk.ac.manchester.tornado.api.ExecutionPlanType;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+
+public final class OffDeferredOutputs extends ExecutionPlanType {
+
+    public OffDeferredOutputs(TornadoExecutionPlan parent) {
+        super(parent);
+    }
+
+}

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithDeferredOutputs.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/plan/types/WithDeferredOutputs.java
@@ -1,0 +1,12 @@
+package uk.ac.manchester.tornado.api.plan.types;
+
+import uk.ac.manchester.tornado.api.ExecutionPlanType;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+
+public final class WithDeferredOutputs extends ExecutionPlanType {
+
+    public WithDeferredOutputs(TornadoExecutionPlan parent) {
+        super(parent);
+    }
+
+}

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -190,6 +190,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.memory.TestMemoryLimit"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestIO"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestMultipleCopyOuts"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestDeferredOutputs"),
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGrid"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGridScheduler"),

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -189,6 +189,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestInitDataTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.memory.TestMemoryLimit"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestIO"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestMultipleCopyOuts"),
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGrid"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGridScheduler"),

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -191,6 +191,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestIO"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestMultipleCopyOuts"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestDeferredOutputs"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestOnDemandTransfers"),
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGrid"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGridScheduler"),

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAMemorySegmentWrapper.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAMemorySegmentWrapper.java
@@ -300,4 +300,10 @@ public class CUDAMemorySegmentWrapper implements XPUBuffer {
         return sizeOfType;
     }
 
+
+    @Override
+    public boolean supportsAsyncRead() {
+        // enqueueRead and read copy the same region for a whole-segment transfer.
+        return true;
+    }
 }

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/mm/MetalMemorySegmentWrapper.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/mm/MetalMemorySegmentWrapper.java
@@ -252,4 +252,10 @@ public class MetalMemorySegmentWrapper implements XPUBuffer {
         return sizeOfType;
     }
 
+
+    @Override
+    public boolean supportsAsyncRead() {
+        // enqueueRead and read copy the same region for a whole-segment transfer.
+        return true;
+    }
 }

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/runtime/MetalTornadoDevice.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/runtime/MetalTornadoDevice.java
@@ -620,7 +620,7 @@ public class MetalTornadoDevice implements TornadoXPUDevice {
     @Override
     public int streamOut(long executionPlanId, Object object, long offset, DeviceBufferState state, int[] events) {
         TornadoInternalError.guarantee(state.hasObjectBuffer(), "invalid variable");
-        int event = state.getXPUBuffer().enqueueRead(executionPlanId, object, offset, events, events == null);
+        int event = state.getXPUBuffer().enqueueRead(executionPlanId, object, offset, events, events != null);
         if (events != null) {
             return event;
         }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/mm/OCLMemorySegmentWrapper.java
@@ -251,4 +251,10 @@ public class OCLMemorySegmentWrapper implements XPUBuffer {
         return sizeOfType;
     }
 
+
+    @Override
+    public boolean supportsAsyncRead() {
+        // enqueueRead and read copy the same region for a whole-segment transfer.
+        return true;
+    }
 }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -603,7 +603,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
     @Override
     public int streamOut(long executionPlanId, Object object, long offset, DeviceBufferState state, int[] events) {
         TornadoInternalError.guarantee(state.hasObjectBuffer(), "invalid variable");
-        int event = state.getXPUBuffer().enqueueRead(executionPlanId, object, offset, events, events == null);
+        int event = state.getXPUBuffer().enqueueRead(executionPlanId, object, offset, events, events != null);
         if (events != null) {
             return event;
         }

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/OnDemandTransfers.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/OnDemandTransfers.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package uk.ac.manchester.tornado.examples;
+
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+
+/**
+ * On-demand copy-outs: a task-graph that produces four results, of which the host usually only
+ * needs one. Declaring the outputs with {@link DataTransferMode#UNDER_DEMAND} keeps them on the
+ * device until {@link TornadoExecutionResult#transferToHost} asks for them, and asking for
+ * several at once costs one host wait rather than one per object.
+ *
+ * <p>
+ * Run with.
+ * </p>
+ * <code>
+ * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.OnDemandTransfers
+ * </code>
+ */
+public class OnDemandTransfers {
+
+    private static final int SIZE = 1 << 20;
+    private static final int ITERATIONS = 20;
+
+    private static void scale(FloatArray input, FloatArray output, float alpha) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, alpha * input.get(i));
+        }
+    }
+
+    public static void main(String[] args) throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(1.0f);
+
+        FloatArray outA = new FloatArray(SIZE);
+        FloatArray outB = new FloatArray(SIZE);
+        FloatArray outC = new FloatArray(SIZE);
+        FloatArray outD = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("onDemand") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", OnDemandTransfers::scale, input, outA, 1.0f) //
+                .task("b", OnDemandTransfers::scale, input, outB, 2.0f) //
+                .task("c", OnDemandTransfers::scale, input, outC, 3.0f) //
+                .task("d", OnDemandTransfers::scale, input, outD, 4.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, outA, outB, outC, outD);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+
+            // Only the last iteration's results are needed, so nothing is copied back until then.
+            TornadoExecutionResult executionResult = null;
+            long start = System.nanoTime();
+            for (int iteration = 1; iteration <= ITERATIONS; iteration++) {
+                input.init(iteration);
+                executionResult = executionPlan.execute();
+            }
+            long compute = System.nanoTime() - start;
+
+            // One call for all four outputs: the reads are issued together and waited for once.
+            start = System.nanoTime();
+            executionResult.transferToHost(outA, outB, outC, outD);
+            long transfer = System.nanoTime() - start;
+
+            System.out.printf("%d executions in %.2f ms, copy-out of 4 x %d floats in %.3f ms%n", //
+                    ITERATIONS, compute * 1e-6, SIZE, transfer * 1e-6);
+            System.out.printf("outA[0]=%.1f outB[0]=%.1f outC[0]=%.1f outD[0]=%.1f (expected %d, %d, %d, %d)%n", //
+                    outA.get(0), outB.get(0), outC.get(0), outD.get(0), //
+                    ITERATIONS, 2 * ITERATIONS, 3 * ITERATIONS, 4 * ITERATIONS);
+        }
+    }
+}

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -197,6 +197,14 @@ public class TornadoVM {
         executeActionOnInterpreters(TornadoVMInterpreter::destroyExecutionGraphs);
     }
 
+    /**
+     * Blocks until the copy-outs of the last execution have landed in their host buffers. A
+     * no-op unless {@code tornado.deferred.outputs} left an execution's reads in flight.
+     */
+    public void awaitDeferredOutputs() {
+        executeActionOnInterpreters(TornadoVMInterpreter::awaitDeferredOutputs);
+    }
+
     public void printTimes() {
         executeActionOnInterpreters(TornadoVMInterpreter::printTimes);
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -295,6 +295,16 @@ public class TornadoOptions {
     public static final boolean ENABLE_STREAM_OUT_BLOCKING = getBooleanValue("tornado.enable.streamOut.blocking", TRUE);
 
     /**
+     * How many executions of a plan with deferred outputs may be outstanding before the next one
+     * waits for the oldest. Consecutive executions do not have to be serialised against each other
+     * on a single in-order queue, so allowing a few in flight lets the host run ahead of the
+     * device; the bound stops it running ahead without limit. Defaults to 4, which is where the
+     * measured gain flattens out.
+     */
+    public static final int MAX_DEFERRED_EXECUTIONS_IN_FLIGHT = getIntValue("tornado.deferred.outputs.maxInFlight", "4");
+
+
+    /**
      * Option to run concurrently on multiple device in single or multi-backend
      * configuration. False by default.
      */

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoExecutionContext.java
@@ -96,6 +96,7 @@ public class TornadoExecutionContext {
     private long executionPlanId;  // This is set at runtime. Thus, no need to clone this value.
     private long currentDeviceMemoryUsage;
     private boolean isExecutionGraphEnabled;
+    private boolean isDeferredOutputsEnabled;
     private boolean isIntraPlanConcurrencyEnabled;
     private boolean isStagedTransfersEnabled;
 
@@ -122,6 +123,7 @@ public class TornadoExecutionContext {
         this.profiler = null;
         this.isDataDependencyDetected = isDataDependencyInTaskGraph();
         this.isExecutionGraphEnabled = false;
+        this.isDeferredOutputsEnabled = false;
         this.isIntraPlanConcurrencyEnabled = false;
         // Defaults to the -Dtornado.staged.transfers property, so the plan-level API overrides it
         // rather than replacing it.
@@ -694,6 +696,7 @@ public class TornadoExecutionContext {
         newExecutionContext.executionPlanMemoryLimit = this.executionPlanMemoryLimit;
 
         newExecutionContext.isExecutionGraphEnabled = this.isExecutionGraphEnabled;
+        newExecutionContext.isDeferredOutputsEnabled = this.isDeferredOutputsEnabled;
         newExecutionContext.isIntraPlanConcurrencyEnabled = this.isIntraPlanConcurrencyEnabled;
         newExecutionContext.isStagedTransfersEnabled = this.isStagedTransfersEnabled;
 
@@ -727,6 +730,18 @@ public class TornadoExecutionContext {
 
     public void setExecutionGraphEnabled(boolean enabled) {
         this.isExecutionGraphEnabled = enabled;
+    }
+
+    /**
+     * Whether this plan keeps its copy-outs in flight after an execution, so that the wait
+     * happens when the results are observed rather than inside execute().
+     */
+    public void setDeferredOutputsEnabled(boolean enabled) {
+        this.isDeferredOutputsEnabled = enabled;
+    }
+
+    public boolean isDeferredOutputsEnabled() {
+        return this.isDeferredOutputsEnabled;
     }
 
     public boolean isExecutionGraphEnabled() {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/graph/TornadoVMGraphCompiler.java
@@ -141,8 +141,9 @@ public class TornadoVMGraphCompiler {
                         graph, intermediateTornadoGraph);
             }
 
-            // Last operation -> perform synchronisation
-            if (!useCUDAGraphs) {
+            // Last operation -> perform synchronisation. Deferred outputs skip it entirely: the
+            // wait moves out of the execution and into whoever observes the results.
+            if (!useCUDAGraphs && !executionContext.isDeferredOutputsEnabled()) {
                 if (TornadoOptions.ENABLE_STREAM_OUT_BLOCKING) {
                     synchronizeOperationLastByteCode(tornadoVMBytecodeBuilder, intermediateTornadoGraph.getNumberOfDependencies());
                 } else {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -118,6 +118,10 @@ public class TornadoVMInterpreter {
     private boolean insideCaptureRegion = false;
     private boolean executionGraphEnabled = true;
 
+    /** Executions that returned with their copy-outs still in flight. */
+    private int deferredExecutionsInFlight = 0;
+
+
     private TornadoLogger logger = new TornadoLogger(this.getClass());
 
     /**
@@ -295,6 +299,14 @@ public class TornadoVMInterpreter {
 
     private Event execute(boolean isWarmup) {
         isWarmup = isWarmup || VIRTUAL_DEVICE_ENABLED;
+
+        // A previous execution may have left its copy-outs in flight. Waiting for them here is only
+        // necessary when the ordering that makes pipelining safe does not hold, or when too many
+        // executions are already outstanding.
+        if (deferredExecutionsInFlight >= TornadoOptions.MAX_DEFERRED_EXECUTIONS_IN_FLIGHT || isIntraPlanConcurrencyActive()) {
+            awaitDeferredOutputs();
+        }
+
         interpreterDevice.enableThreadSharing();
 
         // Push the per-plan intra-plan-concurrency setting to the backend before issuing any
@@ -510,7 +522,12 @@ public class TornadoVMInterpreter {
                 barrier = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), event);
             }
 
-            if (TornadoOptions.USE_VM_FLUSH) {
+            if (deferOutputs()) {
+                // Leave the copy-outs in flight. flush() would drain the stream, which is the
+                // wait this option exists to avoid; the marker above is not needed either,
+                // because awaitDeferredOutputs() synchronises the whole queue.
+                deferredExecutionsInFlight++;
+            } else if (TornadoOptions.USE_VM_FLUSH) {
                 interpreterDevice.flush(graphExecutionContext.getExecutionPlanId());
             }
         }
@@ -674,6 +691,27 @@ public class TornadoVMInterpreter {
                 executionGraphHandles.get(graphId));
 
         return event;
+    }
+
+    /**
+     * Whether this execution may return before its copy-outs have landed. The profiler reads
+     * device timestamps at the end of the run, which needs a drained stream, so it keeps the
+     * synchronous tail.
+     */
+    private boolean deferOutputs() {
+        return graphExecutionContext.isDeferredOutputsEnabled() && !TornadoOptions.isProfilerEnabled();
+    }
+
+    /**
+     * Blocks until the copy-outs of the previous execution have landed in their host buffers.
+     * A no-op unless an execution actually left work in flight, so every observation point can
+     * call it unconditionally.
+     */
+    public void awaitDeferredOutputs() {
+        if (deferredExecutionsInFlight > 0) {
+            deferredExecutionsInFlight = 0;
+            interpreterDevice.sync(graphExecutionContext.getExecutionPlanId());
+        }
     }
 
     private void initWaitEventList() {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -994,7 +994,8 @@ public class TornadoVMInterpreter {
         // host wait for no benefit, so this takes the asynchronous read whenever the blocking
         // variant is not doing something extra: it also covers atomics, under-demand partial
         // copies and batch chunks, none of which enqueueRead supports.
-        final boolean canReadAsync = !objectState.isAtomicRegionPresent() //
+        final boolean canReadAsync = objectState.getXPUBuffer().supportsAsyncRead() //
+                && !objectState.isAtomicRegionPresent() //
                 && objectState.getPartialCopySize() == 0 //
                 && sizeBatch <= 0;
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -987,7 +987,20 @@ public class TornadoVMInterpreter {
             DebugInterpreter.logTransferToHostAlways(object, interpreterDevice, sizeObject, sizeBatch, offset, eventId, logBuilder);
         }
 
-        int readEvent = interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList);
+        // TRANSFER_DEVICE_TO_HOST_ALWAYS is the non-terminal copy-out: the graph compiler patches
+        // only the last one into TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING, which - together with the
+        // sync in TornadoTaskGraph.waitOn() - is what makes the outputs visible when execute()
+        // returns. Reading synchronously here as well makes every intermediate copy-out its own
+        // host wait for no benefit, so this takes the asynchronous read whenever the blocking
+        // variant is not doing something extra: it also covers atomics, under-demand partial
+        // copies and batch chunks, none of which enqueueRead supports.
+        final boolean canReadAsync = !objectState.isAtomicRegionPresent() //
+                && objectState.getPartialCopySize() == 0 //
+                && sizeBatch <= 0;
+
+        int readEvent = canReadAsync
+                ? interpreterDevice.streamOut(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList)
+                : interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList);
 
         resetEventIndexes(eventId);
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -307,7 +307,15 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     @Override
     public boolean isFinished() {
+        awaitDeferredOutputs();
         return this.isFinished;
+    }
+
+    @Override
+    public void awaitDeferredOutputs() {
+        if (vm != null) {
+            vm.awaitDeferredOutputs();
+        }
     }
 
     @Override
@@ -1091,6 +1099,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
 
     @Override
     public void waitOn() {
+        if (executionContext.isDeferredOutputsEnabled() && !TornadoOptions.isProfilerEnabled()) {
+            // The execution keeps its copy-outs in flight; awaitDeferredOutputs() does this wait
+            // when something can observe the output buffers.
+            return;
+        }
         if ((TornadoOptions.VM_USE_DEPS || executionContext.isIntraPlanConcurrencyEnabled()) && event != null) {
             event.waitOn();
         } else {
@@ -1355,6 +1368,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             return;
         }
 
+        awaitDeferredOutputs();
         vm.destroyExecutionGraphs();
         LibraryRegistry.destroyContexts(executionPlanId);
         freeIOObjects();
@@ -1470,6 +1484,8 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         if (vm == null) {
             return;
         }
+
+        awaitDeferredOutputs();
 
         List<Event> events = new ArrayList<>();
         for (Object object : objects) {
@@ -1982,6 +1998,17 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     @Override
     public void withCUDAGraph() {
         executionContext.setExecutionGraphEnabled(true);
+    }
+
+    @Override
+    public void withDeferredOutputs() {
+        executionContext.setDeferredOutputsEnabled(true);
+    }
+
+    @Override
+    public void withoutDeferredOutputs() {
+        awaitDeferredOutputs();
+        executionContext.setDeferredOutputsEnabled(false);
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -1426,6 +1426,42 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         return null;
     }
 
+    /**
+     * Whether an on-demand copy-out of this object can be issued asynchronously, so that a
+     * transfer of several objects costs one host wait instead of one per object.
+     *
+     * <p>The blocking read does more than wait: it also covers atomics and under-demand partial
+     * copies, and batched plans read the object chunk by chunk. Those keep the blocking path, as do
+     * buffers whose asynchronous read is not equivalent to their blocking one (field buffers, for
+     * instance - see {@code XPUBuffer.supportsAsyncRead}), and profiled runs, which time each
+     * copy-out through its own event.
+     */
+    private boolean canEnqueueSyncAsync(XPUDeviceBufferState deviceState) {
+        return deviceState.getXPUBuffer().supportsAsyncRead() //
+                && !TornadoOptions.isProfilerEnabled() //
+                && batchSizeBytes == TornadoExecutionContext.INIT_VALUE //
+                && !deviceState.isAtomicRegionPresent() //
+                && deviceState.getPartialCopySize() == 0;
+    }
+
+    /**
+     * Issues the copy-out of one object without waiting for it. Returns {@code true} when a read
+     * was enqueued, in which case the caller owes a device synchronisation before the host may
+     * read the object.
+     */
+    private boolean enqueueSyncObject(Object object) {
+        Access objectAccess = getObjectAccess(object);
+        final LocalObjectState localState = executionContext.getLocalStateObject(object, objectAccess);
+        final DataObjectState dataObjectState = localState.getDataObjectState();
+        final TornadoXPUDevice device = meta().getXPUDevice();
+        final XPUDeviceBufferState deviceState = dataObjectState.getDeviceBufferState(device);
+        if (!deviceState.isLockedBuffer() || !canEnqueueSyncAsync(deviceState)) {
+            return false;
+        }
+        device.streamOut(executionPlanId, object, 0, deviceState, null);
+        return true;
+    }
+
     private Event syncObjectInnerLazy(Object object, long hostOffset, long bufferSize) {
         Access objectAccess = getObjectAccess(object);
         final LocalObjectState localState = executionContext.getLocalStateObject(object, objectAccess);
@@ -1488,6 +1524,7 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         awaitDeferredOutputs();
 
         List<Event> events = new ArrayList<>();
+        boolean pendingAsyncReads = false;
         for (Object object : objects) {
             if (DEBUG) {
                 if (copyUnderDemand(object)) {
@@ -1497,10 +1534,19 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
             // Check if it is an argument captured by the scope (not in the parameter list).
             if (!argumentsLookUp.contains(object)) {
                 syncField(object);
+            } else if (enqueueSyncObject(object)) {
+                // Read issued, not waited for: the objects requested in one call are independent,
+                // so they are all put on the queue first and waited for once, below.
+                pendingAsyncReads = true;
+                events.add(null);
             } else {
                 Event eventParameter = syncParameter(object);
                 events.add(eventParameter);
             }
+        }
+
+        if (pendingAsyncReads) {
+            meta().getXPUDevice().sync(executionPlanId);
         }
 
         if (TornadoOptions.isProfilerEnabled()) {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDeferredOutputs.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestDeferredOutputs.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Tests for {@link TornadoExecutionPlan#withDeferredOutputs()}: an execution returns with its
+ * copy-outs still in flight, and the outputs become valid once the execution has been awaited -
+ * explicitly through the {@link TornadoExecutionResult}, or implicitly at the next execution of
+ * the same plan.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.api.TestDeferredOutputs
+ * </code>
+ */
+public class TestDeferredOutputs extends TornadoTestBase {
+
+    private static final int SIZE = 1 << 16;
+
+    public static void scale(FloatArray input, FloatArray output, float alpha) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, alpha * input.get(i));
+        }
+    }
+
+    private static TaskGraph buildGraph(FloatArray input, FloatArray output) {
+        return new TaskGraph("deferred") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("t", TestDeferredOutputs::scale, input, output, 2.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+    }
+
+    /** Busy-waits, so that it does not park the thread the way a sleep would. */
+    private static long hostWork(long micros) {
+        long deadline = System.nanoTime() + micros * 1000;
+        long spins = 0;
+        while (System.nanoTime() < deadline) {
+            spins++;
+        }
+        return spins;
+    }
+
+    @Test
+    public void testAwaitMakesOutputsVisible() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            executionPlan.execute().await();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(6.0f, output.get(i), 0.001f);
+        }
+    }
+
+    /**
+     * The point of the option: host work between {@code execute()} and {@code await()} overlaps
+     * with the read-back, and the results are still correct afterwards.
+     */
+    @Test
+    public void testHostWorkBetweenExecuteAndAwait() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray output = new FloatArray(SIZE);
+        long spins = 0;
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            for (int iteration = 1; iteration <= 8; iteration++) {
+                input.init(iteration);
+                TornadoExecutionResult executionResult = executionPlan.execute();
+                spins += hostWork(200);
+                executionResult.await();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(2.0f * iteration, output.get(i), 0.001f);
+                }
+            }
+        }
+        assertTrue(spins > 0);
+    }
+
+    /**
+     * Nothing is lost when the caller never awaits: the next execution of the same plan awaits
+     * the previous one before it can overwrite anything.
+     */
+    @Test
+    public void testNextExecutionAwaitsThePreviousOne() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            for (int iteration = 1; iteration <= 8; iteration++) {
+                input.init(iteration);
+                executionPlan.execute();
+            }
+            executionPlan.execute().await();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(16.0f, output.get(i), 0.001f);
+        }
+    }
+
+    /** {@code isReady()} is an observation point, so it awaits like {@code await()} does. */
+    @Test
+    public void testIsReadyAwaits() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(5.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            TornadoExecutionResult executionResult = executionPlan.execute();
+            assertTrue(executionResult.isReady());
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(10.0f, output.get(i), 0.001f);
+            }
+        }
+    }
+
+    /** Switching the option back off restores the synchronous contract for later executions. */
+    @Test
+    public void testWithoutDeferredOutputsRestoresBlockingExecution() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            input.init(1.0f);
+            executionPlan.execute().await();
+
+            executionPlan.withoutDeferredOutputs();
+            for (int iteration = 2; iteration <= 4; iteration++) {
+                input.init(iteration);
+                executionPlan.execute();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(2.0f * iteration, output.get(i), 0.001f);
+                }
+            }
+        }
+    }
+
+    /** A deferred plan that is simply closed must not leave a copy-out in flight. */
+    @Test
+    public void testCloseAwaitsPendingOutputs() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(7.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph(input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(14.0f, output.get(i), 0.001f);
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestMultipleCopyOuts.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestMultipleCopyOuts.java
@@ -31,6 +31,7 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
 
 /**
@@ -53,6 +54,14 @@ public class TestMultipleCopyOuts extends TornadoTestBase {
     public static void scale(FloatArray input, FloatArray output, float alpha) {
         for (@Parallel int i = 0; i < input.getSize(); i++) {
             output.set(i, alpha * input.get(i));
+        }
+    }
+
+    public static void scaleMatrix(Matrix2DFloat input, Matrix2DFloat output, float alpha) {
+        for (@Parallel int i = 0; i < input.getNumRows(); i++) {
+            for (@Parallel int j = 0; j < input.getNumColumns(); j++) {
+                output.set(i, j, alpha * input.get(i, j));
+            }
         }
     }
 
@@ -220,6 +229,42 @@ public class TestMultipleCopyOuts extends TornadoTestBase {
                 for (int i = 0; i < batchedSize; i++) {
                     assertEquals(2.0f * iteration, output.get(i), 0.001f);
                 }
+            }
+        }
+    }
+
+    /**
+     * Two matrix outputs: the first one is a non-terminal copy-out, so it goes through the
+     * asynchronous read while the second stays blocking. Matrices use a different buffer wrapper
+     * from the flat arrays the other tests cover.
+     */
+    @Test
+    public void testTwoMatrixOutputs() throws TornadoExecutionPlanException {
+        final int n = 64;
+        Matrix2DFloat input = new Matrix2DFloat(n, n);
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                input.set(i, j, i + j);
+            }
+        }
+        Matrix2DFloat outA = new Matrix2DFloat(n, n);
+        Matrix2DFloat outB = new Matrix2DFloat(n, n);
+
+        TaskGraph taskGraph = new TaskGraph("matrixOut") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestMultipleCopyOuts::scaleMatrix, input, outA, 2.0f) //
+                .task("b", TestMultipleCopyOuts::scaleMatrix, input, outB, 3.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, outA, outB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                assertEquals(2.0f * (i + j), outA.get(i, j), 0.001f);
+                assertEquals(3.0f * (i + j), outB.get(i, j), 0.001f);
             }
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestMultipleCopyOuts.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestMultipleCopyOuts.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.DataRange;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Task graphs with more than one copy-out. Only the last copy-out of a graph is compiled into
+ * the blocking bytecode; the others are read asynchronously, so these tests check that every
+ * output is still complete and up to date by the time {@code execute()} returns, including the
+ * cases that keep the blocking read (partial copies and batches).
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.api.TestMultipleCopyOuts
+ * </code>
+ */
+public class TestMultipleCopyOuts extends TornadoTestBase {
+
+    private static final int SIZE = 8192;
+
+    public static void scale(FloatArray input, FloatArray output, float alpha) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, alpha * input.get(i));
+        }
+    }
+
+    public static void increment(IntArray input, IntArray output, int delta) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, input.get(i) + delta);
+        }
+    }
+
+    /**
+     * Four outputs: three of them are non-terminal copy-outs, so three asynchronous reads have
+     * to have landed before {@code execute()} returns.
+     */
+    @Test
+    public void testFourOutputsInOneGraph() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(2.0f);
+
+        FloatArray outA = new FloatArray(SIZE);
+        FloatArray outB = new FloatArray(SIZE);
+        FloatArray outC = new FloatArray(SIZE);
+        FloatArray outD = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("multiOut") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestMultipleCopyOuts::scale, input, outA, 1.0f) //
+                .task("b", TestMultipleCopyOuts::scale, input, outB, 2.0f) //
+                .task("c", TestMultipleCopyOuts::scale, input, outC, 3.0f) //
+                .task("d", TestMultipleCopyOuts::scale, input, outD, 4.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, outA, outB, outC, outD);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(2.0f, outA.get(i), 0.001f);
+            assertEquals(4.0f, outB.get(i), 0.001f);
+            assertEquals(6.0f, outC.get(i), 0.001f);
+            assertEquals(8.0f, outD.get(i), 0.001f);
+        }
+    }
+
+    /**
+     * Same graph executed repeatedly with a different input each time. A read that has not
+     * landed shows up here as an output from the previous execution rather than as a wrong
+     * value, which a single-execution test would miss.
+     */
+    @Test
+    public void testMultipleOutputsAcrossExecutions() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray outA = new FloatArray(SIZE);
+        FloatArray outB = new FloatArray(SIZE);
+        FloatArray outC = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("multiOutRepeat") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestMultipleCopyOuts::scale, input, outA, 1.0f) //
+                .task("b", TestMultipleCopyOuts::scale, input, outB, 2.0f) //
+                .task("c", TestMultipleCopyOuts::scale, input, outC, 3.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, outA, outB, outC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            for (int iteration = 1; iteration <= 8; iteration++) {
+                input.init(iteration);
+                executionPlan.execute();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(iteration, outA.get(i), 0.001f);
+                    assertEquals(2.0f * iteration, outB.get(i), 0.001f);
+                    assertEquals(3.0f * iteration, outC.get(i), 0.001f);
+                }
+            }
+        }
+    }
+
+    /**
+     * Mixed output types, so the reads go through different buffer wrappers within one graph.
+     */
+    @Test
+    public void testMixedOutputTypes() throws TornadoExecutionPlanException {
+        FloatArray floatInput = new FloatArray(SIZE);
+        floatInput.init(1.5f);
+        IntArray intInput = new IntArray(SIZE);
+        intInput.init(7);
+
+        FloatArray floatOutput = new FloatArray(SIZE);
+        IntArray intOutput = new IntArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("mixedOut") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, floatInput, intInput) //
+                .task("f", TestMultipleCopyOuts::scale, floatInput, floatOutput, 2.0f) //
+                .task("i", TestMultipleCopyOuts::increment, intInput, intOutput, 5) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, floatOutput, intOutput);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(3.0f, floatOutput.get(i), 0.001f);
+            assertEquals(12, intOutput.get(i));
+        }
+    }
+
+    /**
+     * An under-demand partial copy-out alongside an every-execution one. The partial read keeps
+     * the blocking path, so this covers the guard rather than the asynchronous read.
+     */
+    @Test
+    public void testPartialCopyOutWithSecondOutput() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray eagerOutput = new FloatArray(SIZE);
+        FloatArray onDemandOutput = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("partialOut") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestMultipleCopyOuts::scale, input, eagerOutput, 2.0f) //
+                .task("b", TestMultipleCopyOuts::scale, input, onDemandOutput, 5.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, eagerOutput) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, onDemandOutput);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            TornadoExecutionResult executionResult = executionPlan.execute();
+
+            DataRange dataRange = new DataRange(onDemandOutput);
+            executionResult.transferToHost(dataRange.withSize(SIZE / 2));
+            executionResult.transferToHost(dataRange.withOffset(SIZE / 2).withSize(SIZE / 2));
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(6.0f, eagerOutput.get(i), 0.001f);
+            assertEquals(15.0f, onDemandOutput.get(i), 0.001f);
+        }
+    }
+
+    /**
+     * Batched copy-out, repeated so the per-chunk reads are exercised more than once. Batch
+     * chunks keep the blocking read, so this is the other half of the guard.
+     *
+     * <p>Deliberately a single output: a batched graph with two outputs fails on {@code develop}
+     * with a null device buffer, independently of how the reads are issued.
+     */
+    @Test
+    public void testBatchedCopyOut() throws TornadoExecutionPlanException {
+        final int batchedSize = 1024 * 1024;
+        FloatArray input = new FloatArray(batchedSize);
+        FloatArray output = new FloatArray(batchedSize);
+
+        TaskGraph taskGraph = new TaskGraph("batchedOut") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestMultipleCopyOuts::scale, input, output, 2.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withBatch("1MB");
+            for (int iteration = 1; iteration <= 3; iteration++) {
+                input.init(iteration);
+                executionPlan.execute();
+                for (int i = 0; i < batchedSize; i++) {
+                    assertEquals(2.0f * iteration, output.get(i), 0.001f);
+                }
+            }
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandTransfers.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandTransfers.java
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.DataRange;
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * On-demand copy-outs: objects declared with {@link DataTransferMode#UNDER_DEMAND} are only read
+ * back when {@link TornadoExecutionResult#transferToHost} asks for them. Several objects asked for
+ * in one call are read together and waited for once, so these tests check that every object is
+ * complete and up to date when the call returns.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.api.TestOnDemandTransfers
+ * </code>
+ */
+public class TestOnDemandTransfers extends TornadoTestBase {
+
+    private static final int SIZE = 8192;
+
+    public static void scale(FloatArray input, FloatArray output, float alpha) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, alpha * input.get(i));
+        }
+    }
+
+    public static void accumulate(FloatArray input, FloatArray accumulator) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            accumulator.set(i, accumulator.get(i) + input.get(i));
+        }
+    }
+
+    public static void scaleMatrix(Matrix2DFloat input, Matrix2DFloat output, float alpha) {
+        for (@Parallel int i = 0; i < input.getNumRows(); i++) {
+            for (@Parallel int j = 0; j < input.getNumColumns(); j++) {
+                output.set(i, j, alpha * input.get(i, j));
+            }
+        }
+    }
+
+    public static void increment(IntArray input, IntArray output, int delta) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, input.get(i) + delta);
+        }
+    }
+
+    /** Four on-demand outputs asked for in a single call. */
+    @Test
+    public void testTransferFourObjectsInOneCall() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(2.0f);
+        FloatArray outA = new FloatArray(SIZE);
+        FloatArray outB = new FloatArray(SIZE);
+        FloatArray outC = new FloatArray(SIZE);
+        FloatArray outD = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("onDemand") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransfers::scale, input, outA, 1.0f) //
+                .task("b", TestOnDemandTransfers::scale, input, outB, 2.0f) //
+                .task("c", TestOnDemandTransfers::scale, input, outC, 3.0f) //
+                .task("d", TestOnDemandTransfers::scale, input, outD, 4.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, outA, outB, outC, outD);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute().transferToHost(outA, outB, outC, outD);
+
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(2.0f, outA.get(i), 0.001f);
+                assertEquals(4.0f, outB.get(i), 0.001f);
+                assertEquals(6.0f, outC.get(i), 0.001f);
+                assertEquals(8.0f, outD.get(i), 0.001f);
+            }
+        }
+    }
+
+    /**
+     * Repeated executions with a different input each time. A read that has not landed shows up
+     * here as the previous execution's values rather than as a wrong number.
+     */
+    @Test
+    public void testOnDemandTransfersAcrossExecutions() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray outA = new FloatArray(SIZE);
+        FloatArray outB = new FloatArray(SIZE);
+        FloatArray outC = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("onDemandRepeat") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransfers::scale, input, outA, 1.0f) //
+                .task("b", TestOnDemandTransfers::scale, input, outB, 2.0f) //
+                .task("c", TestOnDemandTransfers::scale, input, outC, 3.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, outA, outB, outC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            for (int iteration = 1; iteration <= 8; iteration++) {
+                input.init(iteration);
+                executionPlan.execute().transferToHost(outA, outB, outC);
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(iteration, outA.get(i), 0.001f);
+                    assertEquals(2.0f * iteration, outB.get(i), 0.001f);
+                    assertEquals(3.0f * iteration, outC.get(i), 0.001f);
+                }
+            }
+        }
+    }
+
+    /** Objects transferred one at a time must behave exactly as when asked for together. */
+    @Test
+    public void testTransferObjectsOneByOne() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(4.0f);
+        FloatArray outA = new FloatArray(SIZE);
+        FloatArray outB = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("onDemandOneByOne") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransfers::scale, input, outA, 2.0f) //
+                .task("b", TestOnDemandTransfers::scale, input, outB, 3.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, outA, outB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            TornadoExecutionResult executionResult = executionPlan.execute();
+            executionResult.transferToHost(outA);
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(8.0f, outA.get(i), 0.001f);
+            }
+            executionResult.transferToHost(outB);
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(12.0f, outB.get(i), 0.001f);
+            }
+        }
+    }
+
+    /** Mixed types in one on-demand call, so the reads go through different buffer wrappers. */
+    @Test
+    public void testMixedTypesInOneCall() throws TornadoExecutionPlanException {
+        FloatArray floatInput = new FloatArray(SIZE);
+        floatInput.init(1.5f);
+        IntArray intInput = new IntArray(SIZE);
+        intInput.init(7);
+        FloatArray floatOutput = new FloatArray(SIZE);
+        IntArray intOutput = new IntArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("onDemandMixed") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, floatInput, intInput) //
+                .task("f", TestOnDemandTransfers::scale, floatInput, floatOutput, 2.0f) //
+                .task("i", TestOnDemandTransfers::increment, intInput, intOutput, 5) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, floatOutput, intOutput);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute().transferToHost(floatOutput, intOutput);
+
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(3.0f, floatOutput.get(i), 0.001f);
+                assertEquals(12, intOutput.get(i));
+            }
+        }
+    }
+
+    /**
+     * A partial on-demand copy next to a whole-object one. The partial read keeps the blocking
+     * path, so this covers the guard rather than the batched reads.
+     */
+    @Test
+    public void testPartialAndWholeObjectOnDemand() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray whole = new FloatArray(SIZE);
+        FloatArray partial = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("onDemandPartial") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransfers::scale, input, whole, 2.0f) //
+                .task("b", TestOnDemandTransfers::scale, input, partial, 5.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, whole, partial);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            TornadoExecutionResult executionResult = executionPlan.execute();
+
+            DataRange dataRange = new DataRange(partial);
+            executionResult.transferToHost(dataRange.withSize(SIZE / 2));
+            executionResult.transferToHost(dataRange.withOffset(SIZE / 2).withSize(SIZE / 2));
+            executionResult.transferToHost(whole);
+
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(6.0f, whole.get(i), 0.001f);
+                assertEquals(15.0f, partial.get(i), 0.001f);
+            }
+        }
+    }
+
+    /**
+     * A read-write object that stays on the device across executions and is only copied back at
+     * the end, next to two write-only outputs asked for in the same call. The accumulator makes a
+     * stale read visible as a wrong iteration count rather than as a wrong value.
+     */
+    @Test
+    public void testReadWriteAccumulatorWithOtherOutputs() throws TornadoExecutionPlanException {
+        final int iterations = 10;
+        FloatArray accumulator = new FloatArray(SIZE);
+        accumulator.init(0.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(1.0f);
+        FloatArray outA = new FloatArray(SIZE);
+        FloatArray outB = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("onDemandAccumulator") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, accumulator) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("acc", TestOnDemandTransfers::accumulate, input, accumulator) //
+                .task("a", TestOnDemandTransfers::scale, input, outA, 3.0f) //
+                .task("b", TestOnDemandTransfers::scale, input, outB, 4.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, accumulator, outA, outB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            TornadoExecutionResult executionResult = null;
+            for (int iteration = 0; iteration < iterations; iteration++) {
+                executionResult = executionPlan.execute();
+            }
+            executionResult.transferToHost(accumulator, outA, outB);
+
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(iterations, accumulator.get(i), 0.001f);
+                assertEquals(3.0f, outA.get(i), 0.001f);
+                assertEquals(4.0f, outB.get(i), 0.001f);
+            }
+        }
+    }
+
+    /**
+     * On-demand outputs alongside an every-execution one. The eager output is copied back by the
+     * execution itself, the others only when asked for, and both have to end up correct.
+     */
+    @Test
+    public void testMixedTransferModesInOneGraph() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray eager = new FloatArray(SIZE);
+        FloatArray lazyA = new FloatArray(SIZE);
+        FloatArray lazyB = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("onDemandMixedModes") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("e", TestOnDemandTransfers::scale, input, eager, 2.0f) //
+                .task("a", TestOnDemandTransfers::scale, input, lazyA, 3.0f) //
+                .task("b", TestOnDemandTransfers::scale, input, lazyB, 4.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, eager) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, lazyA, lazyB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            for (int iteration = 1; iteration <= 4; iteration++) {
+                input.init(iteration);
+                TornadoExecutionResult executionResult = executionPlan.execute();
+
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(2.0f * iteration, eager.get(i), 0.001f);
+                }
+
+                executionResult.transferToHost(lazyA, lazyB);
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(3.0f * iteration, lazyA.get(i), 0.001f);
+                    assertEquals(4.0f * iteration, lazyB.get(i), 0.001f);
+                }
+            }
+        }
+    }
+
+    /**
+     * Only a subset of the on-demand outputs is asked for, and a different subset each time. The
+     * objects that were not requested must keep the values of the execution they were last read
+     * after, not pick up the current one.
+     */
+    @Test
+    public void testSubsetOfOutputsRequestedPerExecution() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray outA = new FloatArray(SIZE);
+        FloatArray outB = new FloatArray(SIZE);
+        FloatArray outC = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("onDemandSubset") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransfers::scale, input, outA, 1.0f) //
+                .task("b", TestOnDemandTransfers::scale, input, outB, 2.0f) //
+                .task("c", TestOnDemandTransfers::scale, input, outC, 3.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, outA, outB, outC);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            input.init(1.0f);
+            executionPlan.execute().transferToHost(outA);
+
+            input.init(2.0f);
+            executionPlan.execute().transferToHost(outB, outC);
+
+            for (int i = 0; i < SIZE; i++) {
+                // outA was read after the first execution and never again.
+                assertEquals(1.0f, outA.get(i), 0.001f);
+                assertEquals(4.0f, outB.get(i), 0.001f);
+                assertEquals(6.0f, outC.get(i), 0.001f);
+            }
+
+            // Asking again without executing returns the same values.
+            executionPlan.execute();
+            input.init(3.0f);
+            executionPlan.execute().transferToHost(outA, outB, outC);
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(3.0f, outA.get(i), 0.001f);
+                assertEquals(6.0f, outB.get(i), 0.001f);
+                assertEquals(9.0f, outC.get(i), 0.001f);
+            }
+        }
+    }
+
+    /**
+     * Two task-graphs in one execution plan. {@code transferToHost} is applied to every graph of
+     * the plan, so the batched reads are issued per graph and must all have landed when the call
+     * returns.
+     */
+    @Test
+    public void testTwoTaskGraphsInOnePlan() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(2.0f);
+        FloatArray firstA = new FloatArray(SIZE);
+        FloatArray firstB = new FloatArray(SIZE);
+        FloatArray secondA = new FloatArray(SIZE);
+        FloatArray secondB = new FloatArray(SIZE);
+
+        TaskGraph first = new TaskGraph("onDemandGraph0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransfers::scale, input, firstA, 1.0f) //
+                .task("b", TestOnDemandTransfers::scale, input, firstB, 2.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, firstA, firstB);
+
+        TaskGraph second = new TaskGraph("onDemandGraph1") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransfers::scale, input, secondA, 3.0f) //
+                .task("b", TestOnDemandTransfers::scale, input, secondB, 4.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, secondA, secondB);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(first.snapshot(), second.snapshot())) {
+            executionPlan.execute().transferToHost(firstA, firstB, secondA, secondB);
+
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(2.0f, firstA.get(i), 0.001f);
+                assertEquals(4.0f, firstB.get(i), 0.001f);
+                assertEquals(6.0f, secondA.get(i), 0.001f);
+                assertEquals(8.0f, secondB.get(i), 0.001f);
+            }
+        }
+    }
+
+    /**
+     * Matrix outputs, so the reads go through a different buffer wrapper from the flat arrays the
+     * other tests use.
+     */
+    @Test
+    public void testMatrixOutputsOnDemand() throws TornadoExecutionPlanException {
+        final int n = 64;
+        Matrix2DFloat input = new Matrix2DFloat(n, n);
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                input.set(i, j, i + j);
+            }
+        }
+        Matrix2DFloat outA = new Matrix2DFloat(n, n);
+        Matrix2DFloat outB = new Matrix2DFloat(n, n);
+
+        TaskGraph taskGraph = new TaskGraph("onDemandMatrices") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransfers::scaleMatrix, input, outA, 2.0f) //
+                .task("b", TestOnDemandTransfers::scaleMatrix, input, outB, 3.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, outA, outB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute().transferToHost(outA, outB);
+        }
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                assertEquals(2.0f * (i + j), outA.get(i, j), 0.001f);
+                assertEquals(3.0f * (i + j), outB.get(i, j), 0.001f);
+            }
+        }
+    }
+
+    /**
+     * On-demand transfers on a plan that also defers its outputs: the transfer has to await the
+     * execution that is still in flight before it issues its own reads.
+     */
+    @Test
+    public void testOnDemandWithDeferredOutputs() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        FloatArray eager = new FloatArray(SIZE);
+        FloatArray lazyA = new FloatArray(SIZE);
+        FloatArray lazyB = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("onDemandDeferred") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("e", TestOnDemandTransfers::scale, input, eager, 2.0f) //
+                .task("a", TestOnDemandTransfers::scale, input, lazyA, 3.0f) //
+                .task("b", TestOnDemandTransfers::scale, input, lazyB, 4.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, eager) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, lazyA, lazyB);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withDeferredOutputs();
+            for (int iteration = 1; iteration <= 4; iteration++) {
+                input.init(iteration);
+                executionPlan.execute().transferToHost(lazyA, lazyB);
+
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(2.0f * iteration, eager.get(i), 0.001f);
+                    assertEquals(3.0f * iteration, lazyA.get(i), 0.001f);
+                    assertEquals(4.0f * iteration, lazyB.get(i), 0.001f);
+                }
+            }
+        }
+    }
+
+    /** Eight on-demand outputs of mixed types in one call. */
+    @Test
+    public void testEightMixedOutputsInOneCall() throws TornadoExecutionPlanException {
+        FloatArray floatInput = new FloatArray(SIZE);
+        floatInput.init(2.0f);
+        IntArray intInput = new IntArray(SIZE);
+        intInput.init(10);
+
+        FloatArray[] floatOutputs = new FloatArray[4];
+        IntArray[] intOutputs = new IntArray[4];
+        for (int i = 0; i < 4; i++) {
+            floatOutputs[i] = new FloatArray(SIZE);
+            intOutputs[i] = new IntArray(SIZE);
+        }
+
+        TaskGraph taskGraph = new TaskGraph("onDemandEight") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, floatInput, intInput);
+        for (int i = 0; i < 4; i++) {
+            taskGraph = taskGraph.task("f" + i, TestOnDemandTransfers::scale, floatInput, floatOutputs[i], 1.0f + i) //
+                    .task("i" + i, TestOnDemandTransfers::increment, intInput, intOutputs[i], i);
+        }
+        taskGraph = taskGraph.transferToHost(DataTransferMode.UNDER_DEMAND, floatOutputs[0], floatOutputs[1], floatOutputs[2], floatOutputs[3], //
+                intOutputs[0], intOutputs[1], intOutputs[2], intOutputs[3]);
+
+        ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute().transferToHost(floatOutputs[0], floatOutputs[1], floatOutputs[2], floatOutputs[3], //
+                    intOutputs[0], intOutputs[1], intOutputs[2], intOutputs[3]);
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            for (int k = 0; k < 4; k++) {
+                assertEquals(2.0f * (1.0f + k), floatOutputs[k].get(i), 0.001f);
+                assertEquals(10 + k, intOutputs[k].get(i));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #1030 (which is stacked on #1029). Review those first; this PR's diff is the last two commits.

## The problem

`TornadoExecutionResult.transferToHost(a, b, c, d)` read each object with `streamOutBlocking` and then waited on its event — **one full host round trip per object**, strictly serialised, even though the objects are independent and the caller asked for them in a single call.

## Change

`syncRuntimeTransferToHost(Object...)` enqueues every eligible object's read with the asynchronous `streamOut` and performs **one** `device.sync(executionPlanId)` after the loop.

Eligibility is explicit, and the same guard shape as #1029: the blocking read also covers atomics, under-demand partial copies and batched (chunked) plans, and profiled runs time each copy-out through its own event. Those keep the blocking path — as do buffers whose `enqueueRead` is not equivalent to their `read`, via `XPUBuffer.supportsAsyncRead()` from #1029.

## Numbers

RTX 4090, JDK 21, CUDA backend. Median `transferToHost` over 5000 executions:

| objects | 16 KB each: before → after | 256 KB each: before → after |
|---|---|---|
| 1 | 14.55 → 14.26 µs | — |
| 2 | 9.79 → 6.14 µs (1.59x) | 28.49 → 24.78 µs (1.15x) |
| 4 | 18.74 → 8.86 µs (2.11x) | 73.92 → 67.31 µs (1.10x) |
| 8 | 36.25 → **13.96 µs (2.60x)** | 149.94 → **122.16 µs (1.23x)** |

Small payloads gain most: what is removed is the per-object host wait, not the PCIe time, so large transfers stay transfer-bound. A single object is unchanged, correctly.

## Testing

`TestOnDemandTransfers`, 12 tests, registered in `tornado-test`, **passing on both CUDA and OpenCL**:

| test | what it covers |
|---|---|
| `testTransferFourObjectsInOneCall` | four objects in one call |
| `testOnDemandTransfersAcrossExecutions` | 8 executions, different input each time — a read that has not landed shows as the previous result |
| `testTransferObjectsOneByOne` | one object per call must behave as when asked together |
| `testMixedTypesInOneCall` | `FloatArray` + `IntArray` in one call |
| `testPartialAndWholeObjectOnDemand` | `DataRange` partial copy next to a whole-object one (guard) |
| `testReadWriteAccumulatorWithOtherOutputs` | read-write accumulator kept on the device over 10 executions, copied back at the end next to two write-only outputs |
| `testMixedTransferModesInOneGraph` | `EVERY_EXECUTION` output alongside two `UNDER_DEMAND` ones |
| `testSubsetOfOutputsRequestedPerExecution` | a different subset requested each execution; unrequested objects must keep their older values |
| `testTwoTaskGraphsInOnePlan` | two task-graphs in one plan, four objects across both |
| `testMatrixOutputsOnDemand` | `Matrix2DFloat` outputs — a different buffer wrapper (this is the case that caught the OpenCL bug in #1029) |
| `testOnDemandWithDeferredOutputs` | on-demand transfer on a plan that also defers its outputs |
| `testEightMixedOutputsInOneCall` | eight objects of mixed types in one call |

Also `tornado-test --quickPass` on CUDA: **85 failures, equal to the `develop` baseline**. `./mvnw checkstyle:check` clean.

New example, `tornado.examples/uk.ac.manchester.tornado.examples.OnDemandTransfers`: a graph with four results that only copies them back at the end of a 20-iteration loop.

```
20 executions in 225.20 ms, copy-out of 4 x 1048576 floats in 1.341 ms
```

## Scope note

I also tried batching `TornadoExecutionContext.sync()` (the captured-field path behind `syncField`) and reverted it: `streamOut` on a `FieldBuffer` fails `TestFields` 3/9 with `Index 3 out of bounds for length 3`. Its `enqueueRead` has a different arity from the segment wrappers' and is genuinely not equivalent — the same family of divergence that `supportsAsyncRead()` now makes explicit. Left alone.

## Backends/OS tested

- CUDA backend, NVIDIA RTX 4090, Ubuntu 24.04, JDK 21.
- OpenCL backend, same machine (NVIDIA + Intel platforms): the three new test classes pass. Aggregate quickPass is not a usable signal there — `develop` itself fails 271 on this box — so I compared per class on the same device.
- Metal not runnable here (Linux).

Part of #1028.
