### PR TITLE
[api] Apply on-demand transfers to every task-graph of the plan, not just the selected one

### DIFF
--- a/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
+++ b/tornado-api/src/main/java/uk/ac/manchester/tornado/api/TornadoExecutor.java
@@ -147,13 +147,23 @@ class TornadoExecutor {
     }
 
     void transferToHost(Object... objects) {
-        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(objects));
+        allTaskGraphs().forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(objects));
     }
 
     void partialTransferToHost(DataRange dataRange) {
         // At this point we compute the offsets and the total size in bytes.
         dataRange.materialize();
-        immutableTaskGraphList.forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(dataRange.getArray(), dataRange.getOffset(), dataRange.getPartialSize()));
+        allTaskGraphs().forEach(immutableTaskGraph -> immutableTaskGraph.transferToHost(dataRange.getArray(), dataRange.getOffset(), dataRange.getPartialSize()));
+    }
+
+    /**
+     * Every task-graph of the plan, including the ones a {@code withGraph(i)} has currently
+     * selected away. A transfer names an object, not a graph: the graph that owns the object is
+     * not necessarily the one selected to run next, and asking the selected graph alone makes the
+     * transfer a silent no-op.
+     */
+    private List<ImmutableTaskGraph> allTaskGraphs() {
+        return subgraphList != null ? subgraphList : immutableTaskGraphList;
     }
 
     boolean isFinished() {

--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -189,6 +189,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestInitDataTypes"),
     TestEntry("uk.ac.manchester.tornado.unittests.memory.TestMemoryLimit"),
     TestEntry("uk.ac.manchester.tornado.unittests.api.TestIO"),
+    TestEntry("uk.ac.manchester.tornado.unittests.api.TestOnDemandTransferSelection"),
     TestEntry("uk.ac.manchester.tornado.unittests.executor.TestExecutor"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGrid"),
     TestEntry("uk.ac.manchester.tornado.unittests.grid.TestGridScheduler"),

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandTransferSelection.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/api/TestOnDemandTransferSelection.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.DataRange;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * On-demand transfers on a plan that is driven one task-graph at a time with
+ * {@link TornadoExecutionPlan#withGraph(int)}.
+ *
+ * <p>A transfer names an object, not a graph. The graph that owns the object is not necessarily
+ * the one selected to run next, so asking only the selected graph turns the transfer into a silent
+ * no-op and the caller reads whatever the host array held before.
+ *
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.api.TestOnDemandTransferSelection
+ * </code>
+ */
+public class TestOnDemandTransferSelection extends TornadoTestBase {
+
+    private static final int SIZE = 4096;
+
+    public static void scale(FloatArray input, FloatArray output, float alpha) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, alpha * input.get(i));
+        }
+    }
+
+    /** The requested object belongs to a graph that is not the selected one. */
+    @Test
+    public void testTransferToHostOfAnUnselectedGraph() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(2.0f);
+        FloatArray outputOfFirst = new FloatArray(SIZE);
+        FloatArray outputOfSecond = new FloatArray(SIZE);
+
+        TaskGraph first = new TaskGraph("selectionFirst") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransferSelection::scale, input, outputOfFirst, 3.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, outputOfFirst);
+
+        TaskGraph second = new TaskGraph("selectionSecond") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("b", TestOnDemandTransferSelection::scale, input, outputOfSecond, 5.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, outputOfSecond);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(first.snapshot(), second.snapshot())) {
+            plan.withGraph(0).execute();
+            TornadoExecutionResult executionResult = plan.withGraph(1).execute();
+
+            // outputOfFirst is owned by graph 0, which is no longer the selected graph.
+            executionResult.transferToHost(outputOfFirst, outputOfSecond);
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(6.0f, outputOfFirst.get(i), 0.001f);
+            assertEquals(10.0f, outputOfSecond.get(i), 0.001f);
+        }
+    }
+
+    /** The same for a partial transfer through a {@link DataRange}. */
+    @Test
+    public void testPartialTransferToHostOfAnUnselectedGraph() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(2.0f);
+        FloatArray outputOfFirst = new FloatArray(SIZE);
+        FloatArray outputOfSecond = new FloatArray(SIZE);
+
+        TaskGraph first = new TaskGraph("partialSelectionFirst") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransferSelection::scale, input, outputOfFirst, 4.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, outputOfFirst);
+
+        TaskGraph second = new TaskGraph("partialSelectionSecond") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("b", TestOnDemandTransferSelection::scale, input, outputOfSecond, 6.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, outputOfSecond);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(first.snapshot(), second.snapshot())) {
+            plan.withGraph(0).execute();
+            TornadoExecutionResult executionResult = plan.withGraph(1).execute();
+
+            DataRange dataRange = new DataRange(outputOfFirst);
+            executionResult.transferToHost(dataRange.withSize(SIZE / 2));
+            executionResult.transferToHost(dataRange.withOffset(SIZE / 2).withSize(SIZE / 2));
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(8.0f, outputOfFirst.get(i), 0.001f);
+        }
+    }
+
+    /** Selecting a graph and asking for its own object keeps working. */
+    @Test
+    public void testTransferToHostOfTheSelectedGraph() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(3.0f);
+        FloatArray output = new FloatArray(SIZE);
+        FloatArray unrelated = new FloatArray(SIZE);
+
+        TaskGraph first = new TaskGraph("ownFirst") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("a", TestOnDemandTransferSelection::scale, input, output, 2.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, output);
+
+        TaskGraph second = new TaskGraph("ownSecond") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("b", TestOnDemandTransferSelection::scale, input, unrelated, 7.0f) //
+                .transferToHost(DataTransferMode.UNDER_DEMAND, unrelated);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(first.snapshot(), second.snapshot())) {
+            TornadoExecutionResult executionResult = plan.withGraph(0).execute();
+            executionResult.transferToHost(output);
+        }
+
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(6.0f, output.get(i), 0.001f);
+        }
+    }
+}


### PR DESCRIPTION
## The bug

`TornadoExecutionResult.transferToHost(...)` silently does nothing — and the caller reads whatever the host array held before — when the plan is being driven one graph at a time and the requested object belongs to a graph that is not the selected one.

```java
plan.withGraph(0).execute();
TornadoExecutionResult result = plan.withGraph(1).execute();
result.transferToHost(outputOfGraph0, outputOfGraph1);

// outputOfGraph0[0] == 0.0   <- never copied back, no error
// outputOfGraph1[0] == 10.0
```

`TornadoExecutor.selectGraph(i)` replaces `immutableTaskGraphList` with the selected graph (keeping the full list in `subgraphList`), and `transferToHost` iterates `immutableTaskGraphList`. So the graph that owns the object is never asked.

That combination is not exotic: driving a plan graph-by-graph is how a pipeline runs — each stage selected in turn — and `UNDER_DEMAND` outputs exist precisely so results can be collected afterwards, at which point the "current" graph is whichever ran last.

## Fix

A transfer names an object, not a graph, so it applies to every task-graph of the plan:

```java
private List<ImmutableTaskGraph> allTaskGraphs() {
    return subgraphList != null ? subgraphList : immutableTaskGraphList;
}
```

used by `transferToHost(Object...)` and `partialTransferToHost(DataRange)`. Graphs that do not know an object already skip it (`argumentsLookUp`), so widening the loop cannot transfer anything extra — it only stops the owning graph from being skipped.

Deliberately limited to the two on-demand transfer paths, which are the ones whose failure mode is a wrong number rather than an error. `freeDeviceMemory`, `resetDevice` and friends keep their current behaviour.

## Testing

New `TestOnDemandTransferSelection` (3 tests, registered in `tornado-test`), passing on **CUDA and OpenCL**:

- an object owned by an unselected graph is copied back (fails on `develop`: reads 0.0);
- the same through a partial `DataRange` transfer in two halves;
- asking the selected graph for its own object still works.

`tornado-test --quickPass` on CUDA: 86 vs the 85-failure baseline, the difference being the known-flaky `MMwithBytes` (4/4 in isolated re-runs). `./mvnw checkstyle:check` clean.

## Backends/OS tested

- CUDA backend, NVIDIA RTX 4090, Ubuntu 24.04, JDK 21.
- OpenCL backend, same machine.
- Metal not runnable here (Linux); the change is in the backend-neutral API layer.

Found while making the same rule hold for the copy-in direction in #1036. Part of #1028.
