### PR TITLE
[cuda] Align native array payload to 32 bytes to restore coalesced access

### DIFF
--- a/docs/source/flags.rst
+++ b/docs/source/flags.rst
@@ -137,6 +137,7 @@ TornadoVM's **CUDA C** backend targets NVIDIA GPUs: it emits CUDA C, compiled to
    ================================================================  ==================================================================================================================
    ``-Dtornado.cuda.compiler.flags=FLAGS``                           Passes additional flags to NVRTC when compiling the generated CUDA C source (default: none).
    ``-Dtornado.cuda.host.pinning=false``                             Disables pinning host memory for faster host↔device transfers (default: true).
+   ``-Dtornado.cuda.payloadAlignment=N``                             Byte boundary that a native array's first data element is aligned to, by prepending ``N``-byte-aligned padding to the device allocation (default: 32). The 16-byte array header otherwise offsets the payload half of a 32-byte L2 sector, so every warp-wide access fetches 5 sectors instead of 4; aligning to 32 restores 4-sector loads at a cost of 16 bytes per buffer. Set to ``0`` to disable the padding and restore the previous layout. Applies to non-batched allocations only; the generated kernel is byte-identical either way.
    ================================================================  ==================================================================================================================
 
 .. note::

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAMemorySegmentWrapper.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/mm/CUDAMemorySegmentWrapper.java
@@ -45,9 +45,42 @@ import uk.ac.manchester.tornado.runtime.common.exceptions.TornadoUnsupportedErro
 public class CUDAMemorySegmentWrapper implements XPUBuffer {
 
     private static final int INIT_VALUE = -1;
+
+    /**
+     * Alignment, in bytes, that the first data element of a native array is placed on.
+     *
+     * <p>
+     * A warp reads 32 x 4 = 128 contiguous bytes and the L1-to-L2 path is addressed in 32-byte sectors, so an aligned
+     * warp-wide access is served by exactly 4 sectors. {@code cuMemAlloc} returns a suitably aligned base, but the
+     * generated kernel reaches the data at {@code base + ARRAY_HEADER} -- 16 bytes in -- and that sub-sector offset
+     * makes every warp-wide access straddle a fifth sector: 5 transactions instead of 4.
+     * </p>
+     *
+     * <p>
+     * Only sub-sector misalignment costs anything, so <b>32 bytes is sufficient</b> and is the default. Measured on an
+     * RTX 4090 (sm_89) by sweeping the base offset of a single compiled kernel, varying nothing else: a payload on a
+     * 32-, 64- or 128-byte boundary all give 4.00 sectors per request, while the current 16-byte offset gives 5.00.
+     * Aligning to 128 instead would pad every buffer by 112 bytes rather than 16 for the same sector count.
+     * </p>
+     */
+    private static final long PAYLOAD_ALIGNMENT = Long.getLong("tornado.cuda.payloadAlignment", 32L);
+
+    /**
+     * Bytes prepended to the device allocation so that {@code base + HEADER_PAD + ARRAY_HEADER} is
+     * {@link #PAYLOAD_ALIGNMENT}-aligned. The kernel is handed the padded pointer and still indexes at
+     * {@code + ARRAY_HEADER}, so the generated code and any pre-built kernel are unchanged -- only where the buffer
+     * starts moves.
+     */
+    private static final long HEADER_PAD = PAYLOAD_ALIGNMENT <= 0 ? 0 : Math.floorMod(-TornadoNativeArray.ARRAY_HEADER, PAYLOAD_ALIGNMENT);
+
     private final CUDADeviceContext deviceContext;
     private final long batchSize;
     private long bufferId;
+    /**
+     * The address the buffer provider handed out, which is what has to be given back on release. {@link #bufferId} is
+     * this plus {@link #HEADER_PAD} whenever this wrapper owns its allocation.
+     */
+    private long bufferIdBase;
     private long bufferOffset;
     private long bufferSize;
 
@@ -63,6 +96,7 @@ public class CUDAMemorySegmentWrapper implements XPUBuffer {
         this.batchSize = batchSize;
         this.bufferSize = bufferSize;
         this.bufferId = INIT_VALUE;
+        this.bufferIdBase = INIT_VALUE;
         this.bufferOffset = 0;
         this.access = access;
         this.sizeOfType = sizeOfType;
@@ -91,7 +125,10 @@ public class CUDAMemorySegmentWrapper implements XPUBuffer {
 
     @Override
     public void setBuffer(XPUBufferWrapper bufferWrapper) {
+        // A buffer handed over by someone else: it is not ours to pad or to release, so bufferIdBase tracks it
+        // unchanged and no alignment padding is applied.
         this.bufferId = bufferWrapper.buffer;
+        this.bufferIdBase = bufferWrapper.buffer;
         this.bufferOffset = bufferWrapper.bufferOffset;
 
         bufferWrapper.bufferOffset += bufferSize;
@@ -201,11 +238,19 @@ public class CUDAMemorySegmentWrapper implements XPUBuffer {
         segment = getSegmentWithHeader(reference);
 
         if (batchSize <= 0) {
+            // HEADER_PAD extra bytes are requested and skipped over, so that the data the kernel reaches at
+            // base + ARRAY_HEADER starts on a PAYLOAD_ALIGNMENT boundary. Every transfer below is expressed relative
+            // to toBuffer(), so shifting the base shifts the header and the payload together.
             bufferSize = segment.byteSize();
-            bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize, access);
+            bufferIdBase = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize + HEADER_PAD, access);
+            bufferId = bufferIdBase + HEADER_PAD;
         } else {
+            // Batched slots are not padded. The slot size is chosen by the user (e.g. withBatch("300MB")) and is
+            // checked against the device heap, so growing the request by HEADER_PAD would turn an allocation that
+            // exactly fits into one that does not.
             bufferSize = batchSize;
-            bufferId = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize + TornadoNativeArray.ARRAY_HEADER, access);
+            bufferIdBase = deviceContext.getBufferProvider().getOrAllocateBufferWithSize(bufferSize + TornadoNativeArray.ARRAY_HEADER, access);
+            bufferId = bufferIdBase;
         }
 
         // Pin the full host segment so async H2D/D2H transfers DMA directly (no driver
@@ -252,8 +297,9 @@ public class CUDAMemorySegmentWrapper implements XPUBuffer {
             pinnedHostPointer = 0;
         }
 
-        deviceContext.getBufferProvider().markBufferReleased(bufferId, access);
+        deviceContext.getBufferProvider().markBufferReleased(bufferIdBase, access);
         bufferId = INIT_VALUE;
+        bufferIdBase = INIT_VALUE;
         bufferSize = INIT_VALUE;
 
         if (TornadoOptions.FULL_DEBUG) {
@@ -293,6 +339,9 @@ public class CUDAMemorySegmentWrapper implements XPUBuffer {
         final long sizeSource = oclMemorySegmentWrapper.bufferSize;
         final long sizeDest = bufferSize;
         this.bufferId = deviceContext.mapOnDeviceMemoryRegion(executionPlanId, this.bufferId, oclMemorySegmentWrapper.bufferId, offset, sizeOfType, sizeSource, sizeDest);
+        // The mapped region replaces this wrapper's allocation; keep release behaviour exactly as it was before the
+        // alignment padding was introduced, i.e. hand back whatever bufferId now points at.
+        this.bufferIdBase = this.bufferId;
     }
 
     @Override


### PR DESCRIPTION
Fixes #1065.

## The problem

`TornadoNativeArray` places its data `ARRAY_HEADER` (16) bytes into the buffer, so a generated kernel reaches element 0 at `base + 16`:

```c
i_2  =  (blockIdx.x*blockDim.x+threadIdx.x);
l_4  =  (long long) i_2;
l_5  =  l_4 + 4L;        // 16-byte header, in float-sized elements
l_6  =  l_5 << 2;
ul_7 =  ul_0 + l_6;
f_8  =  *(( float *) ul_7);
```

A warp reads 32 x 4 = 128 contiguous bytes, and the L1-to-L2 path is addressed in **32-byte sectors**, so an aligned warp-wide access is served by exactly **4 sectors**. The 16-byte payload offset makes every one of them straddle a fifth: **5 sectors instead of 4**, measured as 5.00 vs 4.00 sectors per request in Nsight Compute.

## Why the header size cannot simply be raised

My first attempt was to round `ARRAY_HEADER` up to 128. It works and it is fast, but it breaks six tests, and the reason is worth recording: **the header size is part of a pre-built kernel ABI.**

`examples/generated/add.cu` hardcodes the offset:

```c
l_7  =  l_6 + 16L;
```

there is a separate `add_uncompressed.cu` carrying `+ 24L`, and `PrebuiltTests` picks between them with `coops = TornadoNativeArray.ARRAY_HEADER == 16`. Changing the constant makes every existing pre-built kernel read at the wrong offset and **silently compute wrong results** — no exception, just bad data. That did not seem like an acceptable thing to ship, so this PR does not do it.

## What this PR does instead

Leave the ABI alone and move the buffer. Allocate `HEADER_PAD` extra bytes and hand the kernel a pointer at `base + HEADER_PAD`, chosen so that `base + HEADER_PAD + ARRAY_HEADER` is `PAYLOAD_ALIGNMENT`-aligned:

```java
bufferIdBase = provider.getOrAllocateBufferWithSize(bufferSize + HEADER_PAD, access);
bufferId = bufferIdBase + HEADER_PAD;
```

The kernel still indexes at `+ ARRAY_HEADER`, so **generated code is byte-identical** (`+ 4L`, verified with `--printKernel`) and pre-built kernels are unaffected. Every transfer in this class is already expressed relative to `toBuffer()`, so shifting the base shifts the header and the payload together.

Two details:

- `bufferIdBase` tracks the address the provider handed out, because `markBufferReleased()` keys on it.
- **Batched slots are deliberately not padded.** Their size is chosen by the user (`withBatch("300MB")`) and checked against the device heap, so growing the request turns an allocation that exactly fits into one that does not. Without this, nine `TestBatches` cases fail with `Unable to allocate 300000128 bytes`.

Scope is `tornado-drivers/cuda` only — one file. OpenCL and Metal are not touched at all.

## Measurements

RTX 4090, CUDA 12.6.85, driver 565.57.01, JDK 25.0.2. **Kernel time only**, from `nsys stats --report cuda_gpu_kern_sum`, mean of 20 executions.

### The benefit is workload-dependent

Elementwise copy kernel (1 read, 1 write), swept by buffer size:

| buffer | before | after | speedup |
|---|---|---|---|
| 1 MB | 1838 ns | 1811 ns | 1.02x |
| 4 MB | 4248 ns | 3634 ns | 1.17x |
| **16 MB** | **13898 ns** | **10797 ns** | **1.29x** |
| 64 MB | 126197 ns | 113709 ns | 1.11x |
| 256 MB | 560078 ns | 549959 ns | 1.02x |

It peaks on L2-resident working sets, where the kernel is bound by memory *requests*, and tapers off once the kernel saturates DRAM bandwidth and neighbouring warps share the straddled line through L2. At no size is it a regression.

Worth being explicit: the suite's own `saxpy` at 16M elements runs at roughly 90% of this card's peak DRAM bandwidth and gains only ~1.5%. If your workload is already bandwidth-saturated, this change does very little for it.

### Against hand-written CUDA

Three kernels ported to CUDA C++ with identical block size (256), identical grid, identical arithmetic including bounds checks, and no `-use_fast_math` on either side. 16 MB buffers:

| kernel | before | after | hand-written CUDA |
|---|---|---|---|
| `elementwise` (memory-bound) | 13944 ns | **10675 ns** | 10621 ns |
| `stencil` (memory-bound) | 14322 ns | **11930 ns** | 11546 ns |
| `polynomial` (compute-bound) | 35236 ns | 34704 ns | 39926 ns |

The memory-bound kernels go from 1.31x / 1.24x slower than hand-written CUDA to within **0.5%** and **3.3%** of it. The compute-bound kernel is unchanged, as expected — it was already faster than the C++ version because `degree` is a task argument and Graal unrolls the FMA chain on its actual value.

### Attribution

To confirm the cause was alignment and not something else, the identical CUDA kernel was run at offset 0 and at offset 4 floats:

```
elementwise  offset=0 floats : median 12.5 us
stencil      offset=0 floats : median 13.2 us
elementwise  offset=4 floats : median 16.0 us     (1.28x)
stencil      offset=4 floats : median 16.7 us     (1.27x)
```

1.28x / 1.27x from the offset alone, against the 1.31x / 1.24x measured between TornadoVM and hand-written CUDA. The offset accounts for essentially the whole gap.

Sources for the benchmark and both probes: https://github.com/mikepapadim/tornadovm-devoxx2026-cuda-demos/tree/main/demos/15-kernel-time-comparison

## Correctness

`make fast-tests`, CUDA backend, JDK 25:

```
{'[PASS]': 1084, '[FAILED]': 8, '[UNSUPPORTED]': 90}
```

Exit code 0. The 8 failures are the same whitelisted ones, **test for test**, that an unpatched build of this same commit produces (`TestDevices#test04/06`, `ComputeTests#testJuliaSets/testMandelbrot`, `TestReductionsFloats#testComputePi`, `TestMatrixMultiplicationKernelContext#mxm2DKernelContext01/02`, `TransformerKernelsTest#testReductionOneBlockWithLayer`). I ran the unpatched build first specifically so the comparison would mean something. No regressions, and no accidental fixes either.

`mvnw checkstyle:check` passes. `test-native.sh` passes.

## Cost and escape hatch

112 bytes per non-batched device allocation.

`-Dtornado.cuda.payloadAlignment=<bytes>` tunes it; set it to `1` to restore exactly the previous layout, which is also how the before/after numbers above were produced from a single build.

## Notes for reviewers

- I have only tested the CUDA backend. The change is confined to `CUDAMemorySegmentWrapper`, so OpenCL and Metal are unaffected by construction rather than by assumption.
- `OCLMemorySegmentWrapper` and `MetalMemorySegmentWrapper` have the same shape and would presumably benefit similarly. I did not touch them because I could not measure them properly here; happy to follow up if that is wanted.
- Raw Java array buffers (`CUDAArrayWrapper`) are also unpadded and would have the same issue. Left alone for the same reason — #1065 is about `TornadoNativeArray`, and I would rather keep this change small enough to review.
- `PAYLOAD_ALIGNMENT` defaults to 32 and is overridable with `-Dtornado.cuda.payloadAlignment`; 0 disables the padding. If you would rather derive it from a device property than default it, say so and I will change it.



---

### Update: alignment reduced from 128 to 32 bytes

Rebased onto `e06a2e56f` and the default changed from 128 to **32** bytes, after measuring what the requirement actually is.

Sweeping the base offset of a **single compiled kernel**, varying nothing else, on an RTX 4090 (sm_89), driver 565.57.01, CUDA 12.6.85:

| payload offset | ld sectors/req | st sectors/req | median of 30 |
|---|---|---|---|
| 0 B | 4.00 | 4.00 | 11.7 µs |
| **16 B — current behaviour** | **5.00** | **5.00** | **15.0 µs** |
| 32 B | 4.00 | 4.00 | 12.0 µs |
| 64 B | 4.00 | 4.00 | 12.0 µs |
| 128 B | 4.00 | 4.00 | 11.7 µs |

Only **sub-sector** misalignment costs anything, so any 32-byte-aligned payload already gives 4.00 sectors per request. Since `HEADER_PAD = floorMod(-ARRAY_HEADER, PAYLOAD_ALIGNMENT)`:

| `PAYLOAD_ALIGNMENT` | padding per buffer | sectors/req |
|---|---|---|
| 128 | **112 bytes** | 4.00 |
| 64 | 48 bytes | 4.00 |
| **32** | **16 bytes** | **4.00** |

**128 costs 7x the padding of 32 for an identical sector count**, which is a real cost on workloads with many small arrays. The property remains overridable if anyone wants to measure a different boundary.

One caveat on the time column, worth stating because it is easy to over-read: these are steady-state medians on a bandwidth-bound elementwise kernel. On the same kernel under Nsight Compute — serialised launches, flushed caches, no clock boost — the ratio largely disappears, because both variants become DRAM-latency-bound. The **sector counts** are the robust part of this measurement; the time recovered depends on how bandwidth-bound the kernel is.

Raw captures and method: `results/nvidia-meeting/AlignmentSweep.cu` and `alignment-sweep-*.{csv,log}` in [mikepapadim/tornadovm-devoxx2026-cuda-demos](https://github.com/mikepapadim/tornadovm-devoxx2026-cuda-demos). Single host, sm_89 only.
