### PR TITLE
[cublaslt] Add factories for the RELU, GELU and RELU_BIAS epilogues

### DIFF
--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/CuBlasLt.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/CuBlasLt.java
@@ -128,4 +128,54 @@ public final class CuBlasLt {
                 .withParameters(new Object[] { transa, transb, m, n, k, alpha, matrixA, lda, matrixB, ldb, beta, matrixC, ldc, bias }) //
                 .withAccess(readOnlyExcept(14, 11, beta));
     }
+
+    /**
+     * FP16 matmul with a fused ReLU: C = ReLU(alpha * op(A) * op(B) + beta * C).
+     *
+     * <p>The activation is applied by the cuBLASLt epilogue, so no separate pass over C is
+     * needed. Use {@link #ltMatmulReluBiasFP16} when a bias is also wanted.</p>
+     */
+    public static LibraryTaskDescriptor ltMatmulReluFP16(int transa, int transb, int m, int n, int k, //
+            float alpha, HalfFloatArray matrixA, int lda, HalfFloatArray matrixB, int ldb, //
+            float beta, HalfFloatArray matrixC, int ldc) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("ltMatmulReluFP16") //
+                .withParameters(new Object[] { transa, transb, m, n, k, alpha, matrixA, lda, matrixB, ldb, beta, matrixC, ldc }) //
+                .withAccess(readOnlyExcept(13, 11, beta));
+    }
+
+    /**
+     * FP16 matmul with a fused GELU (tanh approximation):
+     * C = GELU(alpha * op(A) * op(B) + beta * C).
+     *
+     * <p>The bias-free counterpart of {@link #ltMatmulGeluBiasFP16}.</p>
+     */
+    public static LibraryTaskDescriptor ltMatmulGeluFP16(int transa, int transb, int m, int n, int k, //
+            float alpha, HalfFloatArray matrixA, int lda, HalfFloatArray matrixB, int ldb, //
+            float beta, HalfFloatArray matrixC, int ldc) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("ltMatmulGeluFP16") //
+                .withParameters(new Object[] { transa, transb, m, n, k, alpha, matrixA, lda, matrixB, ldb, beta, matrixC, ldc }) //
+                .withAccess(readOnlyExcept(13, 11, beta));
+    }
+
+    /**
+     * FP16 matmul with fused bias add and ReLU:
+     * C = ReLU(alpha * op(A) * op(B) + beta * C + bias).
+     *
+     * <p>The bias is a length-{@code m} vector broadcast over the rows of the column-major
+     * result, matching {@link #ltMatmulBiasFP16}. The ReLU counterpart of
+     * {@link #ltMatmulGeluBiasFP16}.</p>
+     */
+    public static LibraryTaskDescriptor ltMatmulReluBiasFP16(int transa, int transb, int m, int n, int k, //
+            float alpha, HalfFloatArray matrixA, int lda, HalfFloatArray matrixB, int ldb, //
+            float beta, HalfFloatArray matrixC, int ldc, HalfFloatArray bias) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("ltMatmulReluBiasFP16") //
+                .withParameters(new Object[] { transa, transb, m, n, k, alpha, matrixA, lda, matrixB, ldb, beta, matrixC, ldc, bias }) //
+                .withAccess(readOnlyExcept(14, 11, beta));
+    }
 }

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLtLibraryProvider.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLtLibraryProvider.java
@@ -70,7 +70,10 @@ public final class CuBlasLtLibraryProvider implements TornadoLibraryProvider {
             "ltMatmulFP16", new LtCall(CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_16F, CuBlasLtEpilogue.CUBLASLT_EPILOGUE_DEFAULT, false), //
             "ltMatmulFP8", new LtCall(CudaDataType.CUDA_R_8F_E4M3, CudaDataType.CUDA_R_16F, CuBlasLtEpilogue.CUBLASLT_EPILOGUE_DEFAULT, false), //
             "ltMatmulBiasFP16", new LtCall(CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_16F, CuBlasLtEpilogue.CUBLASLT_EPILOGUE_BIAS, true), //
-            "ltMatmulGeluBiasFP16", new LtCall(CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_16F, CuBlasLtEpilogue.CUBLASLT_EPILOGUE_GELU_BIAS, true));
+            "ltMatmulGeluBiasFP16", new LtCall(CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_16F, CuBlasLtEpilogue.CUBLASLT_EPILOGUE_GELU_BIAS, true), //
+            "ltMatmulReluFP16", new LtCall(CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_16F, CuBlasLtEpilogue.CUBLASLT_EPILOGUE_RELU, false), //
+            "ltMatmulGeluFP16", new LtCall(CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_16F, CuBlasLtEpilogue.CUBLASLT_EPILOGUE_GELU, false), //
+            "ltMatmulReluBiasFP16", new LtCall(CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_16F, CuBlasLtEpilogue.CUBLASLT_EPILOGUE_RELU_BIAS, true));
 
     @Override
     public String libraryName() {

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlasLt.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlasLt.java
@@ -83,6 +83,15 @@ public class TestCuBlasLt extends TornadoTestBase {
      * (per row of C_cm) is per column of the row-major C.
      */
     private static void reference(FloatArray a, FloatArray b, FloatArray c, float[] bias, boolean gelu, int size) {
+        reference(a, b, c, bias, gelu ? Activation.GELU : Activation.NONE, size);
+    }
+
+    /** The epilogue activations exercised by these tests. */
+    private enum Activation {
+        NONE, RELU, GELU
+    }
+
+    private static void reference(FloatArray a, FloatArray b, FloatArray c, float[] bias, Activation activation, int size) {
         for (int i = 0; i < size; i++) {
             for (int j = 0; j < size; j++) {
                 float sum = 0.0f;
@@ -92,7 +101,11 @@ public class TestCuBlasLt extends TornadoTestBase {
                 if (bias != null) {
                     sum += bias[j];
                 }
-                c.set(i * size + j, gelu ? geluTanh(sum) : sum);
+                c.set(i * size + j, switch (activation) {
+                    case NONE -> sum;
+                    case RELU -> Math.max(0.0f, sum);
+                    case GELU -> geluTanh(sum);
+                });
             }
         }
     }
@@ -308,6 +321,113 @@ public class TestCuBlasLt extends TornadoTestBase {
         reference(matrixA, matrixB, expected, null, false, SIZE);
         for (int i = 0; i < SIZE * SIZE; i++) {
             assertEquals(expected.get(i), matrixC.get(i), 0.01f * Math.max(1.0f, Math.abs(expected.get(i))));
+        }
+    }
+
+    // ---- epilogues declared in CuBlasLtEpilogue that previously had no factory ----
+
+    /** C = ReLU(A * B), the bias-free ReLU epilogue. */
+    @Test
+    public void testLtMatmulReluFP16() throws TornadoExecutionPlanException {
+        HalfFloatArray matrixA = new HalfFloatArray(SIZE * SIZE);
+        HalfFloatArray matrixB = new HalfFloatArray(SIZE * SIZE);
+        HalfFloatArray matrixC = new HalfFloatArray(SIZE * SIZE);
+        FloatArray aF = new FloatArray(SIZE * SIZE);
+        FloatArray bF = new FloatArray(SIZE * SIZE);
+        FloatArray expected = new FloatArray(SIZE * SIZE);
+        for (int i = 0; i < SIZE * SIZE; i++) {
+            matrixA.set(i, new HalfFloat(random.nextFloat() - 0.5f));
+            matrixB.set(i, new HalfFloat(random.nextFloat() - 0.5f));
+            aF.set(i, matrixA.get(i).getFloat32());
+            bF.set(i, matrixB.get(i).getFloat32());
+        }
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, matrixA, matrixB) //
+                .libraryTask("lt", CuBlasLt::ltMatmulReluFP16, //
+                        CuBlasOperation.CUBLAS_OP_N.operation(), CuBlasOperation.CUBLAS_OP_N.operation(), //
+                        SIZE, SIZE, SIZE, 1.0f, matrixB, SIZE, matrixA, SIZE, 0.0f, matrixC, SIZE) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+
+        reference(aF, bF, expected, null, Activation.RELU, SIZE);
+        for (int i = 0; i < SIZE * SIZE; i++) {
+            assertEquals(expected.get(i), matrixC.get(i).getFloat32(), 2e-2f * Math.max(0.1f, Math.abs(expected.get(i))));
+        }
+    }
+
+    /** C = GELU(A * B), the bias-free GELU epilogue. */
+    @Test
+    public void testLtMatmulGeluFP16() throws TornadoExecutionPlanException {
+        HalfFloatArray matrixA = new HalfFloatArray(SIZE * SIZE);
+        HalfFloatArray matrixB = new HalfFloatArray(SIZE * SIZE);
+        HalfFloatArray matrixC = new HalfFloatArray(SIZE * SIZE);
+        FloatArray aF = new FloatArray(SIZE * SIZE);
+        FloatArray bF = new FloatArray(SIZE * SIZE);
+        FloatArray expected = new FloatArray(SIZE * SIZE);
+        for (int i = 0; i < SIZE * SIZE; i++) {
+            matrixA.set(i, new HalfFloat(random.nextFloat() - 0.5f));
+            matrixB.set(i, new HalfFloat(random.nextFloat() - 0.5f));
+            aF.set(i, matrixA.get(i).getFloat32());
+            bF.set(i, matrixB.get(i).getFloat32());
+        }
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, matrixA, matrixB) //
+                .libraryTask("lt", CuBlasLt::ltMatmulGeluFP16, //
+                        CuBlasOperation.CUBLAS_OP_N.operation(), CuBlasOperation.CUBLAS_OP_N.operation(), //
+                        SIZE, SIZE, SIZE, 1.0f, matrixB, SIZE, matrixA, SIZE, 0.0f, matrixC, SIZE) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+
+        reference(aF, bF, expected, null, Activation.GELU, SIZE);
+        for (int i = 0; i < SIZE * SIZE; i++) {
+            assertEquals(expected.get(i), matrixC.get(i).getFloat32(), 2e-2f * Math.max(0.1f, Math.abs(expected.get(i))));
+        }
+    }
+
+    /** C = ReLU(A * B + bias), the ReLU counterpart of the GELU_BIAS epilogue. */
+    @Test
+    public void testLtMatmulReluBiasFP16() throws TornadoExecutionPlanException {
+        HalfFloatArray matrixA = new HalfFloatArray(SIZE * SIZE);
+        HalfFloatArray matrixB = new HalfFloatArray(SIZE * SIZE);
+        HalfFloatArray matrixC = new HalfFloatArray(SIZE * SIZE);
+        HalfFloatArray bias = new HalfFloatArray(SIZE);
+        FloatArray aF = new FloatArray(SIZE * SIZE);
+        FloatArray bF = new FloatArray(SIZE * SIZE);
+        float[] biasF = new float[SIZE];
+        FloatArray expected = new FloatArray(SIZE * SIZE);
+        for (int i = 0; i < SIZE * SIZE; i++) {
+            matrixA.set(i, new HalfFloat(random.nextFloat() - 0.5f));
+            matrixB.set(i, new HalfFloat(random.nextFloat() - 0.5f));
+            aF.set(i, matrixA.get(i).getFloat32());
+            bF.set(i, matrixB.get(i).getFloat32());
+        }
+        for (int i = 0; i < SIZE; i++) {
+            bias.set(i, new HalfFloat(random.nextFloat() - 0.5f));
+            biasF[i] = bias.get(i).getFloat32();
+        }
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, matrixA, matrixB, bias) //
+                .libraryTask("lt", CuBlasLt::ltMatmulReluBiasFP16, //
+                        CuBlasOperation.CUBLAS_OP_N.operation(), CuBlasOperation.CUBLAS_OP_N.operation(), //
+                        SIZE, SIZE, SIZE, 1.0f, matrixB, SIZE, matrixA, SIZE, 0.0f, matrixC, SIZE, bias) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+
+        reference(aF, bF, expected, biasF, Activation.RELU, SIZE);
+        for (int i = 0; i < SIZE * SIZE; i++) {
+            assertEquals(expected.get(i), matrixC.get(i).getFloat32(), 2e-2f * Math.max(0.1f, Math.abs(expected.get(i))));
         }
     }
 }


### PR DESCRIPTION
## What

`CuBlasLtEpilogue` declares six epilogues, but only three are reachable:

| Epilogue | Value | Factory before this PR |
|---|---|---|
| `DEFAULT` | 1 | ✅ `ltMatmulFP32` / `FP16` / `FP8` |
| **`RELU`** | 2 | ❌ none |
| `BIAS` | 4 | ✅ `ltMatmulBiasFP16` |
| **`RELU_BIAS`** | 6 | ❌ none |
| **`GELU`** | 32 | ❌ none |
| `GELU_BIAS` | 36 | ✅ `ltMatmulGeluBiasFP16` |

Three values could be named but not executed. This adds the missing factories.

## Why it is small

The provider is already generic. Its registry maps a function name to a configuration record:

```java
private record LtCall(CudaDataType inputType, CudaDataType outputType, CuBlasLtEpilogue epilogue, boolean hasBias) {}
```

and the dispatch path passes `call.epilogue().value()` straight to `cublasLtMatmulDescSetAttribute`. So reaching the remaining three needs **no new machinery** — three factories and three registry entries.

## Added

```java
ltMatmulReluFP16      // C = ReLU(alpha*op(A)*op(B) + beta*C)
ltMatmulGeluFP16      // C = GELU(alpha*op(A)*op(B) + beta*C)
ltMatmulReluBiasFP16  // C = ReLU(alpha*op(A)*op(B) + beta*C + bias)
```

The bias-free forms take 13 arguments like `ltMatmulFP16`; the bias form takes 14 like `ltMatmulBiasFP16`, with the bias broadcast over the rows of the column-major result. All three derive the output access class through the existing `readOnlyExcept(numArgs, outputIndex, beta)` helper, so `β ≠ 0` marks the output `READ_WRITE` exactly as the other Lt factories do.

## Why these three are worth having

ReLU without a bias is the activation of a plain CNN or MLP block. GELU without a bias appears wherever the bias has already been folded into a preceding operation. Both previously needed a separate JIT task over the whole result to do work the epilogue performs inside the same kernel.

## Tests

Three added to `TestCuBlasLt`, each validated against a CPU reference at the same tolerance as the existing epilogue tests:

- `testLtMatmulReluFP16`
- `testLtMatmulGeluFP16`
- `testLtMatmulReluBiasFP16`

The reference helper is generalised from a `boolean gelu` flag to an `Activation {NONE, RELU, GELU}` enum. The previous boolean signature is kept and delegates, so **the existing tests are unchanged**.

## Verification

RTX 4090 (sm_89), driver 565.57.01, CUDA 12.6.85, JDK 25.0.2, built with `make jdk22plus BACKEND=cuda`:

```
tornado-test -V uk.ac.manchester.tornado.unittests.cublas.TestCuBlasLt
Test ran: 9, Failed: 0, Unsupported: 0
```

9 = the 6 pre-existing tests plus the 3 new ones. `./mvnw checkstyle:check` clean.

## Not in this PR

The other unreached parts of the cuBLASLt surface — the backward epilogues (`DRELU`, `DGELU`, `BGRADA`/`BGRADB`), `GELU_AUX`, batching via the layout attributes, and FP8 scale pointers — are left alone. Those need enum values and API decisions this PR does not make; these three were already declared and only lacked a factory.
