### PR TITLE
[build] Validate the BACKEND variable in the Makefile against the supported backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,26 @@ all: build
 # make BACKEND=<comma_separated_backend_list>
 BACKEND ?= opencl
 
+# Reject backends that are not supported, mirroring the check the installer performs on --backend
+# (__SUPPORTED_BACKENDS__ in bin/tornadovm-installer). Without this an unsupported name is handed
+# to bin/compile, becomes a non-existent Maven profile, and fails much later and far less clearly.
+COMMA := ,
+EMPTY :=
+SPACE := $(EMPTY) $(EMPTY)
+SUPPORTED_BACKENDS := opencl cuda metal
+BACKEND_LIST := $(strip $(subst $(COMMA),$(SPACE),$(BACKEND)))
+UNSUPPORTED_BACKENDS := $(filter-out $(SUPPORTED_BACKENDS),$(BACKEND_LIST))
+
+# `make BACKEND=` sets the variable to an empty value, so `?=` above does not restore the default:
+# without this it would build nothing and only fail deep inside Maven.
+ifeq ($(BACKEND_LIST),)
+$(error [ERROR] No backend specified in BACKEND. Provide one of the supported backends: $(subst $(SPACE),$(COMMA)$(SPACE),$(SUPPORTED_BACKENDS)) -- e.g. make BACKEND=opencl or make BACKEND=opencl$(COMMA)cuda)
+endif
+
+ifneq ($(UNSUPPORTED_BACKENDS),)
+$(error [ERROR] Unsupported backends specified in BACKEND: $(subst $(SPACE),$(COMMA)$(SPACE),$(UNSUPPORTED_BACKENDS)). Supported backends: $(subst $(SPACE),$(COMMA)$(SPACE),$(SUPPORTED_BACKENDS)))
+endif
+
 # JDK profile used by the `sdk`, `test-reflection` and `test-reflection-only` targets
 # { jdk21, jdk22plus }, derived from JAVA_HOME rather than hardcoded.
 #


### PR DESCRIPTION
#### Description

`make BACKEND=<list>` accepted any value and passed it straight through to  `bin/compile`, which turns each entry into a Maven profile name. A typo or an unsupported backend was therefore only caught deep inside the Maven reactor, as a confusing failure that never mentions `BACKEND`.                                                                                                   
This patch adds a parse-time guard to the `Makefile` that validates `BACKEND` against the supported backends (`opencl`, `cuda`, `metal`) and aborts with a clear message before any build work starts. It mirrors the check the installer already performs on `--backend` (`__SUPPORTED_BACKENDS__` in `bin/tornadovm-installer`), so the two entry points now reject the same inputs the same way.                                                                                      
                                                                                                                                                     
Two cases are rejected:                                                                                                                            
  - an unsupported backend name, e.g. `make BACKEND=ptx` or `make BACKEND=opencl,spirv`                                                              
  - an empty backend list, e.g. `make BACKEND=`                                                                                                      
                                                                                                                                                     
Behaviour for every valid invocation is unchanged. 

#### Problem description

Two related issues, both build-system only (no runtime impact):                                                                                    
                                                                                                                                                     
**1. Unsupported backend names were silently accepted.**                                                                                           
```
$ make BACKEND=ptx                                                                                                                                 
bin/compile --jdk jdk21 --backend ptx        
```                                                                                                      

The build then runs until Maven fails on the non-existent `ptx-backend` profile.                                                                                                                       
                                                                                                                                                     
**2. `make BACKEND=` built nothing.**                                                                                                              
```
$ make BACKEND=                                                                                                                                    
bin/compile --jdk jdk21 --backend               
```                                                                                                   
                                                                                                                                                     
`BACKEND ?= opencl` does not rescue this: `make BACKEND=` sets the variable to an empty value, which counts as "already set", so the default never applies.                                                                          
                                                                                                                                                     
After this patch:                                                                                                                                  
                                                                                                                                                     
```
$ make BACKEND=ptx                                                                                                                                 
Makefile:24: *** [ERROR] Unsupported backends specified in BACKEND: ptx. Supported backends: opencl, cuda, metal.  Stop.
```
```
$ make BACKEND=                                                                                                                                    
Makefile:20: *** [ERROR] No backend specified in BACKEND. Provide one of the supported backends: opencl, cuda, metal -- e.g. make BACKEND=opencl or make BACKEND=opencl,cuda.  Stop.
```

#### Backend/s tested

This patch is backend-independent: it only validates the `BACKEND` variable before `bin/compile` is invoked, and does not touch any backend code or build profile.

- [ ] OpenCL
- [ ] CUDA
- [ ] Metal

#### OS tested

Mark the OS where this PR is tested.

- [x] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?

Invalid input is now rejected (both exit 2):                                                                                                       
                                                                                                                                                     
  ```bash                                                                                                                                            
  make BACKEND=ptx            # ERROR: Unsupported backends specified in BACKEND: ptx                                                             
  make BACKEND=opencl,spirv   # ERROR: Unsupported backends specified in BACKEND: spirv                                                           
  make BACKEND=               # ERROR: No backend specified in BACKEND                                                                            
  make BACKEND=,              # ERROR: No backend specified in BACKEND 
