### PR TITLE
Honour an absolute code-cache directory instead of appending it to TORNADOVM_HOME

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACodeCache.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACodeCache.java
@@ -47,6 +47,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.drivers.cuda.enums.CUDABuildStatus;
 import uk.ac.manchester.tornado.drivers.cuda.enums.CUDADeviceType;
 import uk.ac.manchester.tornado.drivers.cuda.graal.CUDAInstalledCode;
+import uk.ac.manchester.tornado.runtime.common.CodeCacheDirectory;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
@@ -61,9 +62,9 @@ public class CUDACodeCache {
     private final boolean OPENCL_CACHE_ENABLE = Boolean.parseBoolean(getProperty("tornado.opencl.codecache.enable", FALSE));
     private final boolean OPENCL_DUMP_BINS = Boolean.parseBoolean(getProperty("tornado.opencl.codecache.dump", FALSE));
     private final boolean OPENCL_DUMP_SOURCE = Boolean.parseBoolean(getProperty("tornado.opencl.source.dump", FALSE));
-    private final String OPENCL_CACHE_DIR = getProperty("tornado.opencl.codecache.dir", "/var/opencl-codecache");
-    private final String OPENCL_SOURCE_DIR = getProperty("tornado.opencl.source.dir", "/var/opencl-compiler");
-    private final String OPENCL_LOG_DIR = getProperty("tornado.opencl.log.dir", "/var/opencl-logs");
+    private final String OPENCL_CACHE_DIR = getProperty("tornado.opencl.codecache.dir", "var/opencl-codecache");
+    private final String OPENCL_SOURCE_DIR = getProperty("tornado.opencl.source.dir", "var/opencl-compiler");
+    private final String OPENCL_LOG_DIR = getProperty("tornado.opencl.log.dir", "var/opencl-logs");
 
     /**
      * Persist compiled module images and reload them on the next run, so that a kernel is only handed to
@@ -71,7 +72,7 @@ public class CUDACodeCache {
      * compilation again, which dominates start-up for applications with many kernels.
      */
     private final boolean CUDA_CODE_CACHE_ENABLE = Boolean.parseBoolean(getProperty("tornado.cuda.codecache.enable", TRUE));
-    private final String CUDA_CODE_CACHE_DIR = getProperty("tornado.cuda.codecache.dir", "/var/cuda-codecache");
+    private final String CUDA_CODE_CACHE_DIR = getProperty("tornado.cuda.codecache.dir", "var/cuda-codecache");
 
     private final ConcurrentHashMap<String, CUDAInstalledCode> cache;
     private final CUDADeviceContextInterface deviceContext;
@@ -97,9 +98,8 @@ public class CUDACodeCache {
     }
 
     private Path resolveDirectory(String dir) {
-        final String tornadoRoot = System.getenv("TORNADOVM_HOME");
         final String deviceDir = String.format("device-%d-%d", deviceContext.getPlatformContext().getPlatformIndex(), deviceContext.getDevice().getIndex());
-        final Path outDir = Paths.get(tornadoRoot + "/" + dir + "/" + deviceDir);
+        final Path outDir = CodeCacheDirectory.resolve(dir, deviceDir);
         createOrReuseDirectory(outDir);
         return outDir;
     }

--- a/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/MetalCodeCache.java
+++ b/tornado-drivers/metal/src/main/java/uk/ac/manchester/tornado/drivers/metal/MetalCodeCache.java
@@ -42,6 +42,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoRuntimeException;
 import uk.ac.manchester.tornado.drivers.metal.enums.MetalBuildStatus;
 import uk.ac.manchester.tornado.drivers.metal.exceptions.MetalException;
 import uk.ac.manchester.tornado.drivers.metal.graal.MetalInstalledCode;
+import uk.ac.manchester.tornado.runtime.common.CodeCacheDirectory;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.common.TornadoOptions;
@@ -55,9 +56,9 @@ public class MetalCodeCache {
     private final boolean METAL_DUMP_BINS = Boolean.parseBoolean(getProperty("tornado.metal.codecache.dump", FALSE));
     private final boolean METAL_DUMP_SOURCE = Boolean.parseBoolean(getProperty("tornado.metal.source.dump", FALSE));
     private final boolean PRINT_LOAD_TIME = false;
-    private final String METAL_CACHE_DIR = getProperty("tornado.metal.codecache.dir", "/var/metal-codecache");
-    private final String METAL_SOURCE_DIR = getProperty("tornado.metal.source.dir", "/var/metal-compiler");
-    private final String METAL_LOG_DIR = getProperty("tornado.metal.log.dir", "/var/metal-logs");
+    private final String METAL_CACHE_DIR = getProperty("tornado.metal.codecache.dir", "var/metal-codecache");
+    private final String METAL_SOURCE_DIR = getProperty("tornado.metal.source.dir", "var/metal-compiler");
+    private final String METAL_LOG_DIR = getProperty("tornado.metal.log.dir", "var/metal-logs");
 
     private final ConcurrentHashMap<String, MetalInstalledCode> cache;
     private final MetalDeviceContextInterface deviceContext;
@@ -83,9 +84,8 @@ public class MetalCodeCache {
     }
 
     private Path resolveDirectory(String dir) {
-        final String tornadoRoot = System.getenv("TORNADO_SDK");
         final String deviceDir = String.format("device-%d-%d", deviceContext.getPlatformContext().getPlatformIndex(), deviceContext.getDevice().getIndex());
-        final Path outDir = Paths.get(tornadoRoot + "/" + dir + "/" + deviceDir);
+        final Path outDir = CodeCacheDirectory.resolve(dir, deviceDir);
         createOrReuseDirectory(outDir);
         return outDir;
     }

--- a/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
+++ b/tornado-drivers/opencl/src/main/java/uk/ac/manchester/tornado/drivers/opencl/OCLCodeCache.java
@@ -42,6 +42,7 @@ import uk.ac.manchester.tornado.api.exceptions.TornadoBailoutRuntimeException;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLBuildStatus;
 import uk.ac.manchester.tornado.drivers.opencl.enums.OCLDeviceType;
 import uk.ac.manchester.tornado.drivers.opencl.graal.OCLInstalledCode;
+import uk.ac.manchester.tornado.runtime.common.CodeCacheDirectory;
 import uk.ac.manchester.tornado.runtime.common.RuntimeUtilities;
 import uk.ac.manchester.tornado.runtime.common.TornadoLogger;
 import uk.ac.manchester.tornado.runtime.tasks.meta.TaskDataContext;
@@ -54,9 +55,9 @@ public class OCLCodeCache {
     private final boolean OPENCL_CACHE_ENABLE = Boolean.parseBoolean(getProperty("tornado.opencl.codecache.enable", FALSE));
     private final boolean OPENCL_DUMP_BINS = Boolean.parseBoolean(getProperty("tornado.opencl.codecache.dump", FALSE));
     private final boolean OPENCL_DUMP_SOURCE = Boolean.parseBoolean(getProperty("tornado.opencl.source.dump", FALSE));
-    private final String OPENCL_CACHE_DIR = getProperty("tornado.opencl.codecache.dir", "/var/opencl-codecache");
-    private final String OPENCL_SOURCE_DIR = getProperty("tornado.opencl.source.dir", "/var/opencl-compiler");
-    private final String OPENCL_LOG_DIR = getProperty("tornado.opencl.log.dir", "/var/opencl-logs");
+    private final String OPENCL_CACHE_DIR = getProperty("tornado.opencl.codecache.dir", "var/opencl-codecache");
+    private final String OPENCL_SOURCE_DIR = getProperty("tornado.opencl.source.dir", "var/opencl-compiler");
+    private final String OPENCL_LOG_DIR = getProperty("tornado.opencl.log.dir", "var/opencl-logs");
 
     private final ConcurrentHashMap<String, OCLInstalledCode> cache;
     private final OCLDeviceContextInterface deviceContext;
@@ -82,9 +83,8 @@ public class OCLCodeCache {
     }
 
     private Path resolveDirectory(String dir) {
-        final String tornadoRoot = System.getenv("TORNADOVM_HOME");
         final String deviceDir = String.format("device-%d-%d", deviceContext.getPlatformContext().getPlatformIndex(), deviceContext.getDevice().getIndex());
-        final Path outDir = Paths.get(tornadoRoot + "/" + dir + "/" + deviceDir);
+        final Path outDir = CodeCacheDirectory.resolve(dir, deviceDir);
         createOrReuseDirectory(outDir);
         return outDir;
     }

--- a/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/CodeCacheDirectory.java
+++ b/tornado-runtime/src/main/java/uk/ac/manchester/tornado/runtime/common/CodeCacheDirectory.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.runtime.common;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Resolves the on-disk directory a backend uses for its code cache, generated sources or
+ * compiler logs.
+ *
+ * <p>
+ * Each backend used to do this itself, with the same line in all three:
+ *
+ * <pre>
+ * Paths.get(System.getenv("TORNADOVM_HOME") + "/" + dir + "/" + deviceDir)
+ * </pre>
+ *
+ * String concatenation, so a configured directory could only ever land underneath
+ * {@code TORNADOVM_HOME}. Setting {@code -Dtornado.cuda.codecache.dir=/tmp/cache} produced
+ * {@code $TORNADOVM_HOME/tmp/cache/device-0-0} -- the absolute path silently ignored and the
+ * cache written into the SDK installation instead, which fails outright when the SDK is
+ * read-only or shared between users. And with {@code TORNADOVM_HOME} unset the concatenation
+ * yields the string {@code "null/..."}, so a directory literally named {@code null} appeared
+ * in the working directory.
+ *
+ * <p>
+ * Resolution here is the conventional one:
+ *
+ * <ul>
+ * <li>an <b>absolute</b> configured directory is used as given;</li>
+ * <li>a <b>relative</b> one is resolved against {@code TORNADOVM_HOME};</li>
+ * <li>if {@code TORNADOVM_HOME} is unset or blank, a relative directory falls back to
+ * {@code ${java.io.tmpdir}/tornadovm}, which keeps an embedded use working instead of
+ * writing to {@code null/}.</li>
+ * </ul>
+ *
+ * <p>
+ * The per-backend defaults are relative ({@code var/cuda-codecache} and friends), so the
+ * default location is unchanged: {@code $TORNADOVM_HOME/var/cuda-codecache/device-0-0}.
+ */
+public final class CodeCacheDirectory {
+
+    private static final String TORNADOVM_HOME = "TORNADOVM_HOME";
+    private static final String FALLBACK_DIRECTORY_NAME = "tornadovm";
+
+    private CodeCacheDirectory() {
+    }
+
+    /**
+     * Resolves {@code configuredDirectory}, then appends the per-device subdirectory.
+     *
+     * @param configuredDirectory
+     *     value of the backend's {@code *.dir} property. Absolute is honoured as given;
+     *     relative is resolved against {@code TORNADOVM_HOME}.
+     * @param deviceDirectory
+     *     per-device leaf, e.g. {@code device-0-0}.
+     *
+     * @return the directory to use. Not created -- the caller does that.
+     */
+    public static Path resolve(String configuredDirectory, String deviceDirectory) {
+        return resolveBase(configuredDirectory).resolve(deviceDirectory);
+    }
+
+    /**
+     * The configured directory without the per-device leaf. Exposed for tests and for callers
+     * that do not partition by device.
+     */
+    public static Path resolveBase(String configuredDirectory) {
+        final Path configured = Paths.get(configuredDirectory);
+        if (configured.isAbsolute()) {
+            return configured;
+        }
+        return root().resolve(configured);
+    }
+
+    private static Path root() {
+        final String home = System.getenv(TORNADOVM_HOME);
+        if (home == null || home.isBlank()) {
+            // Not fatal: TornadoVM is usable as a library, where the launcher never runs and so
+            // never exports TORNADOVM_HOME. Writing to "null/" was the previous behaviour and was
+            // never intentional.
+            return Paths.get(System.getProperty("java.io.tmpdir")).resolve(FALLBACK_DIRECTORY_NAME);
+        }
+        return Paths.get(home);
+    }
+}

--- a/tornado-runtime/src/test/java/uk/ac/manchester/tornado/runtime/common/CodeCacheDirectoryTest.java
+++ b/tornado-runtime/src/test/java/uk/ac/manchester/tornado/runtime/common/CodeCacheDirectoryTest.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Tornado: A heterogeneous programming framework:
+ * https://github.com/beehive-lab/tornadovm
+ *
+ * Copyright (c) 2025, APT Group, Department of Computer Science,
+ * The University of Manchester. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+package uk.ac.manchester.tornado.runtime.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link CodeCacheDirectory}.
+ *
+ * <p>
+ * The behaviour these pin down is what the three backends got wrong for years: a configured
+ * absolute directory was concatenated onto {@code TORNADOVM_HOME} rather than used, so the
+ * cache went into the SDK installation instead of where it was asked to go.
+ *
+ * <p>
+ * {@code TORNADOVM_HOME} is an environment variable and cannot be set from a test without
+ * reflecting into the JDK's environment map, so the tests are written to hold whether or not
+ * it happens to be set in the running shell. Where the expected value depends on it, it is
+ * read rather than assumed.
+ */
+public class CodeCacheDirectoryTest {
+
+    private static final String DEVICE = "device-0-0";
+
+    private static String home() {
+        final String home = System.getenv("TORNADOVM_HOME");
+        return home == null || home.isBlank() ? null : home;
+    }
+
+    /** The regression: an absolute directory is used as given, never appended to the SDK root. */
+    @Test
+    public void anAbsoluteDirectoryIsHonoured() {
+        Path resolved = CodeCacheDirectory.resolve("/tmp/tornado-cache-test", DEVICE);
+        assertEquals(Paths.get("/tmp/tornado-cache-test", DEVICE), resolved);
+    }
+
+    /** Specifically: it does not land under TORNADOVM_HOME, which is what used to happen. */
+    @Test
+    public void anAbsoluteDirectoryDoesNotLandUnderTornadoHome() {
+        final String home = home();
+        if (home == null) {
+            return; // nothing to be under
+        }
+        Path resolved = CodeCacheDirectory.resolve("/tmp/tornado-cache-test", DEVICE);
+        assertTrue("absolute path was resolved under TORNADOVM_HOME: " + resolved, !resolved.startsWith(Paths.get(home)));
+    }
+
+    /** A relative directory keeps the historical location, so defaults do not move. */
+    @Test
+    public void aRelativeDirectoryResolvesAgainstTornadoHomeWhenSet() {
+        final String home = home();
+        if (home == null) {
+            return;
+        }
+        assertEquals(Paths.get(home, "var/cuda-codecache", DEVICE), CodeCacheDirectory.resolve("var/cuda-codecache", DEVICE));
+    }
+
+    /**
+     * With no {@code TORNADOVM_HOME} the result must still be an absolute, usable path -- the
+     * previous code produced the literal string {@code "null/var/..."}.
+     */
+    @Test
+    public void aRelativeDirectoryNeverResolvesToTheStringNull() {
+        Path resolved = CodeCacheDirectory.resolve("var/cuda-codecache", DEVICE);
+        assertTrue("resolved path is absolute", resolved.isAbsolute());
+        for (Path element : resolved) {
+            assertEquals("a path element is the literal string \"null\": " + resolved, false, "null".equals(element.toString()));
+        }
+    }
+
+    /** The per-device leaf is always the last element. */
+    @Test
+    public void theDeviceDirectoryIsTheLeaf() {
+        assertEquals(Paths.get(DEVICE), CodeCacheDirectory.resolve("/tmp/tornado-cache-test", DEVICE).getFileName());
+        assertEquals(Paths.get("device-1-2"), CodeCacheDirectory.resolve("var/x", "device-1-2").getFileName());
+    }
+
+    /** resolveBase is resolve without the leaf. */
+    @Test
+    public void resolveBaseOmitsTheDeviceDirectory() {
+        assertEquals(CodeCacheDirectory.resolveBase("/tmp/tornado-cache-test").resolve(DEVICE), CodeCacheDirectory.resolve("/tmp/tornado-cache-test", DEVICE));
+    }
+
+    /** A trailing separator or a redundant one must not change the result. */
+    @Test
+    public void redundantSeparatorsAreNormalised() {
+        assertEquals(CodeCacheDirectory.resolve("/tmp/tornado-cache-test", DEVICE), CodeCacheDirectory.resolve("/tmp//tornado-cache-test/", DEVICE));
+    }
+}


### PR DESCRIPTION
## The problem

All three backends resolved their cache, source and log directories by string concatenation:

```java
Paths.get(System.getenv("TORNADOVM_HOME") + "/" + dir + "/" + deviceDir)
```

so a configured directory could only ever land *underneath* `TORNADOVM_HOME`. Setting

```bash
-Dtornado.cuda.codecache.dir=/tmp/mycache
```

produces `$TORNADOVM_HOME/tmp/mycache/device-0-0` — the absolute path silently ignored and the cache written **into the SDK installation**. Verified on an RTX 4090 before the fix:

```
$ tornado --jvm=-Dtornado.cuda.codecache.dir=/tmp/mycache --classpath . MatMulLadder
$ ls /tmp/mycache
ls: cannot access '/tmp/mycache': No such file or directory

$ find "$TORNADOVM_HOME" -path "*mycache*"
.../tornadovm-6.0.1-jdk22plus-dev-cuda/tmp/mycache/device-0-0/kcRegisterTiled-b2be….cubin
.../tornadovm-6.0.1-jdk22plus-dev-cuda/tmp/mycache/device-0-0/kcTiled-1f31….cubin
.../tornadovm-6.0.1-jdk22plus-dev-cuda/tmp/mycache/device-0-0/naive-f515….cubin
```

That matters because it fails outright when the SDK is **read-only or shared between users**, and it is why the cache cannot be pointed at fast local storage or isolated per CI job. The cache itself works — on this machine a warm cache takes a three-kernel run from 1.19 s to 1.06 s, so ~130 ms of NVRTC is genuinely skipped — you just cannot put it where you want it.

Two further defects fall out of the same line.

**`TORNADOVM_HOME` unset yields the string `"null/..."`.** A directory literally named `null` is created in the working directory. TornadoVM is usable as a library, where the launcher never runs and so never exports the variable.

**`MetalCodeCache` reads `TORNADO_SDK`**, which #773 deprecated in favour of `TORNADOVM_HOME`. It is the last Java reference to that variable in the tree:

```
$ grep -rn "TORNADO_SDK" --include=*.java .
tornado-drivers/metal/…/MetalCodeCache.java:86:  final String tornadoRoot = System.getenv("TORNADO_SDK");
```

and `bin/tornado` only maps it in the *other* direction (`TORNADO_SDK` → `TORNADOVM_HOME`, with a deprecation warning). So on any normal Metal run it reads `null` and takes the `null/` path above. I have no Mac, so that one is by inspection rather than measurement.

## The fix

Resolution moves into one place, `CodeCacheDirectory`, and becomes the conventional thing:

- an **absolute** configured directory is used as given;
- a **relative** one resolves against `TORNADOVM_HOME`;
- a relative one with no `TORNADOVM_HOME` falls back to `${java.io.tmpdir}/tornadovm` rather than `null/`.

The per-backend defaults were spelled `"/var/cuda-codecache"` but were only ever *relative* in intent — they were being concatenated, so the leading slash never meant anything. They are now written relative (`"var/cuda-codecache"`), which is what keeps the default location unchanged under the new rule.

## Backward compatibility

**The default location does not move.** Still `$TORNADOVM_HOME/var/cuda-codecache/device-0-0`, verified end to end after the change:

```
$ rm -rf "$TORNADOVM_HOME/var/cuda-codecache"
$ tornado --classpath . MatMulLadder 512 3
$ ls "$TORNADOVM_HOME/var/cuda-codecache/device-0-0/"
kcRegisterTiled-b2be….cubin  kcTiled-1f31….cubin  naive-f515….cubin
```

and with the property set, the cubins now land in `/tmp/mycache/device-0-0/` with **nothing** written into the SDK tree.

**One behaviour change worth calling out:** anyone passing an absolute path today gets it appended to `TORNADOVM_HOME`, and will now get the path they asked for. That is the bug being fixed, but if any tooling depends on the old concatenation it will notice. Relative values are unaffected.

## Testing

- **7 new no-GPU unit tests** for the helper, in the existing reflection lane — 51 pass. They pin the regression directly (an absolute directory must not resolve under `TORNADOVM_HOME`) and assert no path element is ever the literal string `null`. They are written to hold whether or not `TORNADOVM_HOME` happens to be set in the running shell, since it is an environment variable and cannot be set from a test without reflecting into the JDK's environment map.
- **`tornado-test --quickPass`** on the CUDA backend: 1174 tests, 7 failures, all four classes pre-existing on `develop` (`TestReductionsFloats`, `TestMatrixMultiplicationKernelContext`, `ComputeTests`, `TestDevices`).
- Checkstyle clean.
- OpenCL and Metal are compile-and-CI only from here — I have neither an OpenCL device configured nor a Mac, so their behaviour change rests on the shared helper and its unit tests.
