### PR TITLE
[cusparse] Expose alpha and beta on SpMV and SpMM

### DIFF
--- a/tornado-cusparse/src/main/java/uk/ac/manchester/tornado/cusparse/Cusparse.java
+++ b/tornado-cusparse/src/main/java/uk/ac/manchester/tornado/cusparse/Cusparse.java
@@ -37,6 +37,15 @@ import uk.ac.manchester.tornado.api.types.arrays.IntArray;
  * zero-based): {@code csrRowOffsets} has {@code rows + 1} entries,
  * {@code csrColInd} and {@code csrValues} have {@code nnz} entries. Dense
  * operands are row-major, matching the TornadoVM native array layout. All FP32.
+ *
+ * <p>
+ * Each operation has two forms. The short form computes the plain product
+ * ({@code alpha = 1}, {@code beta = 0}); the long form takes {@code alpha} and
+ * {@code beta} explicitly and computes the accumulating form
+ * {@code y = alpha * A * x + beta * y}. When {@code beta != 0} the output
+ * operand is read before it is written, so it is declared
+ * {@link Access#READ_WRITE} rather than {@link Access#WRITE_ONLY} and its
+ * device contents are kept live by the data-flow graph.
  */
 public final class Cusparse {
 
@@ -49,15 +58,34 @@ public final class Cusparse {
      * Sparse matrix-vector product {@code y = A * x}, with {@code A} an
      * {@code rows x cols} CSR matrix and {@code x}, {@code y} dense vectors of
      * length {@code cols} and {@code rows}.
+     *
+     * <p>
+     * Equivalent to {@link #cusparseSpMV(int, int, int, float, IntArray, IntArray, FloatArray, FloatArray, float, FloatArray)}
+     * with {@code alpha = 1.0f} and {@code beta = 0.0f}.
      */
     public static LibraryTaskDescriptor cusparseSpMV(int rows, int cols, int nnz, IntArray csrRowOffsets, IntArray csrColInd, FloatArray csrValues, FloatArray x, FloatArray y) {
-        Access[] access = new Access[8];
+        return cusparseSpMV(rows, cols, nnz, 1.0f, csrRowOffsets, csrColInd, csrValues, x, 0.0f, y);
+    }
+
+    /**
+     * Scaled sparse matrix-vector product {@code y = alpha * A * x + beta * y},
+     * with {@code A} an {@code rows x cols} CSR matrix and {@code x}, {@code y}
+     * dense vectors of length {@code cols} and {@code rows}.
+     *
+     * <p>
+     * With {@code beta != 0} the previous contents of {@code y} take part in the
+     * result, so {@code y} is declared {@link Access#READ_WRITE} and TornadoVM
+     * keeps its device buffer live across the call.
+     */
+    public static LibraryTaskDescriptor cusparseSpMV(int rows, int cols, int nnz, float alpha, IntArray csrRowOffsets, IntArray csrColInd, FloatArray csrValues, FloatArray x, float beta,
+            FloatArray y) {
+        Access[] access = new Access[10];
         Arrays.fill(access, Access.READ_ONLY);
-        access[7] = Access.WRITE_ONLY; // y
+        access[9] = (beta != 0.0f) ? Access.READ_WRITE : Access.WRITE_ONLY; // y
         return new LibraryTaskDescriptor() //
                 .withLibrary(LIBRARY_NAME) //
                 .withFunction("cusparseSpMV") //
-                .withParameters(new Object[] { rows, cols, nnz, csrRowOffsets, csrColInd, csrValues, x, y }) //
+                .withParameters(new Object[] { rows, cols, nnz, alpha, csrRowOffsets, csrColInd, csrValues, x, beta, y }) //
                 .withAccess(access);
     }
 
@@ -65,15 +93,35 @@ public final class Cusparse {
      * Sparse matrix-dense-matrix product {@code C = A * B}, with {@code A} an
      * {@code rows x k} CSR matrix, {@code B} a dense {@code k x n} row-major
      * matrix, and {@code C} a dense {@code rows x n} row-major matrix.
+     *
+     * <p>
+     * Equivalent to {@link #cusparseSpMM(int, int, int, int, float, IntArray, IntArray, FloatArray, FloatArray, float, FloatArray)}
+     * with {@code alpha = 1.0f} and {@code beta = 0.0f}.
      */
     public static LibraryTaskDescriptor cusparseSpMM(int rows, int k, int n, int nnz, IntArray csrRowOffsets, IntArray csrColInd, FloatArray csrValues, FloatArray b, FloatArray c) {
-        Access[] access = new Access[9];
+        return cusparseSpMM(rows, k, n, nnz, 1.0f, csrRowOffsets, csrColInd, csrValues, b, 0.0f, c);
+    }
+
+    /**
+     * Scaled sparse matrix-dense-matrix product
+     * {@code C = alpha * A * B + beta * C}, with {@code A} an {@code rows x k}
+     * CSR matrix, {@code B} a dense {@code k x n} row-major matrix, and {@code C}
+     * a dense {@code rows x n} row-major matrix.
+     *
+     * <p>
+     * With {@code beta != 0} the previous contents of {@code C} take part in the
+     * result, so {@code C} is declared {@link Access#READ_WRITE} and TornadoVM
+     * keeps its device buffer live across the call.
+     */
+    public static LibraryTaskDescriptor cusparseSpMM(int rows, int k, int n, int nnz, float alpha, IntArray csrRowOffsets, IntArray csrColInd, FloatArray csrValues, FloatArray b, float beta,
+            FloatArray c) {
+        Access[] access = new Access[11];
         Arrays.fill(access, Access.READ_ONLY);
-        access[8] = Access.WRITE_ONLY; // c
+        access[10] = (beta != 0.0f) ? Access.READ_WRITE : Access.WRITE_ONLY; // c
         return new LibraryTaskDescriptor() //
                 .withLibrary(LIBRARY_NAME) //
                 .withFunction("cusparseSpMM") //
-                .withParameters(new Object[] { rows, k, n, nnz, csrRowOffsets, csrColInd, csrValues, b, c }) //
+                .withParameters(new Object[] { rows, k, n, nnz, alpha, csrRowOffsets, csrColInd, csrValues, b, beta, c }) //
                 .withAccess(access);
     }
 }

--- a/tornado-cusparse/src/main/java/uk/ac/manchester/tornado/cusparse/provider/CusparseLibraryProvider.java
+++ b/tornado-cusparse/src/main/java/uk/ac/manchester/tornado/cusparse/provider/CusparseLibraryProvider.java
@@ -130,41 +130,45 @@ public final class CusparseLibraryProvider implements TornadoLibraryProvider {
         CusparseNativeLib.checkStatus(status, functionName);
     }
 
-    // (rows, cols, nnz, csrRowOffsets, csrColInd, csrValues, x, y)
+    // (rows, cols, nnz, alpha, csrRowOffsets, csrColInd, csrValues, x, beta, y)
     private static int spmv(CusparseContext context, LibraryInvocation invocation) {
         int rows = (int) invocation.getArg(0);
         int cols = (int) invocation.getArg(1);
         int nnz = (int) invocation.getArg(2);
-        long dRow = invocation.getDevicePointer(3);
-        long dCol = invocation.getDevicePointer(4);
-        long dVal = invocation.getDevicePointer(5);
-        long dX = invocation.getDevicePointer(6);
-        long dY = invocation.getDevicePointer(7);
-        long needed = CusparseNativeLib.spmvBufferSize(context.handle, rows, cols, nnz, dRow, dCol, dVal, dX, dY, 1.0f, 0.0f);
+        float alpha = (float) invocation.getArg(3);
+        long dRow = invocation.getDevicePointer(4);
+        long dCol = invocation.getDevicePointer(5);
+        long dVal = invocation.getDevicePointer(6);
+        long dX = invocation.getDevicePointer(7);
+        float beta = (float) invocation.getArg(8);
+        long dY = invocation.getDevicePointer(9);
+        long needed = CusparseNativeLib.spmvBufferSize(context.handle, rows, cols, nnz, dRow, dCol, dVal, dX, dY, alpha, beta);
         if (needed < 0) {
             throw new TornadoRuntimeException("[ERROR] cusparseSpMV_bufferSize failed");
         }
         context.growWorkspace(needed, invocation.isCapturing());
-        return CusparseNativeLib.spmv(context.handle, rows, cols, nnz, dRow, dCol, dVal, dX, dY, 1.0f, 0.0f, context.workspacePtr);
+        return CusparseNativeLib.spmv(context.handle, rows, cols, nnz, dRow, dCol, dVal, dX, dY, alpha, beta, context.workspacePtr);
     }
 
-    // (rows, k, n, nnz, csrRowOffsets, csrColInd, csrValues, b, c)
+    // (rows, k, n, nnz, alpha, csrRowOffsets, csrColInd, csrValues, b, beta, c)
     private static int spmm(CusparseContext context, LibraryInvocation invocation) {
         int rows = (int) invocation.getArg(0);
         int k = (int) invocation.getArg(1);
         int n = (int) invocation.getArg(2);
         int nnz = (int) invocation.getArg(3);
-        long dRow = invocation.getDevicePointer(4);
-        long dCol = invocation.getDevicePointer(5);
-        long dVal = invocation.getDevicePointer(6);
-        long dB = invocation.getDevicePointer(7);
-        long dC = invocation.getDevicePointer(8);
-        long needed = CusparseNativeLib.spmmBufferSize(context.handle, rows, k, n, nnz, dRow, dCol, dVal, dB, dC, 1.0f, 0.0f);
+        float alpha = (float) invocation.getArg(4);
+        long dRow = invocation.getDevicePointer(5);
+        long dCol = invocation.getDevicePointer(6);
+        long dVal = invocation.getDevicePointer(7);
+        long dB = invocation.getDevicePointer(8);
+        float beta = (float) invocation.getArg(9);
+        long dC = invocation.getDevicePointer(10);
+        long needed = CusparseNativeLib.spmmBufferSize(context.handle, rows, k, n, nnz, dRow, dCol, dVal, dB, dC, alpha, beta);
         if (needed < 0) {
             throw new TornadoRuntimeException("[ERROR] cusparseSpMM_bufferSize failed");
         }
         context.growWorkspace(needed, invocation.isCapturing());
-        return CusparseNativeLib.spmm(context.handle, rows, k, n, nnz, dRow, dCol, dVal, dB, dC, 1.0f, 0.0f, context.workspacePtr);
+        return CusparseNativeLib.spmm(context.handle, rows, k, n, nnz, dRow, dCol, dVal, dB, dC, alpha, beta, context.workspacePtr);
     }
 
     @Override

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cusparse/TestCusparse.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cusparse/TestCusparse.java
@@ -358,4 +358,149 @@ public class TestCusparse extends TornadoTestBase {
             }
         }
     }
+
+    // ---- alpha / beta scaling ----
+
+    /** y = alpha * A * x with beta = 0: pure scaling of the product. */
+    @Test
+    public void testSpMVAlphaScaling() throws TornadoExecutionPlanException {
+        final float alpha = 2.5f;
+        Csr a = randomCsr(256, 256, 0.05);
+        FloatArray x = randomVector(256);
+        FloatArray y = new FloatArray(256);
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a.rowOffsets, a.colInd, a.values, x) //
+                .libraryTask("spmv", Cusparse::cusparseSpMV, a.rows, a.cols, a.nnz, alpha, a.rowOffsets, a.colInd, a.values, x, 0.0f, y) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, y);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.execute();
+        }
+
+        FloatArray base = spmvReference(a, x);
+        FloatArray expected = new FloatArray(256);
+        for (int i = 0; i < 256; i++) {
+            expected.set(i, alpha * base.get(i));
+        }
+        assertClose(256, expected, y);
+    }
+
+    /**
+     * y = alpha * A * x + beta * y with beta != 0. This is the case the
+     * single-argument form cannot express: the prior contents of y take part in
+     * the result, so y must reach the device as READ_WRITE.
+     */
+    @Test
+    public void testSpMVAlphaBeta() throws TornadoExecutionPlanException {
+        final float alpha = 1.5f;
+        final float beta = 0.75f;
+        final int n = 256;
+        Csr a = randomCsr(n, n, 0.05);
+        FloatArray x = randomVector(n);
+        FloatArray y = randomVector(n);
+
+        FloatArray base = spmvReference(a, x);
+        FloatArray expected = new FloatArray(n);
+        for (int i = 0; i < n; i++) {
+            expected.set(i, alpha * base.get(i) + beta * y.get(i));
+        }
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a.rowOffsets, a.colInd, a.values, x, y) //
+                .libraryTask("spmv", Cusparse::cusparseSpMV, a.rows, a.cols, a.nnz, alpha, a.rowOffsets, a.colInd, a.values, x, beta, y) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, y);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.execute();
+        }
+        assertClose(n, expected, y);
+    }
+
+    /**
+     * beta = 1 turns SpMV into an accumulation. Repeated executions must sum,
+     * which only holds if y survives on the device between calls.
+     */
+    @Test
+    public void testSpMVBetaAccumulates() throws TornadoExecutionPlanException {
+        final int n = 128;
+        final int iterations = 4;
+        Csr a = randomCsr(n, n, 0.05);
+        FloatArray x = randomVector(n);
+        FloatArray y = new FloatArray(n); // starts at zero
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, a.rowOffsets, a.colInd, a.values, x, y) //
+                .libraryTask("spmv", Cusparse::cusparseSpMV, a.rows, a.cols, a.nnz, 1.0f, a.rowOffsets, a.colInd, a.values, x, 1.0f, y) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, y);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            for (int it = 0; it < iterations; it++) {
+                plan.execute();
+            }
+        }
+
+        FloatArray base = spmvReference(a, x);
+        FloatArray expected = new FloatArray(n);
+        for (int i = 0; i < n; i++) {
+            expected.set(i, iterations * base.get(i));
+        }
+        assertClose(n, expected, y);
+    }
+
+    /** The short form must stay identical to the long form with alpha=1, beta=0. */
+    @Test
+    public void testSpMVShortFormMatchesLongForm() throws TornadoExecutionPlanException {
+        final int n = 256;
+        Csr a = randomCsr(n, n, 0.05);
+        FloatArray x = randomVector(n);
+        FloatArray shortForm = new FloatArray(n);
+        FloatArray longForm = new FloatArray(n);
+
+        runSpMV(a, x, shortForm);
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a.rowOffsets, a.colInd, a.values, x) //
+                .libraryTask("spmv", Cusparse::cusparseSpMV, a.rows, a.cols, a.nnz, 1.0f, a.rowOffsets, a.colInd, a.values, x, 0.0f, longForm) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, longForm);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.execute();
+        }
+        assertClose(n, shortForm, longForm);
+    }
+
+    /** C = alpha * A * B + beta * C, the SpMM counterpart. */
+    @Test
+    public void testSpMMAlphaBeta() throws TornadoExecutionPlanException {
+        final float alpha = 2.0f;
+        final float beta = 0.5f;
+        final int rows = 128;
+        final int k = 128;
+        final int n = 32;
+        Csr a = randomCsr(rows, k, 0.05);
+        FloatArray b = randomVector(k * n);
+        FloatArray c = randomVector(rows * n);
+
+        float[] prior = new float[rows * n];
+        for (int i = 0; i < rows * n; i++) {
+            prior[i] = c.get(i);
+        }
+
+        FloatArray expected = new FloatArray(rows * n);
+        for (int i = 0; i < rows; i++) {
+            for (int j = 0; j < n; j++) {
+                float sum = 0.0f;
+                for (int kk = 0; kk < k; kk++) {
+                    sum += a.dense[i * k + kk] * b.get(kk * n + j);
+                }
+                expected.set(i * n + j, alpha * sum + beta * prior[i * n + j]);
+            }
+        }
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, a.rowOffsets, a.colInd, a.values, b, c) //
+                .libraryTask("spmm", Cusparse::cusparseSpMM, rows, k, n, a.nnz, alpha, a.rowOffsets, a.colInd, a.values, b, beta, c) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, c);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.execute();
+        }
+        assertClose(rows * n, expected, c);
+    }
 }


### PR DESCRIPTION
## What

`cusparseSpMV` and `cusparseSpMM` compute `y = α·A·x + β·y` and `C = α·A·B + β·C`, but the factories took no scalars and the provider hard-coded `1.0f` and `0.0f` at both the buffer-size query and the call:

```java
// CusparseNativeLib already took them as parameters
static int spmv(long handle, ..., float alpha, float beta, long workspace)

// CusparseLibraryProvider passed literals
return CusparseNativeLib.spmv(context.handle, ..., 1.0f, 0.0f, context.workspacePtr);
```

So only the Java signature withheld them. This exposes both.

## Why it matters

`β = 0` makes the accumulating form unreachable. A caller wanting `y = A·x + y` had to add a separate JIT task to do the addition — an extra kernel launch and a full pass over `y` for something cuSPARSE does inside the same kernel.

## The part that is not plumbing

**With `β ≠ 0` the output is read before it is written**, so it is now declared `READ_WRITE` rather than `WRITE_ONLY`:

```java
access[9] = (beta != 0.0f) ? Access.READ_WRITE : Access.WRITE_ONLY; // y
```

Without this the accumulating form would read a buffer the data-flow graph has not kept resident, and return a **wrong result rather than an error**.

This is the same inference `tornado-cublas` already makes in `readOnlyExcept(numArgs, outputIndex, beta)` for `gemv` and `gemm`, so the two providers now derive the access class the same way.

## Compatibility

The existing short forms are unchanged and delegate:

```java
public static LibraryTaskDescriptor cusparseSpMV(int rows, int cols, int nnz,
        IntArray csrRowOffsets, IntArray csrColInd, FloatArray csrValues, FloatArray x, FloatArray y) {
    return cusparseSpMV(rows, cols, nnz, 1.0f, csrRowOffsets, csrColInd, csrValues, x, 0.0f, y);
}
```

Delegation rather than a second descriptor is deliberate: the provider dispatches on function name alone, so two parameter layouts behind one name would not be distinguishable. This keeps exactly one layout per function.

Scalar placement follows the BLAS convention already used by `cublasSgemv` — `alpha` before the matrix, `beta` before the output.

## Tests

Five added to `TestCusparse`:

| Test | Covers |
|---|---|
| `testSpMVAlphaScaling` | α ≠ 1 with β = 0 |
| `testSpMVAlphaBeta` | α and β ≠ 0 against a CPU reference |
| `testSpMVBetaAccumulates` | β = 1 summing across 4 executions — **fails if the output buffer is not live between calls** |
| `testSpMVShortFormMatchesLongForm` | guards the delegation |
| `testSpMMAlphaBeta` | the SpMM counterpart |

## Verification

RTX 4090 (sm_89), driver 565.57.01, CUDA 12.6.85, JDK 25.0.2, built with `make jdk22plus BACKEND=cuda`:

```
tornado-test -V uk.ac.manchester.tornado.unittests.cusparse.TestCusparse
Test ran: 16, Failed: 0, Unsupported: 0
```

16 = the 11 pre-existing tests plus the 5 new ones. `./mvnw checkstyle:check` clean.

## Not in this PR

The other fixed configuration in this provider — CSR-only, FP32-only, `NON_TRANSPOSE`, default algorithm — is left alone. Those need real API surface decisions; this one only needed the signature widened.
