### PR TITLE
[runtime] Fix silent zero output when a prebuiltTask follows a JIT task in the same graph

### DIFF
--- a/tornado-assembly/src/bin/tornado-test
+++ b/tornado-assembly/src/bin/tornado-test
@@ -150,6 +150,7 @@ __TEST_THE_WORLD__ = [
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestInts"),
     TestEntry("uk.ac.manchester.tornado.unittests.vectortypes.TestVectorAllocation"),
     TestEntry("uk.ac.manchester.tornado.unittests.prebuilt.PrebuiltTests"),
+    TestEntry("uk.ac.manchester.tornado.unittests.prebuilt.TestPrebuiltTaskOrdering"),
     TestEntry("uk.ac.manchester.tornado.unittests.cublas.TestCuBlas"),
     TestEntry("uk.ac.manchester.tornado.unittests.cublas.TestCuBlasLt"),
     TestEntry("uk.ac.manchester.tornado.unittests.cufft.TestCuFft"),

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/tasks/PrebuiltTask.java
@@ -131,8 +131,14 @@ public class PrebuiltTask implements SchedulableTask {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof CompilableTask other) {
-            return getId().equals(other.getId());
+        // This used to test `obj instanceof CompilableTask`, so a PrebuiltTask was not equal to
+        // itself. List.indexOf then never found one, and the interpreter's global-to-local task
+        // index fell back to slot 0 - handing the prebuilt task whichever code was installed for
+        // the first task of the graph.
+        if (obj instanceof PrebuiltTask other) {
+            return getId().equals(other.getId()) //
+                    && Objects.equals(entryPoint, other.entryPoint) //
+                    && Objects.equals(filename, other.filename);
         }
         return false;
     }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/TestPrebuiltTaskOrdering.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/prebuilt/TestPrebuiltTaskOrdering.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.unittests.prebuilt;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.AccessorParameters;
+import uk.ac.manchester.tornado.api.GridScheduler;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.WorkerGrid;
+import uk.ac.manchester.tornado.api.WorkerGrid1D;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.common.Access;
+import uk.ac.manchester.tornado.api.common.TornadoDevice;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * A graph whose task list mixes a JIT-compiled task with a {@code prebuiltTask} has to produce the
+ * same result whichever order the two are declared in. A prebuilt task that silently writes nothing
+ * because a JIT task was declared before it is the worst shape of failure: no exception, no warning,
+ * and a zero-filled output that a caller cannot distinguish from a legitimate result.
+ *
+ * <p>
+ * How to test?
+ * </p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.prebuilt.TestPrebuiltTaskOrdering
+ * </code>
+ */
+public class TestPrebuiltTaskOrdering extends TornadoTestBase {
+
+    private static final int SIZE = 8;
+
+    private static TornadoDevice defaultDevice;
+    private static TornadoVMBackendType backendType;
+    private static boolean coops;
+
+    @BeforeClass
+    public static void init() {
+        backendType = TornadoRuntimeProvider.getTornadoRuntime().getBackendType(0);
+        defaultDevice = TornadoRuntimeProvider.getTornadoRuntime().getBackend(0).getDevice(0);
+        coops = TornadoNativeArray.ARRAY_HEADER == 16;
+    }
+
+    private static String addKernelPath() {
+        String basePath = System.getenv("TORNADOVM_HOME") + "/examples/generated/";
+        String fileStem = coops ? "add" : "add_uncompressed";
+        String extension = switch (backendType) {
+            case OPENCL -> ".cl";
+            case METAL -> ".metal";
+            case CUDA -> ".cu";
+            default -> throw new TornadoRuntimeException("Backend not supported");
+        };
+        return basePath + fileStem + extension;
+    }
+
+    /** Writes into a buffer the prebuilt kernel does not read. */
+    public static void bias(IntArray unrelated) {
+        for (@Parallel int i = 0; i < unrelated.getSize(); i++) {
+            unrelated.set(i, unrelated.get(i) + 100);
+        }
+    }
+
+    /** Consumes the prebuilt kernel's output. */
+    public static void doubleIt(IntArray c, IntArray d) {
+        for (@Parallel int i = 0; i < c.getSize(); i++) {
+            d.set(i, c.get(i) * 2);
+        }
+    }
+
+    private static AccessorParameters addAccessors(IntArray a, IntArray b, IntArray c) {
+        AccessorParameters accessorParameters = new AccessorParameters(3);
+        accessorParameters.set(0, a, Access.READ_ONLY);
+        accessorParameters.set(1, b, Access.READ_ONLY);
+        accessorParameters.set(2, c, Access.WRITE_ONLY);
+        return accessorParameters;
+    }
+
+    /** The prebuilt task alone: the control. */
+    @Test
+    public void testPrebuiltAlone() throws TornadoExecutionPlanException {
+        IntArray a = new IntArray(SIZE);
+        IntArray b = new IntArray(SIZE);
+        IntArray c = new IntArray(SIZE);
+        a.init(1);
+        b.init(2);
+        c.init(0);
+
+        TaskGraph taskGraph = new TaskGraph("solo") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .prebuiltTask("p", "add", addKernelPath(), addAccessors(a, b, c)) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+
+        GridScheduler gridScheduler = new GridScheduler("solo.p", new WorkerGrid1D(SIZE));
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.withGridScheduler(gridScheduler).withDevice(defaultDevice).execute();
+        }
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(3, c.get(i));
+        }
+    }
+
+    /** Prebuilt first, then a JIT task that consumes its output: known to work. */
+    @Test
+    public void testPrebuiltThenJit() throws TornadoExecutionPlanException {
+        IntArray a = new IntArray(SIZE);
+        IntArray b = new IntArray(SIZE);
+        IntArray c = new IntArray(SIZE);
+        IntArray d = new IntArray(SIZE);
+        a.init(1);
+        b.init(2);
+        c.init(0);
+        d.init(0);
+
+        TaskGraph taskGraph = new TaskGraph("post") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .prebuiltTask("p", "add", addKernelPath(), addAccessors(a, b, c)) //
+                .task("j", TestPrebuiltTaskOrdering::doubleIt, c, d) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c, d);
+
+        WorkerGrid worker = new WorkerGrid1D(SIZE);
+        GridScheduler gridScheduler = new GridScheduler("post.p", worker);
+        gridScheduler.addWorkerGrid("post.j", worker);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.withGridScheduler(gridScheduler).withDevice(defaultDevice).execute();
+        }
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals(3, c.get(i));
+            assertEquals(6, d.get(i));
+        }
+    }
+
+    /** A JIT task on an unrelated buffer declared first, then the prebuilt task. */
+    @Test
+    public void testJitOnUnrelatedBufferThenPrebuilt() throws TornadoExecutionPlanException {
+        IntArray a = new IntArray(SIZE);
+        IntArray b = new IntArray(SIZE);
+        IntArray c = new IntArray(SIZE);
+        IntArray unrelated = new IntArray(SIZE);
+        a.init(1);
+        b.init(2);
+        c.init(0);
+        unrelated.init(1);
+
+        TaskGraph taskGraph = new TaskGraph("preIndep") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b, unrelated) //
+                .task("j", TestPrebuiltTaskOrdering::bias, unrelated) //
+                .prebuiltTask("p", "add", addKernelPath(), addAccessors(a, b, c)) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c, unrelated);
+
+        WorkerGrid worker = new WorkerGrid1D(SIZE);
+        GridScheduler gridScheduler = new GridScheduler("preIndep.p", worker);
+        gridScheduler.addWorkerGrid("preIndep.j", worker);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.withGridScheduler(gridScheduler).withDevice(defaultDevice).execute();
+        }
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals("the JIT task ran", 101, unrelated.get(i));
+            assertEquals("the prebuilt task ran", 3, c.get(i));
+        }
+    }
+
+    /** A JIT task that writes one of the prebuilt kernel's inputs, then the prebuilt task. */
+    @Test
+    public void testJitWritingPrebuiltInputThenPrebuilt() throws TornadoExecutionPlanException {
+        IntArray a = new IntArray(SIZE);
+        IntArray b = new IntArray(SIZE);
+        IntArray c = new IntArray(SIZE);
+        a.init(1);
+        b.init(1);
+        c.init(0);
+
+        TaskGraph taskGraph = new TaskGraph("pre") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a, b) //
+                .task("j", TestPrebuiltTaskOrdering::bias, b) //
+                .prebuiltTask("p", "add", addKernelPath(), addAccessors(a, b, c)) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c, b);
+
+        WorkerGrid worker = new WorkerGrid1D(SIZE);
+        GridScheduler gridScheduler = new GridScheduler("pre.p", worker);
+        gridScheduler.addWorkerGrid("pre.j", worker);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.withGridScheduler(gridScheduler).withDevice(defaultDevice).execute();
+        }
+        for (int i = 0; i < SIZE; i++) {
+            assertEquals("the JIT task ran", 101, b.get(i));
+            assertEquals("the prebuilt task saw the JIT task's result", 102, c.get(i));
+        }
+    }
+}


### PR DESCRIPTION
## The bug

A `prebuiltTask` declared **after** a JIT task in the same graph silently writes nothing. No
exception, no warning, no non-zero exit — the output buffer simply comes back zero-filled, which a
caller cannot tell from a legitimate result.

| graph | result |
|---|---|
| prebuilt alone | correct |
| prebuilt, then a JIT task | correct |
| **a JIT task, then prebuilt** | **output all zeros** |
| **a JIT task writing a prebuilt input, then prebuilt** | **output all zeros** |

The JIT task's own effect is present in both failing cases, so only the prebuilt task is lost.

## Root cause

`PrebuiltTask.equals` compares against the wrong type:

```java
public boolean equals(Object obj) {
    if (obj instanceof CompilableTask other) {   // never true for a PrebuiltTask
        return getId().equals(other.getId());
    }
    return false;
}
```

**A `PrebuiltTask` is therefore not equal to itself**, which breaks the reflexivity requirement of
`Object.equals` and everything built on it. The chain:

1. `localTaskList.indexOf(prebuiltTask)` searches with `equals` and always returns `-1`.
2. `TornadoVMInterpreter.globalToLocalTaskIndex` maps that miss to slot **0**:
   `localTaskList.indexOf(...) == -1 ? 0 : ...`.
3. With a JIT task at index 0, the prebuilt task now shares slot 0. `shouldCompile(installedCodes[0])`
   is false — the JIT task already installed valid code there — so **the prebuilt kernel is never
   installed**, and the JIT task's kernel is launched in its place.
4. The prebuilt task's output buffer is never written.

Instrumenting the mapping shows it directly, in both orderings:

```
[dbg] taskIndex=0 id=preIndep.j class=CompilableTask localIdx=0  localSize=2
[dbg] taskIndex=1 id=preIndep.p class=PrebuiltTask   localIdx=-1 localSize=2   <-- always -1
```

This also explains why the two working arrangements work: at index 0 the bogus slot happens to be
the correct one.

Ruled out along the way, so they are not the cause: the bytecode is correct (both `LAUNCH`es are
issued, with the right transfers and copy-out), and the launch geometry is identical to the passing
control (`[8,1,1]`).

## The fix

Compare against `PrebuiltTask`, using the same fields `hashCode` already uses, so `equals` and
`hashCode` agree:

```java
if (obj instanceof PrebuiltTask other) {
    return getId().equals(other.getId())
            && Objects.equals(entryPoint, other.entryPoint)
            && Objects.equals(filename, other.filename);
}
```

## A related hazard, deliberately left alone

`globalToLocalTaskIndex`'s `-1 → 0` fallback is what turned a lookup miss into wrong results rather
than an error. Hardening it is tempting, but an interpreter's `localTaskList` holds only the tasks
for *its* device while `taskIndex` is global, so a multi-device graph may look up a task that is
legitimately absent. Tightening that without understanding the multi-device path could break it, so
this PR fixes the miss rather than the fallback. Happy to follow up if maintainers can confirm what
the fallback is for.

## Testing

New `TestPrebuiltTaskOrdering`, 4 tests, registered in `tornado-test`, covering both working and
both failing arrangements so the asymmetry itself is the assertion. It reuses the `add` prebuilt
kernel already shipped in `examples/generated/`, so no new fixtures.

- Before: 2 pass, 2 fail (`expected:<3> but was:<0>` and `expected:<102> but was:<0>`).
- After: 4/4 pass.
- Existing `PrebuiltTests` 2/2 and `TestAtomics` 27/27 (it also uses `prebuiltTask`) unchanged.
- Full `tornado-test` suite on CUDA: **11 failures across 6 classes, identical to the `develop`
  baseline on this machine** (`TestReductionsFloats`, `TestMatrixMultiplicationKernelContext`,
  `TestProfiler`, `ComputeTests`, `TransformerKernelsTest`, `TestDevices`).
- `./mvnw checkstyle:check` clean.

The change is in backend-neutral runtime code, so all backends get it.

Environment: NVIDIA RTX 4090, Ubuntu 24.04, JDK 21, CUDA backend.
