### PR TITLE
[cuda] Skip stream synchronisation when nothing has been enqueued since the last drain (3 per execution to 1)

### DIFF
--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACommandQueue.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/CUDACommandQueue.java
@@ -244,6 +244,7 @@ public class CUDACommandQueue extends CommandQueue {
      */
     private static long recordEvent(CUDAHandles.Queue queue) throws CUDAException {
         long event = createEvent(eventFlags(), "cuEventCreate");
+        queue.markPending();
         int result = CUDADriverAPI.cuEventRecord(event, queue.stream());
         if (result != CUDADriverAPI.CUDA_SUCCESS) {
             CUDADriverAPI.cuEventDestroy(event);
@@ -271,6 +272,7 @@ public class CUDACommandQueue extends CommandQueue {
             return 0;
         }
         long start = createEvent(CU_EVENT_DEFAULT, "cuEventCreate(start)");
+        queue.markPending();
         int result = CUDADriverAPI.cuEventRecord(start, queue.stream());
         if (result != CUDADriverAPI.CUDA_SUCCESS) {
             CUDADriverAPI.cuEventDestroy(start);
@@ -293,6 +295,7 @@ public class CUDACommandQueue extends CommandQueue {
             destroyEvent(start);
             throw e;
         }
+        queue.markPending();
         int result = CUDADriverAPI.cuEventRecord(end, queue.stream());
         if (result != CUDADriverAPI.CUDA_SUCCESS) {
             destroyEvent(start);
@@ -333,6 +336,7 @@ public class CUDACommandQueue extends CommandQueue {
         for (int i = 0; i < count; i++) {
             CUDAHandles.Event event = CUDAHandles.resolve(events[i + 1], CUDAHandles.Event.class);
             if (event != null) {
+                queue.markPending();
                 CUDADriverAPI.cuStreamWaitEvent(queue.stream(), event.event(), 0);
             }
         }
@@ -451,6 +455,7 @@ public class CUDACommandQueue extends CommandQueue {
             CUDADriverAPI.cuCtxSetCurrent(queue.context());
             waitEvents(queue, events);
             long start = beginEvent(queue);
+            queue.markPending();
             int result = CUDADriverAPI.cuLaunchKernel(kernel.function, grid[0], grid[1], grid[2], block[0], block[1], block[2], 0, queue.stream(), kernelParameters(arena, kernel),
                     MemorySegment.NULL);
             long launchEvent = endEvent(start, queue);
@@ -504,9 +509,15 @@ public class CUDACommandQueue extends CommandQueue {
             CUDADriverAPI.cuCtxSetCurrent(queue.context());
             waitEvents(queue, events);
             long start = beginEvent(queue);
+            queue.markPending();
             int result = CUDADriverAPI.cuMemcpyHtoDAsync(devicePointer + deviceOffset, hostPointer + hostOffset, numBytes, queue.stream());
-            result = syncIfNeeded(queue, result, syncAfter);
+            // Record the completion event BEFORE draining, not after. Recording afterwards puts
+            // fresh work on the stream and re-arms `pending`, so the flush that follows an
+            // execution synchronises an otherwise idle stream. With this order the drain covers the
+            // event record too and the stream is genuinely clear afterwards. The event still marks
+            // the end of the copy either way -- it is recorded on the stream after it.
             long event = endEvent(start, queue);
+            result = syncIfNeeded(queue, result, syncAfter);
             if (result != CUDADriverAPI.CUDA_SUCCESS) {
                 discardEvent(event);
                 throw new CUDAException(CUDADriverAPI.describe("cuMemcpyHtoDAsync", result));
@@ -525,9 +536,15 @@ public class CUDACommandQueue extends CommandQueue {
             CUDADriverAPI.cuCtxSetCurrent(queue.context());
             waitEvents(queue, events);
             long start = beginEvent(queue);
+            queue.markPending();
             int result = CUDADriverAPI.cuMemcpyDtoHAsync(hostPointer + hostOffset, devicePointer + deviceOffset, numBytes, queue.stream());
-            result = syncIfNeeded(queue, result, syncAfter);
+            // Record the completion event BEFORE draining, not after. Recording afterwards puts
+            // fresh work on the stream and re-arms `pending`, so the flush that follows an
+            // execution synchronises an otherwise idle stream. With this order the drain covers the
+            // event record too and the stream is genuinely clear afterwards. The event still marks
+            // the end of the copy either way -- it is recorded on the stream after it.
             long event = endEvent(start, queue);
+            result = syncIfNeeded(queue, result, syncAfter);
             if (result != CUDADriverAPI.CUDA_SUCCESS) {
                 discardEvent(event);
                 throw new CUDAException(CUDADriverAPI.describe("cuMemcpyDtoHAsync", result));
@@ -543,8 +560,33 @@ public class CUDACommandQueue extends CommandQueue {
         if (!syncAfter || isCapturing(queue)) {
             return copyResult;
         }
-        int sync = CUDADriverAPI.cuStreamSynchronize(queue.stream());
+        int sync = drain(queue);
         return copyResult != CUDADriverAPI.CUDA_SUCCESS ? copyResult : sync;
+    }
+
+    /**
+     * Synchronises the stream, unless nothing has been enqueued since it was last drained.
+     *
+     * <p>
+     * A task-graph execution ends with a blocking read-back, then a flush, then a wait: three
+     * {@code cuStreamSynchronize} calls, of which the last two are issued against a stream the
+     * read-back already emptied. The driver round trip for those buys nothing, and on a
+     * dispatch-bound plan it is a measurable share of the per-execution cost.
+     *
+     * <p>
+     * The flag is only ever cleared after the driver reports success, so a failed synchronise
+     * leaves the queue marked pending and the next caller tries again rather than assuming the
+     * stream drained.
+     */
+    private static int drain(CUDAHandles.Queue queue) {
+        if (!queue.isPending()) {
+            return CUDADriverAPI.CUDA_SUCCESS;
+        }
+        int result = CUDADriverAPI.cuStreamSynchronize(queue.stream());
+        if (result == CUDADriverAPI.CUDA_SUCCESS) {
+            queue.clearPending();
+        }
+        return result;
     }
 
     /**
@@ -716,7 +758,7 @@ public class CUDACommandQueue extends CommandQueue {
         if (queue == null) {
             return;
         }
-        int result = CUDADriverAPI.cuStreamSynchronize(queue.stream());
+        int result = drain(queue);
         if (result != CUDADriverAPI.CUDA_SUCCESS) {
             throw new CUDAException(CUDADriverAPI.describe("cuStreamSynchronize", result));
         }
@@ -796,6 +838,7 @@ public class CUDACommandQueue extends CommandQueue {
             return CUDA_ERROR_INVALID_VALUE;
         }
         CUDADriverAPI.cuCtxSetCurrent(queue.context());
+        queue.markPending();
         return CUDADriverAPI.cuGraphLaunch(graphExecHandle, queue.stream());
     }
 
@@ -809,9 +852,23 @@ public class CUDACommandQueue extends CommandQueue {
 
     /* ---- Native interop (external libraries, e.g. cuBLAS) ---- */
 
+    /**
+     * Hands the raw stream to an external library (cuBLAS, cuDNN, cuFFT, CUTLASS, ...).
+     *
+     * <p>
+     * Those libraries enqueue on it without going through this class, so the queue is marked
+     * pending here: we cannot see what they do, and skipping a later synchronise because our own
+     * bookkeeping says the stream is idle would read their results before they land. Marking on
+     * handing out the pointer is deliberately conservative -- a library task simply never takes the
+     * skip -- and it costs one flag write per dispatch, not per operation.
+     */
     private static long getStreamPointer(long queueId) {
         CUDAHandles.Queue queue = CUDAHandles.resolve(queueId, CUDAHandles.Queue.class);
-        return queue == null ? 0 : queue.stream();
+        if (queue == null) {
+            return 0;
+        }
+        queue.markPending();
+        return queue.stream();
     }
 
     private static long getContextPointer(long queueId) {

--- a/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/ffm/CUDAHandles.java
+++ b/tornado-drivers/cuda/src/main/java/uk/ac/manchester/tornado/drivers/cuda/ffm/CUDAHandles.java
@@ -92,7 +92,65 @@ public final class CUDAHandles {
      * {@code properties} carries the OpenCL-style queue property bits the Java layer created it
      * with, which is what tells the profiler whether the queue was asked to time its operations.
      */
-    public record Queue(long stream, long context, int device, long properties) {
+    /**
+     * A command queue: a CUDA stream plus the context it belongs to.
+     *
+     * <p>
+     * Not a record, because it carries one piece of mutable state. {@code pending} says whether
+     * anything has been enqueued on the stream since it was last drained, so that a
+     * {@code cuStreamSynchronize} against a stream that is already empty can be skipped. A task
+     * graph ends with a blocking read-back, a flush and a wait, and the last two synchronise a
+     * stream that the read-back already drained.
+     *
+     * <p>
+     * It is {@code volatile} rather than an {@code AtomicBoolean} because the transitions are a
+     * plain set and a plain clear -- there is no read-modify-write to lose -- and every write is a
+     * conservative "assume work is outstanding".
+     */
+    public static final class Queue {
+
+        private final long stream;
+        private final long context;
+        private final int device;
+        private final long properties;
+        private volatile boolean pending;
+
+        public Queue(long stream, long context, int device, long properties) {
+            this.stream = stream;
+            this.context = context;
+            this.device = device;
+            this.properties = properties;
+        }
+
+        public long stream() {
+            return stream;
+        }
+
+        public long context() {
+            return context;
+        }
+
+        public int device() {
+            return device;
+        }
+
+        public long properties() {
+            return properties;
+        }
+
+        /** Records that work may now be outstanding on the stream. Always safe to call. */
+        public void markPending() {
+            pending = true;
+        }
+
+        /** Records that the stream has been drained. Only ever called after a successful sync. */
+        public void clearPending() {
+            pending = false;
+        }
+
+        public boolean isPending() {
+            return pending;
+        }
     }
 
     /**


### PR DESCRIPTION
## The problem

A task-graph execution ends with a blocking device-to-host read-back, then `flush()`, then `waitOn()` — **three `cuStreamSynchronize` per execution, two of them issued against a stream the read-back already emptied.** Measured on `develop`, saxpy n=1024:

```
cuStreamSynchronize   3.00 calls/execution   4.19 us/execution
```

## The change

The queue gains a `pending` flag, set by every enqueue — both transfer helpers, `cuLaunchKernel`, every `cuEventRecord`, `cuStreamWaitEvent`, `cuGraphLaunch` — and cleared only after a **successful** drain, so a failed synchronise leaves the queue marked and the next caller tries again rather than assuming the stream drained. Both synchronisation sites (`syncIfNeeded` for the blocking copy, `clFlush`/`clFinish`) route through one `drain()` helper that returns immediately when nothing has been enqueued, in which case the stream is empty by construction.

**The second half matters as much as the flag.** The transfer helpers now record their completion event *before* draining rather than after. Recording afterwards put fresh work on the stream and re-armed `pending`, so the following flush still synchronised an idle stream — with the flag alone the count only went 3 → 2. With the reorder the drain covers the event record too and the count reaches 1. The event still marks the end of the copy, since it is recorded on the stream after it.

`Queue` becomes a final class rather than a record, since it now carries that one piece of mutable state. All accessors keep their names, and there is exactly one construction site.

## The hazard worth reviewing carefully

`getStreamPointer` hands the raw stream to external libraries — cuBLAS, cuDNN, cuFFT, CUTLASS — which enqueue on it **without going through `CUDACommandQueue`**. Skipping a later synchronise because our own bookkeeping says the stream is idle would read their results before they land: silent wrong answers, not a crash.

Handing out the pointer therefore marks the queue pending. A library task simply never takes the skip, and the cost is one flag write per dispatch rather than per operation. This has no counterpart in the original JNI implementation, where every stream user funnelled through one place.

All six library suites pass — see Testing.

## Numbers, and what I am not claiming

RTX 4090, saxpy n=1024, **same tree** measured with and without the change:

| | calls/execution | us/execution |
|---|---|---|
| `develop` | 3.00 | 4.19 |
| this PR | **1.00** | **2.55** |

Steady-state wall clock is **11 us either way** (3 runs each, 30,000 executions to reach steady state). On this workload the removed calls were near-no-ops.

**So the honest claim is a deterministic reduction in driver work — two round trips per execution — not a wall-clock win on this benchmark.** #1023 said the same of itself: "on its own this change is worth nothing measurable on the workload it was profiled against… and 4.2% once #1022's per-launch copy is gone." Where it should matter is a plan whose synchronisation is not already overlapped with real transfer time.

One thing worth flagging for anyone measuring this area: TornadoVM's per-execution host cost takes **~1000 executions** to reach steady state (173 us for the first executions, 11 us by 30,000 — a 14x spread, dominated by JVM JIT). A benchmark shorter than that is measuring the JIT, not the runtime.

## History — why this is a reimplementation

This restores the change from **#1023**, which was closed as *"Folded into #1022 and closing this one… Nothing is dropped."* That fold-in did not land:

- the merged #1022 (`bb19d9e7e`) touches three files — `CUDADeviceContext`, `CUDAInstalledCode`, `CUDAKernelStackFrame` — none of them the queue, and contains no `pending`/`sync_stream` logic;
- none of the three commits carrying this work are ancestors of `develop` (they live only on `perf/cuda-skip-idle-stream-sync`, `perf/cuda-dispatch-overhead` and a backup branch).

The measurement agrees: `develop` still does 3 syncs per execution, which is the pre-#1023 behaviour.

They also cannot simply be cherry-picked. The original targets `cuda_queue_t` in the JNI backend, which the FFM port replaced, so this is a reimplementation of the same design against the current code.

## Testing

- **Full device suite: 1209 tests, zero regressions** against the same `develop` baseline. The 11 failures are identical to the baseline's and pre-exist (`TestDevices#test04/06`, `ComputeTests#testMandelbrot/testJuliaSets`, `TransformerKernelsTest#testReductionOneBlockWithLayer`, `TestMatrixMultiplicationKernelContext#mxm2DKernelContext01/02`, three `TestProfiler` cases, `TestReductionsFloats#testComputePi`).
- **All six library suites pass**, which is the specific validation for the `getStreamPointer` hazard: `TestCuBlas` 17, `TestCuBlasLt` 6, `TestCuFft` 8, `TestCuDnn` 11, `TestCusparse` 11, `TestCutlass` 25 — 78 tests, 0 failures.
- Checkstyle clean.
