### PR TITLE
[build] Stop blocking the build on Python modules nothing imports

### DIFF
--- a/bin/install_python_modules.py
+++ b/bin/install_python_modules.py
@@ -17,49 +17,78 @@
 # limitations under the License.
 #
 
+import importlib
 import subprocess
+import sys
+
+# Modules the build and installer tooling actually imports, with the pip
+# distribution that provides each. Keep this list in step with the imports:
+# a module listed here that nothing imports blocks the build on every machine
+# where pip cannot install it, for no benefit.
+#
+#   requests, tqdm, urllib3 -> bin/pull_graal_jars.py
+#   packaging               -> bin/tornadovm-installer ("from packaging import version")
+REQUIRED_MODULES = (
+    ("requests", "requests"),
+    ("tqdm", "tqdm"),
+    ("urllib3", "urllib3"),
+    ("packaging", "packaging"),
+)
+
+
+def _install_hint(module, distribution, pip_output):
+    """
+    Explain what to do, including the case pip refuses outright.
+    """
+    lines = [
+        "[ERROR] TornadoVM's build tooling needs the Python module '%s' and it could not be installed automatically." % module,
+    ]
+    if pip_output:
+        lines.append("")
+        lines.append("pip reported:")
+        lines.extend("    " + line for line in pip_output.strip().splitlines())
+    lines.append("")
+    if "externally-managed-environment" in (pip_output or ""):
+        # PEP 668. The default on Debian 12+, Ubuntu 23.04+ and Fedora 38+, where a
+        # bare `pip3 install` into the system interpreter is refused by design.
+        lines.append("This interpreter is externally managed (PEP 668), so install it one of these ways:")
+        lines.append("    sudo apt install python3-%s        # or the equivalent for your distribution" % distribution)
+        lines.append("    python3 -m venv ~/.tornadovm-venv && source ~/.tornadovm-venv/bin/activate")
+        lines.append("    pip3 install --user %s" % distribution)
+    else:
+        lines.append("Install it with:")
+        lines.append("    pip3 install %s" % distribution)
+    return "\n".join(lines)
 
 
 def check_python_dependencies():
     """
     Check the required dependencies for the installation of TornadoVM.
+
+    Missing modules are installed with pip when that is possible. When it is not,
+    the reason pip gave is reported rather than discarded -- a bare ImportError
+    traceback gives no clue that the real problem is an externally-managed
+    interpreter.
     """
-    
-    try:
-        import requests
-    except:
-        subprocess.call(["pip3", "install", "requests"], stderr=subprocess.DEVNULL)
-        import requests
-    
-    try:
-        import tqdm
-    except:
-        subprocess.call(["pip3", "install", "tqdm"], stderr=subprocess.DEVNULL)
-        import tqdm
-    
-    try:
-        import urllib3
-    except:
-        subprocess.call(["pip3", "install", "urllib3"], stderr=subprocess.DEVNULL)
-        import urllib3
-    
-    try:
-        import wget
-    except:
-        subprocess.call(["pip3", "install", "wget"], stderr=subprocess.DEVNULL)
-        import wget
+    for module, distribution in REQUIRED_MODULES:
+        try:
+            importlib.import_module(module)
+            continue
+        except ImportError:
+            pass
 
-    try:
-        import packaging
-    except:
-        subprocess.call(["pip3", "install", "packaging"], stderr=subprocess.DEVNULL)
-        import packaging
+        completed = subprocess.run(
+            [sys.executable, "-m", "pip", "install", distribution],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
 
-    try:
-        import streamlit
-    except:
-        subprocess.call(["pip3", "install", "streamlit"], stderr=subprocess.DEVNULL)
-        import streamlit
+        try:
+            importlib.invalidate_caches()
+            importlib.import_module(module)
+        except ImportError:
+            print(_install_hint(module, distribution, completed.stdout), file=sys.stderr)
+            sys.exit(1)
 
     return 0
-    


### PR DESCRIPTION
#### Description

`check_python_dependencies()` in `bin/install_python_modules.py` gates every run
of `bin/compile` and `bin/tornadovm-installer` on six Python modules. Two of
them — **`streamlit` and `wget` — are imported nowhere in the repository**.
`streamlit` appears only in the three lines that install it:

```
$ grep -rn "import streamlit" --include=*.py .
bin/install_python_modules.py:59:        import streamlit
bin/install_python_modules.py:62:        import streamlit
```

This PR drops those two, keeps the four that are actually imported, and records
against each one which file imports it so the list stays checkable.

It also stops discarding pip's error output, and exits with a stated error
instead of letting `ImportError` escape through the caller.

#### Problem description

Unused dependencies are harmless while pip can install them, and fatal once it
cannot. On Debian 12+, Ubuntu 23.04+ and Fedora 38+ the system interpreter is
externally managed (PEP 668) and refuses `pip3 install` by design. The build
then stops here:

```
$ make BACKEND=cuda
bin/compile --jdk jdk21 --backend cuda
Traceback (most recent call last):
  File "/home/.../bin/install_python_modules.py", line 59, in check_python_dependencies
    import streamlit
ModuleNotFoundError: No module named 'streamlit'
...
make: *** [Makefile:45: build] Error 1
```

on a machine that has every module the build actually uses. Only `streamlit` was
missing, and nothing imports it.

The diagnosis is harder than it needs to be as well: the installer passes
`stderr=subprocess.DEVNULL`, so pip's `error: externally-managed-environment` is
thrown away and the user gets a bare `ModuleNotFoundError` traceback out of the
file whose job is to install that module. Nothing on screen points at pip, at
PEP 668, or at the fact that the module is unused.

To reproduce: on any distribution shipping a PEP 668 interpreter, with
`requests`, `tqdm`, `urllib3` and `packaging` installed but not `streamlit`, run
`make BACKEND=<any>`.

#### What the patch does

- Drops `streamlit` and `wget`. Keeps `requests`, `tqdm`, `urllib3` (used by
  `bin/pull_graal_jars.py`) and `packaging` — the last is easy to miss because
  `bin/tornadovm-installer` reaches it through `from packaging import version`
  rather than `import packaging`.
- Shows pip's own output when an install fails, and for the PEP 668 case names
  the three ways out (distribution package, virtualenv, `pip3 install --user`).
- Uses `sys.executable -m pip` rather than a bare `pip3`, so modules land in the
  interpreter that will import them rather than whichever `pip3` is first on
  `PATH`.
- Exits with a stated error rather than re-raising `ImportError`.

#### Backend/s tested

- [ ] OpenCL
- [x] CUDA
- [ ] Metal

Backend-independent: this is build tooling and runs before any backend is
selected.

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

Ubuntu 23.10, Python 3.11.6 (externally managed).

#### How to test the new patch?

Before the patch, on a PEP 668 interpreter without `streamlit`:

```bash
make BACKEND=cuda     # ModuleNotFoundError: No module named 'streamlit'
```

After it, the same command proceeds into the build. The new failure path can be
exercised directly:

```python
import sys; sys.path.insert(0, "bin")
import install_python_modules as m
m.REQUIRED_MODULES = (("streamlit", "streamlit"),)   # a module pip will refuse
m.check_python_dependencies()
```

which now prints pip's `externally-managed-environment` message followed by the
three remedies, and exits 1 instead of raising.
