### PR TITLE
[test] Say which profiler counter was zero instead of failing with a null reason

### DIFF
--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/profiler/TestProfiler.java
@@ -51,6 +51,41 @@ import uk.ac.manchester.tornado.unittests.common.TornadoTestBase;
  */
 public class TestProfiler extends TornadoTestBase {
 
+    /**
+     * Asserts every counter a profiled execution is expected to populate, naming the counter and
+     * the value it actually held when one of them does not.
+     *
+     * <p>
+     * The same twelve assertions were written out at three call sites with no messages, so a zero
+     * counter failed as {@code [REASON] null} -- identifying neither which assertion tripped nor
+     * what it read. That matters here because the counters do not fail as a group: a backend can
+     * report real compile and write times while a dispatch counter is stuck at zero.
+     * </p>
+     */
+    private static void assertProfilerCountersPopulated(TornadoProfilerResult profiler) {
+        assertPositive("getTotalTime()", profiler.getTotalTime());
+        assertPositive("getTornadoCompilerTime()", profiler.getTornadoCompilerTime());
+        assertPositive("getCompileTime()", profiler.getCompileTime());
+        assertNotNegative("getDataTransfersTime()", profiler.getDataTransfersTime());
+        assertNotNegative("getDeviceWriteTime()", profiler.getDeviceWriteTime());
+        assertPositive("getDataTransferDispatchTime()", profiler.getDataTransferDispatchTime());
+        assertPositive("getKernelDispatchTime()", profiler.getKernelDispatchTime());
+        assertPositive("getDeviceReadTime()", profiler.getDeviceReadTime());
+
+        assertEquals("getDeviceWriteTime() + getDeviceReadTime() should equal getDataTransfersTime()", //
+                profiler.getDeviceWriteTime() + profiler.getDeviceReadTime(), profiler.getDataTransfersTime());
+        assertEquals("getTornadoCompilerTime() + getDriverInstallTime() should equal getCompileTime()", //
+                profiler.getTornadoCompilerTime() + profiler.getDriverInstallTime(), profiler.getCompileTime());
+    }
+
+    private static void assertPositive(String counter, long value) {
+        assertTrue(counter + " should be > 0, was " + value, value > 0);
+    }
+
+    private static void assertNotNegative(String counter, long value) {
+        assertTrue(counter + " should be >= 0, was " + value, value >= 0);
+    }
+
     private static void reduction(float[] input, @Reduce float[] output) {
         for (@Parallel int i = 0; i < input.length; i++) {
             output[0] += input[i];
@@ -86,21 +121,7 @@ public class TestProfiler extends TornadoTestBase {
             // Execute the plan (default TornadoVM optimization choices)
             TornadoExecutionResult executionResult = plan.withProfiler(ProfilerMode.SILENT).execute();
 
-            assertTrue(executionResult.getProfilerResult().getTotalTime() > 0);
-            assertTrue(executionResult.getProfilerResult().getTornadoCompilerTime() > 0);
-            assertTrue(executionResult.getProfilerResult().getCompileTime() > 0);
-            assertTrue(executionResult.getProfilerResult().getDataTransfersTime() >= 0);
-            assertTrue(executionResult.getProfilerResult().getDeviceReadTime() >= 0);
-            assertTrue(executionResult.getProfilerResult().getDeviceWriteTime() >= 0);
-            assertTrue(executionResult.getProfilerResult().getDataTransferDispatchTime() > 0);
-            assertTrue(executionResult.getProfilerResult().getKernelDispatchTime() > 0);
-            assertTrue(executionResult.getProfilerResult().getDeviceWriteTime() >= 0);
-            assertTrue(executionResult.getProfilerResult().getDeviceReadTime() > 0);
-
-            assertEquals(executionResult.getProfilerResult().getDeviceWriteTime() + executionResult.getProfilerResult().getDeviceReadTime(), executionResult.getProfilerResult()
-                    .getDataTransfersTime());
-            assertEquals(executionResult.getProfilerResult().getTornadoCompilerTime() + executionResult.getProfilerResult().getDriverInstallTime(), executionResult.getProfilerResult()
-                    .getCompileTime());
+            assertProfilerCountersPopulated(executionResult.getProfilerResult());
 
             // Disable profiler
             plan.withoutProfiler();
@@ -172,19 +193,7 @@ public class TestProfiler extends TornadoTestBase {
 
                 TornadoProfilerResult profilerResult = executionResult.getProfilerResult();
 
-            assertTrue(profilerResult.getTotalTime() > 0);
-            assertTrue(profilerResult.getTornadoCompilerTime() > 0);
-            assertTrue(profilerResult.getCompileTime() > 0);
-            assertTrue(profilerResult.getDataTransfersTime() >= 0);
-            assertTrue(profilerResult.getDeviceReadTime() >= 0);
-            assertTrue(profilerResult.getDeviceWriteTime() >= 0);
-            assertTrue(profilerResult.getDataTransferDispatchTime() > 0);
-            assertTrue(profilerResult.getKernelDispatchTime() > 0);
-            assertTrue(profilerResult.getDeviceWriteTime() >= 0);
-            assertTrue(profilerResult.getDeviceReadTime() > 0);
-
-            assertEquals(profilerResult.getDeviceWriteTime() + profilerResult.getDeviceReadTime(), profilerResult.getDataTransfersTime());
-            assertEquals(profilerResult.getTornadoCompilerTime() + profilerResult.getDriverInstallTime(), profilerResult.getCompileTime());
+            assertProfilerCountersPopulated(profilerResult);
         }
     }
 
@@ -214,21 +223,7 @@ public class TestProfiler extends TornadoTestBase {
             // Execute the plan (default TornadoVM optimization choices)
             TornadoExecutionResult executionResult = executionPlan.execute();
 
-                assertTrue(executionResult.getProfilerResult().getTotalTime() > 0);
-            assertTrue(executionResult.getProfilerResult().getTornadoCompilerTime() > 0);
-            assertTrue(executionResult.getProfilerResult().getCompileTime() > 0);
-            assertTrue(executionResult.getProfilerResult().getDataTransfersTime() >= 0);
-            assertTrue(executionResult.getProfilerResult().getDeviceReadTime() >= 0);
-            assertTrue(executionResult.getProfilerResult().getDeviceWriteTime() >= 0);
-            assertTrue(executionResult.getProfilerResult().getDataTransferDispatchTime() > 0);
-            assertTrue(executionResult.getProfilerResult().getKernelDispatchTime() > 0);
-            assertTrue(executionResult.getProfilerResult().getDeviceWriteTime() >= 0);
-            assertTrue(executionResult.getProfilerResult().getDeviceReadTime() > 0);
-
-            assertEquals(executionResult.getProfilerResult().getDeviceWriteTime() + executionResult.getProfilerResult().getDeviceReadTime(), executionResult.getProfilerResult()
-                    .getDataTransfersTime());
-            assertEquals(executionResult.getProfilerResult().getTornadoCompilerTime() + executionResult.getProfilerResult().getDriverInstallTime(), executionResult.getProfilerResult()
-                    .getCompileTime());
+            assertProfilerCountersPopulated(executionResult.getProfilerResult());
 
             executionPlan.withoutProfiler().execute();
         }


### PR DESCRIPTION
#### Description

`TestProfiler`'s three profiled-execution tests (`testProfilerEnabled`,
`testProfilerFromExecutionPlan`, `testProfilerOnAndOff`) each wrote out the same
twelve assertions, none carrying a message. When one trips the runner prints:

```
	Running test: testProfilerEnabled        ................  [FAILED]
		\_[REASON] null
```

which identifies neither which assertion failed nor what it read. After this
patch, the same failure reports:

```
	Running test: testProfilerEnabled        ................  [FAILED]
		\_[REASON] getDataTransferDispatchTime() should be > 0, was 0
```

The three copies are folded into one `assertProfilerCountersPopulated` helper —
which is also what makes adding messages worth doing once instead of thirty-six
times.

#### Problem description

Not a product bug; a diagnosis one. It cost a bisect through the assertion block
to establish that the CUDA backend returns 0 from `getDataTransferDispatchTime()`,
which is the subject of #1071.

It matters more than a routine "add assertion messages" cleanup because **these
counters do not fail as a group**. A backend can report perfectly good compile,
total and device-write times while one dispatch counter is stuck at zero — so
"one of twelve assertions in this test failed" is a much weaker clue than it
looks, and the reader has no way to narrow it without editing the test.

#### What changed

- One `assertProfilerCountersPopulated(TornadoProfilerResult)` helper replaces
  three identical inline blocks.
- Failures name the counter and the observed value.
- Two assertions in each copy were exact duplicates of an earlier line in the same
  block — `getDeviceWriteTime() >= 0` appeared twice, and `getDeviceReadTime() >= 0`
  sat alongside the stronger `> 0` that follows it. The helper keeps the stronger
  check of each pair, so the set of conditions enforced is unchanged.

Net −43/+38 lines in one test file. No production code is touched.

#### Backend/s tested

- [ ] OpenCL
- [x] CUDA
- [ ] Metal

Backend-independent — a test-only change.

#### OS tested

- [x] Linux
- [ ] OSx
- [ ] Windows

#### How to test the new patch?

```bash
make BACKEND=cuda
tornado-test -V uk.ac.manchester.tornado.unittests.profiler.TestProfiler
```

**The same three tests fail and the same six pass before and after** — verified on
a CUDA build against RTX 5070 Ti, CUDA 13.0.88, JDK 25.0.2. The only difference is
that the reason is now stated rather than `null`. On a backend where all twelve
hold, all nine pass as before.

`mvnw checkstyle:check -pl tornado-unittests` passes.
