### PR TITLE
[opencl][metal] Honour the wait list on blocking copy-outs (useDeps was inverted)

### DIFF
--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/runtime/MetalTornadoDevice.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/runtime/MetalTornadoDevice.java
@@ -642,7 +642,7 @@ public class MetalTornadoDevice implements TornadoXPUDevice {
         } else {
             // Read for any other buffer that is not an atomic buffer
             TornadoInternalError.guarantee(state.hasObjectBuffer(), "invalid variable");
-            return state.getXPUBuffer().read(executionPlanId, object, hostOffset, partialCopySize, events, events == null);
+            return state.getXPUBuffer().read(executionPlanId, object, hostOffset, partialCopySize, events, events != null);
         }
     }
 

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/runtime/OCLTornadoDevice.java
@@ -625,7 +625,7 @@ public class OCLTornadoDevice implements TornadoXPUDevice {
         } else {
             // Read for any other buffer that is not an atomic buffer
             TornadoInternalError.guarantee(state.hasObjectBuffer(), "invalid variable");
-            return state.getXPUBuffer().read(executionPlanId, object, hostOffset, partialCopySize, events, events == null);
+            return state.getXPUBuffer().read(executionPlanId, object, hostOffset, partialCopySize, events, events != null);
         }
     }
 


### PR DESCRIPTION
## The bug

`streamOutBlocking` passes the caller's dependency list to the buffer read, together with a flag saying whether to use it. CUDA:

```java
return state.getXPUBuffer().read(executionPlanId, object, hostOffset, partialCopySize, events, events != null);
```

OpenCL and Metal:

```java
return state.getXPUBuffer().read(executionPlanId, object, hostOffset, partialCopySize, events, events == null);
```

Inverted. The buffer implementations all do `(useDeps) ? events : null`, so on OpenCL and Metal:

- **with** a wait list (`events != null`) the flag is `false`, the list is dropped, and the read is issued with no dependencies — and the method returns `-1` instead of the read event, so the caller cannot wait on it either;
- **without** one (`events == null`) the flag is `true`, which selects `events` — still `null`, so no harm, but it is true for the wrong reason.

This is the terminal copy-out of every task graph. It matters whenever the runtime tracks dependencies — `-Dtornado.vm.deps=True`, or `withIntraPlanConcurrency()`, where operations are spread over several queues and the wait list is the only thing ordering the read behind the kernel that produced the data.

Same inversion as the one in `streamOut` fixed by #1029, but that one was unreachable; this one is on the live path.

## Change

Two characters, twice: `events == null` → `events != null`, matching CUDA.

## Testing

This is a latent ordering bug rather than a deterministic failure — dropping a wait list makes a read unordered, not wrong, so it needs contention to bite. I could not construct a reliable failing case on this machine, so what I can report is that the fix is not a regression:

- OpenCL, `-Dtornado.vm.deps=True`, `tornado-test --quickPass`: **271 failures with the fix vs 272 on `develop`** — the same set, one flaky difference. Note the baseline itself is 271 failures on this box (`develop` fails `TestArrays` 4/23 with deps off as well), so the aggregate is only useful as a "nothing new broke" signal.
- OpenCL, deps on, per class: `TestArrays` 23 run / 4 failed both before and after; `TestMultipleTasksSingleDevice` 4/0 both.
- CUDA is unaffected by this diff (it already had the correct expression) and is unchanged at 85 quickPass failures.
- `./mvnw checkstyle:check` clean.

Metal is not runnable here (Linux); the change makes it match the other two backends.

I would rather send this as a small obvious correctness fix than sit on it because the machine cannot prove the race — but flagging clearly that the evidence is "matches CUDA, breaks nothing", not "reproduced and fixed".

Found while writing the copy-out contract tests in #1032, which do **not** catch it — see that PR's description for why.

Part of #1028.
