### PR TITLE
[profiler] Count copy-out bytes even when the transfer produced no event to time

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -240,6 +240,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.fields.TestFields"),
     TestEntry("uk.ac.manchester.tornado.unittests.fields.TestInheritedFields"),
     TestEntry("uk.ac.manchester.tornado.unittests.profiler.TestProfiler"),
+    TestEntry("uk.ac.manchester.tornado.unittests.profiler.TestProfilerTransferBytes"),
     TestEntry("uk.ac.manchester.tornado.unittests.bitsets.BitSetTests"),
     TestEntry("uk.ac.manchester.tornado.unittests.quantization.QuantizationTests"),
     TestEntry("uk.ac.manchester.tornado.unittests.fails.TestFails"),

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/interpreter/TornadoVMInterpreter.java
@@ -1108,14 +1108,20 @@ public class TornadoVMInterpreter {
 
         resetEventIndexes(eventId);
 
+        if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion) {
+            // The size is known whether or not the copy produced an event to time: a copy-out
+            // issued without dependency tracking returns -1 (XPUBuffer.read ends in
+            // `useDeps ? returnEvent : -1`), which used to skip this accounting entirely and left
+            // getTotalBytesCopyOut() reporting 0 for transfers that demonstrably happened.
+            timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
+        }
+
         if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && readEvent != -1) {
             Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), readEvent);
             event.waitForEvents(graphExecutionContext.getExecutionPlanId());
             long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
             value += event.getElapsedTime();
             timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
-
-            timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
 
             long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
             dispatchValue += event.getDriverDispatchTime();
@@ -1140,14 +1146,20 @@ public class TornadoVMInterpreter {
         }
         final int readEvent = interpreterDevice.streamOutBlocking(graphExecutionContext.getExecutionPlanId(), object, offset, objectState, eventWaitList);
 
+        if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion) {
+            // The size is known whether or not the copy produced an event to time: a copy-out
+            // issued without dependency tracking returns -1 (XPUBuffer.read ends in
+            // `useDeps ? returnEvent : -1`), which used to skip this accounting entirely and left
+            // getTotalBytesCopyOut() reporting 0 for transfers that demonstrably happened.
+            timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
+        }
+
         if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && readEvent != -1) {
             Event event = interpreterDevice.resolveEvent(graphExecutionContext.getExecutionPlanId(), readEvent);
             event.waitForEvents(graphExecutionContext.getExecutionPlanId());
             long value = timeProfiler.getTimer(ProfilerType.COPY_OUT_TIME);
             value += event.getElapsedTime();
             timeProfiler.setTimer(ProfilerType.COPY_OUT_TIME, value);
-
-            timeProfiler.addValueToMetric(ProfilerType.TOTAL_COPY_OUT_SIZE_BYTES, TimeProfiler.NO_TASK_NAME, objectState.getXPUBuffer().size());
 
             long dispatchValue = timeProfiler.getTimer(ProfilerType.TOTAL_DISPATCH_DATA_TRANSFERS_TIME);
             dispatchValue += event.getDriverDispatchTime();

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfilerTransferBytes.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfilerTransferBytes.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.profiler;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.TornadoExecutionResult;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.ProfilerMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * The profiler's transferred-byte counters have to account for a transfer whether or not that
+ * transfer produced an event to time. A copy-out issued with dependency tracking off returns no
+ * event, and the size of the buffer is known regardless.
+ *
+ * <p>
+ * How to test?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.profiler.TestProfilerTransferBytes
+ * </code>
+ */
+public class TestProfilerTransferBytes extends TornadoTestBase {
+
+    private static final int SIZE = 8192;
+
+    public static void scale(FloatArray input, FloatArray output) {
+        for (@Parallel int i = 0; i < input.getSize(); i++) {
+            output.set(i, input.get(i) * 2.0f);
+        }
+    }
+
+    @Test
+    public void testCopyOutBytesAreCounted() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(1.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("copyOutBytes") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("t", TestProfilerTransferBytes::scale, input, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            TornadoExecutionResult result = plan.withProfiler(ProfilerMode.SILENT).execute();
+
+            // The data really did come back.
+            for (int i = 0; i < SIZE; i++) {
+                assertEquals(2.0f, output.get(i), 0.001f);
+            }
+
+            long copyIn = result.getProfilerResult().getTotalBytesCopyIn();
+            long copyOut = result.getProfilerResult().getTotalBytesCopyOut();
+
+            assertTrue("copy-in bytes should be counted, got " + copyIn, copyIn > 0);
+            assertTrue("copy-out bytes should be counted, got " + copyOut, copyOut > 0);
+        }
+    }
+
+    @Test
+    public void testCopyOutBytesAccumulateAcrossExecutions() throws TornadoExecutionPlanException {
+        FloatArray input = new FloatArray(SIZE);
+        input.init(1.0f);
+        FloatArray output = new FloatArray(SIZE);
+
+        TaskGraph taskGraph = new TaskGraph("copyOutRepeat") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, input) //
+                .task("t", TestProfilerTransferBytes::scale, input, output) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.withProfiler(ProfilerMode.SILENT);
+            long previous = 0;
+            for (int iteration = 0; iteration < 3; iteration++) {
+                TornadoExecutionResult result = plan.execute();
+                long copyOut = result.getProfilerResult().getTotalBytesCopyOut();
+                assertTrue("copy-out bytes should be counted on execution " + iteration + ", got " + copyOut, copyOut > 0);
+                previous = copyOut;
+            }
+            assertTrue(previous > 0);
+        }
+    }
+}


### PR DESCRIPTION
## The bug

`getTotalBytesCopyOut()` returns **0 while the device is demonstrably copying out**. In the test
added here the same execution that reports `copyOut=0` also validates the data that came back:

```
execution 0: copyIn=4194344 B copyOut=0 B
execution 1: copyIn=24 B      copyOut=0 B
...
```

The counter is wrong, not the transfer.

## Root cause

Both copy-out sites in `TornadoVMInterpreter` account for the transfer inside a guard that also
requires an event to time:

```java
if (TornadoOptions.isProfilerEnabled() && !insideCaptureRegion && readEvent != -1) {
    ...COPY_OUT_TIME...
    timeProfiler.addValueToMetric(TOTAL_COPY_OUT_SIZE_BYTES, ..., objectState.getXPUBuffer().size());
    ...TOTAL_DISPATCH_DATA_TRANSFERS_TIME...
}
```

and the copy-out path returns no event when dependency tracking is off, which is the default:

```java
// XPUBuffer.read(...) — CUDA, OpenCL and Metal alike
return useDeps ? returnEvent : -1;
```

So with `tornado.vm.deps` off, `readEvent == -1` and the whole block is skipped — the timing *and*
the byte count.

Copy-in is unaffected, and the asymmetry is the tell: `enqueueWrite` returns its event list
**unconditionally**, so `allEvents != null` always holds and `TOTAL_COPY_IN_SIZE_BYTES` accumulates
normally. That is why `getTotalBytesCopyIn()` is usable today and `getTotalBytesCopyOut()` is not.

## The fix

Move the size accounting out of the event guard, at both sites. The number of bytes a transfer moved
is known from the buffer whether or not the transfer produced an event; only the elapsed and dispatch
*times* need one, and those stay exactly where they are.

This is deliberately the smaller of the two possible fixes — see below.

## The larger fix, and why it is not in this PR

The same dead block also sets `COPY_OUT_TIME`, which is what `getProfilerResult().getDeviceReadTime()`
returns. So the identical root cause explains three test failures already on `develop`:

- `TestProfiler.testProfilerEnabled`
- `TestProfiler.testProfilerFromExecutionPlan`
- `TestProfiler.testProfilerOnAndOff`

each of which asserts `getDeviceReadTime() > 0`. They still fail after this PR, and this PR does not
claim to fix them.

Making them pass means making reads symmetric with writes — returning the event id regardless of
`useDeps`. That is a change to the event-return contract at **15 sites across the CUDA, OpenCL and
Metal buffer classes**, and `-1` may carry meaning elsewhere in the interpreter's event chaining, so
it wants its own change and its own review rather than riding along inside a counter fix. I would be
glad to follow up with it if maintainers agree the symmetry is the right target.

## Testing

New `TestProfilerTransferBytes`, 2 tests, registered in `tornado-test`:

- a single execution with `transferToHost(EVERY_EXECUTION, ...)` under `ProfilerMode.SILENT`
  asserts the output values *and* that both byte counters are non-zero;
- three consecutive executions assert the copy-out count stays non-zero.

Both fail on `develop` with `copy-out bytes should be counted, got 0` — in the same test run whose
value assertions pass — and both pass with this change.

- CUDA: 2/2 new, and the full `tornado-test` suite shows **11 failures across 6 classes, identical
  to the `develop` baseline on this machine** (`TestReductionsFloats`,
  `TestMatrixMultiplicationKernelContext`, `TestProfiler`, `ComputeTests`, `TransformerKernelsTest`,
  `TestDevices`).
- `./mvnw checkstyle:check` clean.

The change is in backend-neutral runtime code, so OpenCL and Metal get it too; `TestProfiler`'s
counts are unchanged on both sides of the patch.

Environment: NVIDIA RTX 4090, Ubuntu 24.04, JDK 21, CUDA backend.
