### PR TITLE
[api] TornadoExecutionPlan.transferToDevice(): ad-hoc copy-in without running a kernel to force it

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -154,6 +154,10 @@ public class ImmutableTaskGraph {
         return taskGraph.isFinished();
     }
 
+    void transferDataToDevice(ExecutorFrame executionPackage) {
+        taskGraph.transferDataToDevice(executionPackage);
+    }
+
     void dumpProfiles() {
         taskGraph.dumpProfiles();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/ImmutableTaskGraph.java
@@ -158,6 +158,10 @@ public class ImmutableTaskGraph {
         taskGraph.transferDataToDevice(executionPackage);
     }
 
+    void transferDataToDevice(ExecutorFrame executionPackage, Object... objects) {
+        taskGraph.transferDataToDevice(executionPackage, objects);
+    }
+
     void dumpProfiles() {
         taskGraph.dumpProfiles();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -1108,6 +1108,10 @@ public class TaskGraph implements TaskGraphInterface {
         taskGraphImpl.transferDataToDevice(executionPackage);
     }
 
+    void transferDataToDevice(ExecutorFrame executionPackage, Object... objects) {
+        taskGraphImpl.transferDataToDevice(executionPackage, objects);
+    }
+
     public Set<Object> getArgumentsLookup() {
         return taskGraphImpl.getArgumentsLookup();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TaskGraph.java
@@ -1104,6 +1104,10 @@ public class TaskGraph implements TaskGraphInterface {
         return taskGraphImpl.isFinished();
     }
 
+    void transferDataToDevice(ExecutorFrame executionPackage) {
+        taskGraphImpl.transferDataToDevice(executionPackage);
+    }
+
     public Set<Object> getArgumentsLookup() {
         return taskGraphImpl.getArgumentsLookup();
     }

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -636,6 +636,30 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
         return new WithWarmUpIterations(this, iterations);
     }
 
+    /**
+     * Uploads this plan's inputs to the device without running it: buffers are allocated and every
+     * declared copy-in is performed, while the tasks themselves are skipped. The data is on the
+     * device when the call returns.
+     *
+     * <p>This is the copy-in counterpart of
+     * {@link TornadoExecutionResult#transferToHost(Object...)}. It exists for plans whose inputs
+     * are large and stable - model weights, lookup tables, a mesh - where the first execution
+     * would otherwise pay the whole upload, and where the alternative today is to run the plan once
+     * on dummy data purely to make the transfer happen.
+     *
+     * <p>Applies to every task-graph of the plan. Objects declared
+     * {@link uk.ac.manchester.tornado.api.enums.DataTransferMode#FIRST_EXECUTION} are uploaded once
+     * and will not be re-uploaded by the first real execution; objects declared
+     * {@code EVERY_EXECUTION} are uploaded here as well and again on each execution, as their mode
+     * says.
+     *
+     * @return {@link TornadoExecutionPlan}
+     */
+    public TornadoExecutionPlan transferToDevice() {
+        tornadoExecutor.transferDataToDevice(executionFrame);
+        return this;
+    }
+
     public TornadoExecutionPlan withCUDAGraph() {
         //TODO: include a check to verify that the BACKEND is CUDA
         tornadoExecutor.withCUDAGraph();

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutionPlan.java
@@ -660,6 +660,24 @@ public sealed class TornadoExecutionPlan implements AutoCloseable permits Execut
         return this;
     }
 
+    /**
+     * Uploads the current host contents of the given objects to the device, without running the
+     * plan. Use it to refresh one input between executions, or to place an input before the first
+     * one, when running the plan is not what you want.
+     *
+     * <p>Each object is uploaded by the task-graphs of this plan that take it as a parameter;
+     * graphs that do not know it ignore it. The data is on the device when the call returns. An
+     * object that has no device buffer yet gets one, so this works before the plan has ever run.
+     *
+     * @param objects
+     *     Host objects to upload.
+     * @return {@link TornadoExecutionPlan}
+     */
+    public TornadoExecutionPlan transferToDevice(Object... objects) {
+        tornadoExecutor.transferDataToDevice(executionFrame, objects);
+        return this;
+    }
+
     public TornadoExecutionPlan withCUDAGraph() {
         //TODO: include a check to verify that the BACKEND is CUDA
         tornadoExecutor.withCUDAGraph();

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -157,11 +157,19 @@ class TornadoExecutor {
     }
 
     void transferDataToDevice(ExecutorFrame executionPackage) {
-        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferDataToDevice(executionPackage));
+        allTaskGraphs().forEach(immutableTaskGraph -> immutableTaskGraph.transferDataToDevice(executionPackage));
     }
 
     void transferDataToDevice(ExecutorFrame executionPackage, Object... objects) {
-        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferDataToDevice(executionPackage, objects));
+        allTaskGraphs().forEach(immutableTaskGraph -> immutableTaskGraph.transferDataToDevice(executionPackage, objects));
+    }
+
+    /**
+     * Every task-graph of the plan, including the ones a {@code withGraph(i)} has currently
+     * selected away: an upload is about the plan's data, not about which graph runs next.
+     */
+    private List<ImmutableTaskGraph> allTaskGraphs() {
+        return subgraphList != null ? subgraphList : immutableTaskGraphList;
     }
 
     boolean isFinished() {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -160,6 +160,10 @@ class TornadoExecutor {
         immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferDataToDevice(executionPackage));
     }
 
+    void transferDataToDevice(ExecutorFrame executionPackage, Object... objects) {
+        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferDataToDevice(executionPackage, objects));
+    }
+
     boolean isFinished() {
         boolean result = true;
         for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -156,6 +156,10 @@ class TornadoExecutor {
         immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(dataRange.getArray(), dataRange.getOffset(), dataRange.getPartialSize()));
     }
 
+    void transferDataToDevice(ExecutorFrame executionPackage) {
+        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferDataToDevice(executionPackage));
+    }
+
     boolean isFinished() {
         boolean result = true;
         for (ImmutableTaskGraph immutableTaskGraph : immutableTaskGraphList) {

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -58,6 +58,11 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
      */
     void transferDataToDevice(ExecutorFrame executionPackage);
 
+    /**
+     * Uploads the current host contents of the given objects, without running anything.
+     */
+    void transferDataToDevice(ExecutorFrame executionPackage, Object... objects);
+
     void withBatch(String batchSize);
 
     void withCUDAGraph();

--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoTaskGraphInterface.java
@@ -53,6 +53,11 @@ public interface TornadoTaskGraphInterface extends ProfilerInterface {
 
     void scheduleInner();
 
+    /**
+     * Allocates this task-graph's buffers and uploads its inputs, without running any task.
+     */
+    void transferDataToDevice(ExecutorFrame executionPackage);
+
     void withBatch(String batchSize);
 
     void withCUDAGraph();

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -191,6 +191,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestIO"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestMultipleCopyOuts"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestNativeArrayLayouts"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestOnDemandCopyIn"),
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGrid"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGridScheduler"),

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -192,6 +192,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestMultipleCopyOuts"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestNativeArrayLayouts"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestOnDemandCopyIn"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestCopyInPipelines"),
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGrid"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGridScheduler"),

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/TornadoVM.java
@@ -181,6 +181,14 @@ public class TornadoVM {
         Arrays.stream(tornadoVMInterpreters).forEach(action::accept);
     }
 
+    /**
+     * Allocates the plan's buffers and uploads its inputs on every interpreter, without running
+     * any task.
+     */
+    public void transferDataToDevice() {
+        executeActionOnInterpreters(TornadoVMInterpreter::transferDataToDevice);
+    }
+
     public void dumpProfiles() {
         executeActionOnInterpreters(TornadoVMInterpreter::dumpProfiles);
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -29,6 +29,7 @@ import static uk.ac.manchester.tornado.runtime.common.TornadoOptions.VM_USE_DEPS
 
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -122,6 +123,22 @@ public class TornadoVMInterpreter {
     private HashMap<Object, Integer> totalEvenBatchesPerObject = new HashMap<>();
     private final HashMap<Integer, Long> executionGraphHandles = new HashMap<>();
     private boolean insideCaptureRegion = false;
+
+    /**
+     * The bytecodes a transfers-only pass walks past: everything that runs work or brings data
+     * back. Their operands are still consumed - the reads are positional - but nothing is issued.
+     */
+    private static final EnumSet<TornadoVMBytecodes> SKIPPED_IN_TRANSFERS_ONLY = EnumSet.of(TornadoVMBytecodes.LAUNCH, TornadoVMBytecodes.TRANSFER_DEVICE_TO_HOST_ALWAYS,
+            TornadoVMBytecodes.TRANSFER_DEVICE_TO_HOST_ALWAYS_BLOCKING, TornadoVMBytecodes.BARRIER, TornadoVMBytecodes.CUDA_GRAPH_LAUNCH, TornadoVMBytecodes.CUDA_GRAPH_BEGIN_CAPTURE,
+            TornadoVMBytecodes.CUDA_GRAPH_END_CAPTURE, TornadoVMBytecodes.CUDA_GRAPH_DESTROY);
+
+    /**
+     * When set, the bytecode is walked for its data transfers only: buffers are allocated and
+     * inputs are uploaded, while kernels, copy-outs and deallocations are skipped. It is how
+     * {@code TornadoExecutionPlan.transferToDevice()} gets a plan's inputs onto the device
+     * without running it.
+     */
+    private boolean transfersOnly = false;
     private boolean executionGraphEnabled = true;
 
     private TornadoLogger logger = new TornadoLogger(this.getClass());
@@ -355,6 +372,10 @@ public class TornadoVMInterpreter {
             if (bytecode == null) {
                 throwErrorInterpreter(op);
             }
+            if (transfersOnly && SKIPPED_IN_TRANSFERS_ONLY.contains(bytecode)) {
+                skipBytecodeOperands(op);
+                continue;
+            }
             switch (bytecode) {
                 case ALLOC -> lastEvent = handleAlloc(logBuilder, lastEvent, isWarmup);
                 case DEALLOC -> lastEvent = handleDealloc(logBuilder, lastEvent, isWarmup);
@@ -388,7 +409,11 @@ public class TornadoVMInterpreter {
                 barrier = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), event);
             }
 
-            if (TornadoOptions.USE_VM_FLUSH) {
+            if (transfersOnly) {
+                // The uploads are the whole point of this pass, so wait for them: the caller is
+                // entitled to assume the data is on the device once the call returns.
+                interpreterDevice.sync(graphExecutionContext.getExecutionPlanId());
+            } else if (TornadoOptions.USE_VM_FLUSH) {
                 interpreterDevice.flush(graphExecutionContext.getExecutionPlanId());
             }
         }
@@ -573,6 +598,9 @@ public class TornadoVMInterpreter {
             return executeAlloc(logBuilder, args, sizeBatch);
     }
 
+    // DEALLOC runs in a transfers-only pass too: it is a no-op for the locked buffers that hold the
+    // uploaded data, and skipping it would let every task-graph of a plan hold its buffers at once -
+    // enough to exhaust the device on a plan of many graphs.
     private int handleDealloc(StringBuilder logBuilder, int lastEvent, boolean isWarmup) {
             final int objectIndex = bytecodeResult.getInt();
             if (isWarmup) {
@@ -1580,6 +1608,19 @@ public class TornadoVMInterpreter {
 
     public Event execute() {
         return execute(false);
+    }
+
+    /**
+     * Allocates this interpreter's buffers and uploads the task-graph's inputs, without running
+     * any task. The transfers are complete when this returns.
+     */
+    public void transferDataToDevice() {
+        transfersOnly = true;
+        try {
+            execute(false);
+        } finally {
+            transfersOnly = false;
+        }
     }
 
     private String captureIndent() {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -532,6 +532,7 @@ public class TornadoVMInterpreter {
             bytecodeResult.getInt();
             bytecodeResult.getInt();
         } else if (op == TornadoVMBytecodes.CUDA_GRAPH_BEGIN_CAPTURE.value()
+                || op == TornadoVMBytecodes.CUDA_GRAPH_END_CAPTURE.value()
                 || op == TornadoVMBytecodes.CUDA_GRAPH_LAUNCH.value()
                 || op == TornadoVMBytecodes.CUDA_GRAPH_DESTROY.value()) {
             bytecodeResult.getInt();  // graphId

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -1038,8 +1038,40 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         runAllTasksJavaSequential();
     }
 
+    /**
+     * Uploads the current host contents of the given objects, without running anything. Objects
+     * this task-graph does not know are left to the other graphs of the plan.
+     */
     @Override
-    public void transferDataToDevice(ExecutorFrame executionPackage) {
+    public void transferDataToDevice(ExecutorFrame executionPackage, Object... objects) {
+        prepareForDataTransfers(executionPackage);
+
+        final TornadoXPUDevice device = meta().getXPUDevice();
+        boolean uploaded = false;
+        for (Object object : objects) {
+            if (object == null || !argumentsLookUp.contains(object)) {
+                continue;
+            }
+            final Access access = getObjectAccess(object);
+            final LocalObjectState localState = executionContext.getLocalStateObject(object, access);
+            final XPUDeviceBufferState deviceState = localState.getDataObjectState().getDeviceBufferState(device);
+            if (!deviceState.hasObjectBuffer()) {
+                // The plan may not have run yet, in which case nothing has allocated for this object.
+                device.allocateObjects(new Object[] { object }, 0L, new XPUDeviceBufferState[] { deviceState }, new Access[] { access });
+                if (TornadoOptions.isReusedBuffersEnabled()) {
+                    deviceState.setLockBuffer(true);
+                }
+            }
+            device.streamIn(executionPlanId, object, 0L, 0L, deviceState, null);
+            uploaded = true;
+        }
+
+        if (uploaded) {
+            device.sync(executionPlanId);
+        }
+    }
+
+    private void prepareForDataTransfers(ExecutorFrame executionPackage) {
         setupProfiler();
         getDevice().getDeviceContext().setResetToFalse();
         timeProfiler.clean();
@@ -1047,6 +1079,11 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         compileComputeGraphToTornadoVMBytecode();
         executionPlanId = executionPackage.getExecutionPlanId();
         executionContext.setExecutionPlanId(executionPlanId);
+    }
+
+    @Override
+    public void transferDataToDevice(ExecutorFrame executionPackage) {
+        prepareForDataTransfers(executionPackage);
         vm.transferDataToDevice();
     }
 

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -1044,6 +1044,13 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
      */
     @Override
     public void transferDataToDevice(ExecutorFrame executionPackage, Object... objects) {
+        // A plan of many task-graphs asks every one of them to upload, and most of them do not
+        // know the object. Answering that question first keeps the whole preparation - profiler,
+        // bytecode check, device reset - off the graphs with nothing to do, which is what makes a
+        // targeted upload cheap enough to sit in a per-iteration loop.
+        if (!ownsAnyOf(objects)) {
+            return;
+        }
         prepareForDataTransfers(executionPackage);
 
         final TornadoXPUDevice device = meta().getXPUDevice();
@@ -1069,6 +1076,15 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
         if (uploaded) {
             device.sync(executionPlanId);
         }
+    }
+
+    private boolean ownsAnyOf(Object... objects) {
+        for (Object object : objects) {
+            if (object != null && argumentsLookUp.contains(object)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void prepareForDataTransfers(ExecutorFrame executionPackage) {

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/TornadoTaskGraph.java
@@ -1039,6 +1039,18 @@ public class TornadoTaskGraph implements TornadoTaskGraphInterface {
     }
 
     @Override
+    public void transferDataToDevice(ExecutorFrame executionPackage) {
+        setupProfiler();
+        getDevice().getDeviceContext().setResetToFalse();
+        timeProfiler.clean();
+
+        compileComputeGraphToTornadoVMBytecode();
+        executionPlanId = executionPackage.getExecutionPlanId();
+        executionContext.setExecutionPlanId(executionPlanId);
+        vm.transferDataToDevice();
+    }
+
+    @Override
     public void scheduleInner() {
         compileComputeGraphToTornadoVMBytecode();
 

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestCopyInPipelines.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestCopyInPipelines.java
@@ -74,6 +74,16 @@ public class TestCopyInPipelines extends TornadoTestBase {
         }
     }
 
+    /**
+     * CUDA graphs are a CUDA-backend feature. On every other backend these tests report the
+     * configuration as unsupported rather than failing - a JUnit Assume would be counted as a PASS
+     * by the test runner, so the typed *NotSupported exceptions are what the guard has to raise.
+     */
+    private void requireCudaGraphs() {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.METAL);
+    }
+
     public static void copyWithContext(KernelContext context, FloatArray input, FloatArray output) {
         int index = context.globalIdx;
         output.set(index, input.get(index));
@@ -327,7 +337,7 @@ public class TestCopyInPipelines extends TornadoTestBase {
      */
     @Test
     public void testPersistConsumePipelineUnderCudaGraphs() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.OPENCL);
+        requireCudaGraphs();
 
         FloatArray weights = new FloatArray(SIZE);
         weights.init(2.0f);
@@ -382,7 +392,7 @@ public class TestCopyInPipelines extends TornadoTestBase {
      */
     @Test
     public void testPersistConsumePipelineUnderCudaGraphsWithKernelContext() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.OPENCL);
+        requireCudaGraphs();
 
         FloatArray weights = new FloatArray(SIZE);
         weights.init(2.0f);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestCopyInPipelines.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestCopyInPipelines.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * {@link TornadoExecutionPlan#transferToDevice(Object...)} in the pipelines it exists for: chains of
+ * task-graphs that hand data to each other through {@code persistOnDevice} and
+ * {@code consumeFromDevice}, where the data a stage needs has to be put on the device at a chosen
+ * moment rather than by running something.
+ *
+ * <p>The pipeline shape here is the one an LLM decode loop uses: a small per-step graph, a run of
+ * layer graphs chained on the device, and a final graph that copies one result back.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.api.TestCopyInPipelines
+ * </code>
+ */
+public class TestCopyInPipelines extends TornadoTestBase {
+
+    private static final int SIZE = 4096;
+    private static final int LAYERS = 4;
+
+    public static void scale(FloatArray input, FloatArray output, float alpha) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, alpha * input.get(i));
+        }
+    }
+
+    public static void scaleInPlace(FloatArray state, FloatArray weights) {
+        for (@Parallel int i = 0; i < state.getSize(); i++) {
+            state.set(i, state.get(i) * weights.get(i));
+        }
+    }
+
+    public static void copy(FloatArray input, FloatArray output) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, input.get(i));
+        }
+    }
+
+    /**
+     * A producer persists its result on the device and a consumer picks it up. The producer's
+     * input is a {@code FIRST_EXECUTION} object, so between runs the only way to change what the
+     * pipeline computes is to upload it explicitly.
+     */
+    @Test
+    public void testUpdateInputOfAPersistingProducer() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray onDeviceState = new FloatArray(SIZE);
+        onDeviceState.init(1.0f);
+        FloatArray result = new FloatArray(SIZE);
+
+        TaskGraph producer = new TaskGraph("producer") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, weights, onDeviceState) //
+                .task("produce", TestCopyInPipelines::scaleInPlace, onDeviceState, weights) //
+                .persistOnDevice(onDeviceState);
+
+        TaskGraph consumer = new TaskGraph("consumer") //
+                .consumeFromDevice("producer", onDeviceState) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, result) //
+                .task("consume", TestCopyInPipelines::copy, onDeviceState, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(producer.snapshot(), consumer.snapshot())) {
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(2.0f, result.get(i), 0.001f);
+            }
+
+            // New weights, uploaded explicitly: the device copy of a FIRST_EXECUTION object would
+            // otherwise keep the values it was given the first time.
+            weights.init(3.0f);
+            plan.transferToDevice(weights);
+
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(6.0f, result.get(i), 0.001f);
+            }
+        }
+    }
+
+    /**
+     * The device-resident state of a pipeline is overwritten from the host mid-run - the case an
+     * application would otherwise fake by running a task whose only purpose is the transfer.
+     */
+    @Test
+    public void testOverwriteAPersistedBufferFromTheHost() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray onDeviceState = new FloatArray(SIZE);
+        onDeviceState.init(1.0f);
+        FloatArray result = new FloatArray(SIZE);
+
+        TaskGraph producer = new TaskGraph("statefulProducer") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, weights, onDeviceState) //
+                .task("produce", TestCopyInPipelines::scaleInPlace, onDeviceState, weights) //
+                .persistOnDevice(onDeviceState);
+
+        TaskGraph consumer = new TaskGraph("statefulConsumer") //
+                .consumeFromDevice("statefulProducer", onDeviceState) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, result) //
+                .task("consume", TestCopyInPipelines::copy, onDeviceState, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(producer.snapshot(), consumer.snapshot())) {
+            // Two rounds: the state doubles each time, so it holds 4.0 on the device.
+            plan.withGraph(0).execute();
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(4.0f, result.get(i), 0.001f);
+            }
+
+            // Reset the device-resident state from the host and carry on.
+            onDeviceState.init(10.0f);
+            plan.transferToDevice(onDeviceState);
+
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(20.0f, result.get(i), 0.001f);
+            }
+        }
+    }
+
+    /**
+     * The shape of an LLM decode loop: a per-step graph that uploads a small input, a chain of
+     * layer graphs that pass their state on the device, and a final graph that reads one result
+     * back. The layer weights are placed with an explicit upload instead of a warm-up run.
+     */
+    @Test
+    public void testLayeredPipelineWithUpFrontWeightUpload() throws TornadoExecutionPlanException {
+        FloatArray stepInput = new FloatArray(SIZE);
+        FloatArray activation = new FloatArray(SIZE);
+        FloatArray[] layerWeights = new FloatArray[LAYERS];
+        for (int layer = 0; layer < LAYERS; layer++) {
+            layerWeights[layer] = new FloatArray(SIZE);
+            layerWeights[layer].init(2.0f);
+        }
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph[] graphs = new ImmutableTaskGraph[LAYERS + 2];
+
+        graphs[0] = new TaskGraph("step") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, stepInput) //
+                .task("activate", TestCopyInPipelines::scale, stepInput, activation, 1.0f) //
+                .persistOnDevice(activation) //
+                .snapshot();
+
+        String producerName = "step";
+        for (int layer = 0; layer < LAYERS; layer++) {
+            String name = "layer" + layer;
+            graphs[1 + layer] = new TaskGraph(name) //
+                    .consumeFromDevice(producerName, activation) //
+                    .transferToDevice(DataTransferMode.FIRST_EXECUTION, layerWeights[layer]) //
+                    .task("apply", TestCopyInPipelines::scaleInPlace, activation, layerWeights[layer]) //
+                    .persistOnDevice(activation) //
+                    .snapshot();
+            producerName = name;
+        }
+
+        graphs[LAYERS + 1] = new TaskGraph("readout") //
+                .consumeFromDevice(producerName, activation) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .task("readout", TestCopyInPipelines::copy, activation, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output) //
+                .snapshot();
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(graphs)) {
+            // What an application would otherwise obtain by running the whole pipeline once on
+            // dummy data: the weights are on the device before anything runs.
+            plan.transferToDevice();
+
+            for (int step = 1; step <= 3; step++) {
+                stepInput.init(step);
+                for (int graph = 0; graph < graphs.length; graph++) {
+                    plan.withGraph(graph).execute();
+                }
+                float expected = step * (float) Math.pow(2.0, LAYERS);
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(expected, output.get(i), 0.001f);
+                }
+            }
+
+            // Swap one layer's weights mid-run, the way a model would swap an adapter.
+            layerWeights[0].init(4.0f);
+            plan.transferToDevice(layerWeights[0]);
+
+            stepInput.init(1.0f);
+            for (int graph = 0; graph < graphs.length; graph++) {
+                plan.withGraph(graph).execute();
+            }
+            float expected = 4.0f * (float) Math.pow(2.0, LAYERS - 1);
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(expected, output.get(i), 0.001f);
+            }
+        }
+    }
+
+    /** The same pipeline with the plan routing its operations over several streams. */
+    @Test
+    public void testPipelineWithIntraPlanConcurrency() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray intermediate = new FloatArray(SIZE);
+        FloatArray output = new FloatArray(SIZE);
+
+        TaskGraph producer = new TaskGraph("concurrentProducer") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, weights) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("produce", TestCopyInPipelines::scale, input, intermediate, 1.0f) //
+                .task("weight", TestCopyInPipelines::scaleInPlace, intermediate, weights) //
+                .persistOnDevice(intermediate);
+
+        TaskGraph consumer = new TaskGraph("concurrentConsumer") //
+                .consumeFromDevice("concurrentProducer", intermediate) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .task("consume", TestCopyInPipelines::copy, intermediate, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(producer.snapshot(), consumer.snapshot())) {
+            plan.withIntraPlanConcurrency();
+            plan.transferToDevice();
+
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(6.0f, output.get(i), 0.001f);
+            }
+
+            weights.init(5.0f);
+            plan.transferToDevice(weights);
+
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(15.0f, output.get(i), 0.001f);
+            }
+        }
+    }
+
+    /** An upload between two executions of the same graph is ordered with respect to both. */
+    @Test
+    public void testUploadBetweenExecutionsIsOrdered() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(1.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("ordering") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, weights) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("t", TestCopyInPipelines::scale, input, output, 1.0f) //
+                .task("w", TestCopyInPipelines::scaleInPlace, output, weights) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            for (int iteration = 1; iteration <= 16; iteration++) {
+                weights.init(iteration);
+                plan.transferToDevice(weights);
+                plan.execute();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals(iteration, output.get(i), 0.001f);
+                }
+            }
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestCopyInPipelines.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestCopyInPipelines.java
@@ -21,11 +21,16 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
@@ -67,6 +72,16 @@ public class TestCopyInPipelines extends TornadoTestBase {
         for (@Parallel int i = 0; i < input.getSize(); i++) {
             output.set(i, input.get(i));
         }
+    }
+
+    public static void copyWithContext(KernelContext context, FloatArray input, FloatArray output) {
+        int index = context.globalIdx;
+        output.set(index, input.get(index));
+    }
+
+    public static void scaleInPlaceWithContext(KernelContext context, FloatArray state, FloatArray weights) {
+        int index = context.globalIdx;
+        state.set(index, state.get(index) * weights.get(index));
     }
 
     /**
@@ -299,6 +314,124 @@ public class TestCopyInPipelines extends TornadoTestBase {
                 for (int i = 0; i < SIZE; i++) {
                     assertEquals(iteration, output.get(i), 0.001f);
                 }
+            }
+        }
+    }
+
+    /**
+     * A persist/consume pipeline under CUDA graphs. The producer's result stays on the device
+     * between the two captured graphs, and the producer's weights are placed by
+     * {@code transferToDevice()} rather than by a warm-up run - so the transfers-only pass runs
+     * over bytecode that contains the capture and launch operations, and the capture that follows
+     * has to see the uploaded data.
+     */
+    @Test
+    public void testPersistConsumePipelineUnderCudaGraphs() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(1.0f);
+        FloatArray intermediate = new FloatArray(SIZE);
+        FloatArray output = new FloatArray(SIZE);
+
+        TaskGraph producer = new TaskGraph("graphProducer") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, weights) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("produce", TestCopyInPipelines::scale, input, intermediate, 1.0f) //
+                .task("weight", TestCopyInPipelines::scaleInPlace, intermediate, weights) //
+                .persistOnDevice(intermediate);
+
+        TaskGraph consumer = new TaskGraph("graphConsumer") //
+                .consumeFromDevice("graphProducer", intermediate) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .task("consume", TestCopyInPipelines::copy, intermediate, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(producer.snapshot(), consumer.snapshot())) {
+            plan.withCUDAGraph();
+            plan.transferToDevice();
+
+            // Iteration 0 captures both graphs, the rest replay them.
+            for (int iteration = 0; iteration < 4; iteration++) {
+                input.init(1.0f + iteration);
+                plan.withGraph(0).execute();
+                plan.withGraph(1).execute();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals("iteration " + iteration, 2.0f * (1.0f + iteration), output.get(i), 0.001f);
+                }
+            }
+
+            // The weights are FIRST_EXECUTION and the graphs are already captured: only an
+            // explicit upload can change what the replay computes.
+            weights.init(5.0f);
+            plan.transferToDevice(weights);
+
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(5.0f * 4.0f, output.get(i), 0.001f);
+            }
+        }
+    }
+
+    /**
+     * The same pipeline written with {@link KernelContext} kernels and a {@link GridScheduler},
+     * captured as CUDA graphs, with the weights placed by an explicit upload and swapped mid-run.
+     */
+    @Test
+    public void testPersistConsumePipelineUnderCudaGraphsWithKernelContext() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(1.0f);
+        FloatArray intermediate = new FloatArray(SIZE);
+        FloatArray output = new FloatArray(SIZE);
+
+        KernelContext producerContext = new KernelContext();
+        KernelContext consumerContext = new KernelContext();
+
+        TaskGraph producer = new TaskGraph("ctxProducer") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, weights) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("produce", TestCopyInPipelines::copyWithContext, producerContext, input, intermediate) //
+                .task("weight", TestCopyInPipelines::scaleInPlaceWithContext, producerContext, intermediate, weights) //
+                .persistOnDevice(intermediate);
+
+        TaskGraph consumer = new TaskGraph("ctxConsumer") //
+                .consumeFromDevice("ctxProducer", intermediate) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .task("consume", TestCopyInPipelines::copyWithContext, consumerContext, intermediate, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        WorkerGrid workerGrid = new WorkerGrid1D(SIZE);
+        GridScheduler gridScheduler = new GridScheduler("ctxProducer.produce", workerGrid);
+        gridScheduler.addWorkerGrid("ctxProducer.weight", workerGrid);
+        gridScheduler.addWorkerGrid("ctxConsumer.consume", workerGrid);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(producer.snapshot(), consumer.snapshot())) {
+            plan.withCUDAGraph().withGridScheduler(gridScheduler);
+            plan.transferToDevice();
+
+            for (int iteration = 0; iteration < 4; iteration++) {
+                input.init(1.0f + iteration);
+                plan.withGraph(0).execute();
+                plan.withGraph(1).execute();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals("iteration " + iteration, 2.0f * (1.0f + iteration), output.get(i), 0.001f);
+                }
+            }
+
+            weights.init(5.0f);
+            plan.transferToDevice(weights);
+
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(5.0f * 4.0f, output.get(i), 0.001f);
             }
         }
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandCopyIn.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandCopyIn.java
@@ -21,11 +21,16 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import uk.ac.manchester.tornado.api.GridScheduler;
 import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.KernelContext;
 import uk.ac.manchester.tornado.api.TaskGraph;
 import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
 import uk.ac.manchester.tornado.api.annotations.Parallel;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
@@ -50,6 +55,11 @@ public class TestOnDemandCopyIn extends TornadoTestBase {
         for (@Parallel int i = 0; i < input.getSize(); i++) {
             output.set(i, weights.get(i) * input.get(i));
         }
+    }
+
+    public static void weightedCopyWithContext(KernelContext context, FloatArray weights, FloatArray input, FloatArray output) {
+        int index = context.globalIdx;
+        output.set(index, weights.get(index) * input.get(index));
     }
 
     private static TaskGraph buildGraph(String name, FloatArray weights, FloatArray input, FloatArray output) {
@@ -313,6 +323,113 @@ public class TestOnDemandCopyIn extends TornadoTestBase {
         for (int i = 0; i < SIZE; i++) {
             assertEquals(4.0f, outputA.get(i), 0.001f);
             assertEquals(5.0f, outputB.get(i), 0.001f);
+        }
+    }
+
+    /**
+     * A transfers-only pass over a plan that uses CUDA graphs. The pass skips the capture and
+     * launch bytecodes, but it still has to consume their operands: the reads are positional, so
+     * getting one wrong leaves a {@code graphId} in the stream and the rest of the bytecode is
+     * decoded from the wrong offset. The plan must still capture and replay correctly afterwards.
+     */
+    @Test
+    public void testTransferToDeviceOnACudaGraphPlan() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph("copyInCudaGraph", weights, input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withCUDAGraph();
+            executionPlan.transferToDevice();
+
+            // Iteration 0 captures, the rest replay; the upload must not have disturbed either.
+            for (int iteration = 0; iteration < 4; iteration++) {
+                input.init(3.0f + iteration);
+                executionPlan.execute();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals("iteration " + iteration, 2.0f * (3.0f + iteration), output.get(i), 0.001f);
+                }
+            }
+        }
+    }
+
+    /**
+     * The same, with the kernel written against {@link KernelContext} and driven by a
+     * {@link GridScheduler}. A KernelContext task carries no {@code @Parallel} loop, so the grid
+     * comes from the plan rather than from the bytecode - the transfers-only pass must leave that
+     * path alone as well.
+     */
+    @Test
+    public void testTransferToDeviceOnACudaGraphPlanWithKernelContext() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        KernelContext context = new KernelContext();
+        TaskGraph taskGraph = new TaskGraph("copyInCudaGraphContext") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, weights) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("t", TestOnDemandCopyIn::weightedCopyWithContext, context, weights, input, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        WorkerGrid workerGrid = new WorkerGrid1D(SIZE);
+        GridScheduler gridScheduler = new GridScheduler("copyInCudaGraphContext.t", workerGrid);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.withCUDAGraph().withGridScheduler(gridScheduler);
+            executionPlan.transferToDevice();
+
+            for (int iteration = 0; iteration < 4; iteration++) {
+                input.init(3.0f + iteration);
+                executionPlan.execute();
+                for (int i = 0; i < SIZE; i++) {
+                    assertEquals("iteration " + iteration, 2.0f * (3.0f + iteration), output.get(i), 0.001f);
+                }
+            }
+        }
+    }
+
+    /**
+     * A targeted upload into a captured plan. The weights are {@code FIRST_EXECUTION}, so once the
+     * graph is captured nothing would ever refresh them: the upload has to reach the buffer the
+     * captured graph reads from, not a new one.
+     */
+    @Test
+    public void testTargetedUploadIntoACapturedCudaGraph() throws TornadoExecutionPlanException {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph("copyInCudaGraphTargeted", weights, input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withCUDAGraph();
+
+            // Captures on the first execution.
+            executionPlan.execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(6.0f, output.get(i), 0.001f);
+            }
+
+            // Replays, with new weights placed into the buffer the captured graph reads.
+            weights.init(5.0f);
+            executionPlan.transferToDevice(weights);
+            executionPlan.execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(15.0f, output.get(i), 0.001f);
+            }
         }
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandCopyIn.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandCopyIn.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.ImmutableTaskGraph;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Tests for {@link TornadoExecutionPlan#transferToDevice()}: the plan's inputs are uploaded
+ * without running any task, so a first execution does not have to pay for them and an
+ * application does not have to run its plan once on dummy data to make the upload happen.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.api.TestOnDemandCopyIn
+ * </code>
+ */
+public class TestOnDemandCopyIn extends TornadoTestBase {
+
+    private static final int SIZE = 8192;
+
+    public static void weightedCopy(FloatArray weights, FloatArray input, FloatArray output) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, weights.get(i) * input.get(i));
+        }
+    }
+
+    private static TaskGraph buildGraph(String name, FloatArray weights, FloatArray input, FloatArray output) {
+        return new TaskGraph(name) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, weights) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("t", TestOnDemandCopyIn::weightedCopy, weights, input, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+    }
+
+    /** Uploading up front must not change what the plan then computes. */
+    @Test
+    public void testTransferToDeviceThenExecute() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph("copyInThenRun", weights, input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.transferToDevice();
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(6.0f, output.get(i), 0.001f);
+        }
+    }
+
+    /** The upload runs the transfers only: no task runs, so no output is produced. */
+    @Test
+    public void testTransferToDeviceDoesNotRunTasks() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+        output.init(-1.0f);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph("copyInOnly", weights, input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.transferToDevice();
+
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(-1.0f, output.get(i), 0.001f);
+            }
+
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(6.0f, output.get(i), 0.001f);
+        }
+    }
+
+    /**
+     * A {@code FIRST_EXECUTION} input really is uploaded by the call, not by the execution that
+     * follows: changing the host copy in between has no effect on the result.
+     */
+    @Test
+    public void testFirstExecutionInputIsUploadedByTheCall() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph("copyInFirstExecution", weights, input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.transferToDevice();
+
+            // Only the FIRST_EXECUTION array is expected to keep the value it had at upload time.
+            weights.init(100.0f);
+            executionPlan.execute();
+
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(6.0f, output.get(i), 0.001f);
+            }
+
+            // EVERY_EXECUTION inputs are re-uploaded, so a change to those does show up.
+            input.init(4.0f);
+            executionPlan.execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(8.0f, output.get(i), 0.001f);
+            }
+        }
+    }
+
+    /** The call applies to every task-graph of the plan. */
+    @Test
+    public void testTransferToDeviceWithTwoTaskGraphs() throws TornadoExecutionPlanException {
+        FloatArray weightsA = new FloatArray(SIZE);
+        weightsA.init(2.0f);
+        FloatArray weightsB = new FloatArray(SIZE);
+        weightsB.init(5.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray outputA = new FloatArray(SIZE);
+        FloatArray outputB = new FloatArray(SIZE);
+
+        ImmutableTaskGraph first = buildGraph("copyInGraph0", weightsA, input, outputA).snapshot();
+        ImmutableTaskGraph second = buildGraph("copyInGraph1", weightsB, input, outputB).snapshot();
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(first, second)) {
+            executionPlan.transferToDevice();
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(6.0f, outputA.get(i), 0.001f);
+            assertEquals(15.0f, outputB.get(i), 0.001f);
+        }
+    }
+
+    /** Calling it more than once, and after an execution, is harmless. */
+    @Test
+    public void testRepeatedTransferToDevice() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph("copyInRepeat", weights, input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.transferToDevice();
+            executionPlan.transferToDevice();
+            executionPlan.execute();
+            executionPlan.transferToDevice();
+            input.init(5.0f);
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(10.0f, output.get(i), 0.001f);
+        }
+    }
+
+    /** Pre-compilation and up-front upload compose: neither needs the other. */
+    @Test
+    public void testTransferToDeviceAfterPreCompilation() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(3.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph("copyInPreCompiled", weights, input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.withPreCompilation();
+            executionPlan.transferToDevice();
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(9.0f, output.get(i), 0.001f);
+        }
+    }
+}

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandCopyIn.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandCopyIn.java
@@ -62,6 +62,16 @@ public class TestOnDemandCopyIn extends TornadoTestBase {
         output.set(index, weights.get(index) * input.get(index));
     }
 
+    /**
+     * CUDA graphs are a CUDA-backend feature. On every other backend these tests report the
+     * configuration as unsupported rather than failing - a JUnit Assume would be counted as a PASS
+     * by the test runner, so the typed *NotSupported exceptions are what the guard has to raise.
+     */
+    private void requireCudaGraphs() {
+        assertNotBackend(TornadoVMBackendType.OPENCL);
+        assertNotBackend(TornadoVMBackendType.METAL);
+    }
+
     private static TaskGraph buildGraph(String name, FloatArray weights, FloatArray input, FloatArray output) {
         return new TaskGraph(name) //
                 .transferToDevice(DataTransferMode.FIRST_EXECUTION, weights) //
@@ -334,7 +344,7 @@ public class TestOnDemandCopyIn extends TornadoTestBase {
      */
     @Test
     public void testTransferToDeviceOnACudaGraphPlan() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.OPENCL);
+        requireCudaGraphs();
 
         FloatArray weights = new FloatArray(SIZE);
         weights.init(2.0f);
@@ -366,7 +376,7 @@ public class TestOnDemandCopyIn extends TornadoTestBase {
      */
     @Test
     public void testTransferToDeviceOnACudaGraphPlanWithKernelContext() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.OPENCL);
+        requireCudaGraphs();
 
         FloatArray weights = new FloatArray(SIZE);
         weights.init(2.0f);
@@ -405,7 +415,7 @@ public class TestOnDemandCopyIn extends TornadoTestBase {
      */
     @Test
     public void testTargetedUploadIntoACapturedCudaGraph() throws TornadoExecutionPlanException {
-        assertNotBackend(TornadoVMBackendType.OPENCL);
+        requireCudaGraphs();
 
         FloatArray weights = new FloatArray(SIZE);
         weights.init(2.0f);

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandCopyIn.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandCopyIn.java
@@ -209,4 +209,110 @@ public class TestOnDemandCopyIn extends TornadoTestBase {
             assertEquals(9.0f, output.get(i), 0.001f);
         }
     }
+
+    /**
+     * Updating one object: the new host contents are on the device without the plan running, so
+     * the next execution sees them even though the object is declared {@code FIRST_EXECUTION} and
+     * would otherwise never be uploaded again.
+     */
+    @Test
+    public void testTransferSingleObject() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph("copyInSingle", weights, input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(6.0f, output.get(i), 0.001f);
+            }
+
+            // FIRST_EXECUTION: without the explicit upload this change would never reach the device.
+            weights.init(10.0f);
+            executionPlan.transferToDevice(weights);
+            executionPlan.execute();
+
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(30.0f, output.get(i), 0.001f);
+            }
+        }
+    }
+
+    /** Uploading one object before the plan has ever run allocates for it on the way. */
+    @Test
+    public void testTransferSingleObjectBeforeFirstExecution() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(4.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(2.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph("copyInSingleUpfront", weights, input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.transferToDevice(weights);
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(8.0f, output.get(i), 0.001f);
+        }
+    }
+
+    /** Several objects in one call, and objects a graph does not know are ignored. */
+    @Test
+    public void testTransferSeveralObjectsAndUnknownOnes() throws TornadoExecutionPlanException {
+        FloatArray weights = new FloatArray(SIZE);
+        weights.init(2.0f);
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+        FloatArray strangerToThisPlan = new FloatArray(SIZE);
+
+        ImmutableTaskGraph immutableTaskGraph = buildGraph("copyInSeveral", weights, input, output).snapshot();
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {
+            executionPlan.execute();
+
+            weights.init(3.0f);
+            input.init(5.0f);
+            executionPlan.transferToDevice(weights, input, strangerToThisPlan);
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(15.0f, output.get(i), 0.001f);
+        }
+    }
+
+    /** The targeted upload reaches every task-graph of the plan that takes the object. */
+    @Test
+    public void testTransferSingleObjectSharedByTwoGraphs() throws TornadoExecutionPlanException {
+        FloatArray weightsA = new FloatArray(SIZE);
+        weightsA.init(2.0f);
+        FloatArray weightsB = new FloatArray(SIZE);
+        weightsB.init(3.0f);
+        FloatArray sharedInput = new FloatArray(SIZE);
+        sharedInput.init(1.0f);
+        FloatArray outputA = new FloatArray(SIZE);
+        FloatArray outputB = new FloatArray(SIZE);
+
+        ImmutableTaskGraph first = buildGraph("copyInShared0", weightsA, sharedInput, outputA).snapshot();
+        ImmutableTaskGraph second = buildGraph("copyInShared1", weightsB, sharedInput, outputB).snapshot();
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(first, second)) {
+            executionPlan.execute();
+
+            weightsA.init(4.0f);
+            weightsB.init(5.0f);
+            executionPlan.transferToDevice(weightsA, weightsB);
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(4.0f, outputA.get(i), 0.001f);
+            assertEquals(5.0f, outputB.get(i), 0.001f);
+        }
+    }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlas.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlas.java
@@ -494,4 +494,92 @@ public class TestCuBlas extends TornadoTestBase {
             }
         }
     }
+
+    /**
+     * A library task whose weight matrix is placed on the device by an explicit upload rather than
+     * by an execution, and swapped for another one between executions. The matrix is declared
+     * {@code FIRST_EXECUTION}, so without the upload the second result would repeat the first.
+     */
+    @Test
+    public void testSgemmWithAdHocWeightUpload() throws TornadoExecutionPlanException {
+        FloatArray matrixA = randomArray(SIZE * SIZE);
+        FloatArray weights = randomArray(SIZE * SIZE);
+        FloatArray matrixC = new FloatArray(SIZE * SIZE);
+        FloatArray expected = new FloatArray(SIZE * SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("gemmUpload") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, weights) //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, matrixA) //
+                .libraryTask("sgemm", CuBlas::cublasSgemm, //
+                        CuBlasOperation.CUBLAS_OP_N.operation(), CuBlasOperation.CUBLAS_OP_N.operation(), //
+                        SIZE, SIZE, SIZE, 1.0f, weights, SIZE, matrixA, SIZE, 0.0f, matrixC, SIZE) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            // The weights reach the device without the plan running.
+            plan.transferToDevice(weights);
+            plan.execute();
+
+            matrixMultiplyJava(matrixA, weights, expected, SIZE);
+            for (int i = 0; i < SIZE * SIZE; i++) {
+                assertEquals(expected.get(i), matrixC.get(i), 0.01f * Math.max(1.0f, Math.abs(expected.get(i))));
+            }
+
+            // Swap the weights for new ones, mid-run.
+            FloatArray newWeights = randomArray(SIZE * SIZE);
+            for (int i = 0; i < SIZE * SIZE; i++) {
+                weights.set(i, newWeights.get(i));
+            }
+            plan.transferToDevice(weights);
+            plan.execute();
+
+            matrixMultiplyJava(matrixA, weights, expected, SIZE);
+            for (int i = 0; i < SIZE * SIZE; i++) {
+                assertEquals(expected.get(i), matrixC.get(i), 0.01f * Math.max(1.0f, Math.abs(expected.get(i))));
+            }
+        }
+    }
+
+    /**
+     * A library task in a pipeline: the GEMM result stays on the device and a second graph reads
+     * it, with the whole plan's inputs uploaded up front.
+     */
+    @Test
+    public void testSgemmPipelineWithUpFrontUpload() throws TornadoExecutionPlanException {
+        FloatArray matrixA = randomArray(SIZE * SIZE);
+        FloatArray matrixB = randomArray(SIZE * SIZE);
+        FloatArray matrixC = new FloatArray(SIZE * SIZE);
+        FloatArray output = new FloatArray(SIZE * SIZE);
+        FloatArray expected = new FloatArray(SIZE * SIZE);
+
+        TaskGraph producer = new TaskGraph("gemmProducer") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, matrixA, matrixB) //
+                .libraryTask("sgemm", CuBlas::cublasSgemm, //
+                        CuBlasOperation.CUBLAS_OP_N.operation(), CuBlasOperation.CUBLAS_OP_N.operation(), //
+                        SIZE, SIZE, SIZE, 1.0f, matrixB, SIZE, matrixA, SIZE, 0.0f, matrixC, SIZE) //
+                .persistOnDevice(matrixC);
+
+        TaskGraph consumer = new TaskGraph("gemmConsumer") //
+                .consumeFromDevice("gemmProducer", matrixC) //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .task("scale", TestCuBlas::scaleByTwo, matrixC, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(producer.snapshot(), consumer.snapshot())) {
+            plan.transferToDevice();
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+        }
+
+        matrixMultiplyJava(matrixA, matrixB, expected, SIZE);
+        for (int i = 0; i < SIZE * SIZE; i++) {
+            assertEquals(2.0f * expected.get(i), output.get(i), 0.02f * Math.max(1.0f, Math.abs(expected.get(i))));
+        }
+    }
+
+    public static void scaleByTwo(FloatArray input, FloatArray output) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, 2.0f * input.get(i));
+        }
+    }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cudnn/TestCuDnn.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cudnn/TestCuDnn.java
@@ -447,4 +447,71 @@ public class TestCuDnn extends TornadoTestBase {
             }
         }
     }
+
+    /**
+     * A cuDNN library task fed by an input placed on the device with an explicit upload, then
+     * refreshed between executions. The input is declared {@code FIRST_EXECUTION}, so the second
+     * result can only differ if the upload actually reached the device.
+     */
+    @Test
+    public void testReluWithAdHocInputUpload() throws TornadoExecutionPlanException {
+        final int size = 4096;
+        FloatArray input = randomArray(size);
+        FloatArray output = new FloatArray(size);
+
+        TaskGraph taskGraph = new TaskGraph("reluUpload") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, input) //
+                .libraryTask("relu", CuDnn::cudnnRelu, input, output, size) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.transferToDevice(input);
+            plan.execute();
+            for (int i = 0; i < size; i++) {
+                assertEquals(Math.max(0.0f, input.get(i)), output.get(i), 0.001f);
+            }
+
+            for (int i = 0; i < size; i++) {
+                input.set(i, -input.get(i));
+            }
+            plan.transferToDevice(input);
+            plan.execute();
+            for (int i = 0; i < size; i++) {
+                assertEquals(Math.max(0.0f, input.get(i)), output.get(i), 0.001f);
+            }
+        }
+    }
+
+    /**
+     * Two cuDNN library tasks in a pipeline that hands its intermediate over on the device, with
+     * the plan's inputs uploaded before anything runs.
+     */
+    @Test
+    public void testReluThenTanhPipelineWithUpFrontUpload() throws TornadoExecutionPlanException {
+        final int size = 4096;
+        FloatArray input = randomArray(size);
+        FloatArray intermediate = new FloatArray(size);
+        FloatArray output = new FloatArray(size);
+
+        TaskGraph producer = new TaskGraph("dnnProducer") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, input) //
+                .libraryTask("relu", CuDnn::cudnnRelu, input, intermediate, size) //
+                .persistOnDevice(intermediate);
+
+        TaskGraph consumer = new TaskGraph("dnnConsumer") //
+                .consumeFromDevice("dnnProducer", intermediate) //
+                .libraryTask("tanh", CuDnn::cudnnTanh, intermediate, output, size) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(producer.snapshot(), consumer.snapshot())) {
+            plan.transferToDevice();
+            plan.withGraph(0).execute();
+            plan.withGraph(1).execute();
+        }
+
+        for (int i = 0; i < size; i++) {
+            float expected = (float) Math.tanh(Math.max(0.0f, input.get(i)));
+            assertEquals(expected, output.get(i), 0.001f);
+        }
+    }
 }


### PR DESCRIPTION
## What this adds

An explicit copy-in, so that getting data onto the device at a chosen moment stops being something you have to fake by running a kernel you do not want.

```java
plan.transferToDevice();              // every input of the plan, no task runs
plan.transferToDevice(weights);       // just this object, now
plan.transferToDevice(a, b, c);       // several
```

The copy-in counterpart of `TornadoExecutionResult.transferToHost(...)`. The data is on the device when the call returns.

- **No arguments** — walks the plan's bytecode for its data transfers only: `ALLOC` and the copy-ins run; `LAUNCH`, the copy-outs, the barrier and the CUDA-graph operations are skipped. (`DEALLOC` deliberately still runs — it is a no-op for the locked buffers holding the uploaded data, and skipping it lets every task-graph of a plan hold its buffers at once, which is enough to exhaust the device on a plan of many graphs.)
- **With arguments** — uploads exactly those objects, through whichever task-graphs of the plan take them as parameters; graphs that do not know an object ignore it. An object with no device buffer yet gets one, so it works before the plan has ever run, and it works for `FIRST_EXECUTION` objects that would otherwise never be uploaded again.

## Why

There is no way today to put data on the device without running something. Applications therefore run work they do not need, purely for the side effect. GPULlama3.java's `forceCopyInReadOnlyData()` runs the activation graph, then **every layer graph**, then the logits graph, on zeroed state, so that the model weights get copied in:

```java
public void forceCopyInReadOnlyData() {
    state.wrapX.clear();
    state.positionHolder.init(0);
    executionPlan.withGraph(taskGraphLayout.activationIdx())...execute();
    for (int layer = 0; layer < config.numberOfLayers(); layer++) {
        executionPlan.withGraph(taskGraphLayout.layerIdx(layer))...execute();
    }
    executionPlan.withGraph(taskGraphLayout.logitsIdx())...execute();
}
```

With this PR that whole method is `executionPlan.transferToDevice();`, and refreshing one buffer mid-run — new weights, a new embedding row, a table swapped between executions — is `executionPlan.transferToDevice(thatObject)` instead of a task graph whose kernel exists only to make the transfer happen.

## Numbers

RTX 4090, JDK 21, CUDA backend. 64 MB of `FIRST_EXECUTION` weights plus a 64 MB `EVERY_EXECUTION` input, after `withPreCompilation()`:

| | `transferToDevice()` | `transferToDevice(weights)` | first `execute()` | second `execute()` |
|---|---|---|---|---|
| no up-front upload | — | 17.34 ms (allocates + uploads) | 63.95 ms | 7.63 ms |
| whole-plan upload first | 34.51 ms | **3.71 ms** (buffer exists: pure H2D) | 52.86 ms | 7.63 ms |
| without either | — | — | 78.95 ms | 7.50 ms |

The first execution loses exactly the upload it no longer has to do, and a targeted refresh of an already-allocated 64 MB buffer costs 3.71 ms — the copy and nothing else.

**GPULlama3.java, Qwen1.5-MoE-A2.7B-Chat Q8_0** — I actually made the replacement (`forceCopyInReadOnlyData()` becomes `executionPlan.transferToDevice()` when CUDA graphs are off; with them on the pass is also the capture, so it stays) and measured both paths in the same build, same 16 GB device heap, two runs each:

| | copy-in phase | decode | wall |
|---|---|---|---|
| dummy forward pass | 3673 / 3698 ms | 83.53 / 83.20 tok/s | 8.52 / 8.58 s |
| `transferToDevice()` | **3529 / 3504 ms** | 76.38 / 76.25 tok/s | 8.56 / 8.55 s |

Read that carefully, because it is not a win yet:

- the copy-in phase is **~4.6% faster** — the phase is dominated by the upload itself (`cuMemHostRegister` plus PCIe, 3.4 s of it in an nsys capture), so skipping the dummy kernels was never going to buy much;
- **decode looks 8% slower**, and that is the same work moving rather than appearing: the dummy pass installs and first-launches every kernel, which the API path leaves for the first real token. The gap shrinks from 8% at 128 tokens to ~3.7% at ~450 tokens, which is what a fixed ~150 ms one-off looks like;
- **wall-clock is identical**, and the plan needs ~2 GB more device heap this way (fails at 14 GB, fine at 16 GB) because nothing releases between graphs when no execution drives them.

So for that application today it is a wash in time and a clear win in intent: a method that ran a full forward pass for a side effect becomes one line that says what it means. The remaining piece — a warm-up that installs code without transferring, so neither path pays first-launch inside the timed loop — is worth doing separately, and is easier to see now that the transfer exists as its own operation.

The microbenchmark above is the honest picture of the mechanism; this is the honest picture of its worth on a start-up bound by something else.

## The `withGraph(i)` interaction, fixed here

`TornadoExecutor.selectGraph(i)` replaces the executor's graph list with the selected graph (keeping the full list in `subgraphList`), so a plan driven graph-by-graph — which is exactly how a pipeline runs — would have had its upload applied only to whichever graph was selected last. Both forms of `transferToDevice` now iterate every task-graph of the plan regardless of the current selection: an upload is about the plan's data, not about which graph runs next. Caught by the pipeline tests below, which fail without it.

## Where the transfers-only mode lives

Rebased on the interpreter dispatch refactor now on `develop`, which replaced the 24-arm `if`/`else` chain in `execute()` with a `switch` over the opcode enum and one handler method per bytecode. Its own comment notes that in the old shape "adding an execution mode meant editing every one of them" — so the transfers-only mode is applied at the dispatch point rather than spread across the handlers: an `EnumSet` of the bytecodes such a pass walks past (`LAUNCH`, both device-to-host transfers, `BARRIER`, the four CUDA-graph operations), checked once before the switch. Their operands are still consumed via `skipBytecodeOperands` — the reads are positional — but nothing is issued.

That routing exposed a latent gap in `skipBytecodeOperands`: it had **no branch for `CUDA_GRAPH_END_CAPTURE`**, because both of its existing callers (`preCompileLaunchesInCaptureRegion`, `skipToAfterEndCapture`) intercept that opcode before ever calling it. Sending it there left the 4-byte `graphId` in the stream and decoded everything after it from the wrong offset:

```
[REASON] [ERROR] TornadoVM Bytecode not recognized
```

Fixed by making the helper total for every opcode reachable in the loop (`INIT` is consumed in the bytecode header, before the loop starts). The five CUDA-graph tests listed below cover it — four of them fail without the fix.

## Testing

`TestOnDemandCopyIn`, **13 tests**, registered in `tornado-test`:

- upload-then-execute matches execute alone; the call runs no task (the output is untouched until the execution);
- a `FIRST_EXECUTION` input really is uploaded by the call — changing the host array afterwards does not change the result, while an `EVERY_EXECUTION` input still refreshes;
- targeted upload of one object **updates a `FIRST_EXECUTION` object that the runtime would never re-upload**, both before the first execution and between executions;
- several objects in one call, with objects the plan does not know ignored;
- a targeted upload reaches every task-graph of the plan that takes the object;
- applies to a plan of two task-graphs; repeated calls are harmless; composes with `withPreCompilation()`;
- **under CUDA graphs**: a transfers-only pass over a plan that captures and replays, the same with `KernelContext` kernels driven by a `GridScheduler`, and a targeted upload into an already-captured graph whose `FIRST_EXECUTION` weights nothing else would refresh.

`TestCopyInPipelines`, **7 tests** — the shapes this API exists for:

- update the input of a producer that persists its result on the device, and see the change through the consumer;
- overwrite a device-resident persisted buffer from the host mid-run (the case an application fakes with a task whose only purpose is the transfer);
- an LLM-shaped pipeline — a per-step graph, four chained layer graphs passing state through `persistOnDevice`/`consumeFromDevice`, a read-out graph — with the layer weights placed by `transferToDevice()` instead of a warm-up run, then one layer's weights swapped mid-run;
- the same pipeline under `withIntraPlanConcurrency()` (multi-stream);
- an upload between two executions of the same graph, 16 times, each one visible in that iteration's result;
- **persist/consume under CUDA graphs**, in both plain and `KernelContext` form: the weights placed by `transferToDevice()` rather than a warm-up run, so the transfers-only pass runs over bytecode containing the capture and launch operations, and swapped again once the graphs are captured.

Hybrid-API (library task) coverage, CUDA-only and skipped elsewhere by the existing guards:

- `TestCuBlas.testSgemmWithAdHocWeightUpload` — a `FIRST_EXECUTION` GEMM operand placed by an upload and then swapped between executions (14/14 in the class);
- `TestCuBlas.testSgemmPipelineWithUpFrontUpload` — `cublasSgemm` result persisted on the device and consumed by a second graph, plan uploaded up front;
- `TestCuDnn.testReluWithAdHocInputUpload` and `TestCuDnn.testReluThenTanhPipelineWithUpFrontUpload` — the same two shapes through cuDNN (11/11 in the class).

The five CUDA-graph tests are guarded with `assertNotBackend(OPENCL)`, so on OpenCL they report `UNSUPPORTED` rather than passing silently.

### Full suite vs. a same-build `develop` baseline

`tornado-test` (all 170 classes, 175 class-runs), RTX 4090, JDK 21, run on this branch and on `develop` built the same way:

| | this branch | `develop` baseline |
|---|---|---|
| **CUDA** | 11 failures / 6 classes | **11 / the same 6** |
| **OpenCL** | 8 failures / 6 classes | **8 / the same 6** |

The failing classes are identical on both sides and none touch the copy-in paths: `TestReductionsFloats`, `TestMatrixMultiplicationKernelContext`, `TestProfiler` (CUDA only), `ComputeTests`, `TransformerKernelsTest`, `TestDevices`, plus `TestMultipleTasksMultipleDevices` on OpenCL. `TransformerKernelsTest` is flaky rather than deterministic — it passed once and failed three consecutive re-runs on `develop`, same method and same float tolerance miss (`testReductionOneBlockWithLayer`, expected 0.8730353, got 0.9308163).

`./mvnw checkstyle:check` clean.

## Backends/OS tested

- CUDA backend, NVIDIA RTX 4090, Ubuntu 24.04, JDK 21.
- OpenCL backend, same machine.
- Metal not runnable here (Linux); the change is backend-neutral — it drives the existing interpreter, `TornadoXPUDevice.streamIn` and `sync`.

Part of #1028.
