### PR TITLE
[hotfix] Emit a switch statement for the table and hash switch lowerings instead of nothing

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/CUDALIRGenerator.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/graal/compiler/CUDALIRGenerator.java
@@ -278,14 +278,36 @@ public class CUDALIRGenerator extends LIRGenerator {
         append(new CUDAControlFlow.SwitchOp(key, strategy.getKeyConstants(), keyTargets, defaultTarget));
     }
 
+    /**
+     * Graal picks this lowering over {@link #emitStrategySwitch} once the keys are dense enough to
+     * be worth a jump table. A jump table is a machine-code notion, though, and this backend emits
+     * C source, so the right output is the same {@code switch} statement in either case - what to
+     * do with it is the C compiler's decision.
+     *
+     * <p>
+     * Emitting nothing here is not an option: the case labels come from
+     * {@code CUDAStructuredControlFlow}, which reads them off the {@code IntegerSwitchNode} in the
+     * HIR, so without this the kernel gets case labels with no enclosing switch. NVRTC rejects it
+     * and TornadoVM falls back to running the method on the host - which silently yields wrong
+     * results whenever the data it reads is device-resident.
+     * </p>
+     */
     @Override
     protected void emitRangeTableSwitch(int lowKey, LabelRef defaultTarget, LabelRef[] targets, AllocatableValue key) {
-
+        JavaConstant[] keyConstants = new JavaConstant[targets.length];
+        for (int i = 0; i < targets.length; i++) {
+            keyConstants[i] = JavaConstant.forInt(lowKey + i);
+        }
+        append(new CUDAControlFlow.SwitchOp(key, keyConstants, targets, defaultTarget));
     }
 
+    /**
+     * As {@link #emitRangeTableSwitch}: the hashed form exists to index a table, which a C
+     * {@code switch} on the original value expresses directly. The hash itself is unused.
+     */
     @Override
     protected void emitHashTableSwitch(JavaConstant[] keys, LabelRef defaultTarget, LabelRef[] targets, AllocatableValue value, Value hash) {
-
+        append(new CUDAControlFlow.SwitchOp(value, keys, targets, defaultTarget));
     }
 
     @Override

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/MetalLIRGenerator.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/graal/compiler/MetalLIRGenerator.java
@@ -297,14 +297,36 @@ public class MetalLIRGenerator extends LIRGenerator {
         append(new MetalControlFlow.SwitchOp(key, strategy.getKeyConstants(), keyTargets, defaultTarget));
     }
 
+    /**
+     * Graal picks this lowering over {@link #emitStrategySwitch} once the keys are dense enough to
+     * be worth a jump table. A jump table is a machine-code notion, though, and this backend emits
+     * source code, so the right output is the same {@code switch} statement in either case - what
+     * to do with it is the source compiler's decision.
+     *
+     * <p>
+     * Emitting nothing here is not an option: the case labels come from the structured control-flow
+     * pass, which reads them off the {@code IntegerSwitchNode} in the HIR, so without this the
+     * kernel gets case labels with no enclosing switch, fails to build, and TornadoVM falls back to
+     * running the method on the host - which silently yields wrong results whenever the data it
+     * reads is device-resident.
+     * </p>
+     */
     @Override
     protected void emitRangeTableSwitch(int lowKey, LabelRef defaultTarget, LabelRef[] targets, AllocatableValue key) {
-
+        JavaConstant[] keyConstants = new JavaConstant[targets.length];
+        for (int i = 0; i < targets.length; i++) {
+            keyConstants[i] = JavaConstant.forInt(lowKey + i);
+        }
+        append(new MetalControlFlow.SwitchOp(key, keyConstants, targets, defaultTarget));
     }
 
+    /**
+     * As {@link #emitRangeTableSwitch}: the hashed form exists to index a table, which a
+     * {@code switch} on the original value expresses directly. The hash itself is unused.
+     */
     @Override
     protected void emitHashTableSwitch(JavaConstant[] keys, LabelRef defaultTarget, LabelRef[] targets, AllocatableValue value, Value hash) {
-
+        append(new MetalControlFlow.SwitchOp(value, keys, targets, defaultTarget));
     }
 
     @Override

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLIRGenerator.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/compiler/OCLLIRGenerator.java
@@ -278,14 +278,36 @@ public class OCLLIRGenerator extends LIRGenerator {
         append(new OCLControlFlow.SwitchOp(key, strategy.getKeyConstants(), keyTargets, defaultTarget));
     }
 
+    /**
+     * Graal picks this lowering over {@link #emitStrategySwitch} once the keys are dense enough to
+     * be worth a jump table. A jump table is a machine-code notion, though, and this backend emits
+     * source code, so the right output is the same {@code switch} statement in either case - what
+     * to do with it is the source compiler's decision.
+     *
+     * <p>
+     * Emitting nothing here is not an option: the case labels come from the structured control-flow
+     * pass, which reads them off the {@code IntegerSwitchNode} in the HIR, so without this the
+     * kernel gets case labels with no enclosing switch, fails to build, and TornadoVM falls back to
+     * running the method on the host - which silently yields wrong results whenever the data it
+     * reads is device-resident.
+     * </p>
+     */
     @Override
     protected void emitRangeTableSwitch(int lowKey, LabelRef defaultTarget, LabelRef[] targets, AllocatableValue key) {
-
+        JavaConstant[] keyConstants = new JavaConstant[targets.length];
+        for (int i = 0; i < targets.length; i++) {
+            keyConstants[i] = JavaConstant.forInt(lowKey + i);
+        }
+        append(new OCLControlFlow.SwitchOp(key, keyConstants, targets, defaultTarget));
     }
 
+    /**
+     * As {@link #emitRangeTableSwitch}: the hashed form exists to index a table, which a
+     * {@code switch} on the original value expresses directly. The hash itself is unused.
+     */
     @Override
     protected void emitHashTableSwitch(JavaConstant[] keys, LabelRef defaultTarget, LabelRef[] targets, AllocatableValue value, Value hash) {
-
+        append(new OCLControlFlow.SwitchOp(value, keys, targets, defaultTarget));
     }
 
     @Override

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compiler/TestSwitchLowering.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/compiler/TestSwitchLowering.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package uk.ac.manchester.tornado.unittests.compiler;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.annotations.Parallel;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+
+/**
+ * Graal turns a long enough chain of {@code x == constant} tests into an {@code IntegerSwitchNode},
+ * and then chooses between three lowerings by key density. The backends emit source code, where a
+ * jump table has no meaning, so all three have to produce the same {@code switch} statement.
+ *
+ * <p>
+ * These tests cover the dense case, which selects the range-table lowering. When that lowering
+ * emits nothing, the case labels - which come from the structured control-flow pass reading the
+ * HIR - are left without an enclosing switch, the kernel fails to build, and execution silently
+ * falls back to the host.
+ * </p>
+ *
+ * <p>
+ * How to run?
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.compiler.TestSwitchLowering
+ * </code>
+ * </p>
+ */
+public class TestSwitchLowering extends TornadoTestBase {
+
+    private static final int NUM_ELEMENTS = 256;
+
+    /** Sixteen dense keys written as an if-else chain, which Graal converts to a switch. */
+    public static void chain16(FloatArray out, FloatArray in, IntArray selector, int n) {
+        int op = selector.get(0);
+        for (@Parallel int i = 0; i < n; i++) {
+            float a = in.get(i);
+            float r;
+            if (op == 0) {
+                r = a + 0.0f;
+            } else if (op == 1) {
+                r = a + 1.0f;
+            } else if (op == 2) {
+                r = a + 2.0f;
+            } else if (op == 3) {
+                r = a + 3.0f;
+            } else if (op == 4) {
+                r = a + 4.0f;
+            } else if (op == 5) {
+                r = a + 5.0f;
+            } else if (op == 6) {
+                r = a + 6.0f;
+            } else if (op == 7) {
+                r = a + 7.0f;
+            } else if (op == 8) {
+                r = a + 8.0f;
+            } else if (op == 9) {
+                r = a + 9.0f;
+            } else if (op == 10) {
+                r = a + 10.0f;
+            } else if (op == 11) {
+                r = a + 11.0f;
+            } else if (op == 12) {
+                r = a + 12.0f;
+            } else if (op == 13) {
+                r = a + 13.0f;
+            } else if (op == 14) {
+                r = a + 14.0f;
+            } else if (op == 15) {
+                r = a + 15.0f;
+            } else {
+                r = -1.0f;
+            }
+            out.set(i, r);
+        }
+    }
+
+    /** The same shape written as a switch statement. */
+    public static void switch16(FloatArray out, FloatArray in, IntArray selector, int n) {
+        int op = selector.get(0);
+        for (@Parallel int i = 0; i < n; i++) {
+            float a = in.get(i);
+            float r;
+            switch (op) {
+                case 0 -> r = a * 1.0f;
+                case 1 -> r = a * 2.0f;
+                case 2 -> r = a * 3.0f;
+                case 3 -> r = a * 4.0f;
+                case 4 -> r = a * 5.0f;
+                case 5 -> r = a * 6.0f;
+                case 6 -> r = a * 7.0f;
+                case 7 -> r = a * 8.0f;
+                case 8 -> r = a * 9.0f;
+                case 9 -> r = a * 10.0f;
+                case 10 -> r = a * 11.0f;
+                case 11 -> r = a * 12.0f;
+                case 12 -> r = a * 13.0f;
+                case 13 -> r = a * 14.0f;
+                case 14 -> r = a * 15.0f;
+                case 15 -> r = a * 16.0f;
+                default -> r = -1.0f;
+            }
+            out.set(i, r);
+        }
+    }
+
+    @Test
+    public void testDenseIfElseChain() throws TornadoExecutionPlanException {
+        FloatArray in = new FloatArray(NUM_ELEMENTS);
+        FloatArray out = new FloatArray(NUM_ELEMENTS);
+        IntArray selector = new IntArray(1);
+        in.init(10.0f);
+
+        TaskGraph taskGraph = new TaskGraph("s0") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, in, selector) //
+                .task("t0", TestSwitchLowering::chain16, out, in, selector, NUM_ELEMENTS) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            for (int op = 0; op < 16; op++) {
+                selector.set(0, op);
+                out.init(Float.NaN);
+                executionPlan.execute();
+                for (int i = 0; i < NUM_ELEMENTS; i++) {
+                    assertEquals("op " + op + ", element " + i, 10.0f + op, out.get(i), 0.0f);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testDenseSwitchStatement() throws TornadoExecutionPlanException {
+        FloatArray in = new FloatArray(NUM_ELEMENTS);
+        FloatArray out = new FloatArray(NUM_ELEMENTS);
+        IntArray selector = new IntArray(1);
+        in.init(2.0f);
+
+        TaskGraph taskGraph = new TaskGraph("s1") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, in, selector) //
+                .task("t0", TestSwitchLowering::switch16, out, in, selector, NUM_ELEMENTS) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            for (int op = 0; op < 16; op++) {
+                selector.set(0, op);
+                out.init(Float.NaN);
+                executionPlan.execute();
+                for (int i = 0; i < NUM_ELEMENTS; i++) {
+                    assertEquals("op " + op + ", element " + i, 2.0f * (op + 1), out.get(i), 0.0f);
+                }
+            }
+        }
+    }
+
+    /** The default arm must still be reachable when the keys are dense. */
+    @Test
+    public void testDefaultArm() throws TornadoExecutionPlanException {
+        FloatArray in = new FloatArray(NUM_ELEMENTS);
+        FloatArray out = new FloatArray(NUM_ELEMENTS);
+        IntArray selector = new IntArray(1);
+        in.init(10.0f);
+
+        TaskGraph taskGraph = new TaskGraph("s2") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, in, selector) //
+                .task("t0", TestSwitchLowering::chain16, out, in, selector, NUM_ELEMENTS) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, out);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            selector.set(0, 99);
+            executionPlan.execute();
+            for (int i = 0; i < NUM_ELEMENTS; i++) {
+                assertEquals("element " + i, -1.0f, out.get(i), 0.0f);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1053.

## Problem

A Java `if / else if` chain of 12 or more `intVar == constant` tests inside a kernel produced
source containing `case` labels with **no enclosing `switch` statement**. The kernel then failed
to build and TornadoVM fell back to running the method sequentially **on the host**.

That fallback is what makes this more than a compilation failure: for a kernel whose data stays
device-resident across dispatches, the host copies are stale, so the program silently produced
**wrong results** rather than merely slow ones.

Observed on both backends I can run here (RTX 4090):

```
# CUDA
tornado_kernel.cu(27): error: a case label may only be used within a switch
[Bailout] Running the sequential implementation.

# OpenCL
<kernel>:30:5: error: 'case' statement not in switch statement
```

Bisected with generated kernels: 8/9/10/11 branches fine, 12/13/14/16/20/24/32/35 broken.

## Cause

Graal converts a long enough chain of equality tests into an `IntegerSwitchNode`, then chooses
between three lowerings by key density. The backends implemented only one of them:

```java
@Override
public void emitStrategySwitch(SwitchStrategy strategy, AllocatableValue key, LabelRef[] keyTargets, LabelRef defaultTarget) {
    append(new CUDAControlFlow.SwitchOp(key, strategy.getKeyConstants(), keyTargets, defaultTarget));
}

@Override
protected void emitRangeTableSwitch(int lowKey, LabelRef defaultTarget, LabelRef[] targets, AllocatableValue key) {
}   // empty

@Override
protected void emitHashTableSwitch(JavaConstant[] keys, LabelRef defaultTarget, LabelRef[] targets, AllocatableValue value, Value hash) {
}   // empty
```

With 12 consecutive keys the density check selects the **range table** lowering, which appended no
LIR, so `SwitchOp` - the thing that emits `switch (x) {` - never ran. The `case` labels still
appeared because the structured control-flow pass derives them from the `IntegerSwitchNode` in the
HIR, not from the LIR, leaving labels with no header.

## Change

Route the two missing lowerings to the same `SwitchOp`. A jump table is a machine-code concept;
these backends emit source, so the correct output for all three lowerings is a plain `switch`, and
the downstream compiler (NVRTC, the OpenCL compiler, Metal) decides how to implement it.

`SwitchOp.emitCode` only emits the `switch (value) {` header - the case labels and bodies already
come from the HIR walker - so this is the minimal change that makes the emitted source well formed.

Applied to CUDA, OpenCL and Metal, which all carried the identical pair of empty stubs.

## Testing

New `uk.ac.manchester.tornado.unittests.compiler.TestSwitchLowering`: a dense 16-branch if-else
chain, the same shape written as a `switch`, and the default arm. It fails before this change and
passes after.

Verified on an RTX 4090 (CUDA 12.6, JDK 21), running the test explicitly against each backend:

| backend | before | after |
|---|---|---|
| CUDA (`1:0`) | miscompiled, host fallback | 3/3 pass |
| OpenCL (`0:0`) | miscompiled, host fallback | 3/3 pass |

`tornado-test --quickPass` with `BACKEND=opencl,cuda`, patched vs. unmodified `develop` on the same
machine: **1171 ran, 8 failed, 272 unsupported in both**, with an identical set of failing classes
(all pre-existing). `./mvnw checkstyle:check` clean.

Metal is changed identically but I have no Apple hardware to verify it on.
