### PR TITLE
docs: add class-level Javadoc to examples #35

### DIFF
--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/Init.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/Init.java
@@ -31,13 +31,19 @@ import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.examples.common.Messages;
 
 /**
+ * Initializes a large {@code FloatArray} on the default device by adding 100
+ * to every element.
  * <p>
- * Run with.
+ * Builds a {@code TaskGraph}, registers a {@code @Parallel} {@code compute}
+ * task, copies the array back with {@code DataTransferMode.EVERY_EXECUTION},
+ * snapshots the graph, and runs it with {@code TornadoExecutionPlan}.
+ * </p>
+ * <p>
+ * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.Init <size>
  * </code>
- *
  */
 public class Init {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/MultipleTasks.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/MultipleTasks.java
@@ -29,13 +29,18 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
+ * Two sequential tasks on the same {@code FloatArray}: {@code foo} adds 100,
+ * then {@code bar} adds 200.
  * <p>
- * Run with.
+ * The {@code TaskGraph} copies {@code x} to the device, runs both
+ * {@code @Parallel} tasks, and copies {@code y} back on every execution.
+ * </p>
+ * <p>
+ * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.MultipleTasks
  * </code>
- *
  */
 public class MultipleTasks {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/VectorAddInt.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/VectorAddInt.java
@@ -26,6 +26,11 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 
 /**
+ * Integer vector addition ({@code c[i] = a[i] + b[i]}) with a profiler dump.
+ * <p>
+ * Copies {@code a} and {@code b} to the device, runs a {@code @Parallel}
+ * {@code vectorAdd} task, copies {@code c} back, and prints the profiler log.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAccInt.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAccInt.java
@@ -25,6 +25,13 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 
 /**
+ * Accumulates into an {@code IntArray} by composing eight {@code acc} tasks
+ * in one graph. Each task adds 1 to every element.
+ * <p>
+ * Copies the array to the device on first execution, registers eight
+ * {@code @Parallel} tasks, copies the result back on every execution, then
+ * runs the snapshot with {@code TornadoExecutionPlan}.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddDouble.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddDouble.java
@@ -25,6 +25,12 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 
 /**
+ * Element-wise addition of two {@code DoubleArray} buffers.
+ * <p>
+ * Copies {@code a} and {@code b} to the device on first execution, runs a
+ * {@code @Parallel} {@code add} task, and copies {@code c} back on every
+ * execution.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddInt.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayAddInt.java
@@ -29,6 +29,12 @@ import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import java.util.Arrays;
 
 /**
+ * Copies {@code a} into {@code c} on the device using an {@code IntArray}
+ * task graph (the {@code add} kernel writes {@code a[i]} into {@code c[i]}).
+ * <p>
+ * Transfers {@code a} and {@code b} on first execution, runs the
+ * {@code @Parallel} task, and copies {@code c} back on every execution.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayMultiplyAdd.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/arrays/ArrayMultiplyAdd.java
@@ -25,9 +25,14 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
- * Example of a task-graph with multiple tasks.
+ * Task graph with two lambdas: {@code t0} multiplies {@code a*b} into {@code c},
+ * then {@code t1} adds {@code c+b} into {@code d} (expected value 8).
  * <p>
- * How to run?:
+ * Transfers inputs on first execution, runs both {@code @Parallel} tasks, and
+ * copies {@code d} back on every execution.
+ * </p>
+ * <p>
+ * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.arrays.ArrayMultiplyAdd

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/Mandelbrot.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/Mandelbrot.java
@@ -38,6 +38,12 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 
 /**
+ * Renders a Mandelbrot set into a Swing window. The kernel writes iteration
+ * counts into a {@code ShortArray} with {@code @Parallel} loops.
+ * <p>
+ * The image component builds a {@code TaskGraph}, copies the output back on
+ * every execution, and displays the result.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication1D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication1D.java
@@ -29,6 +29,13 @@ import uk.ac.manchester.tornado.api.enums.TornadoDeviceType;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
+ * Dense matrix multiplication on {@code FloatArray} buffers using two nested
+ * {@code @Parallel} loops over rows and columns.
+ * <p>
+ * Copies both matrices on first execution, runs {@code matrixMultiplication},
+ * and copies the result back on every execution. Also warms up the plan with
+ * {@code withPreCompilation()}.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication2D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixMultiplication2D.java
@@ -33,6 +33,12 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
 
 /**
+ * Dense matrix multiplication on {@code Matrix2DFloat} with nested
+ * {@code @Parallel} loops, compared against Java parallel streams.
+ * <p>
+ * Copies A and B on first execution, runs the task, and copies C back on
+ * every execution. Pin the device with {@code -Ds0.t0.device=0:0}.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixVectorRowMajor.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MatrixVectorRowMajor.java
@@ -43,11 +43,18 @@ import uk.ac.manchester.tornado.api.types.arrays.Int8Array;
 import uk.ac.manchester.tornado.api.utils.QuantizationUtils;
 
 /**
+ * Benchmarks row-major matrix-vector products, including KernelContext tiles
+ * and FP16 / quantized variants.
+ * <p>
+ * Each variant builds a {@code TaskGraph}, copies inputs on first execution,
+ * and copies the result back on every execution.
+ * </p>
+ * <p>
+ * How to run?
  * </p>
  * <code>
  * $ tornado -m tornado.examples/uk.ac.manchester.tornado.examples.compute.MatrixVectorRowMajor
  * </code>
- *
  */
 public class MatrixVectorRowMajor {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MonteCarlo.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/MonteCarlo.java
@@ -26,15 +26,19 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
- * Montecarlo algorithm to approximate the PI value. This version has been
- * adapted from Marawacc test-suite.
+ * Monte Carlo approximation of PI (adapted from the Marawacc test-suite).
+ * Each {@code @Parallel} iteration samples a point and writes 1 if it falls
+ * inside the unit circle.
+ * <p>
+ * The task graph runs {@code computeMontecarlo} and copies the output back on
+ * every execution. The host sums the hits and multiplies by 4.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.compute.MonteCarlo
  * </code>
- *
  */
 public class MonteCarlo {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/NBody.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/compute/NBody.java
@@ -28,6 +28,12 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
+ * N-body gravity simulation. Each body updates position and velocity from the
+ * force of every other body.
+ * <p>
+ * The {@code @Parallel} {@code nBody} kernel runs inside a {@code TaskGraph}.
+ * Positions transfer on first execution; velocities copy back on demand.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/fft/TestFFT.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/fft/TestFFT.java
@@ -24,10 +24,14 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 
 /**
- * Example of FFT provided by Nikos Foutris.
- *
- * How to run:
- *
+ * Nested-loop FFT sketch provided by Nikos Foutris.
+ * <p>
+ * Copies {@code input}, {@code factors} and {@code dimArr} on first execution,
+ * runs {@code nesting}, and copies {@code input} back on every execution.
+ * </p>
+ * <p>
+ * How to run?
+ * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.fft.TestFFT
  * </code>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/flatmap/FlatMapExample.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/flatmap/FlatMapExample.java
@@ -28,9 +28,19 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
- * Simple example of how to perform a flat-map with TornadoVM. Since we
- * currently don't support dynamic memory allocation, the space for the output
- * has to be allocated before running the method on the target device.
+ * Flat-map over a {@code FloatArray}. Values above 100 expand into {@code SIZE}
+ * outputs. The output buffer is allocated up front because TornadoVM does not
+ * support dynamic device allocation.
+ * <p>
+ * Copies the input on every execution, runs a {@code @Parallel}
+ * {@code computeFlatMap} task, and copies the output back.
+ * </p>
+ * <p>
+ * How to run?
+ * </p>
+ * <code>
+ * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.flatmap.FlatMapExample
+ * </code>
  */
 public class FlatMapExample {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Mandelbrot.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Mandelbrot.java
@@ -41,11 +41,16 @@ import uk.ac.manchester.tornado.api.types.arrays.ShortArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 
 /**
+ * Mandelbrot renderer using the KernelContext API instead of {@code @Parallel}.
+ * <p>
+ * The image component builds a {@code TaskGraph} with a KernelContext task,
+ * copies the output back on every execution, and shows it in a Swing window.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
- *      $ tornado --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.Mandelbrot
+ * $ tornado --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.Mandelbrot
  * </code>
  */
 public class Mandelbrot {

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/MatrixMultiplication1D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/MatrixMultiplication1D.java
@@ -31,6 +31,12 @@ import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 
 /**
+ * Matrix multiplication expressed with KernelContext (explicit global ids)
+ * instead of {@code @Parallel} loops.
+ * <p>
+ * Copies both matrices on first execution, runs the KernelContext task, and
+ * copies the result back on every execution.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Montecarlo.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/Montecarlo.java
@@ -29,15 +29,19 @@ import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 
 /**
- * Montecarlo algorithm to approximate the PI value. This version has been
- * adapted from Marawacc test-suite.
+ * Monte Carlo PI approximation using KernelContext (adapted from Marawacc).
+ * Each work-item samples a point and writes whether it lands in the unit
+ * circle.
+ * <p>
+ * Runs a KernelContext task and copies the output back on every execution.
+ * The host sums the hits and multiplies by 4.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
- *     tornado -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.Montecarlo
+ * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.Montecarlo
  * </code>
- *
  */
 public class Montecarlo {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/NBody.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/compute/NBody.java
@@ -30,15 +30,18 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.profiler.ChromeEventTracer;
 
 /**
- * Montecarlo algorithm to approximate the PI value. This version has been
- * adapted from Marawacc test-suite.
+ * N-body gravity simulation expressed with KernelContext instead of
+ * {@code @Parallel} loops.
+ * <p>
+ * Copies positions and velocities on first execution, runs the KernelContext
+ * {@code nBody} task, and copies results back on every execution.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.kernelcontext.compute.NBody
  * </code>
- *
  */
 public class NBody {
     // CHECKSTYLE:OFF

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/Histogram.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/Histogram.java
@@ -30,6 +30,12 @@ import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import java.util.Random;
 
 /**
+ * Histogram with KernelContext {@code atomicAdd}. Each work-item increments
+ * the bin for its input value.
+ * <p>
+ * The graph runs {@code histogramKernel} on a 1D {@code WorkerGrid} and copies
+ * the histogram back on every execution.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsGlobalMemory.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsGlobalMemory.java
@@ -30,6 +30,11 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
+ * Parallel reduction that stores partial sums in global memory.
+ * <p>
+ * A 1D {@code WorkerGrid} runs the KernelContext reduction, then a second
+ * task folds the partials. The result copies back on every execution.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsLocalMemory.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/kernelcontext/reductions/ReductionsLocalMemory.java
@@ -30,6 +30,12 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
+ * Parallel reduction that uses KernelContext local memory inside each work
+ * group, then folds the per-group partials.
+ * <p>
+ * A 1D {@code WorkerGrid} with local size 256 runs the reduction. The result
+ * copies back on every execution.
+ * </p>
  * <p>
  * How to run?
  * </p>

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/matrices/MatrixAddition2D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/matrices/MatrixAddition2D.java
@@ -31,14 +31,17 @@ import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat4;
 import uk.ac.manchester.tornado.api.types.vectors.Float4;
 
 /**
- * Full example to show to matrix addition with non vector types
+ * 2D matrix addition on {@code Matrix2DFloat} (non-vector types).
+ * <p>
+ * Copies A and B on first execution, runs a {@code @Parallel}
+ * {@code matrixAddition} task, and copies C back on every execution.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.matrices.MatrixAddition2D
  * </code>
- *
  */
 public class MatrixAddition2D {
     // CHECKSTYLE:OFF

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/matrices/MatrixMul1D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/matrices/MatrixMul1D.java
@@ -32,13 +32,18 @@ import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
+ * Matrix multiplication stored in 1D {@code FloatArray} buffers with nested
+ * {@code @Parallel} loops.
+ * <p>
+ * Copies both matrices on first execution, runs {@code matrixMultiplication},
+ * and copies the result back on every execution.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.matrices.MatrixMul1D
  * </code>
- *
  */
 public class MatrixMul1D {
     // CHECKSTYLE:OFF

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/matrices/MatrixMul2D.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/matrices/MatrixMul2D.java
@@ -31,13 +31,18 @@ import uk.ac.manchester.tornado.api.runtime.TornadoRuntimeProvider;
 import uk.ac.manchester.tornado.api.types.matrix.Matrix2DFloat;
 
 /**
+ * Matrix multiplication on {@code Matrix2DFloat}, run once on CUDA and once on
+ * OpenCL when both backends are present.
+ * <p>
+ * Each plan copies A and B on first execution, runs the {@code @Parallel}
+ * kernel, and copies C back on every execution.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.matrices.MatrixMul2D
  * </code>
- *
  */
 public class MatrixMul2D {
     // CHECKSTYLE:OFF

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/memory/TestMemory.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/memory/TestMemory.java
@@ -9,14 +9,18 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
- * Full example to show to matrix addition with non vector types
+ * Stresses device allocation by copying larger {@code FloatArray} buffers
+ * (about 1.5 GB up to 2 GB). May fail on OpenCL devices with a smaller cap.
+ * <p>
+ * Each size builds a {@code TaskGraph}, copies the input on every execution,
+ * runs a {@code @Parallel} {@code moveData} task, and copies the output back.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado --jvm="-Dtornado.device.memory=4GB" -m tornado.examples/uk.ac.manchester.tornado.examples.memory.TestMemory
  * </code>
- *
  */
 public class TestMemory {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/reductions/Integration.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/reductions/Integration.java
@@ -32,13 +32,18 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.math.TornadoMath;
 
 /**
+ * Numerical integration of {@code f(x)} on [1, 4] using a {@code @Reduce}
+ * sum over a {@code @Parallel} loop.
+ * <p>
+ * Copies the input on every execution, runs {@code integrationTornado}, and
+ * copies the reduced sum back.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.reductions.Integration
  * </code>
- *
  */
 public class Integration {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/reductions/PiComputation.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/reductions/PiComputation.java
@@ -31,13 +31,18 @@ import uk.ac.manchester.tornado.api.math.TornadoMath;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
+ * Leibniz series for PI, reduced with {@code @Reduce} on a {@code @Parallel}
+ * loop. The host multiplies the sum by 4.
+ * <p>
+ * Copies the input on every execution, runs {@code computePi}, and copies the
+ * reduced result back.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.reductions.PiComputation
  * </code>
- *
  */
 public class PiComputation {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/reductions/ReductionAddFloats.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/reductions/ReductionAddFloats.java
@@ -31,13 +31,17 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
+ * Sums a {@code FloatArray} with {@code @Reduce} on a {@code @Parallel} loop.
+ * <p>
+ * Copies the input on every execution, runs {@code reductionAddFloats}, and
+ * copies the reduced sum back.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.reductions.ReductionAddFloats
  * </code>
- *
  */
 public class ReductionAddFloats {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/reductions/ReductionIrregular.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/reductions/ReductionIrregular.java
@@ -31,13 +31,18 @@ import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 
 /**
+ * Reduction over a size that is not a power of two ({@code @Reduce} +
+ * {@code @Parallel}).
+ * <p>
+ * Copies the input on every execution, runs {@code reduceFloats}, and copies
+ * the reduced sum back.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado -m tornado.examples/uk.ac.manchester.tornado.examples.reductions.ReductionIrregular
  * </code>
- *
  */
 public class ReductionIrregular {
 

--- a/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/TestCrossPointTriangles.java
+++ b/tornado-examples/src/main/java/uk/ac/manchester/tornado/examples/vectors/TestCrossPointTriangles.java
@@ -32,13 +32,18 @@ import uk.ac.manchester.tornado.api.types.vectors.Double3;
 import java.util.Random;
 
 /**
+ * Triangle intersection test using {@code Double3} vectors and KernelContext
+ * local memory.
+ * <p>
+ * Copies the vertex buffer on first execution and runs
+ * {@code shortCircuitTestKernel} on a 1D {@code WorkerGrid}.
+ * </p>
  * <p>
  * How to run?
  * </p>
  * <code>
  * tornado --threadInfo -m tornado.examples/uk.ac.manchester.tornado.examples.vectors.TestCrossPointTriangles
  * </code>
- *
  */
 public class TestCrossPointTriangles {
 


### PR DESCRIPTION
#### Description

Class-level Javadoc on the examples that only had a run command (or a copied/wrong blurb). Each one now has a short description of the example, how the TaskGraph / KernelContext calls are composed, and how to run it.

Left the longer, already-documented examples alone (MMA, GEMM benchmarks, VectorAddTest, etc.). Also fixed the KernelContext NBody comment that still talked about Monte Carlo, and the TestMemory comment that talked about matrix addition.

#### Problem description

#35 asked for class-level docs on the examples: what the example does, which API calls it uses, and the command line.

#### Backend/s tested

Docs only, no runtime change.

- [ ] OpenCL
- [ ] CUDA
- [ ] Metal

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?

Open any of the touched example classes and check the class Javadoc. No code path changed.
