### PR TITLE
Accept OCLDecompressedReadFieldNode as an address base for FP16 OpenCL devices

### DIFF
--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLAddressLowering.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/graal/lir/OCLAddressLowering.java
@@ -37,6 +37,7 @@ import uk.ac.manchester.tornado.drivers.opencl.graal.OCLArchitecture.OCLMemoryBa
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.FixedArrayNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.FixedArrayCopyNode;
 import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.LocalArrayNode;
+import uk.ac.manchester.tornado.drivers.opencl.graal.nodes.OCLDecompressedReadFieldNode;
 import uk.ac.manchester.tornado.runtime.graal.nodes.calc.TornadoAddressArithmeticNode;
 
 public class OCLAddressLowering extends AddressLoweringByNodePhase.AddressLowering {
@@ -50,7 +51,14 @@ public class OCLAddressLowering extends AddressLoweringByNodePhase.AddressLoweri
             memoryRegister = fixedArrayCopyNode.getMemoryRegister();
         } else if (base instanceof LocalArrayNode localArrayNode) {
             memoryRegister = localArrayNode.getMemoryRegister();
-        } else if (!((base instanceof TornadoAddressArithmeticNode) || (base instanceof ParameterNode) || (base instanceof ReadNode) || (base instanceof FloatingReadNode) || (base instanceof PiNode))) {
+        } else if (!((base instanceof TornadoAddressArithmeticNode) || (base instanceof ParameterNode) || (base instanceof ReadNode) || (base instanceof FloatingReadNode) || (base instanceof PiNode)
+                // An OCLDecompressedReadFieldNode yields the absolute device address of the referenced
+                // object (its generate() decompresses the field's compressed reference against the owning
+                // object's base), so it is a valid base for a further address computation - e.g. writing a
+                // scalar HalfFloat into VectorHalf.storage (a HalfFloatArray field), where the
+                // WriteHalfFloatNode's OffsetAddressNode uses the decompressed storage reference directly
+                // as its base.
+                || (base instanceof OCLDecompressedReadFieldNode))) {
             TornadoInternalError.unimplemented("address origin unimplemented: %s", base.getClass().getName());
         }
 


### PR DESCRIPTION
### Problem

`vectortypes.TestHalfFloats` dot-product tests (`testSimpleDotProductHalf2/3/4/8/16`, `testSimpleDotProductVectorHalf`) fail on FP16-capable OpenCL devices (e.g. Intel UHD Graphics 630) with:

```
unimplemented: address origin unimplemented: ...OCLDecompressedReadFieldNode
```

They only surfaced now because the CI NVIDIA GPUs lack `cl_khr_fp16`, so these cases are skipped there.

### Cause

Writing a scalar `HalfFloat` into `VectorHalf.storage` (a `HalfFloatArray` field) lowers, under compressed oops, to an `OCLDecompressedReadFieldNode` used directly as the base of the write's `OffsetAddressNode` (no `TornadoAddressArithmeticNode`, so `OCLFieldCoopsAccessPhase` does not rewrite it). `OCLAddressLowering.lower()` rejected that base type. `CUDAAddressLowering` and `MetalAddressLowering` already accept their equivalent node.

### Fix

Add `OCLDecompressedReadFieldNode` to the accepted address-base node types in `OCLAddressLowering`, mirroring the CUDA and Metal backends.

### Testing

`tornado-test uk.ac.manchester.tornado.unittests.vectortypes.TestHalfFloats` — 26/26 pass on Intel UHD Graphics 630 (`0:1`); no regression on the NVIDIA device or `foundation.TestHalfFloats`. Checkstyle green.