### PR TITLE
[docs] Add a tornadovm-perf-campaign skill: profiling recipes, probe harness and optimisation-pattern catalogue

### DIFF
--- a/.claude/skills/tornadovm-perf-campaign/SKILL.md
+++ b/.claude/skills/tornadovm-perf-campaign/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: tornadovm-perf-campaign
+description: Run a measured performance/correctness campaign on the TornadoVM runtime — profile first (JFR for host, Nsight Systems for driver), falsify the hypothesis with a standalone probe, A/B against a same-build baseline, then ship one PR per measured claim. Use when asked to make TornadoVM faster, to find where time goes in the runtime/dispatch path, to profile an application on top of TornadoVM (LLM decode, kfusion, benchmarks), or to follow up on issue #1028. For plain build/test/PR mechanics see the `tornadovm` skill; for nsys/hybrid-API specifics see `tornadovm-nvidia`.
+---
+
+# Running a TornadoVM optimisation campaign
+
+A campaign is a loop, not a patch: **measure → attribute → hypothesise → falsify → change → re-measure → ship with numbers**. The hard part is not writing the optimisation; it is knowing which microsecond you are removing and proving you removed it.
+
+Files here:
+- `references/measurement.md` — exact profiling and A/B recipes, baselines, tool gotchas
+- `references/probes.md` — standalone probe harness and ready-made probe shapes
+- `references/catalogue.md` — the optimisation-pattern catalogue and what a previous campaign found (with numbers)
+
+## The loop
+
+1. **Profile before touching anything.** Host time = JFR; driver/device time = nsys. Attribute per phase (start-up vs steady state; per-execution vs per-token). Never profile with `-Dtornado.profiler=True` — TornadoVM's own profiler perturbs a short task graph by ~3x and misreports transfer timers by up to 20x (that was itself a finding, PR #1024).
+2. **State the hypothesis as a number.** "The 24-byte stack-frame upload costs 2.00 µs per launch, the same as the 2 KB user copy" is a hypothesis. "Dispatch feels slow" is not.
+3. **Falsify with a standalone probe before editing runtime code.** A probe is 40 lines in the scratchpad, compiles against the built SDK, and runs in seconds (`references/probes.md`). Several campaign hypotheses died here — cheaply.
+4. **Change one mechanism.** If two changes have separate numbers, they are two PRs.
+5. **A/B in the same build family**: stash the change, rebuild, measure baseline, restore, rebuild, measure. Medians of 3+ runs. Always include a **control** that must not move (a GPU-bound workload) — if it moves, the measurement is wrong.
+6. **Separate displaced work from removed work.** Vary the iteration count: a fixed cost shrinks as a percentage, a per-iteration cost does not. A "speed-up" that vanishes at 512 iterations was a cost you moved, not one you deleted.
+7. **Ship with the numbers, the controls, and the negatives.** See "PR shape" below.
+
+## Rules that keep the numbers honest
+
+- **Bailouts silently run sequential Java.** Every probe and benchmark gets `-Dtornado.recover.bailout=False`, or you are timing the CPU.
+- **Aggregate test counts are only meaningful per machine.** On the reference box CUDA `--quickPass` fails 85 and OpenCL fails 271 on unmodified `develop` — so OpenCL claims must be **per test class, same device, before/after**, never aggregate.
+- **Known flaky:** `compute.MMwithBytes`, `compute.TransformerKernelsTest`. Re-run in isolation before blaming a change.
+- **A profiler-on measurement is a different workload.** Report profiler-on and profiler-off separately.
+- **One machine is one data point.** Say which GPU, driver, JDK and backend in the PR.
+
+## Prioritise by failure mode, not by diff size
+
+When a campaign turns up bugs (it will), rank them:
+
+1. **Silent wrong answer** — worst. Driver errors swallowed (#1025), a copy-out that silently no-ops on a graph-selected plan, a dropped wait list on OpenCL/Metal, an inverted `useDeps` flag (the last three in #1032).
+2. **Crash** — visible, so second (#1035: batched graph with >1 output).
+3. **Slow** — everything else.
+
+A 2-character fix in category 1 outranks a 2x speed-up.
+
+## PR shape for a performance claim
+
+One PR = one mechanism = one number. Body:
+
+1. **The bug / the cost** — with the profile line that shows it.
+2. **Cause** — quote the 3–5 lines of code that do the wrong thing.
+3. **Change** — what now happens, and what is deliberately *not* changed (guards, fallbacks).
+4. **Numbers** — a table, medians, the configuration, and a **control row** that does not move.
+5. **Testing** — new tests; `tornado-test --quickPass` versus the same-machine `develop` baseline (state both numbers); `./mvnw checkstyle:check` clean.
+6. **Backends/OS tested** — including the ones you *could not* test and why.
+7. **Negatives** — where it does not help, what it costs (memory, contract), what remains unproven. A PR that only lists wins reads as unmeasured.
+
+Commit messages: one line, no body, no AI attribution. Base branch `develop`.
+
+## Cadence and cost (reference box: RTX 4090, JDK 21)
+
+| Step | Cost | Note |
+|---|---|---|
+| `make BACKEND=cuda` | ~3 min | Run in background while writing the next probe |
+| `tornado-test --quickPass` | ~3.5 min | Only before a PR, not per edit |
+| single test class | 5–30 s | The inner loop |
+| standalone probe | ~10 s | The real inner loop — prefer this over tests while exploring |
+| nsys capture + `nsys stats` | ~1 min | Counts are robust; totals include start-up |
+| JFR capture + aggregate | ~1 min | Needs a run of a few seconds to get samples |
+
+Rebuilding for an A/B costs two builds. Budget it; do not eyeball a 5% claim without it.
+
+## Claude-side workflow that makes this efficient
+
+- **Caveman mode** (`/caveman full`) for the whole campaign. Long sessions with dozens of build/test cycles produce a lot of narration; compressing it keeps context for the numbers. Code, commits, PR bodies and safety warnings stay in normal prose.
+- **Background the builds.** `Bash(run_in_background: true)` for `make`, then write the probe or the test while it compiles. Never sit idle through a 3-minute build.
+- **Batch independent calls.** Greps, file reads and status checks in one message; they run in parallel.
+- **The scratchpad is the lab.** Probes, `agg.py`, A/B shell loops, nsys reports all live in the session scratchpad — never in the repo. Only tests and the fix land in git.
+- **Forks/subagents for mechanical GitHub work only** — labelling, triage tables, changelog sweeps. They start cold: they cannot re-derive a measurement. Never delegate "find why this is slow".
+- **`/loop` is for polling external state** (a CI run, a long benchmark sweep), not for driving edits. Prefer a long interval and a single check.
+- **Write a resume pointer to memory** when a campaign spans sessions: branch, baseline failure counts, the last measured table, and the next hypothesis. Re-deriving a baseline costs two builds.
+- **Task list for a multi-PR campaign.** A campaign fans out into 5–10 PRs plus an umbrella issue; track them, and keep the umbrella issue updated with each result — it is the campaign's shared memory.
+
+### Git discipline (these bit a previous campaign)
+
+- **Never commit onto a branch that already has an open PR** unless the commit belongs to that PR. Check `git log --oneline origin/<branch>..HEAD` before committing.
+- **`git stash drop` drops `stash@{0}`, whoever pushed it.** List first (`git stash list`), drop by name/index, or use `git stash apply` + explicit drop. A dropped stash is recoverable via `git fsck --unreachable`, but only if you notice.
+- **Stack PRs deliberately**: branch B off A's branch, and say so in B's description. Rebase the whole stack when A changes.
+- `gh pr edit` can fail on repos with classic Projects (`GraphQL: Projects (classic) is being deprecated`). Fall back to `gh api -X PATCH repos/<owner>/<repo>/pulls/<n> -F body=@file.md`.
+
+## Where the campaign usually goes next
+
+Read `references/catalogue.md` first — it lists the patterns that have already paid off (dirty-bit memoization, request coalescing, deferred/lazy completion, high-water marks, capability negotiation) and the open leads with their measured ceilings. Optimising a path that is already 0.1% of wall is the most common way to waste a campaign; the catalogue records the shares.

--- a/.claude/skills/tornadovm-perf-campaign/references/catalogue.md
+++ b/.claude/skills/tornadovm-perf-campaign/references/catalogue.md
@@ -1,0 +1,50 @@
+# Pattern catalogue and prior results
+
+Where the time has actually been, which pattern removed it, and what the measured share was. Use it to avoid optimising a path that is already 0.1% of wall.
+
+## Established shares (RTX 4090, CUDA)
+
+| Workload | Cost split |
+|---|---|
+| `saxpy 512` (dispatch-bound) | ~5.2 µs host driver calls + ~3.0 µs terminal sync vs **2.5 µs** of device work |
+| Java bytecode interpreter | **~1%** of wall on a dispatch-bound graph — the interpreter is not the problem |
+| LLM decode, profiler off | **~90% `cuStreamSynchronize`** (real device wait); Java-side work is noise |
+| LLM short run, whole process | start-up dominates: `cuMemHostRegister` alone ~3.4 s (63% of all CUDA API time) |
+| Per-token activation graph (one 1.2 µs kernel) | **0.0% of GPU time**, ~0.1% of wall — structurally ugly, not worth optimising |
+
+## Patterns that paid
+
+| Pattern | Applied to | Result |
+|---|---|---|
+| **Dirty-bit memoization** — don't re-send state the device already has | per-launch kernel stack frame | 17.5 → 8.6 µs/exec (2.03x) |
+| **Cache a monotone predicate** — don't ask the driver what you already know | stream sync when nothing was enqueued | 3 syncs/exec → 1 |
+| **Deferred/lazy evaluation at a quiescent point** | profiler timestamp reads | profiler-on cost −34%; `cuEventSynchronize` 51.9% → 1.1% of wall |
+| **Bound work by use, not capacity** (high-water mark) | wait-list row clearing (32768 ints/row) | deps-on decode 46 → 72 tok/s (1.57x) |
+| **Request coalescing** — N round trips → 1 | on-demand copy-outs of several objects | 8 objects 36.3 → 14.0 µs (2.6x) |
+| **Latency hiding + bounded in-flight queue** | deferred output materialisation | host-work overlap 1.42x; back-to-back 1.59x; `execute()` returns 11x sooner |
+| **Batch the whole pipeline into one submission** | CUDA graphs (existing feature, under-used) | LLM decode 72 → 103 tok/s (1.42x) |
+| **Capability negotiation over implicit contract** | `XPUBuffer.supportsAsyncRead()` | turned a silent wrong-result path into an explicit opt-in |
+| **Intent-revealing operation** replacing a workaround | `transferToDevice()` instead of a dummy kernel run to force a copy-in | removes a full dummy forward pass; wall-neutral on the LLM, clearer API |
+
+## Anti-patterns found in the runtime (look for their relatives)
+
+- **A global predicate read as a per-object one.** "Is a buffer of this size in use?" answered "may *this* object reuse its buffer" → an unallocated output and a null-buffer crash on batched multi-output graphs.
+- **Two methods that look like a blocking/async pair but are not substitutable.** `read()` handled partial copies, sub-regions and batches; `enqueueRead()` handled none of them and silently copied the wrong region for some buffer types.
+- **A flag computed twice, inverted once.** `events == null` vs `events != null` for the same `useDeps` argument in different backends — dead code hid it until a change made the path reachable.
+- **An operation applied to "the selected graph" when it names an object.** Driving a plan with `withGraph(i)` made on-demand transfers silently no-op for objects owned by other graphs.
+- **Instrumentation that changes the measurement.** Inline timestamp reads serialised the host against the device and inflated the reported copy time ~20x.
+
+Common shape: *an implicit contract that only some implementations honour, with no place to declare it and no test that checks it.* When you find one, prefer declaring the capability over adding another special case.
+
+## Open leads (with measured ceilings)
+
+1. **The terminal blocking read-back** is the largest remaining host cost on dispatch-bound graphs (~36% of the raw sync average, but only ~17% recoverable — much of that sync overlaps work already enqueued). Deferred outputs address it; pipelining needs no double buffering because a single in-order queue already orders copy N before kernel N+1.
+2. **Residual profiler overhead ~2.2x** is now the timing events themselves (`cuEventRecord` 615 ns with timing vs 137 ns without), not the reads. Needs opt-in timing granularity.
+3. **Start-up**: `cuMemHostRegister` and NVRTC dominate short runs. Untouched. Biggest absolute number left.
+4. **Code installation vs data transfer are entangled**: a transfers-only pass leaves first-launch cost for the first real execution, so the win moves rather than appears. A warm-up that installs code without transferring would separate them.
+5. **Transfer-API consolidation** (issue #1028): `read`/`enqueueRead`, `streamOut`/`streamOutBlocking` and ~96 near-identical device-context overloads differing by one boolean. Contract tests exist (`TestTransferContract`) to pin behaviour before the refactor.
+
+## Campaign hygiene
+
+- Keep an **umbrella issue** with the method, the build matrix (A = develop, B = A+PRs, C = B+more) and one comment per result. It is the only shared memory across PRs and sessions.
+- Record **disproven hypotheses** in it too. Three of this campaign's dead ends (an existing "non-blocking stream-out" flag that was slower, an ordering-barrier theory, double-buffered outputs) would otherwise be retried by the next person.

--- a/.claude/skills/tornadovm-perf-campaign/references/measurement.md
+++ b/.claude/skills/tornadovm-perf-campaign/references/measurement.md
@@ -1,0 +1,102 @@
+# Measurement recipes
+
+Reference box for every number quoted here: NVIDIA RTX 4090, Ubuntu 24.04, JDK 21, CUDA backend.
+
+## 1. Host time — JFR
+
+```bash
+tornado --jvm="-Dtornado.recover.bailout=False \
+  -XX:StartFlightRecording=settings=profile,filename=run.jfr \
+  -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints" \
+  -cp $PWD MyProbe
+```
+
+`settings=profile` samples both `jdk.ExecutionSample` (Java frames) and `jdk.NativeMethodSample` (threads in native — where a GPU runtime actually sits). A run of a few seconds is the minimum for usable counts.
+
+Aggregate with `jfr print`, **not** with the JMC UI:
+
+```bash
+JFR=$(dirname $(readlink -f $(which java)))/jfr
+$JFR print --stack-depth 96 --events ExecutionSample,NativeMethodSample run.jfr
+```
+
+Two gotchas that produce wrong conclusions:
+
+- **`--stack-depth` is required.** The default truncates the stack to ~5 frames with `...`, so any phase filter ("only samples under `generateTokensGPU`") matches almost nothing and you conclude the phase is idle.
+- **Do not split the print output on the string `jdk.`** — frames such as `jdk.internal.misc.Unsafe` split events in half. Split on lines matching `^jdk\.(ExecutionSample|NativeMethodSample) \{`.
+
+Phase attribution: filter samples whose stack contains a marker method (`generateTokensGPU` for decode, `initializeTornadoVMPlan` for start-up) and rank the **leaf** frame within the phase.
+
+## 2. Driver and device time — Nsight Systems
+
+```bash
+nsys profile -t cuda --sample=none --cpuctxsw=none -f true -o out <command>
+nsys stats --report cuda_api_sum          out.nsys-rep   # host-side driver calls
+nsys stats --report cuda_gpu_kern_sum     out.nsys-rep   # kernel time
+nsys stats --report cuda_gpu_mem_time_sum out.nsys-rep   # H2D/D2H time
+```
+
+**Call counts are the robust signal**; total times include start-up. Counts per execution answer "how many driver calls does one task graph cost" — the number most dispatch work is really about.
+
+Useful denominators: divide `cuLaunchKernel` count by the number of executions to get kernels/execution; a big gap between that and 1 means the plan is many small graphs.
+
+## 3. Steady-state per-execution cost — the benchmark runner
+
+```bash
+tornado --jvm="-Dtornado.benchmarks.skipserial=True" \
+  -m tornado.benchmarks/uk.ac.manchester.tornado.benchmarks.BenchmarkRunner \
+  --params="saxpy 100000 512"
+```
+
+Prints `median(ns)=...`; the harness already discards warm-up iterations. `saxpy <iters> 512` is the canonical **dispatch-bound** shape (one kernel, one H2D, one blocking D2H, 2 KB moved, ~1.1 µs kernel). Large sizes (`saxpy 2000 16777216`, `nbody 500 16384`) are the **controls** — they must not move.
+
+## 4. A/B protocol
+
+```bash
+# with the change
+make BACKEND=cuda && <measure> > after.txt
+# baseline, same tree, same build system
+git stash push -m ab -- <paths> && make BACKEND=cuda && <measure> > before.txt
+git stash pop && make BACKEND=cuda
+```
+
+- 3 runs minimum, compare medians.
+- Same JVM flags, same device memory, same model/input.
+- Include one control workload in both runs.
+- For anything under 10%, this protocol is mandatory — run-to-run variance on a warm GPU is a few percent.
+
+**Fixed vs per-iteration cost:** repeat the A/B at two iteration counts (e.g. 128 and 512 tokens). A gap that shrinks with more iterations is a one-off cost you *moved*; a gap that holds is work you *removed*.
+
+## 5. Test baselines (reference box)
+
+| Sweep | Unmodified `develop` | Use |
+|---|---|---|
+| CUDA `tornado-test --quickPass` | **85 failures** | Aggregate comparison is valid |
+| OpenCL `tornado-test --quickPass` | **271 failures** (e.g. `TestArrays` 4/23) | Aggregate is meaningless — compare per class, same device |
+| Known flaky | `compute.MMwithBytes`, `compute.TransformerKernelsTest` | Re-run in isolation before blaming a change |
+
+Passing extra JVM flags to `tornado-test` needs the `=` form **and** a leading space, because the argument parser treats a leading `-` as a new flag:
+
+```bash
+tornado-test --jvm=" -Dtornado.vm.deps=True" uk.ac.manchester.tornado.unittests.arrays.TestArrays   # works
+tornado-test --jvm "-Dtornado.vm.deps=True" ...                                                     # "expected one argument"
+```
+
+## 6. Knobs worth knowing
+
+| Flag | Effect |
+|---|---|
+| `-Dtornado.recover.bailout=False` | Fail instead of silently running sequential Java. **Always on when measuring.** |
+| `-Dtornado.vm.deps=True` | Enable dependency tracking (a different, slower code path — measure both) |
+| `-Dtornado.device.memory=NGB` | Device heap; a plan of many graphs can need noticeably more than the sequential path |
+| `-Dtornado.profiler=True` | TornadoVM's own profiler — perturbs; never the default measurement |
+| `-Dtornado.max.events` / `-Dtornado.eventpool.maxwaitevents` | Two *different* knobs with similar names; the first sizes wait-list rows |
+| `--printBytecodes` | What the graph compiler actually emitted (blocking vs non-blocking copy-out, per-chunk ALLOC/DEALLOC) |
+
+Strip ANSI colour before grepping `--printBytecodes` output: `sed 's/\x1b\[[0-9;]*m//g'`.
+
+## 7. Application-level measurement (LLM decode as the example)
+
+`llama-tornado --show-command` prints the raw `java` line; capture it once into a shell script in the scratchpad, then vary one flag per run. That keeps every A/B on an identical command line, which `llama-tornado` itself does not guarantee across invocations.
+
+Split reporting into **start-up** and **steady state** — on a short LLM run, start-up (host-memory pinning, NVRTC) dominates whole-run wall time, so a decode-loop win can be invisible in the total.

--- a/.claude/skills/tornadovm-perf-campaign/references/probes.md
+++ b/.claude/skills/tornadovm-perf-campaign/references/probes.md
@@ -1,0 +1,70 @@
+# Standalone probes
+
+A probe is a single Java file in the scratchpad that drives the built SDK directly. It is the campaign's inner loop: ~10 s per run against ~3.5 min for a test sweep, and it can time phases a unit test cannot.
+
+## Harness
+
+```bash
+SDK=/path/to/TornadoVM/dist/tornadovm-<ver>-jdk21-dev-cuda-linux-amd64/tornadovm-<ver>-jdk21-dev-cuda
+
+javac -g --enable-preview --release 21 \
+      --module-path $SDK/share/java/tornado --add-modules tornado.api \
+      -d . MyProbe.java
+
+source /path/to/TornadoVM/setvars.sh
+tornado --jvm="-Dtornado.recover.bailout=False" -cp $PWD MyProbe
+```
+
+Four gotchas, each of which costs a confusing hour:
+
+1. **`-g` is mandatory.** Without debug info the Graal front end dies with `NullPointerException: ... LocalVariableTable.getLocalsAt(int)`. It looks like a compiler bug; it is a missing `-g`.
+2. **`--enable-preview --release 21`** — the API's native array classes are compiled with preview features on.
+3. **`-Dtornado.recover.bailout=False`** or a failed compilation silently runs sequential Java and you time the CPU.
+4. **`DataTransferMode.EVERY_EXECUTION` is an `int` constant**, not an enum: a helper parameter must be `int`. `new TornadoExecutionPlan(...)` throws `TornadoExecutionPlanException`, so `main` declares `throws Exception`.
+
+## Probe shapes that earned their keep
+
+**Dispatch-bound loop** — per-execution median, the shape most runtime overhead shows up in:
+
+```java
+try (TornadoExecutionPlan plan = new TornadoExecutionPlan(itg)) {
+    for (int i = 0; i < WARMUP; i++) plan.execute();
+    for (int i = 0; i < ITERS; i++) {
+        long t0 = System.nanoTime();
+        plan.execute();
+        samples[i] = System.nanoTime() - t0;
+    }
+}
+// report median and p10 — the mean hides a bimodal distribution
+```
+
+**Phase-split probe** — proves *where* a call blocks, which a total cannot:
+
+```java
+long t0 = System.nanoTime();
+TornadoExecutionResult r = plan.execute();
+long t1 = System.nanoTime();       // submit
+sink += hostWork(micros);          // busy-wait, never Thread.sleep
+long t2 = System.nanoTime();       // host work
+r.await();
+long t3 = System.nanoTime();       // wait
+```
+
+This is what showed that `execute()` was synchronous because of `waitOn()` at the API layer, not because of the blocking copy-out bytecode — the opposite of the initial hypothesis.
+
+**Cardinality sweep** — vary one structural parameter (number of outputs, number of transferred objects, number of graphs) and read the slope. A cost that grows with N is a per-object cost; a flat one is fixed. This turned "multi-output graphs feel slow" into "each extra output costs ~2.4 µs of host round trip".
+
+**Upper-bound probe** — remove the thing entirely (e.g. declare the output `UNDER_DEMAND` so no copy-out happens) to bound what optimising it could ever buy. Cheap, and it kills bad ideas before any runtime edit. Read it as a **bound, not a target**: removing a copy also removes its PCIe time, which a real optimisation would not.
+
+**Correctness inside the probe.** Every probe checks its own results (`mismatches` counter). A performance probe that does not validate will happily report a huge win for a kernel that never ran — exactly the 35x "speed-up" that turned out to be a swallowed launch failure.
+
+## Where probes live
+
+Scratchpad only (`/tmp/claude-.../scratchpad/probe/`). If a probe finds something worth keeping, it becomes a **unit test** under `tornado-unittests/.../unittests/<feature>/` plus a `TestEntry(...)` line in `tornado-assembly/src/bin/tornado-test` — the probe itself is never committed.
+
+## From probe to test
+
+The translation is usually mechanical, with two additions:
+
+- assert against a sequential Java reference, not against a previously observed number;
+- make the test **fail on the bug**: run it against unmodified `develop` first and record the failure text in the PR. A regression test that never failed proves nothing.

--- a/.claude/skills/tornadovm/SKILL.md
+++ b/.claude/skills/tornadovm/SKILL.md
@@ -10,6 +10,7 @@ TornadoVM JIT-compiles Java bytecode to GPU code (OpenCL C, CUDA/NVRTC, Apple Me
 **Backend scope:** this skill covers **OpenCL, CUDA, and Metal** only. **PTX and SPIRV are out of scope** (both are slated for removal in the 6.0.0 roadmap). Never suggest `make BACKEND=ptx` or `make BACKEND=spirv`.
 
 For backend internals (where codegen lives, how to add a node/intrinsic), see `references/codegen-map.md`.
+For profiling and optimisation work on the runtime, see the `tornadovm-perf-campaign` skill.
 
 ## Build
 


### PR DESCRIPTION
Adds `.claude/skills/tornadovm-perf-campaign/`, extracted from the optimisation campaign in #1028, so the next one starts from the recipes rather than from scratch. Documentation only — no code, no build or test changes.

Follows the pattern of the committed `tornadovm` skill (#980), and adds one cross-reference line to it.

## What is in it

**`SKILL.md`** — the campaign loop and the rules that keep numbers honest:

- measure → attribute → hypothesise → **falsify with a probe** → change → re-measure → ship with numbers;
- never measure with `-Dtornado.profiler=True` (it perturbs a short graph ~3x and misreported a transfer timer by 20x — that was itself a finding);
- always `-Dtornado.recover.bailout=False`, or a silent bailout means you are timing sequential Java;
- **separate displaced work from removed work** by varying the iteration count — a gap that shrinks with more iterations is a cost you moved;
- rank bugs by failure mode: **silent wrong answer > crash > slow**. A two-character fix in the first category outranks a 2x speed-up;
- the PR shape for a performance claim, including a control row that must not move and an explicit **negatives** section.

**`references/measurement.md`** — JFR and nsys recipes, the A/B protocol, and the two gotchas that produce wrong conclusions: `jfr print` needs `--stack-depth` or the stack truncates to ~5 frames and every phase filter matches nothing; and its output must not be split on the string `jdk.` because frames like `jdk.internal.misc.Unsafe` split events in half. Also the reference-box test baselines, the known-flaky classes, the `tornado-test --jvm=" -D..."` quoting trap, and the knob table.

**`references/probes.md`** — the standalone-probe harness (a 40-line Java file against the built SDK, ~10 s per run versus ~3.5 min for a test sweep) with its four traps: `-g` or Graal dies with a `LocalVariableTable` NPE; `--enable-preview --release 21`; `recover.bailout=False`; `DataTransferMode` constants are `int`, not an enum. Then the four probe shapes that paid — dispatch loop, phase-split, cardinality sweep, upper-bound — and the rule that **every probe validates its own results**, because a probe that does not will happily report a huge win for a kernel that never ran (the 35x "speed-up" in #1025).

**`references/catalogue.md`** — measured cost shares (the Java interpreter is ~1% of a dispatch-bound graph; LLM decode is ~90% `cuStreamSynchronize`; a per-token activation graph is 0.0% of GPU time), the nine patterns that paid with their numbers, five runtime anti-patterns to look for relatives of, the open leads with their ceilings, and campaign hygiene — including **recording disproven hypotheses** so the next person does not retry the three dead ends this campaign already paid for.

## On the reference-box numbers

Every quoted figure is from one machine (RTX 4090, Ubuntu 24.04, JDK 21) and the files say so. The test baselines in particular — CUDA `--quickPass` 85 failures, OpenCL 271 — are machine-specific, and the skill is explicit that OpenCL comparisons must be per test class on the same device rather than aggregate. Anyone running this elsewhere re-derives those two numbers first.

## Claude-side workflow

The skill also records what made the campaign efficient in practice: background the 3-minute builds and write the next probe while they run, batch independent tool calls, keep probes in the scratchpad and never in git, use subagents for mechanical GitHub work only (they start cold, so "find why this is slow" cannot be delegated), and write a resume pointer when a campaign spans sessions because re-deriving a baseline costs two builds. Plus a short git-discipline block covering the three things that actually bit: committing onto a branch with an open PR, `git stash drop` taking whoever's `stash@{0}` (recoverable via `git fsck --unreachable`, if you notice), and `gh pr edit` failing on repos with classic Projects — with the `gh api -X PATCH` fallback.

Part of #1028.
