### PR TITLE
[curand] Add a cuRAND library-task provider for device-side random number generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -816,6 +816,7 @@
         <module>tornado-api</module>
         <module>tornado-annotation</module>
         <module>tornado-cublas</module>
+        <module>tornado-curand</module>
         <module>tornado-cufft</module>
         <module>tornado-cudnn</module>
         <module>tornado-cusparse</module>

--- a/tornado-assembly/assembly.xml
+++ b/tornado-assembly/assembly.xml
@@ -178,6 +178,7 @@
                 <include>io.github.beehive-lab:tornado-benchmarks</include>
                 <include>io.github.beehive-lab:tornado-unittests</include>
                 <include>io.github.beehive-lab:tornado-cublas</include>
+                <include>io.github.beehive-lab:tornado-curand</include>
                 <include>io.github.beehive-lab:tornado-cufft</include>
                 <include>io.github.beehive-lab:tornado-cudnn</include>
                 <include>io.github.beehive-lab:tornado-cusparse</include>

--- a/tornado-assembly/pom.xml
+++ b/tornado-assembly/pom.xml
@@ -107,6 +107,11 @@
                 </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
+                    <artifactId>tornado-curand</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
                     <artifactId>tornado-cufft</artifactId>
                     <version>${project.version}</version>
                 </dependency>

--- a/tornado-assembly/src/bin/tornado.py
+++ b/tornado-assembly/src/bin/tornado.py
@@ -71,6 +71,7 @@ __CUDA_MODULE__ = "tornado.drivers.cuda"
 __ENABLE_NATIVE_ACCESS__ = "--enable-native-access="
 __FFM_MODULE__ = "tornado.runtime"
 __CUBLAS_MODULE__ = "tornado.cublas"
+__CURAND_MODULE__ = "tornado.curand"
 __CUFFT_MODULE__ = "tornado.cufft"
 __CUDNN_MODULE__ = "tornado.cudnn"
 __CUSPARSE_MODULE__ = "tornado.cusparse"
@@ -1333,7 +1334,7 @@ class TornadoVMRunnerTool():
             tornadoAddModules = tornadoAddModules + "," + __METAL_MODULE__
         if ("cuda-backend" in self.listOfBackends):
             javaFlags = javaFlags + "@" + cuda + " "
-            tornadoAddModules = tornadoAddModules + "," + __CUDA_MODULE__ + "," + __CUBLAS_MODULE__ + "," + __CUFFT_MODULE__ + "," + __CUDNN_MODULE__ + "," + __CUSPARSE_MODULE__ + "," + __CUTLASS_MODULE__
+            tornadoAddModules = tornadoAddModules + "," + __CUDA_MODULE__ + "," + __CUBLAS_MODULE__ + "," + __CURAND_MODULE__ + "," + __CUFFT_MODULE__ + "," + __CUDNN_MODULE__ + "," + __CUSPARSE_MODULE__ + "," + __CUTLASS_MODULE__
 
         javaFlags = javaFlags + tornadoAddModules + " "
 

--- a/tornado-curand/pom.xml
+++ b/tornado-curand/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.beehive-lab</groupId>
+        <artifactId>tornado</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>tornado-curand</artifactId>
+    <name>tornado-curand</name>
+    <description>TornadoVM cuBLAS bindings: NVIDIA cuBLAS library tasks for TornadoVM task graphs</description>
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tornado-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tornado-runtime</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <developers>
+        <developer>
+            <id>beehive-lab</id>
+            <name>Beehive Lab</name>
+            <email>info@tornadovm.org</email>
+        </developer>
+    </developers>
+    <scm>
+        <connection>scm:git:https://github.com/beehive-lab/tornadovm.git</connection>
+        <developerConnection>scm:git:https://github.com/beehive-lab/tornadovm.git</developerConnection>
+        <url>https://github.com/beehive-lab/tornadovm</url>
+    </scm>
+</project>

--- a/tornado-curand/src/main/java/module-info.java
+++ b/tornado-curand/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+open module tornado.curand {
+    requires transitive tornado.api;
+    requires tornado.runtime;
+
+    exports uk.ac.manchester.tornado.curand;
+    exports uk.ac.manchester.tornado.curand.enums;
+    exports uk.ac.manchester.tornado.curand.provider;
+
+    provides uk.ac.manchester.tornado.runtime.library.spi.TornadoLibraryProvider with //
+            uk.ac.manchester.tornado.curand.provider.CuRandLibraryProvider;
+}

--- a/tornado-curand/src/main/java/uk/ac/manchester/tornado/curand/CuRand.java
+++ b/tornado-curand/src/main/java/uk/ac/manchester/tornado/curand/CuRand.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package uk.ac.manchester.tornado.curand;
+
+import java.util.Arrays;
+
+import uk.ac.manchester.tornado.api.common.Access;
+import uk.ac.manchester.tornado.api.common.LibraryTaskDescriptor;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.curand.enums.CuRandRngType;
+
+/**
+ * Random number generation on the device through NVIDIA cuRAND, as a TornadoVM library task.
+ *
+ * <p>
+ * The numbers are written straight into a TornadoVM array that is already on the device, so a
+ * simulation that needs random input does not generate it on the host and upload it. Generation is
+ * issued on the execution plan's own CUDA stream, so it is ordered against the kernels and
+ * transfers of the same task graph like any other task.
+ * </p>
+ *
+ * <p>
+ * Typical use, filling a slice of a larger device-resident buffer:
+ * </p>
+ *
+ * <pre>{@code
+ * TaskGraph graph = new TaskGraph("rng")
+ *         .transferToDevice(DataTransferMode.FIRST_EXECUTION, buffer)
+ *         .libraryTask("normals", CuRand::generateNormal, buffer, offset, count, 0.0f, 1.0f)
+ *         .persistOnDevice(buffer);
+ * }</pre>
+ *
+ * <p>
+ * cuRAND generates normals in pairs, so {@code count} must be even for the single-precision
+ * {@code generateNormal}; an odd count is rejected with {@code CURAND_STATUS_LENGTH_NOT_MULTIPLE}.
+ * </p>
+ */
+public final class CuRand {
+
+    public static final String LIBRARY_NAME = "nvidia/curand";
+
+    /** Seed used unless one is given; matches cuRAND's own default. */
+    public static final long DEFAULT_SEED = 0L;
+
+    private CuRand() {
+    }
+
+    /**
+     * Access flags for a generator call: every argument is read except the destination, which is
+     * READ_WRITE rather than WRITE_ONLY.
+     *
+     * <p>
+     * The distinction matters because a call usually fills a slice of a larger device-resident
+     * buffer. Declaring the destination write-only tells TornadoVM the whole buffer is produced
+     * here, and everything outside the slice would be treated as no longer valid.
+     * </p>
+     */
+    private static Access[] writesInto(int numArgs, int outputIndex) {
+        Access[] accesses = new Access[numArgs];
+        Arrays.fill(accesses, Access.READ_ONLY);
+        accesses[outputIndex] = Access.READ_WRITE;
+        return accesses;
+    }
+
+
+    /**
+     * Fills {@code count} elements of {@code output}, starting at {@code elementOffset}, with
+     * normally distributed single-precision values.
+     *
+     * @param output
+     *     Device-resident destination.
+     * @param elementOffset
+     *     First element to write, in elements.
+     * @param count
+     *     How many values to write. Must be even.
+     * @param mean
+     *     Mean of the distribution.
+     * @param stddev
+     *     Standard deviation of the distribution.
+     */
+    public static LibraryTaskDescriptor generateNormal(FloatArray output, int elementOffset, int count, float mean, float stddev) {
+        return generateNormal(output, elementOffset, count, mean, stddev, DEFAULT_SEED);
+    }
+
+    /** As {@link #generateNormal(FloatArray, int, int, float, float)}, with an explicit seed. */
+    public static LibraryTaskDescriptor generateNormal(FloatArray output, int elementOffset, int count, float mean, float stddev, long seed) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("curandGenerateNormal") //
+                .withParameters(new Object[] { output, elementOffset, count, mean, stddev, seed }) //
+                .withAccess(writesInto(6, 0));
+    }
+
+    /** Double-precision {@link #generateNormal(FloatArray, int, int, float, float)}. */
+    public static LibraryTaskDescriptor generateNormal(DoubleArray output, int elementOffset, int count, double mean, double stddev) {
+        return generateNormal(output, elementOffset, count, mean, stddev, DEFAULT_SEED);
+    }
+
+    /** As {@link #generateNormal(DoubleArray, int, int, double, double)}, with an explicit seed. */
+    public static LibraryTaskDescriptor generateNormal(DoubleArray output, int elementOffset, int count, double mean, double stddev, long seed) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("curandGenerateNormalDouble") //
+                .withParameters(new Object[] { output, elementOffset, count, mean, stddev, seed }) //
+                .withAccess(writesInto(6, 0));
+    }
+
+    /** Uniform values on (0, 1]. */
+    public static LibraryTaskDescriptor generateUniform(FloatArray output, int elementOffset, int count) {
+        return generateUniform(output, elementOffset, count, DEFAULT_SEED);
+    }
+
+    /** As {@link #generateUniform(FloatArray, int, int)}, with an explicit seed. */
+    public static LibraryTaskDescriptor generateUniform(FloatArray output, int elementOffset, int count, long seed) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("curandGenerateUniform") //
+                .withParameters(new Object[] { output, elementOffset, count, seed }) //
+                .withAccess(writesInto(4, 0));
+    }
+
+    /** Double-precision {@link #generateUniform(FloatArray, int, int)}. */
+    public static LibraryTaskDescriptor generateUniform(DoubleArray output, int elementOffset, int count) {
+        return generateUniform(output, elementOffset, count, DEFAULT_SEED);
+    }
+
+    /** As {@link #generateUniform(DoubleArray, int, int)}, with an explicit seed. */
+    public static LibraryTaskDescriptor generateUniform(DoubleArray output, int elementOffset, int count, long seed) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("curandGenerateUniformDouble") //
+                .withParameters(new Object[] { output, elementOffset, count, seed }) //
+                .withAccess(writesInto(4, 0));
+    }
+
+    /** Options selecting the generator; attach with {@code withTuning}. */
+    public static LibraryTaskDescriptor withGenerator(LibraryTaskDescriptor descriptor, CuRandRngType rngType) {
+        return descriptor.withTuning(rngType);
+    }
+}

--- a/tornado-curand/src/main/java/uk/ac/manchester/tornado/curand/enums/CuRandRngType.java
+++ b/tornado-curand/src/main/java/uk/ac/manchester/tornado/curand/enums/CuRandRngType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package uk.ac.manchester.tornado.curand.enums;
+
+/**
+ * Pseudo-random generators of {@code curandRngType_t}, with the values cuRAND uses.
+ *
+ * @see <a href="https://docs.nvidia.com/cuda/curand/group__HOST.html">cuRAND host API</a>
+ */
+public enum CuRandRngType {
+
+    /** Whatever cuRAND considers a good default; currently XORWOW. */
+    CURAND_RNG_PSEUDO_DEFAULT(100),
+    CURAND_RNG_PSEUDO_XORWOW(101),
+    CURAND_RNG_PSEUDO_MRG32K3A(121),
+    CURAND_RNG_PSEUDO_MTGP32(141),
+    CURAND_RNG_PSEUDO_MT19937(142),
+    /** Counter-based; the cheapest of the pseudo-random generators for bulk normals. */
+    CURAND_RNG_PSEUDO_PHILOX4_32_10(161);
+
+    private final int value;
+
+    CuRandRngType(int value) {
+        this.value = value;
+    }
+
+    public int value() {
+        return value;
+    }
+}

--- a/tornado-curand/src/main/java/uk/ac/manchester/tornado/curand/provider/CuRandLibraryProvider.java
+++ b/tornado-curand/src/main/java/uk/ac/manchester/tornado/curand/provider/CuRandLibraryProvider.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * School of Engineering, The University of Manchester. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package uk.ac.manchester.tornado.curand.provider;
+
+import java.util.Map;
+
+import uk.ac.manchester.tornado.api.common.LibraryTaskDescriptor;
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.curand.CuRand;
+import uk.ac.manchester.tornado.curand.enums.CuRandRngType;
+import uk.ac.manchester.tornado.runtime.common.TornadoXPUDevice;
+import uk.ac.manchester.tornado.runtime.library.spi.LibraryContext;
+import uk.ac.manchester.tornado.runtime.library.spi.LibraryInvocation;
+import uk.ac.manchester.tornado.runtime.library.spi.TornadoLibraryProvider;
+import uk.ac.manchester.tornado.runtime.library.spi.TornadoNativeStreamSupport;
+
+/**
+ * Serves {@link CuRand} library tasks by calling NVIDIA cuRAND.
+ *
+ * <p>
+ * One generator is created per execution plan and bound to that plan's CUDA stream, so generation
+ * is ordered against the surrounding kernels and transfers. The generator carries its own sequence
+ * position, which is what makes repeated dispatches produce fresh numbers rather than the same
+ * block again: the seed is applied once, when the generator is created, and re-applying it would
+ * reset the sequence.
+ * </p>
+ */
+public final class CuRandLibraryProvider implements TornadoLibraryProvider {
+
+    private static final class CuRandContext implements LibraryContext {
+        private final long generator;
+        private boolean seeded;
+
+        private CuRandContext(long generator) {
+            this.generator = generator;
+        }
+    }
+
+    @FunctionalInterface
+    private interface CuRandCall {
+        int invoke(long generator, LibraryInvocation invocation);
+    }
+
+    private static final Map<String, CuRandCall> FUNCTIONS = Map.of(//
+            "curandGenerateNormal", CuRandLibraryProvider::generateNormal, //
+            "curandGenerateNormalDouble", CuRandLibraryProvider::generateNormalDouble, //
+            "curandGenerateUniform", CuRandLibraryProvider::generateUniform, //
+            "curandGenerateUniformDouble", CuRandLibraryProvider::generateUniformDouble);
+
+    /**
+     * Whether cuRAND resolved on this host. Exposed so callers and tests can ask rather than
+     * probing for a shared library themselves.
+     */
+    public static boolean isAvailable() {
+        try {
+            CuRandNativeLib.load();
+            return true;
+        } catch (RuntimeException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String libraryName() {
+        return CuRand.LIBRARY_NAME;
+    }
+
+    @Override
+    public boolean canHandle(TornadoXPUDevice device) {
+        // Only the CUDA backend exposes its native stream for library interop
+        return device instanceof TornadoNativeStreamSupport;
+    }
+
+    @Override
+    public LibraryContext createContext(TornadoXPUDevice device, long executionPlanId) {
+        CuRandNativeLib.load();
+        long stream = ((TornadoNativeStreamSupport) device).getNativeStream(executionPlanId);
+        long generator = CuRandNativeLib.curandCreateGenerator(CuRandRngType.CURAND_RNG_PSEUDO_DEFAULT.value());
+        if (generator == 0) {
+            throw new TornadoRuntimeException("[ERROR] curandCreateGenerator failed");
+        }
+        CuRandNativeLib.checkStatus(CuRandNativeLib.curandSetStream(generator, stream), "curandSetStream");
+        return new CuRandContext(generator);
+    }
+
+    @Override
+    public void dispatch(String functionName, LibraryInvocation invocation) {
+        CuRandCall call = FUNCTIONS.get(functionName);
+        if (call == null) {
+            throw new TornadoRuntimeException("[ERROR] Unknown cuRAND function: " + functionName);
+        }
+        CuRandContext context = (CuRandContext) invocation.getContext();
+        seedOnce(context, invocation);
+        CuRandNativeLib.checkStatus(call.invoke(context.generator, invocation), functionName);
+    }
+
+    /**
+     * Applies the requested seed the first time this generator is used. cuRAND restarts the
+     * sequence whenever a seed is set, so seeding on every dispatch would hand out the same numbers
+     * over and over.
+     */
+    private static void seedOnce(CuRandContext context, LibraryInvocation invocation) {
+        if (context.seeded) {
+            return;
+        }
+        long seed = ((Number) invocation.getArg(invocation.getNumArgs() - 1)).longValue();
+        CuRandNativeLib.checkStatus(CuRandNativeLib.curandSetPseudoRandomGeneratorSeed(context.generator, seed), "curandSetPseudoRandomGeneratorSeed");
+        context.seeded = true;
+    }
+
+    /** (output, elementOffset, count, mean, stddev, seed). */
+    private static int generateNormal(long generator, LibraryInvocation invocation) {
+        return CuRandNativeLib.curandGenerateNormal(generator, //
+                invocation.getDevicePointer(0), //
+                ((Number) invocation.getArg(1)).longValue(), //
+                ((Number) invocation.getArg(2)).longValue(), //
+                ((Number) invocation.getArg(3)).floatValue(), //
+                ((Number) invocation.getArg(4)).floatValue());
+    }
+
+    /** (output, elementOffset, count, mean, stddev, seed). */
+    private static int generateNormalDouble(long generator, LibraryInvocation invocation) {
+        return CuRandNativeLib.curandGenerateNormalDouble(generator, //
+                invocation.getDevicePointer(0), //
+                ((Number) invocation.getArg(1)).longValue(), //
+                ((Number) invocation.getArg(2)).longValue(), //
+                ((Number) invocation.getArg(3)).doubleValue(), //
+                ((Number) invocation.getArg(4)).doubleValue());
+    }
+
+    /** (output, elementOffset, count, seed). */
+    private static int generateUniform(long generator, LibraryInvocation invocation) {
+        return CuRandNativeLib.curandGenerateUniform(generator, //
+                invocation.getDevicePointer(0), //
+                ((Number) invocation.getArg(1)).longValue(), //
+                ((Number) invocation.getArg(2)).longValue());
+    }
+
+    /** (output, elementOffset, count, seed). */
+    private static int generateUniformDouble(long generator, LibraryInvocation invocation) {
+        return CuRandNativeLib.curandGenerateUniformDouble(generator, //
+                invocation.getDevicePointer(0), //
+                ((Number) invocation.getArg(1)).longValue(), //
+                ((Number) invocation.getArg(2)).longValue());
+    }
+
+    @Override
+    public void prepare(LibraryTaskDescriptor descriptor, LibraryContext context) {
+        // Generator type is fixed when the context is created; nothing to do per task.
+    }
+
+    @Override
+    public void destroyContext(LibraryContext context) {
+        if (context instanceof CuRandContext c) {
+            CuRandNativeLib.curandDestroyGenerator(c.generator);
+        }
+    }
+}

--- a/tornado-curand/src/main/java/uk/ac/manchester/tornado/curand/provider/CuRandNativeLib.java
+++ b/tornado-curand/src/main/java/uk/ac/manchester/tornado/curand/provider/CuRandNativeLib.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package uk.ac.manchester.tornado.curand.provider;
+
+import static uk.ac.manchester.tornado.runtime.ffm.FFMSupport.C_DOUBLE;
+import static uk.ac.manchester.tornado.runtime.ffm.FFMSupport.C_FLOAT;
+import static uk.ac.manchester.tornado.runtime.ffm.FFMSupport.C_INT;
+import static uk.ac.manchester.tornado.runtime.ffm.FFMSupport.C_LONG;
+import static uk.ac.manchester.tornado.runtime.ffm.FFMSupport.C_POINTER;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+
+import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
+import uk.ac.manchester.tornado.runtime.ffm.FFMSupport;
+
+/**
+ * cuRAND bindings over the Java FFM API.
+ *
+ * <p>
+ * cuRAND's host API is plain C, so no native shim is needed: the entry points are resolved with a
+ * {@link SymbolLookup} at class initialisation and called through downcall handles. Device pointers
+ * cross as {@code C_LONG} and the generator handle is an opaque pointer, likewise a {@code long}.
+ * </p>
+ *
+ * <p>
+ * If libcurand is not present the lookup comes back empty and every handle is null; {@link #load()}
+ * then reports the provider as unavailable rather than failing the build.
+ * </p>
+ */
+final class CuRandNativeLib {
+
+    private static final SymbolLookup LIBCURAND = FFMSupport.loadLibrary("libcurand.so.10", "libcurand.so", "curand64_10.dll", "libcurand.dylib");
+
+    private static final MethodHandle CURAND_CREATE_GENERATOR;
+    private static final MethodHandle CURAND_DESTROY_GENERATOR;
+    private static final MethodHandle CURAND_SET_STREAM;
+    private static final MethodHandle CURAND_SET_SEED;
+    private static final MethodHandle CURAND_SET_OFFSET;
+    private static final MethodHandle CURAND_GENERATE_NORMAL;
+    private static final MethodHandle CURAND_GENERATE_NORMAL_DOUBLE;
+    private static final MethodHandle CURAND_GENERATE_UNIFORM;
+    private static final MethodHandle CURAND_GENERATE_UNIFORM_DOUBLE;
+
+    static {
+        if (LIBCURAND == null) {
+            CURAND_CREATE_GENERATOR = null;
+            CURAND_DESTROY_GENERATOR = null;
+            CURAND_SET_STREAM = null;
+            CURAND_SET_SEED = null;
+            CURAND_SET_OFFSET = null;
+            CURAND_GENERATE_NORMAL = null;
+            CURAND_GENERATE_NORMAL_DOUBLE = null;
+            CURAND_GENERATE_UNIFORM = null;
+            CURAND_GENERATE_UNIFORM_DOUBLE = null;
+        } else {
+            // curandCreateGenerator writes the handle through an out-parameter and returns a status.
+            CURAND_CREATE_GENERATOR = FFMSupport.downcall(LIBCURAND, FunctionDescriptor.of(C_INT, C_POINTER, C_INT), "curandCreateGenerator");
+            CURAND_DESTROY_GENERATOR = FFMSupport.downcall(LIBCURAND, FunctionDescriptor.of(C_INT, C_LONG), "curandDestroyGenerator");
+            CURAND_SET_STREAM = FFMSupport.downcall(LIBCURAND, FunctionDescriptor.of(C_INT, C_LONG, C_LONG), "curandSetStream");
+            CURAND_SET_SEED = FFMSupport.downcall(LIBCURAND, FunctionDescriptor.of(C_INT, C_LONG, C_LONG), "curandSetPseudoRandomGeneratorSeed");
+            CURAND_SET_OFFSET = FFMSupport.downcall(LIBCURAND, FunctionDescriptor.of(C_INT, C_LONG, C_LONG), "curandSetGeneratorOffset");
+            CURAND_GENERATE_NORMAL = FFMSupport.downcall(LIBCURAND, FunctionDescriptor.of(C_INT, C_LONG, C_LONG, C_LONG, C_FLOAT, C_FLOAT), "curandGenerateNormal");
+            CURAND_GENERATE_NORMAL_DOUBLE = FFMSupport.downcall(LIBCURAND, FunctionDescriptor.of(C_INT, C_LONG, C_LONG, C_LONG, C_DOUBLE, C_DOUBLE), "curandGenerateNormalDouble");
+            CURAND_GENERATE_UNIFORM = FFMSupport.downcall(LIBCURAND, FunctionDescriptor.of(C_INT, C_LONG, C_LONG, C_LONG), "curandGenerateUniform");
+            CURAND_GENERATE_UNIFORM_DOUBLE = FFMSupport.downcall(LIBCURAND, FunctionDescriptor.of(C_INT, C_LONG, C_LONG, C_LONG), "curandGenerateUniformDouble");
+        }
+    }
+
+    private CuRandNativeLib() {
+    }
+
+    /**
+     * Verifies that libcurand resolved. Nothing is loaded lazily -- the symbol lookup happens at
+     * class initialisation -- so this only reports whether the library is usable.
+     */
+    static synchronized void load() {
+        if (LIBCURAND == null || CURAND_CREATE_GENERATOR == null) {
+            throw new TornadoRuntimeException("[ERROR] Unable to load cuRAND. Install the CUDA Toolkit and make sure libcurand is on the library path.");
+        }
+    }
+
+    private static RuntimeException rethrow(Throwable t) {
+        if (t instanceof RuntimeException runtimeException) {
+            throw runtimeException;
+        }
+        throw new IllegalStateException(t);
+    }
+
+    /** Returns the generator handle, or 0 on failure. */
+    static long curandCreateGenerator(int rngType) {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment handle = arena.allocate(C_POINTER);
+            if ((int) CURAND_CREATE_GENERATOR.invokeExact(handle, rngType) != CURAND_STATUS_SUCCESS) {
+                return 0;
+            }
+            return handle.get(C_POINTER, 0).address();
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    static void curandDestroyGenerator(long generator) {
+        if (generator == 0) {
+            return;
+        }
+        try {
+            int ignored = (int) CURAND_DESTROY_GENERATOR.invokeExact(generator);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    static int curandSetStream(long generator, long streamPtr) {
+        try {
+            return (int) CURAND_SET_STREAM.invokeExact(generator, streamPtr);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    static int curandSetPseudoRandomGeneratorSeed(long generator, long seed) {
+        try {
+            return (int) CURAND_SET_SEED.invokeExact(generator, seed);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    static int curandSetGeneratorOffset(long generator, long offset) {
+        try {
+            return (int) CURAND_SET_OFFSET.invokeExact(generator, offset);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    static int curandGenerateNormal(long generator, long devicePtr, long elementOffset, long n, float mean, float stddev) {
+        try {
+            return (int) CURAND_GENERATE_NORMAL.invokeExact(generator, devicePtr + elementOffset * Float.BYTES, n, mean, stddev);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    static int curandGenerateNormalDouble(long generator, long devicePtr, long elementOffset, long n, double mean, double stddev) {
+        try {
+            return (int) CURAND_GENERATE_NORMAL_DOUBLE.invokeExact(generator, devicePtr + elementOffset * Double.BYTES, n, mean, stddev);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    static int curandGenerateUniform(long generator, long devicePtr, long elementOffset, long n) {
+        try {
+            return (int) CURAND_GENERATE_UNIFORM.invokeExact(generator, devicePtr + elementOffset * Float.BYTES, n);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    static int curandGenerateUniformDouble(long generator, long devicePtr, long elementOffset, long n) {
+        try {
+            return (int) CURAND_GENERATE_UNIFORM_DOUBLE.invokeExact(generator, devicePtr + elementOffset * Double.BYTES, n);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    /** {@code curandStatus_t} success value. */
+    private static final int CURAND_STATUS_SUCCESS = 0;
+
+    static String decodeStatus(int status) {
+        return switch (status) {
+            case 0 -> "CURAND_STATUS_SUCCESS";
+            case 100 -> "CURAND_STATUS_VERSION_MISMATCH";
+            case 101 -> "CURAND_STATUS_NOT_INITIALIZED";
+            case 102 -> "CURAND_STATUS_ALLOCATION_FAILED";
+            case 103 -> "CURAND_STATUS_TYPE_ERROR";
+            case 104 -> "CURAND_STATUS_OUT_OF_RANGE";
+            case 105 -> "CURAND_STATUS_LENGTH_NOT_MULTIPLE";
+            case 106 -> "CURAND_STATUS_DOUBLE_PRECISION_REQUIRED";
+            case 201 -> "CURAND_STATUS_LAUNCH_FAILURE";
+            case 202 -> "CURAND_STATUS_PREEXISTING_FAILURE";
+            case 203 -> "CURAND_STATUS_INITIALIZATION_FAILED";
+            case 204 -> "CURAND_STATUS_ARCH_MISMATCH";
+            case 999 -> "CURAND_STATUS_INTERNAL_ERROR";
+            default -> "CURAND_STATUS_" + status;
+        };
+    }
+
+    static void checkStatus(int status, String what) {
+        if (status != CURAND_STATUS_SUCCESS) {
+            throw new TornadoRuntimeException("[ERROR] " + what + " failed: " + decodeStatus(status));
+        }
+    }
+}

--- a/tornado-curand/src/main/resources/META-INF/services/uk.ac.manchester.tornado.runtime.library.spi.TornadoLibraryProvider
+++ b/tornado-curand/src/main/resources/META-INF/services/uk.ac.manchester.tornado.runtime.library.spi.TornadoLibraryProvider
@@ -1,0 +1,1 @@
+uk.ac.manchester.tornado.curand.provider.CuRandLibraryProvider

--- a/tornado-unittests/pom.xml
+++ b/tornado-unittests/pom.xml
@@ -32,6 +32,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>tornado-curand</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>tornado-cufft</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/tornado-unittests/src/main/java/module-info.java
+++ b/tornado-unittests/src/main/java/module-info.java
@@ -2,6 +2,7 @@ open module tornado.unittests {
     requires transitive junit;
     requires transitive tornado.api;
     requires tornado.cublas;
+    requires tornado.curand;
     requires tornado.cufft;
     requires tornado.cudnn;
     requires tornado.cusparse;
@@ -19,6 +20,7 @@ open module tornado.unittests {
     exports uk.ac.manchester.tornado.unittests.branching;
     exports uk.ac.manchester.tornado.unittests.common;
     exports uk.ac.manchester.tornado.unittests.cublas;
+    exports uk.ac.manchester.tornado.unittests.curand;
     exports uk.ac.manchester.tornado.unittests.nvtx;
     exports uk.ac.manchester.tornado.unittests.cufft;
     exports uk.ac.manchester.tornado.unittests.cudnn;

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/curand/TestCuRand.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/curand/TestCuRand.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ * The University of Manchester.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package uk.ac.manchester.tornado.unittests.curand;
+
+import static uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider.getTornadoRuntime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
+import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
+import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
+import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.curand.CuRand;
+import uk.ac.manchester.tornado.curand.provider.CuRandLibraryProvider;
+import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
+import uk.ac.manchester.tornado.unittests.common.TornadoVMCUDANotSupported;
+
+/**
+ * Random number generation on the device through cuRAND.
+ *
+ * <p>
+ * How to run?
+ * <p>
+ * <code>
+ * tornado-test -V uk.ac.manchester.tornado.unittests.curand.TestCuRand
+ * </code>
+ * </p>
+ */
+public class TestCuRand extends TornadoTestBase {
+
+    @Before
+    public void curandMustBeAvailable() {
+        TornadoVMBackendType backendType = getTornadoRuntime().getDefaultDevice().getTornadoVMBackend();
+        if (backendType != TornadoVMBackendType.CUDA) {
+            String message = "cuRAND library tasks require the CUDA backend (default device is " + backendType + ")";
+            switch (backendType) {
+                case OPENCL, METAL -> assertNotBackend(backendType, message);
+                default -> throw new TornadoVMCUDANotSupported(message);
+            }
+        }
+        if (!CuRandLibraryProvider.isAvailable()) {
+            throw new TornadoVMCUDANotSupported("cuRAND is not available on this host");
+        }
+    }
+
+    private static final int NUM_ELEMENTS = 1 << 16;
+
+    private static double mean(FloatArray values, int from, int to) {
+        double total = 0.0;
+        for (int i = from; i < to; i++) {
+            total += values.get(i);
+        }
+        return total / (to - from);
+    }
+
+    private static double stddev(FloatArray values, int from, int to, double mean) {
+        double total = 0.0;
+        for (int i = from; i < to; i++) {
+            double d = values.get(i) - mean;
+            total += d * d;
+        }
+        return Math.sqrt(total / (to - from));
+    }
+
+    @Test
+    public void testGenerateNormal() throws TornadoExecutionPlanException {
+        FloatArray output = new FloatArray(NUM_ELEMENTS);
+        output.init(0.0f);
+
+        TaskGraph taskGraph = new TaskGraph("rng") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .libraryTask("normals", CuRand::generateNormal, output, 0, NUM_ELEMENTS, 0.0f, 1.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.execute();
+        }
+
+        double m = mean(output, 0, NUM_ELEMENTS);
+        double s = stddev(output, 0, NUM_ELEMENTS, m);
+        // 65536 standard normals: the sample mean has standard error 1/256, so 0.05 is ~13 sigma.
+        assertEquals("sample mean", 0.0, m, 0.05);
+        assertEquals("sample standard deviation", 1.0, s, 0.05);
+    }
+
+    @Test
+    public void testGenerateNormalWithMeanAndStdDev() throws TornadoExecutionPlanException {
+        FloatArray output = new FloatArray(NUM_ELEMENTS);
+
+        TaskGraph taskGraph = new TaskGraph("rng") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .libraryTask("normals", CuRand::generateNormal, output, 0, NUM_ELEMENTS, 5.0f, 2.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.execute();
+        }
+
+        double m = mean(output, 0, NUM_ELEMENTS);
+        assertEquals("sample mean", 5.0, m, 0.10);
+        assertEquals("sample standard deviation", 2.0, stddev(output, 0, NUM_ELEMENTS, m), 0.10);
+    }
+
+    /**
+     * Writing a slice must leave the rest of the buffer alone: the destination is declared
+     * READ_WRITE precisely so TornadoVM keeps the untouched region valid.
+     */
+    @Test
+    public void testGenerateIntoSlice() throws TornadoExecutionPlanException {
+        int half = NUM_ELEMENTS / 2;
+        FloatArray output = new FloatArray(NUM_ELEMENTS);
+        output.init(-7.0f);
+
+        TaskGraph taskGraph = new TaskGraph("rng") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .libraryTask("normals", CuRand::generateNormal, output, half, half, 0.0f, 1.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < half; i++) {
+            assertEquals("element " + i + " outside the slice must be untouched", -7.0f, output.get(i), 0.0f);
+        }
+        double m = mean(output, half, NUM_ELEMENTS);
+        assertEquals("sample mean of the slice", 0.0, m, 0.05);
+    }
+
+    /** Successive executions must advance the sequence rather than repeat it. */
+    @Test
+    public void testSuccessiveExecutionsDiffer() throws TornadoExecutionPlanException {
+        FloatArray output = new FloatArray(NUM_ELEMENTS);
+
+        TaskGraph taskGraph = new TaskGraph("rng") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .libraryTask("normals", CuRand::generateNormal, output, 0, NUM_ELEMENTS, 0.0f, 1.0f) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.execute();
+            float[] first = new float[16];
+            for (int i = 0; i < first.length; i++) {
+                first[i] = output.get(i);
+            }
+
+            executionPlan.execute();
+            int identical = 0;
+            for (int i = 0; i < first.length; i++) {
+                if (first[i] == output.get(i)) {
+                    identical++;
+                }
+            }
+            assertNotEquals("a second execution returned the same block of numbers", first.length, identical);
+        }
+    }
+
+    @Test
+    public void testGenerateUniform() throws TornadoExecutionPlanException {
+        FloatArray output = new FloatArray(NUM_ELEMENTS);
+
+        TaskGraph taskGraph = new TaskGraph("rng") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .libraryTask("uniform", CuRand::generateUniform, output, 0, NUM_ELEMENTS) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.execute();
+        }
+
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            float v = output.get(i);
+            assertTrue("uniform value out of (0,1]: " + v, v > 0.0f && v <= 1.0f);
+        }
+        assertEquals("sample mean", 0.5, mean(output, 0, NUM_ELEMENTS), 0.02);
+    }
+
+    @Test
+    public void testGenerateNormalDouble() throws TornadoExecutionPlanException {
+        DoubleArray output = new DoubleArray(NUM_ELEMENTS);
+
+        TaskGraph taskGraph = new TaskGraph("rng") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, output) //
+                .libraryTask("normals", CuRand::generateNormal, output, 0, NUM_ELEMENTS, 0.0d, 1.0d) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, output);
+
+        try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            executionPlan.execute();
+        }
+
+        double total = 0.0;
+        for (int i = 0; i < NUM_ELEMENTS; i++) {
+            total += output.get(i);
+        }
+        assertEquals("sample mean", 0.0, total / NUM_ELEMENTS, 0.05);
+    }
+}


### PR DESCRIPTION
## What

A cuRAND library-task provider, so a TornadoVM program can generate random numbers **into a buffer
that is already on the device** instead of generating them on the host and uploading them.

```java
TaskGraph graph = new TaskGraph("rng")
        .transferToDevice(DataTransferMode.FIRST_EXECUTION, buffer)
        .libraryTask("normals", CuRand::generateNormal, buffer, offset, count, 0.0f, 1.0f)
        .persistOnDevice(buffer);
```

Follows the existing cuBLAS/cuSPARSE/cuTENSOR layout: `tornado-curand` for the Java side and
`tornado-drivers/curand-jni` for the JNI, registered in the aggregator poms, the assembly and
`tornado.py`.

Covers `curandGenerateNormal` / `curandGenerateNormalDouble` and
`curandGenerateUniform` / `curandGenerateUniformDouble`, for `FloatArray` and `DoubleArray`,
writing at an element offset so a caller can fill one slice of a larger buffer.

## Why

Monte-Carlo simulation on the GPU is often limited by getting the random numbers there rather than
by the arithmetic. Measured on a finmath-lib Black-Scholes valuation ported to TornadoVM
(RTX 4090, 1M paths, 40 time steps):

| phase | CPU | GPU |
|---|---|---|
| model arithmetic | 483.7 ms | 23.3 ms |
| Brownian increments | 430.4 ms | 1031.6 ms |

The arithmetic is 20.8x faster and completely hidden, because the increments were still generated
by a host RNG and then uploaded - 160 MB of transfers, on top of paying the same host RNG cost the
CPU baseline pays. With this provider a 1M-element draw of normals costs **0.198 ms**, against
about 25.8 ms per draw for generate-on-host-and-upload: **~130x** on that phase.

## Details worth review

- **The generator is bound to the execution plan's CUDA stream** (`curandSetStream`), so generation
  is ordered against the kernels and transfers of the same task graph, exactly as the cuBLAS
  provider does.
- **The seed is applied once, when the generator is created, not per dispatch.** cuRAND restarts
  the sequence whenever a seed is set, so re-seeding on each call would hand out the same block of
  numbers every time. `testSuccessiveExecutionsDiffer` pins this.
- **The destination is declared `READ_WRITE`, not `WRITE_ONLY`.** A call typically fills a slice of
  a larger buffer; declaring it write-only tells TornadoVM the whole buffer is produced here and
  the region outside the slice would stop being valid. `testGenerateIntoSlice` pins this.
- Element offsets are converted to byte offsets in the native layer, so the Java side never deals
  in element sizes. `getDevicePointer` already points past the TornadoVM array header.

## Testing

New `uk.ac.manchester.tornado.unittests.curand.TestCuRand`, 6 tests, all passing on an RTX 4090
(CUDA 12.6, JDK 21): distribution mean and standard deviation for normals, mean and range for
uniforms, a non-default mean/stddev, generation into a slice with the rest of the buffer left
intact, successive executions producing different numbers, and the double-precision path.

`tornado-test --quickPass` with `BACKEND=cuda`, against unmodified `develop` on the same machine:
**1168 vs 1162 ran (the 6 new tests), 8 failed, 77 unsupported in both**, with an identical set of
failing classes (all pre-existing). `./mvnw checkstyle:check` clean.

CMake locates cuRAND from the CUDA toolkit the same way the cuBLAS module locates cuBLAS, and warns
and falls back to `-lcurand` if it cannot.
