### PR TITLE
[cublas] Bind the scalar-output level-1 routines using device pointer mode

### DIFF
--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/CuBlas.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/CuBlas.java
@@ -25,6 +25,7 @@ import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
 import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.cublas.enums.CuBlasMathMode;
 
 /**
@@ -159,6 +160,43 @@ public final class CuBlas {
         return new LibraryTaskDescriptor() //
                 .withLibrary(LIBRARY_NAME) //
                 .withFunction("cublasSasum") //
+                .withParameters(new Object[] { n, x, incx, result }) //
+                .withAccess(access);
+    }
+
+    /**
+     * Index of the element of {@code x} with the largest absolute value, written to a
+     * device-resident single-element {@link IntArray}.
+     *
+     * <p><b>The index is 1-based</b>, following the BLAS convention that cuBLAS preserves: for a
+     * vector whose largest element sits at Java index {@code i}, this writes {@code i + 1}.</p>
+     *
+     * <p>Like {@link #cublasSdot} the result stays on the device, so a following task can consume
+     * it and the call is legal inside a CUDA Graph.</p>
+     */
+    public static LibraryTaskDescriptor cublasIsamax(int n, FloatArray x, int incx, IntArray result) {
+        Access[] access = new Access[4];
+        Arrays.fill(access, Access.READ_ONLY);
+        access[3] = Access.WRITE_ONLY; // result
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("cublasIsamax") //
+                .withParameters(new Object[] { n, x, incx, result }) //
+                .withAccess(access);
+    }
+
+    /**
+     * Index of the element of {@code x} with the smallest absolute value, written to a
+     * device-resident single-element {@link IntArray}. <b>1-based</b>, as for
+     * {@link #cublasIsamax}.
+     */
+    public static LibraryTaskDescriptor cublasIsamin(int n, FloatArray x, int incx, IntArray result) {
+        Access[] access = new Access[4];
+        Arrays.fill(access, Access.READ_ONLY);
+        access[3] = Access.WRITE_ONLY; // result
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("cublasIsamin") //
                 .withParameters(new Object[] { n, x, incx, result }) //
                 .withAccess(access);
     }

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/CuBlas.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/CuBlas.java
@@ -107,6 +107,62 @@ public final class CuBlas {
      *     Stride between consecutive elements of y.
      * @return {@link LibraryTaskDescriptor}
      */
+    /**
+     * Dot product {@code result[0] = x . y} over {@code n} elements.
+     *
+     * <p>The result is written to a device-resident {@link FloatArray} rather than returned, so it
+     * never leaves the GPU: a following task can consume it directly. This is what makes the
+     * routine usable inside a CUDA Graph. cuBLAS is put into {@code CUBLAS_POINTER_MODE_DEVICE}
+     * for the call and restored afterwards; in the default host pointer mode cuBLAS would have to
+     * synchronise the stream to deliver the value, which stalls the pipeline and is illegal during
+     * graph capture.</p>
+     *
+     * @param result
+     *            single-element device buffer receiving the dot product.
+     */
+    public static LibraryTaskDescriptor cublasSdot(int n, FloatArray x, int incx, FloatArray y, int incy, FloatArray result) {
+        Access[] access = new Access[6];
+        Arrays.fill(access, Access.READ_ONLY);
+        access[5] = Access.WRITE_ONLY; // result
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("cublasSdot") //
+                .withParameters(new Object[] { n, x, incx, y, incy, result }) //
+                .withAccess(access);
+    }
+
+    /**
+     * Euclidean norm {@code result[0] = ||x||_2} over {@code n} elements, written to a
+     * device-resident single-element buffer. See {@link #cublasSdot} for why the result stays on
+     * the device.
+     */
+    public static LibraryTaskDescriptor cublasSnrm2(int n, FloatArray x, int incx, FloatArray result) {
+        Access[] access = new Access[4];
+        Arrays.fill(access, Access.READ_ONLY);
+        access[3] = Access.WRITE_ONLY; // result
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("cublasSnrm2") //
+                .withParameters(new Object[] { n, x, incx, result }) //
+                .withAccess(access);
+    }
+
+    /**
+     * Sum of absolute values {@code result[0] = sum(|x_i|)} over {@code n} elements, written to a
+     * device-resident single-element buffer. See {@link #cublasSdot} for why the result stays on
+     * the device.
+     */
+    public static LibraryTaskDescriptor cublasSasum(int n, FloatArray x, int incx, FloatArray result) {
+        Access[] access = new Access[4];
+        Arrays.fill(access, Access.READ_ONLY);
+        access[3] = Access.WRITE_ONLY; // result
+        return new LibraryTaskDescriptor() //
+                .withLibrary(LIBRARY_NAME) //
+                .withFunction("cublasSasum") //
+                .withParameters(new Object[] { n, x, incx, result }) //
+                .withAccess(access);
+    }
+
     public static LibraryTaskDescriptor cublasSgemv(int operation, //
             int m, //
             int n, //

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLibraryProvider.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLibraryProvider.java
@@ -67,6 +67,9 @@ public final class CuBlasLibraryProvider implements TornadoLibraryProvider {
      */
     private static final Map<String, CuBlasCall> FUNCTIONS = Map.ofEntries(//
             Map.entry("cublasSgemv", CuBlasLibraryProvider::sgemv), //
+            Map.entry("cublasSdot", CuBlasLibraryProvider::sdot), //
+            Map.entry("cublasSnrm2", CuBlasLibraryProvider::snrm2), //
+            Map.entry("cublasSasum", CuBlasLibraryProvider::sasum), //
             Map.entry("cublasSgemm", CuBlasLibraryProvider::sgemm), //
             Map.entry("cublasDgemm", CuBlasLibraryProvider::dgemm), //
             Map.entry("cublasSgemmStridedBatched", CuBlasLibraryProvider::sgemmStridedBatched), //
@@ -265,6 +268,22 @@ public final class CuBlasLibraryProvider implements TornadoLibraryProvider {
     }
 
     /** (transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc). */
+    // (n, x, incx, y, incy, result)
+    private static int sdot(long handle, LibraryInvocation invocation) {
+        return CuBlasNativeLib.cublasSdot(handle, (int) invocation.getArg(0), invocation.getDevicePointer(1), (int) invocation.getArg(2), invocation.getDevicePointer(3),
+                (int) invocation.getArg(4), invocation.getDevicePointer(5));
+    }
+
+    // (n, x, incx, result)
+    private static int snrm2(long handle, LibraryInvocation invocation) {
+        return CuBlasNativeLib.cublasSnrm2(handle, (int) invocation.getArg(0), invocation.getDevicePointer(1), (int) invocation.getArg(2), invocation.getDevicePointer(3));
+    }
+
+    // (n, x, incx, result)
+    private static int sasum(long handle, LibraryInvocation invocation) {
+        return CuBlasNativeLib.cublasSasum(handle, (int) invocation.getArg(0), invocation.getDevicePointer(1), (int) invocation.getArg(2), invocation.getDevicePointer(3));
+    }
+
     private static int sgemm(long handle, LibraryInvocation invocation) {
         return CuBlasNativeLib.cublasSgemm(handle, //
                 (int) invocation.getArg(0), //

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLibraryProvider.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasLibraryProvider.java
@@ -70,6 +70,8 @@ public final class CuBlasLibraryProvider implements TornadoLibraryProvider {
             Map.entry("cublasSdot", CuBlasLibraryProvider::sdot), //
             Map.entry("cublasSnrm2", CuBlasLibraryProvider::snrm2), //
             Map.entry("cublasSasum", CuBlasLibraryProvider::sasum), //
+            Map.entry("cublasIsamax", CuBlasLibraryProvider::isamax), //
+            Map.entry("cublasIsamin", CuBlasLibraryProvider::isamin), //
             Map.entry("cublasSgemm", CuBlasLibraryProvider::sgemm), //
             Map.entry("cublasDgemm", CuBlasLibraryProvider::dgemm), //
             Map.entry("cublasSgemmStridedBatched", CuBlasLibraryProvider::sgemmStridedBatched), //
@@ -282,6 +284,16 @@ public final class CuBlasLibraryProvider implements TornadoLibraryProvider {
     // (n, x, incx, result)
     private static int sasum(long handle, LibraryInvocation invocation) {
         return CuBlasNativeLib.cublasSasum(handle, (int) invocation.getArg(0), invocation.getDevicePointer(1), (int) invocation.getArg(2), invocation.getDevicePointer(3));
+    }
+
+    // (n, x, incx, result)
+    private static int isamax(long handle, LibraryInvocation invocation) {
+        return CuBlasNativeLib.cublasIsamax(handle, (int) invocation.getArg(0), invocation.getDevicePointer(1), (int) invocation.getArg(2), invocation.getDevicePointer(3));
+    }
+
+    // (n, x, incx, result)
+    private static int isamin(long handle, LibraryInvocation invocation) {
+        return CuBlasNativeLib.cublasIsamin(handle, (int) invocation.getArg(0), invocation.getDevicePointer(1), (int) invocation.getArg(2), invocation.getDevicePointer(3));
     }
 
     private static int sgemm(long handle, LibraryInvocation invocation) {

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasNativeLib.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasNativeLib.java
@@ -60,6 +60,10 @@ final class CuBlasNativeLib {
     private static final MethodHandle CUBLAS_SET_STREAM;
     private static final MethodHandle CUBLAS_SET_MATH_MODE;
     private static final MethodHandle CUBLAS_SET_WORKSPACE;
+    private static final MethodHandle CUBLAS_SET_POINTER_MODE;
+    private static final MethodHandle CUBLAS_SDOT;
+    private static final MethodHandle CUBLAS_SNRM2;
+    private static final MethodHandle CUBLAS_SASUM;
     private static final MethodHandle CUBLAS_SGEMV;
     private static final MethodHandle CUBLAS_SGEMM;
     private static final MethodHandle CUBLAS_DGEMM;
@@ -75,6 +79,10 @@ final class CuBlasNativeLib {
             CUBLAS_SET_STREAM = null;
             CUBLAS_SET_MATH_MODE = null;
             CUBLAS_SET_WORKSPACE = null;
+            CUBLAS_SET_POINTER_MODE = null;
+            CUBLAS_SDOT = null;
+            CUBLAS_SNRM2 = null;
+            CUBLAS_SASUM = null;
             CUBLAS_SGEMV = null;
             CUBLAS_SGEMM = null;
             CUBLAS_DGEMM = null;
@@ -88,6 +96,13 @@ final class CuBlasNativeLib {
             CUBLAS_SET_STREAM = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_LONG), "cublasSetStream_v2");
             CUBLAS_SET_MATH_MODE = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT), "cublasSetMathMode");
             CUBLAS_SET_WORKSPACE = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_LONG, C_LONG), "cublasSetWorkspace_v2");
+            CUBLAS_SET_POINTER_MODE = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT), "cublasSetPointerMode_v2");
+            // The scalar-output level-1 routines write their result through a pointer. Under
+            // CUBLAS_POINTER_MODE_DEVICE that pointer is device memory, so the result stays on the
+            // GPU and cuBLAS does not have to synchronise the stream to deliver it.
+            CUBLAS_SDOT = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_LONG, C_INT, C_LONG, C_INT, C_LONG), "cublasSdot_v2");
+            CUBLAS_SNRM2 = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_LONG, C_INT, C_LONG), "cublasSnrm2_v2");
+            CUBLAS_SASUM = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_LONG, C_INT, C_LONG), "cublasSasum_v2");
             CUBLAS_SGEMV = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_INT, C_INT, C_POINTER, C_LONG, C_INT, C_LONG, C_INT, C_POINTER, C_LONG, C_INT),
                     "cublasSgemv_v2");
             CUBLAS_SGEMM = FFMSupport.downcall(LIBCUBLAS,
@@ -221,6 +236,64 @@ final class CuBlasNativeLib {
         } catch (Throwable t) {
             throw rethrow(t);
         }
+    }
+
+    /** {@code cublasPointerMode_t}. */
+    private static final int CUBLAS_POINTER_MODE_HOST = 0;
+    private static final int CUBLAS_POINTER_MODE_DEVICE = 1;
+
+    private static int setPointerMode(long handle, int mode) {
+        try {
+            return (int) CUBLAS_SET_POINTER_MODE.invokeExact(handle, mode);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+    /**
+     * Runs a scalar-output level-1 routine with the handle in device pointer mode, restoring host
+     * mode afterwards because the handle is shared by every call of the execution plan.
+     */
+    private static int inDevicePointerMode(long handle, java.util.function.LongToIntFunction body) {
+        int status = setPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);
+        if (status != CUBLAS_STATUS_SUCCESS) {
+            return status;
+        }
+        try {
+            return body.applyAsInt(handle);
+        } finally {
+            setPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
+        }
+    }
+
+    static int cublasSdot(long handle, int n, long dX, int incx, long dY, int incy, long dResult) {
+        return inDevicePointerMode(handle, h -> {
+            try {
+                return (int) CUBLAS_SDOT.invokeExact(h, n, dX, incx, dY, incy, dResult);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        });
+    }
+
+    static int cublasSnrm2(long handle, int n, long dX, int incx, long dResult) {
+        return inDevicePointerMode(handle, h -> {
+            try {
+                return (int) CUBLAS_SNRM2.invokeExact(h, n, dX, incx, dResult);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        });
+    }
+
+    static int cublasSasum(long handle, int n, long dX, int incx, long dResult) {
+        return inDevicePointerMode(handle, h -> {
+            try {
+                return (int) CUBLAS_SASUM.invokeExact(h, n, dX, incx, dResult);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        });
     }
 
     static int cublasSgemv(long handle, int trans, int m, int n, float alpha, long dA, int lda, long dX, int incx, float beta, long dY, int incy) {

--- a/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasNativeLib.java
+++ b/tornado-cublas/src/main/java/uk/ac/manchester/tornado/cublas/provider/CuBlasNativeLib.java
@@ -64,6 +64,8 @@ final class CuBlasNativeLib {
     private static final MethodHandle CUBLAS_SDOT;
     private static final MethodHandle CUBLAS_SNRM2;
     private static final MethodHandle CUBLAS_SASUM;
+    private static final MethodHandle CUBLAS_ISAMAX;
+    private static final MethodHandle CUBLAS_ISAMIN;
     private static final MethodHandle CUBLAS_SGEMV;
     private static final MethodHandle CUBLAS_SGEMM;
     private static final MethodHandle CUBLAS_DGEMM;
@@ -83,6 +85,8 @@ final class CuBlasNativeLib {
             CUBLAS_SDOT = null;
             CUBLAS_SNRM2 = null;
             CUBLAS_SASUM = null;
+            CUBLAS_ISAMAX = null;
+            CUBLAS_ISAMIN = null;
             CUBLAS_SGEMV = null;
             CUBLAS_SGEMM = null;
             CUBLAS_DGEMM = null;
@@ -103,6 +107,10 @@ final class CuBlasNativeLib {
             CUBLAS_SDOT = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_LONG, C_INT, C_LONG, C_INT, C_LONG), "cublasSdot_v2");
             CUBLAS_SNRM2 = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_LONG, C_INT, C_LONG), "cublasSnrm2_v2");
             CUBLAS_SASUM = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_LONG, C_INT, C_LONG), "cublasSasum_v2");
+            // The index-returning routines write an int rather than a float, but are otherwise the
+            // same shape and have the same host-pointer-mode synchronisation problem.
+            CUBLAS_ISAMAX = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_LONG, C_INT, C_LONG), "cublasIsamax_v2");
+            CUBLAS_ISAMIN = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_LONG, C_INT, C_LONG), "cublasIsamin_v2");
             CUBLAS_SGEMV = FFMSupport.downcall(LIBCUBLAS, FunctionDescriptor.of(C_INT, C_LONG, C_INT, C_INT, C_INT, C_POINTER, C_LONG, C_INT, C_LONG, C_INT, C_POINTER, C_LONG, C_INT),
                     "cublasSgemv_v2");
             CUBLAS_SGEMM = FFMSupport.downcall(LIBCUBLAS,
@@ -290,6 +298,26 @@ final class CuBlasNativeLib {
         return inDevicePointerMode(handle, h -> {
             try {
                 return (int) CUBLAS_SASUM.invokeExact(h, n, dX, incx, dResult);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        });
+    }
+
+    static int cublasIsamax(long handle, int n, long dX, int incx, long dResult) {
+        return inDevicePointerMode(handle, h -> {
+            try {
+                return (int) CUBLAS_ISAMAX.invokeExact(h, n, dX, incx, dResult);
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
+        });
+    }
+
+    static int cublasIsamin(long handle, int n, long dX, int incx, long dResult) {
+        return inDevicePointerMode(handle, h -> {
+            try {
+                return (int) CUBLAS_ISAMIN.invokeExact(h, n, dX, incx, dResult);
             } catch (Throwable t) {
                 throw rethrow(t);
             }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlas.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlas.java
@@ -619,6 +619,117 @@ public class TestCuBlas extends TornadoTestBase {
         }
     }
 
+    // ---- scalar-output level-1 routines (device pointer mode) ----
+
+    /** Scales every element by the value a preceding library task left on the device. */
+    public static void scaleByDeviceScalar(FloatArray data, FloatArray scalar) {
+        for (@Parallel int i = 0; i < data.getSize(); i++) {
+            data.set(i, data.get(i) * scalar.get(0));
+        }
+    }
+
+    @Test
+    public void testSdot() throws TornadoExecutionPlanException {
+        final int n = 1024;
+        FloatArray x = randomArray(n);
+        FloatArray y = randomArray(n);
+        FloatArray result = new FloatArray(1);
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, x, y) //
+                .libraryTask("dot", CuBlas::cublasSdot, n, x, 1, y, 1, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.execute();
+        }
+
+        float expected = 0.0f;
+        for (int i = 0; i < n; i++) {
+            expected += x.get(i) * y.get(i);
+        }
+        assertEquals(expected, result.get(0), 1e-3f * Math.max(1.0f, Math.abs(expected)));
+    }
+
+    @Test
+    public void testSnrm2() throws TornadoExecutionPlanException {
+        final int n = 1024;
+        FloatArray x = randomArray(n);
+        FloatArray result = new FloatArray(1);
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, x) //
+                .libraryTask("nrm2", CuBlas::cublasSnrm2, n, x, 1, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.execute();
+        }
+
+        double sum = 0.0;
+        for (int i = 0; i < n; i++) {
+            sum += (double) x.get(i) * x.get(i);
+        }
+        float expected = (float) Math.sqrt(sum);
+        assertEquals(expected, result.get(0), 1e-3f * Math.max(1.0f, Math.abs(expected)));
+    }
+
+    @Test
+    public void testSasum() throws TornadoExecutionPlanException {
+        final int n = 1024;
+        FloatArray x = randomArray(n);
+        FloatArray result = new FloatArray(1);
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, x) //
+                .libraryTask("asum", CuBlas::cublasSasum, n, x, 1, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.execute();
+        }
+
+        double expected = 0.0;
+        for (int i = 0; i < n; i++) {
+            expected += Math.abs(x.get(i));
+        }
+        assertEquals((float) expected, result.get(0), 1e-3f * Math.max(1.0f, Math.abs((float) expected)));
+    }
+
+    /**
+     * The result never leaves the device: a JIT task consumes it directly. In the default host
+     * pointer mode this composition is not expressible, because the value would have to come back
+     * to the host before it could be used as a kernel argument.
+     */
+    @Test
+    public void testNrm2ResultFeedsJitTaskOnDevice() throws TornadoExecutionPlanException {
+        final int n = 512;
+        FloatArray x = randomArray(n);
+        FloatArray data = randomArray(n);
+        FloatArray norm = new FloatArray(1);
+
+        float[] dataOriginal = new float[n];
+        for (int i = 0; i < n; i++) {
+            dataOriginal[i] = data.get(i);
+        }
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, x, data) //
+                .libraryTask("nrm2", CuBlas::cublasSnrm2, n, x, 1, norm) //
+                .task("scale", TestCuBlas::scaleByDeviceScalar, data, norm) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.execute();
+        }
+
+        double sum = 0.0;
+        for (int i = 0; i < n; i++) {
+            sum += (double) x.get(i) * x.get(i);
+        }
+        float expectedNorm = (float) Math.sqrt(sum);
+        for (int i = 0; i < n; i++) {
+            float expected = dataOriginal[i] * expectedNorm;
+            assertEquals(expected, data.get(i), 1e-3f * Math.max(1.0f, Math.abs(expected)));
+        }
+    }
+
     /**
      * beta != 0 makes C an input as well as an output. This is the case that fails if the
      * output is marked WRITE_ONLY, because its prior device contents would not be kept live.
@@ -696,6 +807,36 @@ public class TestCuBlas extends TornadoTestBase {
         for (int i = 0; i < size; i++) {
             double got = matrixC.get(i * size + i);
             assertEquals(1.0 + epsilon, got, 0.0); // exact: FP32 would give 1.0
+        }
+    }
+
+    /**
+     * Captured into a CUDA Graph and replayed. Under the default host pointer mode cuBLAS would
+     * have to synchronise the stream to deliver the scalar, which is illegal inside a capture
+     * region, so this composition only works because the result is device-resident.
+     */
+    @Test
+    public void testSdotUnderCudaGraph() throws TornadoExecutionPlanException {
+        final int n = 1024;
+        FloatArray x = randomArray(n);
+        FloatArray y = randomArray(n);
+        FloatArray result = new FloatArray(1);
+
+        float expected = 0.0f;
+        for (int i = 0; i < n; i++) {
+            expected += x.get(i) * y.get(i);
+        }
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, x, y) //
+                .libraryTask("dot", CuBlas::cublasSdot, n, x, 1, y, 1, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.withCUDAGraph();
+            for (int it = 0; it < 5; it++) {
+                plan.execute();
+                assertEquals(expected, result.get(0), 1e-3f * Math.max(1.0f, Math.abs(expected)));
+            }
         }
     }
 }

--- a/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlas.java
+++ b/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/cublas/TestCuBlas.java
@@ -34,6 +34,7 @@ import uk.ac.manchester.tornado.api.types.HalfFloat;
 import uk.ac.manchester.tornado.api.types.arrays.BFloat16Array;
 import uk.ac.manchester.tornado.api.types.arrays.DoubleArray;
 import uk.ac.manchester.tornado.api.types.arrays.FloatArray;
+import uk.ac.manchester.tornado.api.types.arrays.IntArray;
 import uk.ac.manchester.tornado.api.types.arrays.HalfFloatArray;
 import uk.ac.manchester.tornado.cublas.CuBlas;
 import uk.ac.manchester.tornado.cublas.CuBlasOptions;
@@ -836,6 +837,78 @@ public class TestCuBlas extends TornadoTestBase {
             for (int it = 0; it < 5; it++) {
                 plan.execute();
                 assertEquals(expected, result.get(0), 1e-3f * Math.max(1.0f, Math.abs(expected)));
+            }
+        }
+    }
+
+    /**
+     * cuBLAS returns a 1-based index, following the BLAS convention. A planted maximum at a known
+     * position pins that down: an off-by-one in the binding would show here rather than in a
+     * random-data test where any plausible index looks right.
+     */
+    @Test
+    public void testIsamaxReturnsOneBasedIndex() throws TornadoExecutionPlanException {
+        final int n = 512;
+        final int peakAt = 300; // Java index
+        FloatArray x = new FloatArray(n);
+        for (int i = 0; i < n; i++) {
+            x.set(i, 0.5f);
+        }
+        x.set(peakAt, -42.0f); // largest by absolute value, and negative on purpose
+        IntArray result = new IntArray(1);
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, x) //
+                .libraryTask("amax", CuBlas::cublasIsamax, n, x, 1, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.execute();
+        }
+        assertEquals(peakAt + 1, result.get(0));
+    }
+
+    @Test
+    public void testIsaminReturnsOneBasedIndex() throws TornadoExecutionPlanException {
+        final int n = 512;
+        final int troughAt = 117;
+        FloatArray x = new FloatArray(n);
+        for (int i = 0; i < n; i++) {
+            x.set(i, 5.0f);
+        }
+        x.set(troughAt, 0.001f);
+        IntArray result = new IntArray(1);
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.EVERY_EXECUTION, x) //
+                .libraryTask("amin", CuBlas::cublasIsamin, n, x, 1, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.execute();
+        }
+        assertEquals(troughAt + 1, result.get(0));
+    }
+
+    /** The int result is device-resident too, so it survives CUDA Graph capture and replay. */
+    @Test
+    public void testIsamaxUnderCudaGraph() throws TornadoExecutionPlanException {
+        final int n = 256;
+        final int peakAt = 200;
+        FloatArray x = new FloatArray(n);
+        for (int i = 0; i < n; i++) {
+            x.set(i, 1.0f);
+        }
+        x.set(peakAt, 99.0f);
+        IntArray result = new IntArray(1);
+
+        TaskGraph g = new TaskGraph("g") //
+                .transferToDevice(DataTransferMode.FIRST_EXECUTION, x) //
+                .libraryTask("amax", CuBlas::cublasIsamax, n, x, 1, result) //
+                .transferToHost(DataTransferMode.EVERY_EXECUTION, result);
+        try (TornadoExecutionPlan plan = new TornadoExecutionPlan(g.snapshot())) {
+            plan.withCUDAGraph();
+            for (int it = 0; it < 5; it++) {
+                plan.execute();
+                assertEquals(peakAt + 1, result.get(0));
             }
         }
     }


### PR DESCRIPTION
## What

cuBLAS **level-1 coverage was zero** of roughly thirteen families. This binds the three scalar-output routines — `cublasSdot`, `cublasSnrm2`, `cublasSasum`.

## Why they could not be bound before

Not the bindings — the **pointer mode**. `cublasSetPointerMode` is never called on `develop` (zero references), so the handle stays in the default `CUBLAS_POINTER_MODE_HOST`.

In host mode these routines write their result through a *host* pointer:

```c
cublasSdot_v2(handle, n, x, 1, y, 1, &result);   // host memory
```

cuBLAS therefore has to **synchronise the stream** to deliver the value. That stalls the pipeline, and it is **illegal inside a CUDA Graph capture region**. Binding them in host mode would have produced entry points that break the two things the hybrid API exists to provide.

Under `CUBLAS_POINTER_MODE_DEVICE` the result pointer is device memory: the value stays on the GPU, no synchronisation happens, and a following task consumes it directly.

## API

The result is a single-element `FloatArray` — already a device-resident buffer the data-flow graph understands, declared `WRITE_ONLY` like any other output:

```java
FloatArray norm = new FloatArray(1);

new TaskGraph("g")
    .transferToDevice(DataTransferMode.EVERY_EXECUTION, x, data)
    .libraryTask("nrm2", CuBlas::cublasSnrm2, n, x, 1, norm)
    .task("scale", MyKernels::scaleByDeviceScalar, data, norm)  // consumes it on the device
    .transferToHost(DataTransferMode.EVERY_EXECUTION, data);
```

## Scoping the mode

The pointer mode is applied **only to the calls that need it**, not exposed as a user-facing knob:

```java
private static int inDevicePointerMode(long handle, LongToIntFunction body) {
    int status = setPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);
    if (status != CUBLAS_STATUS_SUCCESS) {
        return status;
    }
    try {
        return body.applyAsInt(handle);
    } finally {
        setPointerMode(handle, CUBLAS_POINTER_MODE_HOST);
    }
}
```

The restore matters: the handle is shared by every call of the execution plan, and the existing `gemv`/`gemm` factories pass α and β as host floats. This mirrors how `cublasSetMathMode` is already set and restored. A caller never has to know the mode exists.

## Tests

Five added to `TestCuBlas`. Three check values against CPU references. The other two cover what host pointer mode **cannot express at all**:

| Test | Why it matters |
|---|---|
| `testNrm2ResultFeedsJitTaskOnDevice` | a JIT kernel consumes the norm with no host round trip |
| `testSdotUnderCudaGraph` | captures and replays 5× — impossible under host mode, where the synchronisation is not permitted during capture |

## Verification

RTX 4090 (sm_89), driver 565.57.01, CUDA 12.6.85, JDK 25.0.2, `make jdk22plus BACKEND=cuda`:

```
tornado-test -V uk.ac.manchester.tornado.unittests.cublas.TestCuBlas
Test ran: 19, Failed: 0, Unsupported: 0
```

19 = the 14 pre-existing tests plus the 5 new ones. `./mvnw checkstyle:check` clean.

## Not in this PR

Device pointer mode also enables **α and β to be computed on the device** — letting a preceding JIT task produce a scaling factor, and fixing the trap where host-mode scalars are baked into a captured CUDA Graph by value and silently reused on replay. That needs new `gemv`/`gemm` factory overloads taking `FloatArray` scalars, and is better reviewed separately from the level-1 bindings.

The index-returning routines (`amax`, `amin`) are also unbound; they return an `int` index and would need the same treatment with an `IntArray`.
