### PR TITLE
[cublas] Bind cublasDgemm for FP64 matrix multiply

### DIFF
--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/CuBlas.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/CuBlas.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 
 import uk.ac.manchester.tornado.api.common.Access;
 import uk.ac.manchester.tornado.api.common.LibraryTaskDescriptor;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
@@ -59,6 +60,18 @@ public final class CuBlas {
         Access[] accesses = new Access[numArgs];
         Arrays.fill(accesses, Access.READ_ONLY);
         accesses[outputIndex] = (beta != 0.0f) ? Access.READ_WRITE : Access.WRITE_ONLY;
+        return accesses;
+    }
+
+    /**
+     * Double-precision counterpart of {@link #readOnlyExcept(int, int, float)}. Comparing the
+     * double directly matters: narrowing to float first would round a small non-zero beta to
+     * 0.0f and mark an operand WRITE_ONLY that cuBLAS is going to read.
+     */
+    private static Access[] readOnlyExcept(int numArgs, int outputIndex, double beta) {
+        Access[] accesses = new Access[numArgs];
+        Arrays.fill(accesses, Access.READ_ONLY);
+        accesses[outputIndex] = (beta != 0.0d) ? Access.READ_WRITE : Access.WRITE_ONLY;
         return accesses;
     }
 
@@ -164,6 +177,24 @@ public final class CuBlas {
         return new LibraryTaskDescriptor() //
                 .withLibrary(LIBRARY_NAME) //
                 .withFunction("cublasSgemm") //
+                .withParameters(new Object[] { transa, transb, m, n, k, alpha, matrixA, lda, matrixB, ldb, beta, matrixC, ldc }) //
+                .withAccess(readOnlyExcept(13, 11, beta));
+    }
+
+    /**
+     * FP64 matrix-matrix product via {@code cublasDgemm}:
+     * C = alpha * op(A) * op(B) + beta * C, with all operands {@link DoubleArray}.
+     *
+     * <p>The double-precision counterpart of {@link #cublasSgemm}. cuBLAS is column-major, so a
+     * row-major C = A * B is expressed by swapping the operands (C_cm = B_cm * A_cm), exactly as
+     * for the FP32 form.</p>
+     */
+    public static LibraryTaskDescriptor cublasDgemm(int transa, int transb, int m, int n, int k, //
+            double alpha, DoubleArray matrixA, int lda, DoubleArray matrixB, int ldb, //
+            double beta, DoubleArray matrixC, int ldc) {
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("cublasDgemm") //
                 .withParameters(new Object[] { transa, transb, m, n, k, alpha, matrixA, lda, matrixB, ldb, beta, matrixC, ldc }) //
                 .withAccess(readOnlyExcept(13, 11, beta));
     }

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLibraryProvider.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLibraryProvider.java
@@ -65,13 +65,14 @@ public final class CuBlasLibraryProvider implements TornadoLibraryProvider {
     /**
      * Dispatch registry: function name -> marshalling call.
      */
-    private static final Map<String, CuBlasCall> FUNCTIONS = Map.of(//
-            "cublasSgemv", CuBlasLibraryProvider::sgemv, //
-            "cublasSgemm", CuBlasLibraryProvider::sgemm, //
-            "cublasSgemmStridedBatched", CuBlasLibraryProvider::sgemmStridedBatched, //
-            "cublasGemmExFP16", (handle, inv) -> gemmEx(handle, inv, CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_16F), //
-            "cublasGemmExFP16FP32", (handle, inv) -> gemmEx(handle, inv, CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_32F), //
-            "cublasGemmExBF16", (handle, inv) -> gemmEx(handle, inv, CudaDataType.CUDA_R_16BF, CudaDataType.CUDA_R_16BF));
+    private static final Map<String, CuBlasCall> FUNCTIONS = Map.ofEntries(//
+            Map.entry("cublasSgemv", CuBlasLibraryProvider::sgemv), //
+            Map.entry("cublasSgemm", CuBlasLibraryProvider::sgemm), //
+            Map.entry("cublasDgemm", CuBlasLibraryProvider::dgemm), //
+            Map.entry("cublasSgemmStridedBatched", CuBlasLibraryProvider::sgemmStridedBatched), //
+            Map.entry("cublasGemmExFP16", (handle, inv) -> gemmEx(handle, inv, CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_16F)), //
+            Map.entry("cublasGemmExFP16FP32", (handle, inv) -> gemmEx(handle, inv, CudaDataType.CUDA_R_16F, CudaDataType.CUDA_R_32F)), //
+            Map.entry("cublasGemmExBF16", (handle, inv) -> gemmEx(handle, inv, CudaDataType.CUDA_R_16BF, CudaDataType.CUDA_R_16BF)));
 
     /** cublasGemmAlgo_t CUBLAS_GEMM_DEFAULT: heuristic algorithm selection. */
     private static final int CUBLAS_GEMM_DEFAULT = -1;
@@ -277,6 +278,23 @@ public final class CuBlasLibraryProvider implements TornadoLibraryProvider {
                 invocation.getDevicePointer(8), //
                 (int) invocation.getArg(9), //
                 (float) invocation.getArg(10), //
+                invocation.getDevicePointer(11), //
+                (int) invocation.getArg(12));
+    }
+
+    private static int dgemm(long handle, LibraryInvocation invocation) {
+        return CuBlasNativeLib.cublasDgemm(handle, //
+                (int) invocation.getArg(0), //
+                (int) invocation.getArg(1), //
+                (int) invocation.getArg(2), //
+                (int) invocation.getArg(3), //
+                (int) invocation.getArg(4), //
+                (double) invocation.getArg(5), //
+                invocation.getDevicePointer(6), //
+                (int) invocation.getArg(7), //
+                invocation.getDevicePointer(8), //
+                (int) invocation.getArg(9), //
+                (double) invocation.getArg(10), //
                 invocation.getDevicePointer(11), //
                 (int) invocation.getArg(12));
     }

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasNativeLib.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasNativeLib.java
@@ -62,6 +62,7 @@ final class CuBlasNativeLib {
     private static final MethodHandle CUBLAS_SET_WORKSPACE;
     private static final MethodHandle CUBLAS_SGEMV;
     private static final MethodHandle CUBLAS_SGEMM;
+    private static final MethodHandle CUBLAS_DGEMM;
     private static final MethodHandle CUBLAS_SGEMM_STRIDED_BATCHED;
     private static final MethodHandle CUBLAS_GEMM_EX;
     private static final MethodHandle CUDA_MALLOC;
@@ -76,6 +77,7 @@ final class CuBlasNativeLib {
             CUBLAS_SET_WORKSPACE = null;
             CUBLAS_SGEMV = null;
             CUBLAS_SGEMM = null;
+            CUBLAS_DGEMM = null;
             CUBLAS_SGEMM_STRIDED_BATCHED = null;
             CUBLAS_GEMM_EX = null;
         } else {
@@ -90,6 +92,8 @@ final class CuBlasNativeLib {
                     "cublasSgemv_v2");
             CUBLAS_SGEMM = FFMSupport.downcall(LIBCUBLAS,
                     FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_INT, C_INT, C_INT, C_INT, C_POINTER, C_LONG, C_INT, C_LONG, C_INT, C_POINTER, C_LONG, C_INT), "cublasSgemm_v2");
+            CUBLAS_DGEMM = FFMSupport.downcall(LIBCUBLAS,
+                    FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_INT, C_INT, C_INT, C_INT, C_POINTER, C_LONG, C_INT, C_LONG, C_INT, C_POINTER, C_LONG, C_INT), "cublasDgemm_v2");
             CUBLAS_SGEMM_STRIDED_BATCHED = FFMSupport.downcall(LIBCUBLAS,
                     FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_INT, C_INT, C_INT, C_INT, C_POINTER, C_LONG, C_INT, C_LONG, C_LONG, C_INT, C_LONG, C_POINTER, C_LONG, C_INT, C_LONG, C_INT),
                     "cublasSgemmStridedBatched");
@@ -134,6 +138,14 @@ final class CuBlasNativeLib {
         MemorySegment segment = SCALARS.forBytes(2L * Float.BYTES);
         segment.set(FFMSupport.C_FLOAT, 0, alpha);
         segment.set(FFMSupport.C_FLOAT, Float.BYTES, beta);
+        return segment;
+    }
+
+    /** Writes a double alpha and beta into the per-thread scalar scratch and returns it. */
+    private static MemorySegment scalars(double alpha, double beta) {
+        MemorySegment segment = SCALARS.forBytes(2L * Double.BYTES);
+        segment.set(FFMSupport.C_DOUBLE, 0, alpha);
+        segment.set(FFMSupport.C_DOUBLE, Double.BYTES, beta);
         return segment;
     }
 
@@ -224,6 +236,15 @@ final class CuBlasNativeLib {
         MemorySegment scalars = scalars(alpha, beta);
         try {
             return (int) CUBLAS_SGEMM.invokeExact(handle, transa, transb, m, n, k, scalars.asSlice(0, Float.BYTES), dA, lda, dB, ldb, scalars.asSlice(Float.BYTES, Float.BYTES), dC, ldc);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    static int cublasDgemm(long handle, int transa, int transb, int m, int n, int k, double alpha, long dA, int lda, long dB, int ldb, double beta, long dC, int ldc) {
+        MemorySegment scalars = scalars(alpha, beta);
+        try {
+            return (int) CUBLAS_DGEMM.invokeExact(handle, transa, transb, m, n, k, scalars.asSlice(0, Double.BYTES), dA, lda, dB, ldb, scalars.asSlice(Double.BYTES, Double.BYTES), dC, ldc);
         } catch (Throwable t) {
             throw rethrow(t);
         }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlas.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlas.java
@@ -32,6 +32,7 @@ import uk.ac.manchester.tornado.api.enums.TornadoVMBackendType;
 import uk.ac.manchester.tornado.api.exceptions.TornadoExecutionPlanException;
 import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
+import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.cublas.CuBlas;
@@ -579,6 +580,122 @@ public class TestCuBlas extends TornadoTestBase {
     public static void scaleByTwo(FloatArray input, FloatArray output) {
         for (@Parallel int i = 0; i < input.getSize(); i++) {
             output.set(i, 2.0f * input.get(i));
+        }
+    }
+
+    // ---- FP64 ----
+
+    /** C = A * B in FP64, validated against a double-precision CPU reference. */
+    @Test
+    public void testDgemm() throws TornadoExecutionPlanException {
+        final int size = 128;
+        DoubleArray matrixA = new DoubleArray(size * size);
+        DoubleArray matrixB = new DoubleArray(size * size);
+        DoubleArray matrixC = new DoubleArray(size * size);
+        for (int i = 0; i < size * size; i++) {
+            matrixA.set(i, random.nextDouble() - 0.5);
+            matrixB.set(i, random.nextDouble() - 0.5);
+        }
+
+        // Column-major cuBLAS: row-major C = A * B is C_cm = B_cm * A_cm.
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, matrixA, matrixB) //
+                .libraryTask("dgemm", CuBlas::cublasDgemm, //
+                        CuBlasOperation.CUBLAS_OP_N.operation(), CuBlasOperation.CUBLAS_OP_N.operation(), //
+                        size, size, size, 1.0, matrixB, size, matrixA, size, 0.0, matrixC, size) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < size; j++) {
+                double sum = 0.0;
+                for (int p = 0; p < size; p++) {
+                    sum += matrixA.get(i * size + p) * matrixB.get(p * size + j);
+                }
+                assertEquals(sum, matrixC.get(i * size + j), 1e-10 * Math.max(1.0, Math.abs(sum)));
+            }
+        }
+    }
+
+    /**
+     * beta != 0 makes C an input as well as an output. This is the case that fails if the
+     * output is marked WRITE_ONLY, because its prior device contents would not be kept live.
+     */
+    @Test
+    public void testDgemmBetaReadsC() throws TornadoExecutionPlanException {
+        final int size = 64;
+        final double alpha = 1.0;
+        final double beta = 2.0;
+        DoubleArray matrixA = new DoubleArray(size * size);
+        DoubleArray matrixB = new DoubleArray(size * size);
+        DoubleArray matrixC = new DoubleArray(size * size);
+        double[] priorC = new double[size * size];
+        for (int i = 0; i < size * size; i++) {
+            matrixA.set(i, random.nextDouble() - 0.5);
+            matrixB.set(i, random.nextDouble() - 0.5);
+            double c = random.nextDouble() - 0.5;
+            matrixC.set(i, c);
+            priorC[i] = c;
+        }
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, matrixA, matrixB, matrixC) //
+                .libraryTask("dgemm", CuBlas::cublasDgemm, //
+                        CuBlasOperation.CUBLAS_OP_N.operation(), CuBlasOperation.CUBLAS_OP_N.operation(), //
+                        size, size, size, alpha, matrixB, size, matrixA, size, beta, matrixC, size) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+
+        for (int i = 0; i < size; i++) {
+            for (int j = 0; j < size; j++) {
+                double sum = 0.0;
+                for (int p = 0; p < size; p++) {
+                    sum += matrixA.get(i * size + p) * matrixB.get(p * size + j);
+                }
+                double expected = alpha * sum + beta * priorC[i * size + j];
+                assertEquals(expected, matrixC.get(i * size + j), 1e-10 * Math.max(1.0, Math.abs(expected)));
+            }
+        }
+    }
+
+    /**
+     * FP64 must actually be double precision. The product below is exact in FP64 and not
+     * representable in FP32, so an accidental single-precision path fails here.
+     */
+    @Test
+    public void testDgemmIsTrulyDoublePrecision() throws TornadoExecutionPlanException {
+        final int size = 32;
+        // 1 + 2^-30 is representable in FP64 and rounds to exactly 1.0f in FP32.
+        final double epsilon = Math.pow(2.0, -30);
+        DoubleArray matrixA = new DoubleArray(size * size);
+        DoubleArray matrixB = new DoubleArray(size * size);
+        DoubleArray matrixC = new DoubleArray(size * size);
+        for (int i = 0; i < size * size; i++) {
+            matrixA.set(i, 0.0);
+            matrixB.set(i, 0.0);
+        }
+        for (int i = 0; i < size; i++) {
+            matrixA.set(i * size + i, 1.0 + epsilon); // diagonal
+            matrixB.set(i * size + i, 1.0);
+        }
+
+        TaskGraph taskGraph = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, matrixA, matrixB) //
+                .libraryTask("dgemm", CuBlas::cublasDgemm, //
+                        CuBlasOperation.CUBLAS_OP_N.operation(), CuBlasOperation.CUBLAS_OP_N.operation(), //
+                        size, size, size, 1.0, matrixB, size, matrixA, size, 0.0, matrixC, size) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, matrixC);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(taskGraph.snapshot())) {
+            plan.execute();
+        }
+
+        for (int i = 0; i < size; i++) {
+            double got = matrixC.get(i * size + i);
+            assertEquals(1.0 + epsilon, got, 0.0); // exact: FP32 would give 1.0
         }
     }
 }


### PR DESCRIPTION
## What

cuBLAS had **no double-precision path**. The scaffolding was already in place —
`CudaDataType.CUDA_R_64F`, `CublasComputeType.CUBLAS_COMPUTE_64F`, and the `DoubleArray` native array type all exist — but `cublasDgemm_v2` was not among the bound symbols, so an FP64 GEMM fell back to a JIT kernel.

This binds it and adds `CuBlas.cublasDgemm`.

## Why it is a small change

The FFM descriptor is **identical** to `cublasSgemm_v2`:

```java
FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_INT, C_INT, C_INT, C_INT,
                      C_POINTER, C_LONG, C_INT, C_LONG, C_INT, C_POINTER, C_LONG, C_INT)
```

α and β cross as `C_POINTER` into host scratch, and the matrices as `C_LONG` device pointers, so element width does not change the downcall's shape. Only the marshalling differs — a `double` overload of the per-thread scalar scratch writes them with `C_DOUBLE`.

## Two details that are silent if wrong

**1. The access-class helper.** `readOnlyExcept(numArgs, outputIndex, beta)` took a `float`. Passing a `double` does not merely fail to compile — narrowing first means a small non-zero β such as `1e-300` **rounds to `0.0f`**, and the output would be marked `WRITE_ONLY` when cuBLAS is about to read it. This adds a `double` overload comparing against `0.0d`:

```java
accesses[outputIndex] = (beta != 0.0d) ? Access.READ_WRITE : Access.WRITE_ONLY;
```

**2. Dispatch registration.** The cuBLAS provider dispatches through a `Map<String, CuBlasCall>` of method references, not a `switch`. A marshalling method that exists but is not registered in `FUNCTIONS` **compiles without error** and fails only at runtime with "function not supported".

## Tests

Three added to `TestCuBlas`:

| Test | Covers |
|---|---|
| `testDgemm` | FP64 GEMM against a double-precision CPU reference |
| `testDgemmBetaReadsC` | β ≠ 0 — the case that fails if the output is `WRITE_ONLY` |
| `testDgemmIsTrulyDoublePrecision` | `1 + 2⁻³⁰`, exact in FP64 and rounding to exactly `1.0f` in FP32, asserted at **zero tolerance** |

The third exists because a plain correctness test would not catch an accidental single-precision path — the values would agree to within any reasonable tolerance. This one cannot pass in FP32.

## Verification

RTX 4090 (sm_89), driver 565.57.01, CUDA 12.6.85, JDK 25.0.2, built with `make jdk22plus BACKEND=cuda`:

```
tornado-test -V uk.ac.manchester.tornado.unittests.cublas.TestCuBlas
Test ran: 17, Failed: 0, Unsupported: 0
```

17 = the 14 pre-existing tests plus the 3 new ones. `./mvnw checkstyle:check` clean.

## Scope

Only `dgemm`. `dgemv`, the batched FP64 forms and the complex types remain unbound — each needs its own symbol and marshalling, and they are better reviewed separately than as one large change.
