### PR TITLE
[cuda] Cache the Graal compilation result per device so a new execution plan does not re-run the front end

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACompiledKernel.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACompiledKernel.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.drivers.cuda;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import uk.ac.manchester.tornado.runtime.domain.DomainTree;
+
+/**
+ * The outcome of running the Graal front end for one task: the generated CUDA-C (or SPIR-V)
+ * source plus the identifiers needed to install it.
+ *
+ * <p>
+ * Installed code ({@link uk.ac.manchester.tornado.drivers.cuda.graal.CUDAInstalledCode}) is
+ * cached per execution plan, because plan teardown invalidates the underlying module. The
+ * source produced by the front end has no such affinity, so it is cached once per device and
+ * reused by every later plan. Deliberately holds no {@code TaskDataContext}: the metadata of
+ * the task being compiled now is supplied at install time, so a cached entry never pins the
+ * metadata of the task that first produced it.
+ * </p>
+ *
+ * <p>
+ * {@code domain} is the parallel iteration space that shape analysis derived during that
+ * compilation. It is carried here because shape analysis only runs as part of the front end
+ * (it is skipped once a task's domain is set), so a task served from this cache would otherwise
+ * be launched with no domain at all.
+ * </p>
+ */
+public record CUDACompiledKernel(String id, String entryPoint, byte[] targetCode, ResolvedJavaMethod[] methods, DomainTree domain) {
+}

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContext.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContext.java
@@ -124,6 +124,18 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
      */
     private final Map<Long, CUDACodeCache> codeCache;
 
+    /**
+     * Front-end compilation results, cached once per device and shared by every execution plan.
+     *
+     * <p>
+     * {@link #codeCache} has to be per execution plan because plan teardown invalidates the
+     * installed module. Running the Graal front end again for each new plan is far more
+     * expensive than re-installing the module it produced, so the generated source is kept here
+     * and only the install step is repeated. Keyed by {@link #compilationCacheKey}.
+     * </p>
+     */
+    private final Map<String, CUDACompiledKernel> compiledKernelCache;
+
     public CUDADeviceContext(CUDATargetDevice device, CUDAContext context) {
         this.device = device;
         this.context = context;
@@ -139,6 +151,7 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
             this.powerMetricHandler = new CUDAEmptyPowerMetricHandler();
         }
         codeCache = new ConcurrentHashMap<>();
+        compiledKernelCache = new ConcurrentHashMap<>();
     }
 
     private boolean isDeviceContextOfNvidia() {
@@ -997,6 +1010,16 @@ public class CUDADeviceContext implements CUDADeviceContextInterface {
     @Override
     public CUDACodeCache getCodeCache(long executionPlanId) {
         return getCUDACodeCache(executionPlanId);
+    }
+
+    @Override
+    public CUDACompiledKernel getCompiledKernel(String compilationKey) {
+        return compiledKernelCache.get(compilationKey);
+    }
+
+    @Override
+    public void putCompiledKernel(String compilationKey, CUDACompiledKernel compiledKernel) {
+        compiledKernelCache.put(compilationKey, compiledKernel);
     }
 
     public long mapOnDeviceMemoryRegion(long executionPlanId, long destDevicePtr, long srcDevicePtr, long offset, int sizeOfType, long sizeSource, long sizeDest) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContextInterface.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDADeviceContextInterface.java
@@ -39,6 +39,15 @@ public interface CUDADeviceContextInterface extends TornadoDeviceContext {
 
     CUDACodeCache getCodeCache(long executionPlanId);
 
+    /**
+     * Returns the front-end compilation result cached for {@code compilationKey}, or
+     * {@code null}. Unlike installed code, these are shared by every execution plan on the
+     * device.
+     */
+    CUDACompiledKernel getCompiledKernel(String compilationKey);
+
+    void putCompiledKernel(String compilationKey, CUDACompiledKernel compiledKernel);
+
     boolean isCached(long executionPlanId, String id, String entryPoint);
 
     CUDAInstalledCode getInstalledCode(long executionPlanId, String id, String entryPoint);

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/runtime/CUDATornadoDevice.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/runtime/CUDATornadoDevice.java
@@ -64,11 +64,13 @@ import uk.ac.manchester.tornado.api.types.arrays.Int8Array;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.arrays.LongArray;
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
+import uk.ac.manchester.tornado.api.types.arrays.TornadoNativeArray;
 import uk.ac.manchester.tornado.api.memory.NativeArrayLayouts;
 import uk.ac.manchester.tornado.drivers.common.TornadoBufferProvider;
 import uk.ac.manchester.tornado.drivers.cuda.CUDABackendImpl;
 import uk.ac.manchester.tornado.drivers.cuda.CUDACodeCache;
 import uk.ac.manchester.tornado.drivers.cuda.CUDACommandQueue;
+import uk.ac.manchester.tornado.drivers.cuda.CUDACompiledKernel;
 import uk.ac.manchester.tornado.drivers.cuda.CUDADeviceContext;
 import uk.ac.manchester.tornado.drivers.cuda.CUDADeviceContextInterface;
 import uk.ac.manchester.tornado.drivers.cuda.CUDATargetDevice;
@@ -267,11 +269,41 @@ public class CUDATornadoDevice implements TornadoXPUDevice, TornadoNativeStreamS
         try {
             CUDAProviders providers = (CUDAProviders) getBackend().getProviders();
             TornadoProfiler profiler = task.getProfiler();
+
+            // The front end depends only on the sketch, the device and the task's compilation
+            // shape, none of which are tied to an execution plan. Reuse its result when an
+            // earlier plan on this device already produced it, so a new plan pays only the
+            // install step below.
+            //
+            // This deliberately does not consult shouldCompile(). The interpreter calls
+            // forceCompilation() unconditionally for the last task of every graph, so honouring
+            // it would disable this cache for any single-task graph. The states that genuinely
+            // invalidate generated code - a change of batch threads, and a batch that consumes
+            // the thread id - are both a function of the batch configuration, which
+            // compilationCacheKey() includes; updateBatchThreads() has already run by the time
+            // this executes, so the key reflects the batch about to be compiled.
+            final String compilationKey = TornadoOptions.SHARE_COMPILATION_ACROSS_PLANS ? compilationCacheKey(executable, resolvedMethod) : null;
+            CUDACompiledKernel compiledKernel = compilationKey != null ? deviceContext.getCompiledKernel(compilationKey) : null;
             profiler.start(ProfilerType.TASK_COMPILE_GRAAL_TIME, taskMeta.getId());
-            final CUDACompilationResult result = CUDACompiler.compileSketchForDevice(sketch, executable, providers, getBackend(), executable.getProfiler());
+            if (compiledKernel == null) {
+                final CUDACompilationResult result = CUDACompiler.compileSketchForDevice(sketch, executable, providers, getBackend(), executable.getProfiler());
+                compiledKernel = new CUDACompiledKernel(result.getId(), result.getName(), result.getTargetCode(), result.getMethods(), taskMeta.getDomain());
+                if (compilationKey != null) {
+                    deviceContext.putCompiledKernel(compilationKey, compiledKernel);
+                }
+            } else {
+                // A cache hit still has to leave the task's metadata in the state a fresh
+                // compilation would have left it in: the compiled graph, and the parallel
+                // domain that shape analysis would have derived. Without the domain the task is
+                // launched with no iteration space at all.
+                taskMeta.setCompiledGraph(resolvedMethod);
+                if (taskMeta.getDomain() == null) {
+                    taskMeta.setDomain(compiledKernel.domain());
+                }
+            }
 
             // Update atomics buffer for inner methods that are not inlined
-            ResolvedJavaMethod[] methods = result.getMethods();
+            ResolvedJavaMethod[] methods = compiledKernel.methods();
             if (methods.length > 1) {
                 HashMap<Integer, Integer> mapping;
                 for (ResolvedJavaMethod m : methods) {
@@ -289,8 +321,9 @@ public class CUDATornadoDevice implements TornadoXPUDevice, TornadoNativeStreamS
             profiler.sum(ProfilerType.TOTAL_GRAAL_COMPILE_TIME, profiler.getTaskTimer(ProfilerType.TASK_COMPILE_GRAAL_TIME, taskMeta.getId()));
 
             profiler.start(ProfilerType.TASK_COMPILE_DRIVER_TIME, taskMeta.getId());
-            // Compile the code
-            CUDAInstalledCode installedCode = deviceContext.installCode(executionPlanId, result);
+            // Compile the code. The metadata of the task being compiled now is used, never the
+            // metadata of whichever task first populated the cache entry.
+            CUDAInstalledCode installedCode = deviceContext.installCode(executionPlanId, taskMeta, compiledKernel.id(), compiledKernel.entryPoint(), compiledKernel.targetCode());
             profiler.stop(ProfilerType.TASK_COMPILE_DRIVER_TIME, taskMeta.getId());
             profiler.sum(ProfilerType.TOTAL_DRIVER_COMPILE_TIME, profiler.getTaskTimer(ProfilerType.TASK_COMPILE_DRIVER_TIME, taskMeta.getId()));
 
@@ -304,6 +337,73 @@ public class CUDATornadoDevice implements TornadoXPUDevice, TornadoNativeStreamS
                 throw e;
             }
         }
+    }
+
+    /**
+     * Key identifying one front-end compilation result. It covers everything
+     * {@code CUDACompiler.compileSketchForDevice} reads that can change the generated source:
+     * the method, the backend and device it was sketched for, the task's batch configuration,
+     * and the shape of its arguments.
+     *
+     * <p>
+     * Argument <em>shape</em> matters and is included: shape analysis folds concrete loop
+     * bounds into the parallel domain, so a kernel compiled for an array of one length must not
+     * be reused for another. Array lengths and scalar values are therefore part of the key,
+     * while the contents of arrays are not - installed code is already reused across executions
+     * whose array contents differ.
+     * </p>
+     *
+     * <p>
+     * Returns {@code null} when any argument's shape cannot be characterised exactly, in which
+     * case the task is compiled as before rather than cached. Wrapper types such as images,
+     * matrices and vector types carry their own dimensions, and those dimensions reach the
+     * parallel domain; rather than enumerate them here and risk two differently shaped values
+     * sharing a key, anything outside the set below opts out.
+     * </p>
+     */
+    private static String compilationCacheKey(CompilableTask task, ResolvedJavaMethod resolvedMethod) {
+        final TaskDataContext meta = task.meta();
+        final StringBuilder key = new StringBuilder(task.getId()).append('|') //
+                .append(resolvedMethod.format("%H.%n(%p)")).append('|') //
+                .append(meta.getBackendIndex()).append(':').append(meta.getDeviceIndex()).append('|') //
+                .append(meta.getNumThreads()).append('|') //
+                .append(task.getBatchThreads()).append(':').append(task.getBatchNumber()).append(':').append(task.getBatchSize()).append('|');
+        for (Object argument : task.getArguments()) {
+            if (!appendArgumentShape(key, argument)) {
+                return null;
+            }
+            key.append(',');
+        }
+        return key.toString();
+    }
+
+    /**
+     * Appends the part of {@code argument} that can change generated code: its type, plus its
+     * length for arrays or its value for scalars (a scalar can end up as a loop bound, and so
+     * as the extent of the parallel domain).
+     *
+     * @return {@code false} if this argument's shape cannot be characterised, meaning the task
+     *     must not be served from the compilation cache.
+     */
+    private static boolean appendArgumentShape(StringBuilder key, Object argument) {
+        if (argument == null) {
+            key.append("null");
+            return true;
+        }
+        key.append(argument.getClass().getName());
+        if (argument instanceof TornadoNativeArray nativeArray) {
+            key.append('[').append(nativeArray.getSize()).append(']');
+            return true;
+        }
+        if (argument.getClass().isArray()) {
+            key.append('[').append(java.lang.reflect.Array.getLength(argument)).append(']');
+            return true;
+        }
+        if (argument instanceof Number || argument instanceof Character || argument instanceof Boolean) {
+            key.append('=').append(argument);
+            return true;
+        }
+        return false;
     }
 
     private TornadoInstalledCode compilePreBuiltTask(long executionPlanId, SchedulableTask task) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/runtime/CUDATornadoDevice.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/runtime/CUDATornadoDevice.java
@@ -269,19 +269,6 @@ public class CUDATornadoDevice implements TornadoXPUDevice, TornadoNativeStreamS
         try {
             CUDAProviders providers = (CUDAProviders) getBackend().getProviders();
             TornadoProfiler profiler = task.getProfiler();
-
-            // The front end depends only on the sketch, the device and the task's compilation
-            // shape, none of which are tied to an execution plan. Reuse its result when an
-            // earlier plan on this device already produced it, so a new plan pays only the
-            // install step below.
-            //
-            // This deliberately does not consult shouldCompile(). The interpreter calls
-            // forceCompilation() unconditionally for the last task of every graph, so honouring
-            // it would disable this cache for any single-task graph. The states that genuinely
-            // invalidate generated code - a change of batch threads, and a batch that consumes
-            // the thread id - are both a function of the batch configuration, which
-            // compilationCacheKey() includes; updateBatchThreads() has already run by the time
-            // this executes, so the key reflects the batch about to be compiled.
             final String compilationKey = TornadoOptions.SHARE_COMPILATION_ACROSS_PLANS ? compilationCacheKey(executable, resolvedMethod) : null;
             CUDACompiledKernel compiledKernel = compilationKey != null ? deviceContext.getCompiledKernel(compilationKey) : null;
             profiler.start(ProfilerType.TASK_COMPILE_GRAAL_TIME, taskMeta.getId());

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/virtual/VirtualCUDADeviceContext.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/virtual/VirtualCUDADeviceContext.java
@@ -23,7 +23,9 @@
  */
 package uk.ac.manchester.tornado.drivers.cuda.virtual;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import uk.ac.manchester.tornado.api.common.Event;
 import uk.ac.manchester.tornado.api.common.SchedulableTask;
@@ -31,6 +33,7 @@ import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 import uk.ac.manchester.tornado.drivers.common.TornadoBufferProvider;
 import uk.ac.manchester.tornado.drivers.cuda.CUDABackendImpl;
 import uk.ac.manchester.tornado.drivers.cuda.CUDACodeCache;
+import uk.ac.manchester.tornado.drivers.cuda.CUDACompiledKernel;
 import uk.ac.manchester.tornado.drivers.cuda.CUDADeviceContextInterface;
 import uk.ac.manchester.tornado.drivers.cuda.CUDAProgram;
 import uk.ac.manchester.tornado.drivers.cuda.CUDATargetDevice;
@@ -46,6 +49,7 @@ public class VirtualCUDADeviceContext implements CUDADeviceContextInterface {
     private final CUDATargetDevice device;
     private final VirtualCUDAContext context;
     private final CUDACodeCache codeCache;
+    private final Map<String, CUDACompiledKernel> compiledKernelCache = new ConcurrentHashMap<>();
     private boolean wasReset;
 
     protected VirtualCUDADeviceContext(CUDATargetDevice device, VirtualCUDAContext context) {
@@ -221,6 +225,16 @@ public class VirtualCUDADeviceContext implements CUDADeviceContextInterface {
     @Override
     public CUDACodeCache getCodeCache(long executionPlanId) {
         return codeCache;
+    }
+
+    @Override
+    public CUDACompiledKernel getCompiledKernel(String compilationKey) {
+        return compiledKernelCache.get(compilationKey);
+    }
+
+    @Override
+    public void putCompiledKernel(String compilationKey, CUDACompiledKernel compiledKernel) {
+        compiledKernelCache.put(compilationKey, compiledKernel);
     }
 
     @Override

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/TornadoOptions.java
@@ -222,6 +222,15 @@ public class TornadoOptions {
      * code. This option is True by default.
      */
     public static final boolean RECOVER_BAILOUT = getBooleanValue("tornado.recover.bailout", TRUE);
+
+    /**
+     * Share the result of the Graal front end across execution plans, instead of re-running it
+     * for every new {@code TornadoExecutionPlan}. Installed modules stay per execution plan;
+     * only the generated source is reused, so a new plan pays the (much cheaper) install step
+     * alone. This option is True by default; set it to False to restore the previous behaviour
+     * of compiling from scratch for each plan.
+     */
+    public static final boolean SHARE_COMPILATION_ACROSS_PLANS = getBooleanValue("tornado.compilation.share", TRUE);
     /**
      * Option to log the IP of the current machine on the profiler logs.
      */

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compiler/TestSharedCompilationCache.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compiler/TestSharedCompilationCache.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package uk.ac.manchester.tornado.unittests.compiler;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * The result of the Graal front end is cached per device and shared by every execution plan, so
+ * that creating a new {@link TornadoExecutionPlan} does not re-run the whole JIT pipeline. These
+ * tests pin the cases where a cached entry must NOT be reused: shape analysis folds concrete
+ * loop bounds into the parallel domain, so anything that changes the iteration space has to miss
+ * the cache.
+ *
+ * <p>
+ * How to run?
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.compiler.TestSharedCompilationCache
+ * </code>
+ * </p>
+ */
+public class TestSharedCompilationCache extends TornadoTestBase {
+
+    public static void twice(FloatArray in, FloatArray out) {
+        for (@Parallel int i = 0; i < in.getSize(); i++) {
+            out.set(i, in.get(i) * 2.0f);
+        }
+    }
+
+    public static void fill(IntArray out, int limit) {
+        for (@Parallel int i = 0; i < limit; i++) {
+            out.set(i, i + 1);
+        }
+    }
+
+    /**
+     * Runs the same task graph and task name in a fresh execution plan each time, so every call
+     * after the first is served from the shared compilation cache.
+     */
+    private static void runTwice(int numElements) throws TornadoExecutionPlanException {
+        FloatArray in = new FloatArray(numElements);
+        FloatArray out = new FloatArray(numElements);
+        in.init(1.0f);
+        out.init(-1.0f);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, in) //
+                .task("t0", TestSharedCompilationCache::twice, in, out) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < numElements; i++) {
+            assertEquals("element " + i + " of " + numElements, 2.0f, out.get(i), 0.0f);
+        }
+    }
+
+    /**
+     * A second plan reusing the first plan's compiled code must still produce correct results.
+     */
+    @Test
+    public void testRepeatedExecutionPlansSameSize() throws TornadoExecutionPlanException {
+        runTwice(1024);
+        runTwice(1024);
+        runTwice(1024);
+    }
+
+    /**
+     * The parallel domain is derived from the array length at compile time, so a larger array in
+     * a later plan must not inherit the smaller iteration space. Growing the size is the case
+     * that silently under-computes if the cache ignores argument shape.
+     */
+    @Test
+    public void testExecutionPlansWithDifferentSizes() throws TornadoExecutionPlanException {
+        runTwice(1024);
+        runTwice(4096);
+        runTwice(256);
+        runTwice(4096);
+    }
+
+    /**
+     * Same here for a scalar that bounds the parallel loop: it is folded into the domain, so two
+     * plans differing only in that value must not share compiled code.
+     */
+    @Test
+    public void testExecutionPlansWithDifferentScalarBounds() throws TornadoExecutionPlanException {
+        for (int limit : new int[] { 128, 512, 64, 512 }) {
+            IntArray out = new IntArray(512);
+            out.init(0);
+
+            TaskGraph taskGraph = new TaskGraph("s1") //
+                    .transferToDevice(DataTransferMode.EVERY_EXECUTION, out) //
+                    .task("t0", TestSharedCompilationCache::fill, out, limit) //
+                    .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+            try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+                executionPlan.execute();
+            }
+
+            for (int i = 0; i < limit; i++) {
+                assertEquals("limit " + limit + ", element " + i, i + 1, out.get(i));
+            }
+            for (int i = limit; i < 512; i++) {
+                assertEquals("limit " + limit + ", element " + i + " must be untouched", 0, out.get(i));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The in-memory code cache is scoped per execution plan:
`CUDADeviceContext` keeps a `Map<executionPlanId, CUDACodeCache>`, and plan teardown clears the
entry. A new `TornadoExecutionPlan` therefore starts empty and re-runs the entire Graal front
end for tasks it has already compiled.

Profiling a single-task graph on an RTX 4090 (n=32768), on a freshly created plan:

| Phase | Time |
|---|---|
| `TASK_COMPILE_GRAAL_TIME` | **3.28 ms** |
| `TASK_CODE_GENERATION_TIME` | 0.34 ms |
| `TASK_COMPILE_DRIVER_TIME` (NVRTC) | 0.19 ms |
| `TASK_KERNEL_TIME` (actual GPU work) | **0.005 ms** |

The front end costs roughly **620x the kernel it produces**. NVRTC is not the problem - the
on-disk cubin cache already covers it, and disabling it (`-Dtornado.cuda.codecache.enable=false`)
changes nothing measurable (2.777 vs 2.962 ms). The repeated cost is Graal-side.

This penalty is a fixed ~2.8 ms per plan regardless of problem size, so it hits hardest exactly
where TornadoVM is otherwise cheapest. It matters for any code that builds many short-lived
plans, which is the natural shape for a library that maps an existing API onto TornadoVM.

## Change

Installed code stays per execution plan - plan teardown invalidates the underlying module, and
sharing module handles across concurrent plans would not be safe. What is shared is the *result
of the front end*: the generated source is cached once per device and every later plan pays only
the install step.

`CUDAInstalledCode` already takes `executionPlanId` as a launch-time parameter and holds no
plan-specific state, and `CUDAContext` is created per platform, so this does not change any
module or stream lifetime.

New option `tornado.compilation.share` (default `True`) restores the old behaviour when set to
`False`.

## Results

Cost of creating a plan, running one task, and closing it (RTX 4090, CUDA 12.6, JDK 21):

| n | before | after | speedup |
|---|---|---|---|
| 4 096 | 2.886 ms | 1.226 ms | **2.35x** |
| 32 768 | 2.847 ms | 1.238 ms | **2.30x** |
| 262 144 | 3.349 ms | 1.745 ms | **1.92x** |
| 1 048 576 | 4.927 ms | 3.304 ms | **1.49x** |

`TASK_COMPILE_GRAAL_TIME` drops from 3.28 ms to 0.0011 ms. The reused-plan path is unchanged
(0.046 -> 0.046 ms at n=4096, 0.733 -> 0.727 ms at n=1M), i.e. no cost is added to code that
already reuses a plan. Residual fresh-plan cost is now buffer allocation, module install and
stream setup rather than Graal.

## Correctness

Two traps, both covered by the new tests:

1. **Shape analysis folds concrete loop bounds into the parallel domain**, so compilation is
   specialised to argument *sizes*, not just types. A type-only key silently under-computes: a
   4096-element array served from a 1024-element entry left 3072 elements stale. Array lengths
   and scalar values are part of the key.
2. **`meta.setDomain(...)` is a side effect of the front end** and is skipped once a domain is
   set. A cache hit that does not restore it launches the task with no iteration space, which
   measured ~48x slower at 1M elements. The domain is carried in the cache entry and restored.

The key is conservative: it covers task id, method, backend/device index, batch configuration
and argument shape, and **returns `null` for any argument whose shape cannot be characterised
exactly** - images, matrices and vector types carry their own dimensions, so rather than
enumerate them and risk a collision, those tasks compile as they did before. An earlier revision
that lacked this opt-out regressed `TestImages` (+11) and `vectortypes.TestFloats` (+1); with it,
the failing set is identical to baseline.

It deliberately does not consult `shouldCompile()`: `TornadoVMInterpreter` calls
`forceCompilation()` unconditionally for the last task of every graph, so honouring it would
disable the cache for every single-task graph. The states that genuinely invalidate code (batch
threads change, and a batch consuming the thread id) are functions of the batch configuration,
which the key includes, and `updateBatchThreads()` has already run by that point.

## Testing

- New `uk.ac.manchester.tornado.unittests.compiler.TestSharedCompilationCache` (3 tests, pass):
  repeated plans at one size, plans at differing sizes, and plans differing only in a scalar
  loop bound.
- `tornado-test --quickPass` on CUDA/RTX 4090, both arms of `tornado.compilation.share` on the
  same build: **1162 ran, 8 failed, 77 unsupported in both**, with an identical set of failing
  classes (all pre-existing: `TestDevices`, `ComputeTests`, `TransformerKernelsTest`,
  `TestMatrixMultiplicationKernelContext`, `TestReductionsFloats`).
- `./mvnw checkstyle:check` clean.

## Notes

OpenCL and Metal have the same per-plan cache structure (`Map<Long, OCLCodeCache>`,
`Map<Long, MetalCodeCache>`) and the same opportunity. This PR is CUDA-only so the approach can
be reviewed on hardware I can actually measure on; the other backends are a natural follow-up.
